### PR TITLE
Add initial wasm build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,23 +19,26 @@ log = "0.4"
 num-traits = "0.2"
 spirv = { package = "spirv_headers", version = "1" }
 
-wasm-bindgen = { version = "0.2", optional = true }
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
-console_error_panic_hook = { version = "0.1.1", optional = true }
+console_error_panic_hook = "0.1.1"
 # `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
 # compared to the default allocator's ~10K. It is slower than the default
 # allocator, however.
 #
 # Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
-wee_alloc = { version = "0.4.2", optional = true }
+wee_alloc = "0.4.2"
 
 [dev-dependencies]
 env_logger = "0.6"
 ron = "0.5"
 serde = { version = "1", features = ["serde_derive"] }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.2"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4"
 num-traits = "0.2"
 spirv = { package = "spirv_headers", version = "1" }
 
-wasm-bindgen = "0.2"
+wasm-bindgen = { version = "0.2", optional = true }
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/gfx-rs/naga"
 keywords = ["shader", "SPIR-V"]
 license = "MPL-2.0"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 bitflags = "1"
 fxhash = "0.2"
@@ -16,7 +19,33 @@ log = "0.4"
 num-traits = "0.2"
 spirv = { package = "spirv_headers", version = "1" }
 
+wasm-bindgen = "0.2"
+# The `console_error_panic_hook` crate provides better debugging of panics by
+# logging them with `console.error`. This is great for development, but requires
+# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
+# code size when deploying.
+console_error_panic_hook = { version = "0.1.1", optional = true }
+# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
+# compared to the default allocator's ~10K. It is slower than the default
+# allocator, however.
+#
+# Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
+wee_alloc = { version = "0.4.2", optional = true }
+
 [dev-dependencies]
 env_logger = "0.6"
 ron = "0.5"
 serde = { version = "1", features = ["serde_derive"] }
+wasm-bindgen-test = "0.2"
+
+[profile.release]
+lto = true
+opt-level = 's'
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Os"]
+
+[package.metadata.wasm-pack.profile.release.wasm-bindgen]
+debug-js-glue = false
+demangle-name-section = true
+dwarf-debug-info = false

--- a/README.md
+++ b/README.md
@@ -9,21 +9,40 @@ This is an experimental shader translation library for the needs of gfx-rs proje
 
 ## Supported end-points
 
-Front-end       |       Status       | Notes |
---------------- | ------------------ | ----- |
-SPIR-V (binary) | :construction:     |       |
-WGSL (Tint)     | :construction:     |       |
-GLSL (Vulkan)   |                    |       |
-Rust            |                    |       |
+| Front-end       | Status         | Notes |
+| --------------- | -------------- | ----- |
+| SPIR-V (binary) | :construction: |       |
+| WGSL (Tint)     | :construction: |       |
+| GLSL (Vulkan)   |                |       |
+| Rust            |                |       |
 
-Back-end        |       Status       | Notes |
---------------- | ------------------ | ----- |
-SPIR-V (binary) |                    |       |
-WGSL            |                    |       |
-Metal           | :construction:     |       |
-HLSL            |                    |       |
-GLSL            |                    |       |
-AIR             |                    |       |
-DXIR            |                    |       |
-DXIL            |                    |       |
-DXBC            |                    |       |
+| Back-end        | Status         | Notes |
+| --------------- | -------------- | ----- |
+| SPIR-V (binary) |                |       |
+| WGSL            |                |       |
+| Metal           | :construction: |       |
+| HLSL            |                |       |
+| GLSL            |                |       |
+| AIR             |                |       |
+| DXIR            |                |       |
+| DXIL            |                |       |
+| DXBC            |                |       |
+
+## WASM
+
+You need [wasm-pack](https://rustwasm.github.io/wasm-pack/)
+
+Building (for nodejs):
+
+```
+wasm-pack build --release --target nodejs -- --features wee_alloc
+```
+
+Output is in `pkg` and can be usde like this:
+
+```js
+const naga = require("./pkg/naga");
+const fs = require("fs");
+const input = fs.readFileSync("test-data/quad.wgsl", "utf8");
+naga.wgsl2msl(input);
+```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You need [wasm-pack](https://rustwasm.github.io/wasm-pack/)
 Building (for nodejs):
 
 ```
-wasm-pack build --release --target nodejs -- --features wasm-bindgen,wee_alloc
+wasm-pack build --release --target nodejs
 ```
 
 Output is in `pkg` and can be usde like this:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You need [wasm-pack](https://rustwasm.github.io/wasm-pack/)
 Building (for nodejs):
 
 ```
-wasm-pack build --release --target nodejs -- --features wee_alloc
+wasm-pack build --release --target nodejs -- --features wasm-bindgen,wee_alloc
 ```
 
 Output is in `pkg` and can be usde like this:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod arena;
 pub mod back;
 pub mod front;
 pub mod proc;
+pub mod wasm;
 
 use crate::arena::{Arena, Handle};
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,3 +1,4 @@
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
 // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
@@ -17,7 +18,7 @@ pub fn set_panic_hook() {
     console_error_panic_hook::set_once();
 }
 
-#[wasm_bindgen]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 pub fn wgsl2msl(input: &str) -> String {
     let module = super::front::wgsl::parse_str(&input).unwrap();
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,40 @@
+use wasm_bindgen::prelude::*;
+
+// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
+// allocator.
+#[cfg(feature = "wee_alloc")]
+#[global_allocator]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
+pub fn set_panic_hook() {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}
+
+#[wasm_bindgen]
+pub fn wgsl2msl(input: &str) -> String {
+    let module = super::front::wgsl::parse_str(&input).unwrap();
+
+    println!("Compiled, header {:?}", module.header);
+
+    use super::back::msl;
+    let mut binding_map = msl::BindingMap::default();
+    binding_map.insert(
+        msl::BindSource { set: 0, binding: 0 },
+        msl::BindTarget { buffer: None, texture: Some(1), sampler: None, mutable: false },
+    );
+    binding_map.insert(
+        msl::BindSource { set: 0, binding: 1 },
+        msl::BindTarget { buffer: None, texture: None, sampler: Some(1), mutable: false },
+    );
+    let options = msl::Options {
+        binding_map: &binding_map,
+    };
+    msl::write_string(&module, options).unwrap()
+}


### PR DESCRIPTION
Adds support for building to wasm, using wasm-pack.

Includes size optimization settings for release build in Cargo.toml