### PR TITLE
Remove spirv-headers use from IR, make it optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bitflags = "1"
 fxhash = "0.2"
 log = "0.4"
 num-traits = "0.2"
-spirv = { package = "spirv_headers", version = "1.4.2" }
+spirv = { package = "spirv_headers", version = "1.4.2", optional = true }
 glsl = { version = "4", optional = true }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 [![Matrix](https://img.shields.io/badge/Matrix-%23naga%3Amatrix.org-blueviolet.svg)](https://matrix.to/#/#naga:matrix.org)
 [![Crates.io](https://img.shields.io/crates/v/naga.svg?label=naga)](https://crates.io/crates/naga)
 [![Docs.rs](https://docs.rs/naga/badge.svg)](https://docs.rs/naga)
-[![Build Status](https://travis-ci.org/gfx-rs/naga.svg?branch=master)](https://travis-ci.org/gfx-rs/naga)
+[![Build Status](https://github.com/gfx-rs/naga/workflows/pipeline/badge.svg)](https://github.com/gfx-rs/naga/actions)
 
-This is an experimental shader translation library for the needs of gfx-rs project and WebGPU. It's meant to provide a safe and performant way of converting to and from SPIR-V.
+This is an experimental shader translation library for the needs of gfx-rs project and WebGPU.
 
 ## Supported end-points
 
 Front-end       |       Status       | Notes |
 --------------- | ------------------ | ----- |
 SPIR-V (binary) | :construction:     |       |
-WGSL (Tint)     | :construction:     |       |
+WGSL            | :construction:     |       |
 GLSL (Vulkan)   | :construction:     |       |
 Rust            |                    |       |
 

--- a/examples/convert.rs
+++ b/examples/convert.rs
@@ -29,12 +29,13 @@ fn main() {
         println!("Call with <input> <output>");
         return;
     }
-    let ext = Path::new(&args[1])
+    let module = match Path::new(&args[1])
         .extension()
         .expect("Input has no extension?")
         .to_str()
-        .unwrap();
-    let module = match ext {
+        .unwrap()
+    {
+        #[cfg(feature = "spirv")]
         "spv" => {
             let input = fs::read(&args[1]).unwrap();
             naga::front::spv::parse_u8_slice(&input).unwrap()
@@ -46,28 +47,20 @@ fn main() {
         #[cfg(feature = "glsl")]
         "vert" => {
             let input = fs::read_to_string(&args[1]).unwrap();
-            naga::front::glsl::parse_str(&input, "main".to_string(), spirv::ExecutionModel::Vertex)
+            naga::front::glsl::parse_str(&input, "main".to_string(), naga::ShaderStage::Vertex)
                 .unwrap()
         }
         #[cfg(feature = "glsl")]
         "frag" => {
             let input = fs::read_to_string(&args[1]).unwrap();
-            naga::front::glsl::parse_str(
-                &input,
-                "main".to_string(),
-                spirv::ExecutionModel::Fragment,
-            )
-            .unwrap()
+            naga::front::glsl::parse_str(&input, "main".to_string(), naga::ShaderStage::Fragment)
+                .unwrap()
         }
         #[cfg(feature = "glsl")]
         "comp" => {
             let input = fs::read_to_string(&args[1]).unwrap();
-            naga::front::glsl::parse_str(
-                &input,
-                "main".to_string(),
-                spirv::ExecutionModel::GLCompute,
-            )
-            .unwrap()
+            naga::front::glsl::parse_str(&input, "main".to_string(), naga::ShaderStage::Compute)
+                .unwrap()
         }
         other => panic!("Unknown input extension: {}", other),
     };
@@ -83,50 +76,60 @@ fn main() {
         Err(_) => Parameters::default(),
     };
 
-    if args[2].ends_with(".metal") {
-        use naga::back::msl;
-        let mut binding_map = msl::BindingMap::default();
-        for (key, value) in params.metal_bindings {
-            binding_map.insert(
-                msl::BindSource {
-                    set: key.set,
-                    binding: key.binding,
-                },
-                msl::BindTarget {
-                    buffer: value.buffer,
-                    texture: value.texture,
-                    sampler: value.sampler,
-                    mutable: value.mutable,
-                },
-            );
-        }
-        let options = msl::Options {
-            binding_map: &binding_map,
-        };
-        let msl = msl::write_string(&module, options).unwrap();
-        fs::write(&args[2], msl).unwrap();
-    } else if args[2].ends_with(".spv") {
-        use naga::back::spv;
-
-        let debug_flag = args.get(3).map_or(spv::WriterFlags::DEBUG, |arg| {
-            if arg.parse().unwrap() {
-                spv::WriterFlags::DEBUG
-            } else {
-                spv::WriterFlags::NONE
+    match Path::new(&args[2])
+        .extension()
+        .expect("Output has no extension?")
+        .to_str()
+        .unwrap()
+    {
+        "metal" => {
+            use naga::back::msl;
+            let mut binding_map = msl::BindingMap::default();
+            for (key, value) in params.metal_bindings {
+                binding_map.insert(
+                    msl::BindSource {
+                        set: key.set,
+                        binding: key.binding,
+                    },
+                    msl::BindTarget {
+                        buffer: value.buffer,
+                        texture: value.texture,
+                        sampler: value.sampler,
+                        mutable: value.mutable,
+                    },
+                );
             }
-        });
+            let options = msl::Options {
+                binding_map: &binding_map,
+            };
+            let msl = msl::write_string(&module, options).unwrap();
+            fs::write(&args[2], msl).unwrap();
+        }
+        #[cfg(feature = "spirv")]
+        "spv" => {
+            use naga::back::spv;
 
-        let spv = spv::Writer::new(&module.header, debug_flag).write(&module);
-
-        let bytes = spv
-            .iter()
-            .fold(Vec::with_capacity(spv.len() * 4), |mut v, w| {
-                v.extend_from_slice(&w.to_le_bytes());
-                v
+            let debug_flag = args.get(3).map_or(spv::WriterFlags::DEBUG, |arg| {
+                if arg.parse().unwrap() {
+                    spv::WriterFlags::DEBUG
+                } else {
+                    spv::WriterFlags::NONE
+                }
             });
 
-        fs::write(&args[2], bytes.as_slice()).unwrap();
-    } else {
-        panic!("Unknown output: {:?}", args[2]);
+            let spv = spv::Writer::new(&module.header, debug_flag).write(&module);
+
+            let bytes = spv
+                .iter()
+                .fold(Vec::with_capacity(spv.len() * 4), |mut v, w| {
+                    v.extend_from_slice(&w.to_le_bytes());
+                    v
+                });
+
+            fs::write(&args[2], bytes.as_slice()).unwrap();
+        }
+        other => {
+            panic!("Unknown output extension: {}", other);
+        }
     }
 }

--- a/src/back/mod.rs
+++ b/src/back/mod.rs
@@ -1,2 +1,3 @@
 pub mod msl;
+#[cfg(feature = "spirv")]
 pub mod spv;

--- a/src/front/glsl/helpers.rs
+++ b/src/front/glsl/helpers.rs
@@ -1,6 +1,5 @@
-use crate::{Arena, ImageFlags, ScalarKind, Type, TypeInner, VectorSize};
+use crate::{Arena, ImageDimension, ImageFlags, ScalarKind, Type, TypeInner, VectorSize};
 use glsl::syntax::{BinaryOp, TypeSpecifierNonArray};
-use spirv::Dim;
 
 pub fn glsl_to_spirv_binary_op(op: BinaryOp) -> crate::BinaryOperator {
     match op {
@@ -253,21 +252,34 @@ pub fn glsl_to_spirv_type(ty: TypeSpecifierNonArray, types: &mut Arena<Type>) ->
                 });
 
                 let (dim, flags) = match &ty_name.0[(t_pos + 7)..] {
-                    "1D" => (Dim::Dim1D, ImageFlags::SAMPLED),
-                    "2D" => (Dim::Dim2D, ImageFlags::SAMPLED),
-                    "3D" => (Dim::Dim3D, ImageFlags::SAMPLED),
-                    "1DArray" => (Dim::Dim1D, ImageFlags::SAMPLED | ImageFlags::ARRAYED),
-                    "2DArray" => (Dim::Dim2D, ImageFlags::SAMPLED | ImageFlags::ARRAYED),
-                    "3DArray" => (Dim::Dim3D, ImageFlags::SAMPLED | ImageFlags::ARRAYED),
-                    "2DMS" => (Dim::Dim2D, ImageFlags::SAMPLED | ImageFlags::MULTISAMPLED),
+                    "1D" => (ImageDimension::D1, ImageFlags::SAMPLED),
+                    "2D" => (ImageDimension::D2, ImageFlags::SAMPLED),
+                    "3D" => (ImageDimension::D3, ImageFlags::SAMPLED),
+                    "1DArray" => (
+                        ImageDimension::D1,
+                        ImageFlags::SAMPLED | ImageFlags::ARRAYED,
+                    ),
+                    "2DArray" => (
+                        ImageDimension::D2,
+                        ImageFlags::SAMPLED | ImageFlags::ARRAYED,
+                    ),
+                    "3DArray" => (
+                        ImageDimension::D3,
+                        ImageFlags::SAMPLED | ImageFlags::ARRAYED,
+                    ),
+                    "2DMS" => (
+                        ImageDimension::D2,
+                        ImageFlags::SAMPLED | ImageFlags::MULTISAMPLED,
+                    ),
                     "2DMSArray" => (
-                        Dim::Dim2D,
+                        ImageDimension::D2,
                         ImageFlags::SAMPLED | ImageFlags::ARRAYED | ImageFlags::MULTISAMPLED,
                     ),
-                    "2DRect" => (Dim::DimRect, ImageFlags::SAMPLED),
-                    "Cube" => (Dim::DimCube, ImageFlags::SAMPLED),
-                    "CubeArray" => (Dim::DimCube, ImageFlags::SAMPLED | ImageFlags::ARRAYED),
-                    "Buffer" => (Dim::DimBuffer, ImageFlags::SAMPLED),
+                    "Cube" => (ImageDimension::Cube, ImageFlags::SAMPLED),
+                    "CubeArray" => (
+                        ImageDimension::Cube,
+                        ImageFlags::SAMPLED | ImageFlags::ARRAYED,
+                    ),
                     _ => panic!(),
                 };
 

--- a/src/front/mod.rs
+++ b/src/front/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "glsl")]
 pub mod glsl;
+#[cfg(feature = "spirv")]
 pub mod spv;
 pub mod wgsl;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,47 @@ pub struct Header {
     pub generator: u32,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ShaderStage {
+    Vertex,
+    Fragment,
+    Compute,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum StorageClass {
+    Constant,
+    Function,
+    Input,
+    Output,
+    Private,
+    StorageBuffer,
+    Uniform,
+    WorkGroup,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BuiltIn {
+    // vertex
+    BaseInstance,
+    BaseVertex,
+    ClipDistance,
+    InstanceIndex,
+    Position,
+    VertexIndex,
+    // fragment
+    PointSize,
+    FragCoord,
+    FrontFacing,
+    SampleIndex,
+    FragDepth,
+    // compute
+    GlobalInvocationId,
+    LocalInvocationId,
+    LocalInvocationIndex,
+    WorkGroupId,
+}
+
 pub type Bytes = u8;
 
 #[repr(u8)]
@@ -44,7 +85,7 @@ pub enum ScalarKind {
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ArraySize {
-    Static(spirv::Word),
+    Static(u32),
     Dynamic,
 }
 
@@ -54,7 +95,15 @@ pub struct StructMember {
     pub name: Option<String>,
     pub binding: Option<Binding>,
     pub ty: Handle<Type>,
-    pub offset: spirv::Word,
+    pub offset: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ImageDimension {
+    D1,
+    D2,
+    D3,
+    Cube,
 }
 
 bitflags::bitflags! {
@@ -93,7 +142,7 @@ pub enum TypeInner {
     },
     Pointer {
         base: Handle<Type>,
-        class: spirv::StorageClass,
+        class: StorageClass,
     },
     Array {
         base: Handle<Type>,
@@ -105,7 +154,7 @@ pub enum TypeInner {
     },
     Image {
         base: Handle<Type>,
-        dim: spirv::Dim,
+        dim: ImageDimension,
         flags: ImageFlags,
     },
     Sampler {
@@ -116,7 +165,7 @@ pub enum TypeInner {
 #[derive(Debug, PartialEq)]
 pub struct Constant {
     pub name: Option<String>,
-    pub specialization: Option<spirv::Word>,
+    pub specialization: Option<u32>,
     pub inner: ConstantInner,
     pub ty: Handle<Type>,
 }
@@ -133,12 +182,9 @@ pub enum ConstantInner {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Binding {
-    BuiltIn(spirv::BuiltIn),
-    Location(spirv::Word),
-    Descriptor {
-        set: spirv::Word,
-        binding: spirv::Word,
-    },
+    BuiltIn(BuiltIn),
+    Location(u32),
+    Descriptor { set: u32, binding: u32 },
 }
 
 bitflags::bitflags! {
@@ -151,7 +197,7 @@ bitflags::bitflags! {
 #[derive(Clone, Debug, PartialEq)]
 pub struct GlobalVariable {
     pub name: Option<String>,
-    pub class: spirv::StorageClass,
+    pub class: StorageClass,
     pub binding: Option<Binding>,
     pub ty: Handle<Type>,
 }
@@ -302,7 +348,7 @@ pub enum Statement {
 #[derive(Debug)]
 pub struct Function {
     pub name: Option<String>,
-    pub control: spirv::FunctionControl,
+    //pub control: spirv::FunctionControl,
     pub parameter_types: Vec<Handle<Type>>,
     pub return_type: Option<Handle<Type>>,
     pub global_usage: Vec<GlobalUse>,
@@ -313,7 +359,7 @@ pub struct Function {
 
 #[derive(Debug)]
 pub struct EntryPoint {
-    pub exec_model: spirv::ExecutionModel,
+    pub stage: ShaderStage,
     pub name: String,
     pub function: Handle<Function>,
 }

--- a/tests/convert.rs
+++ b/tests/convert.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "glsl")]
-use spirv::ExecutionModel;
-
 fn load_test_data(name: &str) -> String {
     let path = format!("{}/test-data/{}", env!("CARGO_MANIFEST_DIR"), name);
     std::fs::read_to_string(path).unwrap()
@@ -12,9 +9,9 @@ fn load_wgsl(name: &str) -> naga::Module {
 }
 
 #[cfg(feature = "glsl")]
-fn load_glsl(name: &str, entry: &str, exec: ExecutionModel) -> naga::Module {
+fn load_glsl(name: &str, entry: &str, stage: naga::ShaderStage) -> naga::Module {
     let input = load_test_data(name);
-    naga::front::glsl::parse_str(&input, entry.to_owned(), exec).unwrap()
+    naga::front::glsl::parse_str(&input, entry.to_owned(), stage).unwrap()
 }
 
 #[test]
@@ -94,7 +91,11 @@ fn convert_boids() {
 #[test]
 #[ignore]
 fn convert_phong_lighting() {
-    let module = load_glsl("glsl_phong_lighting.frag", "main", ExecutionModel::Fragment);
+    let module = load_glsl(
+        "glsl_phong_lighting.frag",
+        "main",
+        naga::ShaderStage::Fragment,
+    );
     naga::proc::Validator::new().validate(&module).unwrap();
 
     let header = naga::Header {


### PR DESCRIPTION
Closes #70 
I think it's much nicer now, since we can make IR tighter with respect to various enumeration modes we used to borrow from SPIR-V.