### PR TITLE
[msl] operators, array access, and built-in calls

### DIFF
--- a/tests/convert.rs
+++ b/tests/convert.rs
@@ -27,5 +27,13 @@ fn convert_quad() {
 
 #[test]
 fn convert_boids() {
-    let _module = load_wgsl("boids");
+    let module = load_wgsl("boids");
+    {
+        use naga::back::msl;
+        let binding_map = msl::BindingMap::default();
+        let options = msl::Options {
+            binding_map: &binding_map,
+        };
+        msl::write_string(&module, options).unwrap();
+    }
 }


### PR DESCRIPTION
This PR upgrades the Metal backend to the point of producing *a* result for "boids" without panicing. There is still work to be done before this result is valid and can be consumed by Metal SDK. In the meantime, the tests now do the check for "boids" to ensure we can always convert.