### PR TITLE
Refactor error handling in GLSL frontend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ num-traits = "0.2"
 spirv = { package = "spirv_headers", version = "1.4.2", optional = true }
 glsl = { version = "4", optional = true }
 pomelo = { version = "0.1.4", optional = true }
+thiserror = "1.0"
 
 [features]
 glsl_preprocessor = ["glsl"]

--- a/src/front/glsl/helpers.rs
+++ b/src/front/glsl/helpers.rs
@@ -1,5 +1,16 @@
 use crate::{Arena, ImageDimension, ImageFlags, ScalarKind, Type, TypeInner, VectorSize};
-use glsl::syntax::{BinaryOp, TypeSpecifierNonArray};
+use glsl::syntax::{BinaryOp, TypeSpecifierNonArray, UnaryOp};
+
+pub fn glsl_to_spirv_unary_op(op: UnaryOp) -> crate::UnaryOperator {
+    match op {
+        UnaryOp::Inc => todo!(),
+        UnaryOp::Dec => todo!(),
+        UnaryOp::Add => todo!(),
+        UnaryOp::Minus => crate::UnaryOperator::Negate,
+        UnaryOp::Not => crate::UnaryOperator::Not,
+        UnaryOp::Complement => todo!(),
+    }
+}
 
 pub fn glsl_to_spirv_binary_op(op: BinaryOp) -> crate::BinaryOperator {
     match op {


### PR DESCRIPTION
I tried adding some stuff to the GLSL frontend, but I got annoyed with tracking down all the unwraps so I refactored the error handling. Let me know if you want any changes or if this is even a good direction to go in.

It also contains a few additions to the type checker and support for two unary operations, which is what I was adding when I got sidetracked. I can move them to another PR if you want.