### PR TITLE
Require hex prefix

### DIFF
--- a/grammars/wgsl.pest
+++ b/grammars/wgsl.pest
@@ -185,5 +185,5 @@ float_literal = @{ "-"? ~ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT*)? }
 bool_literal = @{ "true" | "false" }
 string_literal = @{ "\"" ~ ( "\"\"" | (!"\"" ~ ANY) )* ~ "\"" }
 
-WHITESPACE = _{ " " | "\t" | "\n" }
-COMMENT = _{ "#" ~ (!"\n" ~ ANY)* }
+WHITESPACE = _{ " " | "\t" | NEWLINE  }
+COMMENT = _{ "#" ~ (!NEWLINE ~ ANY)* }

--- a/grammars/wgsl.pest
+++ b/grammars/wgsl.pest
@@ -179,8 +179,8 @@ typed_expression = { type_decl ~ "(" ~ argument_expression_list ~ ")" }
 argument_expression_list = _{ (logical_or_expression ~ ",")* ~ logical_or_expression }
 
 ident = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
-int_literal = @{ ("-"? ~ "0x"? ~ ASCII_HEX_DIGIT+) | "0" | ("-"? ~ ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) }
-uint_literal = @{ ("0x"? ~ ASCII_HEX_DIGIT+) | "0" | (ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) }
+int_literal = @{ ("-"? ~ "0x" ~ ASCII_HEX_DIGIT+) | "0" | ("-"? ~ ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) }
+uint_literal = @{ ("0x" ~ ASCII_HEX_DIGIT+) | "0" | (ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) }
 float_literal = @{ "-"? ~ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT*)? }
 bool_literal = @{ "true" | "false" }
 string_literal = @{ "\"" ~ ( "\"\"" | (!"\"" ~ ANY) )* ~ "\"" }

--- a/test-data/quad.wgsl
+++ b/test-data/quad.wgsl
@@ -6,7 +6,7 @@ const c_scale: f32 = 1.2;
 [[builtin position]] var<out> o_position : vec4<f32>;
 
 fn main_vert() -> void {
-  o_position = vec4<f32>(scale * a_pos, 0.0, 1.0);
+  o_position = vec4<f32>(c_scale * a_pos, 0.0, 1.0);
   return;
 }
 entry_point vertex as "main" = main_vert;


### PR DESCRIPTION
Includes stuff from https://github.com/gfx-rs/naga/pull/11

Still not happy with that as handling of int/floats still clashes with hex values ):
0xF will be interpreted as [float]xF and stuck, not sure how to encode this information in pest