### PR TITLE
Reduce duplicate values in IR module

### DIFF
--- a/src/front/wgsl.rs
+++ b/src/front/wgsl.rs
@@ -467,7 +467,7 @@ impl Parser {
                 return Ok(expr);
             }
             Token::Word("true") => {
-                let handle = ctx.constants.append(crate::Constant {
+                let handle = ctx.constants.fetch_or_append(crate::Constant {
                     name: None,
                     specialization: None,
                     inner: crate::ConstantInner::Bool(true),
@@ -482,7 +482,7 @@ impl Parser {
                 crate::Expression::Constant(handle)
             }
             Token::Word("false") => {
-                let handle = ctx.constants.append(crate::Constant {
+                let handle = ctx.constants.fetch_or_append(crate::Constant {
                     name: None,
                     specialization: None,
                     inner: crate::ConstantInner::Bool(false),
@@ -498,7 +498,7 @@ impl Parser {
             }
             Token::Number(word) => {
                 let (inner, kind) = Self::get_constant_inner(word)?;
-                let handle = ctx.constants.append(crate::Constant {
+                let handle = ctx.constants.fetch_or_append(crate::Constant {
                     name: None,
                     specialization: None,
                     inner,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ pub enum TypeInner {
     Sampler,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Constant {
     pub name: Option<String>,
     pub specialization: Option<spirv::Word>,
@@ -91,7 +91,7 @@ pub struct Constant {
     pub ty: Handle<Type>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ConstantInner {
     Sint(i64),
     Uint(u64),


### PR DESCRIPTION
Fix #42 

Reduces the amount of duplicate information in the IR module. Constants and Global Variable arena now only contains unique values.

Also did this for expression to reduce duplicate expressions, but I am not sure if we would want that. Could there be a case where duplicate expressions are acceptable?

Note: Boids IR has been decreased by about ~300 lines.
