### PR TITLE
Typifier skeleton

### DIFF
--- a/src/front/spirv.rs
+++ b/src/front/spirv.rs
@@ -1135,6 +1135,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                     let type_id = self.next()?;
                     let id = self.next()?;
                     let type_lookup = self.lookup_type.lookup(type_id)?;
+                    let ty = type_lookup.handle;
                     let inner = match module.types[type_lookup.handle].inner {
                         crate::TypeInner::Scalar { kind: crate::ScalarKind::Uint, width } => {
                             let low = self.next()?;
@@ -1186,6 +1187,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                                 .and_then(|dec| dec.name),
                             specialization: None, //TODO
                             inner,
+                            ty,
                         }),
                         type_id,
                     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ pub struct Constant {
     pub name: Option<String>,
     pub specialization: Option<spirv::Word>,
     pub inner: ConstantInner,
+    pub ty: Handle<Type>,
 }
 
 #[derive(Debug)]
@@ -94,6 +95,17 @@ pub enum ConstantInner {
     Uint(u64),
     Float(f64),
     Bool(bool),
+}
+
+impl ConstantInner {
+    pub fn scalar_kind(&self) -> ScalarKind {
+        match *self {
+            ConstantInner::Sint(_) => ScalarKind::Sint,
+            ConstantInner::Uint(_) => ScalarKind::Uint,
+            ConstantInner::Float(_) => ScalarKind::Float,
+            ConstantInner::Bool(_) => ScalarKind::Bool,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod arena;
 pub mod back;
 pub mod front;
+pub mod proc;
 
 use crate::arena::{Arena, Handle};
 

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -1,3 +1,3 @@
 mod typifier;
 
-pub use typifier::Typifier;
+pub use typifier::{ResolveError, Typifier};

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -1,0 +1,3 @@
+mod typifier;
+
+pub use typifier::Typifier;

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -4,6 +4,11 @@ pub struct Typifier {
     types: Vec<Handle<crate::Type>>,
 }
 
+#[derive(Debug)]
+pub enum ResolveError {
+    InvalidAccessIndex,
+}
+
 impl Typifier {
     pub fn new() -> Self {
         Typifier {
@@ -15,24 +20,42 @@ impl Typifier {
         &mut self,
         expr_handle: Handle<crate::Expression>,
         expressions: &Arena<crate::Expression>,
-        types: &Arena<crate::Type>,
+        types: &mut Arena<crate::Type>,
         constants: &Arena<crate::Constant>,
         global_vars: &Arena<crate::GlobalVariable>,
         local_vars: &Arena<crate::LocalVariable>,
-    ) -> Handle<crate::Type> {
+    ) -> Result<Handle<crate::Type>, ResolveError> {
         if self.types.len() <= expr_handle.index() {
-            for (_, expr) in expressions.iter().skip(self.types.len()) {
-                self.types.push(match *expr {
+            for (eh, expr) in expressions.iter().skip(self.types.len()) {
+                let ty = match *expr {
                     crate::Expression::Access { base, .. } => {
                         match types[self.types[base.index()]].inner {
-                            crate::TypeInner::Array { base, .. } => self.types[base.index()],
+                            crate::TypeInner::Array { base, .. } => base,
                             ref other => panic!("Can't access into {:?}", other),
                         }
                     }
                     crate::Expression::AccessIndex { base, index } => {
                         match types[self.types[base.index()]].inner {
-                            crate::TypeInner::Array { base, .. } => self.types[base.index()],
-                            crate::TypeInner::Struct { ref members } => members[index as usize].ty,
+                            crate::TypeInner::Vector { size, kind, width } => {
+                                if index >= size as u32 {
+                                    return Err(ResolveError::InvalidAccessIndex)
+                                }
+                                let inner = crate::TypeInner::Scalar { kind, width };
+                                Self::deduce_type_handle(inner, types)
+                            }
+                            crate::TypeInner::Matrix { columns, rows, kind, width } => {
+                                if index >= columns as u32 {
+                                    return Err(ResolveError::InvalidAccessIndex)
+                                }
+                                let inner = crate::TypeInner::Vector { size: rows, kind, width };
+                                Self::deduce_type_handle(inner, types)
+                            }
+                            crate::TypeInner::Array { base, .. } => base,
+                            crate::TypeInner::Struct { ref members } => {
+                                members.get(index as usize)
+                                    .ok_or(ResolveError::InvalidAccessIndex)?
+                                    .ty
+                            }
                             ref other => panic!("Can't access into {:?}", other),
                         }
                     }
@@ -44,16 +67,90 @@ impl Typifier {
                     crate::Expression::Load { .. } => unimplemented!(),
                     crate::Expression::Mul(_, _) => unimplemented!(),
                     crate::Expression::ImageSample { .. } => unimplemented!(),
-                    crate::Expression::Unary { .. } => unimplemented!(),
-                    crate::Expression::Binary { .. } => unimplemented!(),
+                    crate::Expression::Unary { expr, .. } => self.types[expr.index()],
+                    crate::Expression::Binary { op, left, right } => {
+                        match op {
+                            crate::BinaryOperator::Add |
+                            crate::BinaryOperator::Subtract |
+                            crate::BinaryOperator::Divide |
+                            crate::BinaryOperator::Modulo => {
+                                self.types[left.index()]
+                            }
+                            crate::BinaryOperator::Multiply => {
+                                let ty_left = self.types[left.index()];
+                                let ty_right = self.types[right.index()];
+                                if ty_left == ty_right {
+                                    ty_left
+                                } else if let crate::TypeInner::Scalar { .. } = types[ty_right].inner {
+                                    ty_left
+                                } else if let crate::TypeInner::Matrix { columns, kind, width, .. } = types[ty_left].inner {
+                                    let inner = crate::TypeInner::Vector { size: columns, kind, width};
+                                    Self::deduce_type_handle(inner, types)
+                                } else {
+                                    panic!("Incompatible arguments {:?} x {:?}", types[ty_left], types[ty_right]);
+                                }
+                            }
+                            crate::BinaryOperator::Equal |
+                            crate::BinaryOperator::NotEqual |
+                            crate::BinaryOperator::Less |
+                            crate::BinaryOperator::LessEqual |
+                            crate::BinaryOperator::Greater |
+                            crate::BinaryOperator::GreaterEqual |
+                            crate::BinaryOperator::LogicalAnd |
+                            crate::BinaryOperator::LogicalOr => {
+                                self.types[left.index()]
+                            }
+                            crate::BinaryOperator::And |
+                            crate::BinaryOperator::ExclusiveOr |
+                            crate::BinaryOperator::InclusiveOr |
+                            crate::BinaryOperator::ShiftLeftLogical |
+                            crate::BinaryOperator::ShiftRightLogical |
+                            crate::BinaryOperator::ShiftRightArithmetic => {
+                                self.types[left.index()]
+                            }
+                        }
+                    }
                     crate::Expression::Intrinsic { .. } => unimplemented!(),
                     crate::Expression::DotProduct(_, _) => unimplemented!(),
                     crate::Expression::CrossProduct(_, _) => unimplemented!(),
                     crate::Expression::Derivative { .. } => unimplemented!(),
-                    crate::Expression::Call { .. } => unimplemented!(),
-                });
+                    crate::Expression::Call { ref name, ref arguments } => {
+                        match name.as_str() {
+                            "distance" | "length" => {
+                                let ty_handle = self.types[arguments[0].index()];
+                                let inner = match types[ty_handle].inner {
+                                    crate::TypeInner::Vector { kind, width, .. } => {
+                                        crate::TypeInner::Scalar { kind, width }
+                                    }
+                                    ref other => panic!("Unexpected argument {:?}", other),
+                                };
+                                Self::deduce_type_handle(inner, types)
+                            }
+                            "normalize" | "fclamp" => self.types[arguments[0].index()],
+                            _ => panic!("Unknown '{}' call", name),
+                        }
+                    }
+                };
+                log::debug!("Resolving {:?} = {:?} : {:?}", eh, expr, ty);
+                self.types.push(ty);
             };
         }
-        self.types[expr_handle.index()]
+        Ok(self.types[expr_handle.index()])
+    }
+
+    pub fn deduce_type_handle(
+        inner: crate::TypeInner,
+        arena: &mut Arena<crate::Type>,
+    ) -> Handle<crate::Type> {
+        if let Some((token, _)) = arena
+            .iter()
+            .find(|(_, ty)| ty.inner == inner)
+        {
+            return token;
+        }
+        arena.append(crate::Type {
+            name: None,
+            inner,
+        })
     }
 }

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -15,20 +15,32 @@ impl Typifier {
         &mut self,
         expr_handle: Handle<crate::Expression>,
         expressions: &Arena<crate::Expression>,
+        types: &Arena<crate::Type>,
+        constants: &Arena<crate::Constant>,
+        global_vars: &Arena<crate::GlobalVariable>,
+        local_vars: &Arena<crate::LocalVariable>,
     ) -> Handle<crate::Type> {
         if self.types.len() <= expr_handle.index() {
             for (_, expr) in expressions.iter().skip(self.types.len()) {
                 self.types.push(match *expr {
-                    crate::Expression::Access { base, .. } |
-                    crate::Expression::AccessIndex { base, .. } => {
-                        let _ = base;
-                        unimplemented!()
+                    crate::Expression::Access { base, .. } => {
+                        match types[self.types[base.index()]].inner {
+                            crate::TypeInner::Array { base, .. } => self.types[base.index()],
+                            ref other => panic!("Can't access into {:?}", other),
+                        }
                     }
-                    crate::Expression::Constant(_) => unimplemented!(),
+                    crate::Expression::AccessIndex { base, index } => {
+                        match types[self.types[base.index()]].inner {
+                            crate::TypeInner::Array { base, .. } => self.types[base.index()],
+                            crate::TypeInner::Struct { ref members } => members[index as usize].ty,
+                            ref other => panic!("Can't access into {:?}", other),
+                        }
+                    }
+                    crate::Expression::Constant(h) => constants[h].ty,
                     crate::Expression::Compose { ty, .. } => ty,
                     crate::Expression::FunctionParameter(_) => unimplemented!(),
-                    crate::Expression::GlobalVariable(_) => unimplemented!(),
-                    crate::Expression::LocalVariable(_) => unimplemented!(),
+                    crate::Expression::GlobalVariable(h) => global_vars[h].ty,
+                    crate::Expression::LocalVariable(h) => local_vars[h].ty,
                     crate::Expression::Load { .. } => unimplemented!(),
                     crate::Expression::Mul(_, _) => unimplemented!(),
                     crate::Expression::ImageSample { .. } => unimplemented!(),

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -1,0 +1,47 @@
+use crate::arena::{Arena, Handle};
+
+pub struct Typifier {
+    types: Vec<Handle<crate::Type>>,
+}
+
+impl Typifier {
+    pub fn new() -> Self {
+        Typifier {
+            types: Vec::new(),
+        }
+    }
+
+    pub fn resolve(
+        &mut self,
+        expr_handle: Handle<crate::Expression>,
+        expressions: &Arena<crate::Expression>,
+    ) -> Handle<crate::Type> {
+        if self.types.len() <= expr_handle.index() {
+            for (_, expr) in expressions.iter().skip(self.types.len()) {
+                self.types.push(match *expr {
+                    crate::Expression::Access { base, .. } |
+                    crate::Expression::AccessIndex { base, .. } => {
+                        let _ = base;
+                        unimplemented!()
+                    }
+                    crate::Expression::Constant(_) => unimplemented!(),
+                    crate::Expression::Compose { ty, .. } => ty,
+                    crate::Expression::FunctionParameter(_) => unimplemented!(),
+                    crate::Expression::GlobalVariable(_) => unimplemented!(),
+                    crate::Expression::LocalVariable(_) => unimplemented!(),
+                    crate::Expression::Load { .. } => unimplemented!(),
+                    crate::Expression::Mul(_, _) => unimplemented!(),
+                    crate::Expression::ImageSample { .. } => unimplemented!(),
+                    crate::Expression::Unary { .. } => unimplemented!(),
+                    crate::Expression::Binary { .. } => unimplemented!(),
+                    crate::Expression::Intrinsic { .. } => unimplemented!(),
+                    crate::Expression::DotProduct(_, _) => unimplemented!(),
+                    crate::Expression::CrossProduct(_, _) => unimplemented!(),
+                    crate::Expression::Derivative { .. } => unimplemented!(),
+                    crate::Expression::Call { .. } => unimplemented!(),
+                });
+            };
+        }
+        self.types[expr_handle.index()]
+    }
+}


### PR DESCRIPTION
There is a [small TODO](https://github.com/gfx-rs/naga/blob/76eb307d350e63073bd378e0d2d4fc7d2e5676f9/src/front/wgsl.rs#L526) in the current WGSL parser:
```rust
                Token::Separator('.') => {
                    let _ = lexer.next();
                    let _name = lexer.next_ident()?;
                    let expr = crate::Expression::AccessIndex {
                        base: handle,
                        index: 0, //TODO: compute from `name`
                    };
                    handle = ctx.expressions.append(expr);
                }
```

We have a base expression, and we need to access a sub-field. The IR doesn't care about names, so in case of a structure it just needs an index into the member list. The problem, however, is realizing that the base type *is* a structure. In order to compute them, we essentially need to know all the types of all the expressions.

This is where `Typifier` comes in. It's a generic processor of IR that helps to build that type information for a growing list of expressions.