### PR TITLE
Add fuzzing support

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "naga-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+
+[dependencies.naga]
+path = ".."
+features = ["spirv"]
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "spv_parser"
+path = "fuzz_targets/spv_parser.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "wgsl_parser"
+path = "fuzz_targets/wgsl_parser.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/spv_parser.rs
+++ b/fuzz/fuzz_targets/spv_parser.rs
@@ -1,0 +1,8 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use naga::front::spv::Parser;
+
+fuzz_target!(|data: Vec<u32>| {
+    // Ensure the parser can handle potentially malformed data without crashing.
+    let _result = Parser::new(data.into_iter()).parse();
+});

--- a/fuzz/fuzz_targets/wgsl_parser.rs
+++ b/fuzz/fuzz_targets/wgsl_parser.rs
@@ -1,0 +1,8 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use naga::front::wgsl::Parser;
+
+fuzz_target!(|data: String| {
+    // Ensure the parser can handle potentially malformed strings without crashing.
+    let _result = Parser::new().parse(&data);
+});


### PR DESCRIPTION
Adds some `cargo-fuzz` targets for the SPIR-V and WGSL parsers.