### PR TITLE
Remove Expression::Mul

### DIFF
--- a/src/back/msl.rs
+++ b/src/back/msl.rs
@@ -420,10 +420,17 @@ impl<W: Write> Writer<W> {
                     ref other => panic!("Unexpected load pointer {:?}", other),
                 }
             }
-            crate::Expression::Mul(left, right) => {
+            crate::Expression::Binary { op, left, right } => {
+                let op_ch = match op {
+                    crate::BinaryOperator::Add => '+',
+                    crate::BinaryOperator::Multiply => '*',
+                    crate::BinaryOperator::Divide => '/',
+                    crate::BinaryOperator::Modulo => '%',
+                    _ => panic!("Unsupported binary op {:?}", op),
+                };
                 write!(self.out, "(")?;
                 let ty_left = self.put_expression(left, expressions, module)?;
-                write!(self.out, " * ")?;
+                write!(self.out, " {} ", op_ch)?;
                 let ty_right = self.put_expression(right, expressions, module)?;
                 write!(self.out, ")")?;
                 Ok(match (ty_left.borrow(), ty_right.borrow()) {

--- a/src/back/msl.rs
+++ b/src/back/msl.rs
@@ -321,7 +321,7 @@ impl<W: Write> Writer<W> {
         module: &'a crate::Module,
     ) -> Result<MaybeOwned<'a, crate::TypeInner>, Error> {
         let expression = &expressions[expr_handle];
-        log::trace!("expression {:?}", expression);
+        log::trace!("expression {:?} = {:?}", expr_handle, expression);
         match *expression {
             crate::Expression::AccessIndex { base, index } => {
                 match *self.put_expression(base, expressions, module)?.borrow() {
@@ -434,6 +434,7 @@ impl<W: Write> Writer<W> {
                 let ty_right = self.put_expression(right, expressions, module)?;
                 write!(self.out, ")")?;
                 Ok(match (ty_left.borrow(), ty_right.borrow()) {
+                    (&crate::TypeInner::Scalar { .. }, &crate::TypeInner::Vector { size, kind, width }) |
                     (&crate::TypeInner::Vector { size, kind, width }, &crate::TypeInner::Scalar { .. }) =>
                         MaybeOwned::Owned(crate::TypeInner::Vector { size, kind, width }),
                     other => panic!("Unable to infer Mul for {:?}", other),

--- a/src/front/spirv.rs
+++ b/src/front/spirv.rs
@@ -577,7 +577,11 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                         crate::TypeInner::Scalar { kind: crate::ScalarKind::Float, width } if width == res_width => (),
                         _ => return Err(Error::UnsupportedType(scalar_type_lookup.handle)),
                     };
-                    let expr = crate::Expression::Mul(vector_lexp.handle, scalar_lexp.handle);
+                    let expr = crate::Expression::Binary {
+                        op: crate::BinaryOperator::Multiply,
+                        left: vector_lexp.handle,
+                        right: scalar_lexp.handle,
+                    };
                     self.lookup_expression.insert(result_id, LookupExpression {
                         handle: fun.expressions.append(expr),
                         type_id: result_type_id,
@@ -606,7 +610,11 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                         crate::TypeInner::Vector { size, kind: crate::ScalarKind::Float, width } if size == columns && width == res_width => (),
                         _ => return Err(Error::UnsupportedType(vector_type_lookup.handle)),
                     };
-                    let expr = crate::Expression::Mul(matrix_lexp.handle, vector_lexp.handle);
+                    let expr = crate::Expression::Binary {
+                        op: crate::BinaryOperator::Multiply,
+                        left: matrix_lexp.handle,
+                        right: vector_lexp.handle,
+                    };
                     self.lookup_expression.insert(result_id, LookupExpression {
                         handle: fun.expressions.append(expr),
                         type_id: result_type_id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,6 @@ pub enum Expression {
     Load {
         pointer: Handle<Expression>,
     },
-    Mul(Handle<Expression>, Handle<Expression>),
     ImageSample {
         image: Handle<Expression>,
         sampler: Handle<Expression>,

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -65,7 +65,6 @@ impl Typifier {
                     crate::Expression::GlobalVariable(h) => global_vars[h].ty,
                     crate::Expression::LocalVariable(h) => local_vars[h].ty,
                     crate::Expression::Load { .. } => unimplemented!(),
-                    crate::Expression::Mul(_, _) => unimplemented!(),
                     crate::Expression::ImageSample { .. } => unimplemented!(),
                     crate::Expression::Unary { expr, .. } => self.types[expr.index()],
                     crate::Expression::Binary { op, left, right } => {

--- a/tests/convert.rs
+++ b/tests/convert.rs
@@ -1,15 +1,31 @@
-fn convert_wgsl(name: &str) {
+fn load_wgsl(name: &str) -> naga::Module {
     let path = format!("{}/test-data/{}.wgsl", env!("CARGO_MANIFEST_DIR"), name);
     let input = std::fs::read_to_string(path).unwrap();
-    let _module = naga::front::wgsl::parse_str(&input).unwrap();
+    naga::front::wgsl::parse_str(&input).unwrap()
 }
 
 #[test]
 fn convert_quad() {
-    convert_wgsl("quad");
+    let module = load_wgsl("quad");
+    {
+        use naga::back::msl;
+        let mut binding_map = msl::BindingMap::default();
+        binding_map.insert(
+            msl::BindSource { set: 0, binding: 0 },
+            msl::BindTarget { buffer: None, texture: Some(1), sampler: None },
+        );
+        binding_map.insert(
+            msl::BindSource { set: 0, binding: 1 },
+            msl::BindTarget { buffer: None, texture: None, sampler: Some(1) },
+        );
+        let options = msl::Options {
+            binding_map: &binding_map,
+        };
+        msl::write_string(&module, options).unwrap();
+    }
 }
 
 #[test]
 fn convert_boids() {
-    convert_wgsl("boids");
+    let _module = load_wgsl("boids");
 }


### PR DESCRIPTION
We now have a more powerful `Binary` expression type.

This PR also adds quad -> MSL conversion to the tests. This is strictly better than running it in the example, since the example isn't supposed to have any shader-specific information. Yet, the binding mapping is required. So the example would need to support some sort of a RON input with the binding map, but the tests can just have all of it specified in the code.