### PR TITLE
Add support for return value to SPIR-V backend

### DIFF
--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -885,10 +885,24 @@ impl Writer {
         output: &mut Vec<Instruction>,
     ) -> Instruction {
         match statement {
-            crate::Statement::Return { value: _ } => match function.return_type {
-                Some(_) => unimplemented!(),
-                None => Instruction::new(Op::Return),
-            },
+            crate::Statement::Return { value } => {
+                match function.return_type {
+                    Some(_) => {
+                        let value = value.unwrap();
+
+                        // Parse the expression
+                        let value_expression = &function.expressions[value];
+                        let (value_id, _) =
+                            self.parse_expression(ir_module, function, value_expression, output);
+
+                        // Construct the return value instruction
+                        let mut instruction = Instruction::new(Op::ReturnValue);
+                        instruction.add_operand(value_id);
+                        instruction
+                    }
+                    None => Instruction::new(Op::Return),
+                }
+            }
             crate::Statement::Store { pointer, value } => {
                 let mut instruction = Instruction::new(Op::Store);
 

--- a/tests/convert.rs
+++ b/tests/convert.rs
@@ -1,12 +1,25 @@
+#[cfg(feature = "glsl")]
+use spirv::ExecutionModel;
+
+fn load_test_data(name: &str) -> String {
+    let path = format!("{}/test-data/{}", env!("CARGO_MANIFEST_DIR"), name);
+    std::fs::read_to_string(path).unwrap()
+}
+
 fn load_wgsl(name: &str) -> naga::Module {
-    let path = format!("{}/test-data/{}.wgsl", env!("CARGO_MANIFEST_DIR"), name);
-    let input = std::fs::read_to_string(path).unwrap();
+    let input = load_test_data(name);
     naga::front::wgsl::parse_str(&input).unwrap()
+}
+
+#[cfg(feature = "glsl")]
+fn load_glsl(name: &str, entry: &str, exec: ExecutionModel) -> naga::Module {
+    let input = load_test_data(name);
+    naga::front::glsl::parse_str(&input, entry.to_owned(), exec).unwrap()
 }
 
 #[test]
 fn convert_quad() {
-    let module = load_wgsl("quad");
+    let module = load_wgsl("quad.wgsl");
     {
         use naga::back::msl;
         let mut binding_map = msl::BindingMap::default();
@@ -37,7 +50,7 @@ fn convert_quad() {
 
 #[test]
 fn convert_boids() {
-    let module = load_wgsl("boids");
+    let module = load_wgsl("boids.wgsl");
     {
         use naga::back::msl;
         let mut binding_map = msl::BindingMap::default();
@@ -73,4 +86,19 @@ fn convert_boids() {
         };
         msl::write_string(&module, options).unwrap();
     }
+}
+
+#[cfg(feature = "glsl")]
+#[test]
+#[ignore]
+fn convert_phong_lighting() {
+    let module = load_glsl("glsl_phong_lighting.frag", "main", ExecutionModel::Fragment);
+
+    let header = naga::Header {
+        version: (1, 0, 0),
+        generator: 1234,
+    };
+    let writer_flags = naga::back::spv::WriterFlags::empty();
+    let mut w = naga::back::spv::Writer::new(&header, writer_flags);
+    w.write(&module);
 }


### PR DESCRIPTION
Adds support for `Statement::Return { Some(value) }` in SPIR-V backend.

I've added a test to `convert.rs`, which tries to parse the `glsl_phong_lighting.frag` file (with the `glsl` feature) and then convert it to SPIR-V.

After the changes, the test no longer panics on return with value statement. It does fail on `not implemented: Divide`, so I've set it to be ignored.