### PR TITLE
[wgsl] control flow parsing

### DIFF
--- a/src/front/spirv.rs
+++ b/src/front/spirv.rs
@@ -1269,6 +1269,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                             } else {
                                 Some(self.lookup_type.lookup(result_type)?.handle)
                             },
+                            local_variables: Arena::new(),
                             expressions: self.make_expression_storage(),
                             body: Vec::new(),
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,13 @@ pub struct GlobalVariable {
     pub ty: Handle<Type>,
 }
 
+#[derive(Clone, Debug)]
+pub struct LocalVariable {
+    pub name: Option<String>,
+    pub ty: Handle<Type>,
+    pub init: Option<Handle<Expression>>,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum UnaryOperator {
     Negate,
@@ -173,6 +180,7 @@ pub enum Expression {
     },
     FunctionParameter(u32),
     GlobalVariable(Handle<GlobalVariable>),
+    LocalVariable(Handle<LocalVariable>),
     Load {
         pointer: Handle<Expression>,
     },
@@ -216,11 +224,6 @@ pub struct FallThrough;
 pub enum Statement {
     Empty,
     Block(Block),
-    VariableDeclaration {
-        name: String,
-        ty: Handle<Type>,
-        value: Option<Handle<Expression>>,
-    },
     If {
         condition: Handle<Expression>, //bool
         accept: Block,
@@ -231,6 +234,13 @@ pub enum Statement {
         cases: FastHashMap<i32, (Block, Option<FallThrough>)>,
         default: Block,
     },
+    Loop {
+        body: Block,
+        continuing: Block,
+    },
+    //TODO: move terminator variations into a separate enum?
+    Break,
+    Continue,
     Return {
         value: Option<Handle<Expression>>,
     },
@@ -247,6 +257,7 @@ pub struct Function {
     pub control: spirv::FunctionControl,
     pub parameter_types: Vec<Handle<Type>>,
     pub return_type: Option<Handle<Type>>,
+    pub local_variables: Arena<LocalVariable>,
     pub expressions: Arena<Expression>,
     pub body: Block,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,7 @@ pub struct FallThrough;
 
 #[derive(Debug)]
 pub enum Statement {
+    Empty,
     Block(Block),
     VariableDeclaration {
         name: String,


### PR DESCRIPTION
This PR gets us the remaining bits required to parse "boids.wgsl" 🎉 
It also improves IR a bit:
  - adds notion of local variables to function, instead of the variable statements
  - adds loops

We can add "test-data/*.wgsl" to automated testing now.

It will probably needs some work before we are able to generate a sensible SPIR-V, but architecturally we are almost there.