### PR TITLE
Add basic tests for SPIR-V back-end writer

### DIFF
--- a/src/back/spv/layout.rs
+++ b/src/back/spv/layout.rs
@@ -3,7 +3,7 @@ use spirv::*;
 use std::iter;
 
 impl PhysicalLayout {
-    pub(crate) fn new(header: &crate::Header) -> Self {
+    pub(super) fn new(header: &crate::Header) -> Self {
         let version: Word = ((header.version.0 as u32) << 16)
             | ((header.version.1 as u32) << 8)
             | header.version.2 as u32;
@@ -17,7 +17,7 @@ impl PhysicalLayout {
         }
     }
 
-    pub(crate) fn in_words(&self, sink: &mut impl Extend<Word>) {
+    pub(super) fn in_words(&self, sink: &mut impl Extend<Word>) {
         sink.extend(iter::once(self.magic_number));
         sink.extend(iter::once(self.version));
         sink.extend(iter::once(self.generator));
@@ -27,7 +27,7 @@ impl PhysicalLayout {
 }
 
 impl LogicalLayout {
-    pub(crate) fn in_words(&self, sink: &mut impl Extend<Word>) {
+    pub(super) fn in_words(&self, sink: &mut impl Extend<Word>) {
         sink.extend(self.capabilities.iter().cloned());
         sink.extend(self.extensions.iter().cloned());
         sink.extend(self.ext_inst_imports.iter().cloned());
@@ -43,7 +43,7 @@ impl LogicalLayout {
 }
 
 impl Instruction {
-    pub(crate) fn new(op: Op) -> Self {
+    pub(super) fn new(op: Op) -> Self {
         Instruction {
             op,
             wc: 1, // Always start at 1 for the first word (OP + WC),
@@ -53,30 +53,30 @@ impl Instruction {
         }
     }
 
-    pub(crate) fn set_type(&mut self, id: Word) {
+    pub(super) fn set_type(&mut self, id: Word) {
         assert!(self.type_id.is_none(), "Type can only be set once");
         self.type_id = Some(id);
         self.wc += 1;
     }
 
-    pub(crate) fn set_result(&mut self, id: Word) {
+    pub(super) fn set_result(&mut self, id: Word) {
         assert!(self.result_id.is_none(), "Result can only be set once");
         self.result_id = Some(id);
         self.wc += 1;
     }
 
-    pub(crate) fn add_operand(&mut self, operand: Word) {
+    pub(super) fn add_operand(&mut self, operand: Word) {
         self.operands.push(operand);
         self.wc += 1;
     }
 
-    pub(crate) fn add_operands(&mut self, operands: Vec<Word>) {
+    pub(super) fn add_operands(&mut self, operands: Vec<Word>) {
         for operand in operands.into_iter() {
             self.add_operand(operand)
         }
     }
 
-    pub(crate) fn to_words(&self, sink: &mut impl Extend<Word>) {
+    pub(super) fn to_words(&self, sink: &mut impl Extend<Word>) {
         sink.extend(Some((self.wc << 16 | self.op as u32) as u32));
         sink.extend(self.type_id);
         sink.extend(self.result_id);

--- a/src/back/spv/layout_tests.rs
+++ b/src/back/spv/layout_tests.rs
@@ -1,3 +1,4 @@
+use crate::back::spv::test_framework::*;
 use crate::back::spv::{helpers, Instruction, LogicalLayout, PhysicalLayout};
 use crate::Header;
 use spirv::*;
@@ -76,7 +77,7 @@ fn test_logical_layout_in_words() {
     for instruction in instructions {
         let wc = instruction.wc as usize;
         let instruction_output = &output[index..index + wc];
-        validate_instruction(instruction_output, instruction);
+        validate_instruction(instruction_output, &instruction);
         index += wc;
     }
 }
@@ -157,32 +158,7 @@ fn test_instruction_to_words() {
 
     let mut output = vec![];
     instruction.to_words(&mut output);
-    validate_instruction(output.as_slice(), instruction);
-}
-
-fn validate_instruction(words: &[Word], instruction: Instruction) {
-    let mut inst_index = 0;
-    let (wc, op) = ((words[inst_index] >> 16) as u16, words[inst_index] as u16);
-    inst_index += 1;
-
-    assert_eq!(wc, words.len() as u16);
-    assert_eq!(op, instruction.op as u16);
-
-    if instruction.type_id.is_some() {
-        assert_eq!(words[inst_index], instruction.type_id.unwrap());
-        inst_index += 1;
-    }
-
-    if instruction.result_id.is_some() {
-        assert_eq!(words[inst_index], instruction.result_id.unwrap());
-        inst_index += 1;
-    }
-
-    let mut op_index = 0;
-    for i in inst_index..wc as usize {
-        assert_eq!(words[i as usize], instruction.operands[op_index]);
-        op_index += 1;
-    }
+    validate_instruction(output.as_slice(), &instruction);
 }
 
 fn to_word(bytes: &[u8]) -> Word {

--- a/src/back/spv/mod.rs
+++ b/src/back/spv/mod.rs
@@ -3,6 +3,9 @@ mod layout;
 mod writer;
 
 #[cfg(test)]
+mod test_framework;
+
+#[cfg(test)]
 mod layout_tests;
 
 pub use writer::Writer;
@@ -25,7 +28,7 @@ struct PhysicalLayout {
 }
 
 #[derive(Default)]
-pub(crate) struct LogicalLayout {
+struct LogicalLayout {
     capabilities: Vec<Word>,
     extensions: Vec<Word>,
     ext_inst_imports: Vec<Word>,
@@ -39,7 +42,7 @@ pub(crate) struct LogicalLayout {
     function_definitions: Vec<Word>,
 }
 
-struct Instruction {
+pub(self) struct Instruction {
     op: Op,
     wc: u32,
     type_id: Option<Word>,

--- a/src/back/spv/test_framework.rs
+++ b/src/back/spv/test_framework.rs
@@ -1,0 +1,58 @@
+use crate::back::spv::Instruction;
+use spirv::{Op, Word};
+
+pub(super) struct SpecRequirements {
+    pub(super) op: Op,
+    pub(super) wc: u32,
+    pub(super) type_id: bool,
+    pub(super) result_id: bool,
+    pub(super) operands: bool,
+}
+
+/// Basic validation for checking if the instruction complies to the spec requirements
+pub(super) fn validate_spec_requirements(
+    requirements: SpecRequirements,
+    instruction: &Instruction,
+) {
+    assert_eq!(requirements.op, instruction.op);
+
+    // Pass the assert if the minimum referred wc in the spec is met
+    assert!(instruction.wc >= requirements.wc);
+
+    if requirements.type_id {
+        assert!(instruction.type_id.is_some());
+    }
+
+    if requirements.result_id {
+        assert!(instruction.result_id.is_some());
+    }
+
+    if requirements.operands {
+        assert!(!instruction.operands.is_empty());
+    }
+}
+
+pub(super) fn validate_instruction(words: &[Word], instruction: &Instruction) {
+    let mut inst_index = 0;
+    let (wc, op) = ((words[inst_index] >> 16) as u16, words[inst_index] as u16);
+    inst_index += 1;
+
+    assert_eq!(wc, words.len() as u16);
+    assert_eq!(op, instruction.op as u16);
+
+    if instruction.type_id.is_some() {
+        assert_eq!(words[inst_index], instruction.type_id.unwrap());
+        inst_index += 1;
+    }
+
+    if instruction.result_id.is_some() {
+        assert_eq!(words[inst_index], instruction.result_id.unwrap());
+        inst_index += 1;
+    }
+
+    let mut op_index = 0;
+    for i in inst_index..wc as usize {
+        assert_eq!(words[i as usize], instruction.operands[op_index]);
+        op_index += 1;
+    }
+}


### PR DESCRIPTION
Added a basic test framework and already tested the most basic function for the SPIR-V back-end. The more complex ones will take too much time for now for what it is worth at the moment, as they are complex, they most likely will be refactored to smaller and simpler function when I am continuing with compiling the Boids example.

The writer tests will enforce basic spec requirements like Op code correctness, Word count correctness, and a simple check if a instruction is supposed to have: a result id, type id and/or operands. This can potentially be expanded on, to also include type correctness, and maybe some more things I cannot recall now.

The tests also include instruction correctness, which ensures the instruction data is correctly positioned in the output stream.