### PR TITLE
Handle glsl_new parser errors

### DIFF
--- a/src/front/glsl_new/error.rs
+++ b/src/front/glsl_new/error.rs
@@ -1,16 +1,25 @@
+use super::parser::Token;
 use std::{fmt, io};
 
 #[derive(Debug)]
 pub enum ErrorKind {
     InvalidInput,
     IoError(io::Error),
+    InvalidToken(Token),
+    EndOfFile,
+    ParserFail,
+    ParserStackOverflow,
 }
 
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ErrorKind::IoError(error) => write!(f, "IO Error {}", error),
             ErrorKind::InvalidInput => write!(f, "InvalidInput"),
+            ErrorKind::IoError(error) => write!(f, "IO Error {}", error),
+            ErrorKind::InvalidToken(token) => write!(f, "Invalid Token {:?}", token),
+            ErrorKind::EndOfFile => write!(f, "Unexpected end of file"),
+            ErrorKind::ParserFail => write!(f, "Parser failed"),
+            ErrorKind::ParserStackOverflow => write!(f, "Parser stack overflow"),
         }
     }
 }

--- a/src/front/glsl_new/mod.rs
+++ b/src/front/glsl_new/mod.rs
@@ -1,9 +1,11 @@
-use crate::{Arena, Constant, EntryPoint, Function, GlobalVariable, Header, Module, ShaderStage, Type};
+use crate::{
+    Arena, Constant, EntryPoint, Function, GlobalVariable, Header, Module, ShaderStage, Type,
+};
 
 mod lex;
 use lex::Lexer;
 mod error;
-use error::{ErrorKind, ParseError};
+use error::ParseError;
 mod parser;
 mod token;
 
@@ -26,10 +28,9 @@ pub fn parse_str(source: &str, entry: String, stage: ShaderStage) -> Result<Modu
     let mut parser = parser::Parser::new(module);
 
     for token in lex {
-        log::debug!("token: {:#?}", token);
-        parser.parse(token).map_err(|_| ErrorKind::InvalidInput)?;
+        parser.parse(token)?;
     }
-    let (_, mut parsed_module) = parser.end_of_input().map_err(|_| ErrorKind::InvalidInput)?;
+    let (_, mut parsed_module) = parser.end_of_input()?;
 
     // find entry point
     let entry_func = parsed_module

--- a/src/front/glsl_new/parser.rs
+++ b/src/front/glsl_new/parser.rs
@@ -4,12 +4,26 @@ use pomelo::pomelo;
 pomelo! {
     //%verbose;
     %include {
-        use super::super::token::*;
+        use super::super::{error::ErrorKind, token::*};
         use crate::{Arena, Expression, Function, LocalVariable, Module};
     }
     %token #[derive(Debug)] pub enum Token {};
     %extra_argument Module;
     %extra_token TokenMetadata;
+    %error ErrorKind;
+    %syntax_error {
+        match token {
+            Some(token) => Err(ErrorKind::InvalidToken(token)),
+            None => Err(ErrorKind::EndOfFile),
+        }
+    }
+    %parse_fail {
+        ErrorKind::ParserFail
+    }
+    %stack_overflow {
+        ErrorKind::ParserStackOverflow
+    }
+
     %type Identifier String;
     %type IntConstant i64;
     %type UintConstant u64;
@@ -19,16 +33,6 @@ pomelo! {
     %type String String;
     %type arg_list Vec<String>;
     %type function_definition Function;
-
-    %left Else;
-    %right Assign;
-    %left Or;
-    %left And;
-    %nonassoc Equal NotEqual;
-    %nonassoc Less LessEq Greater GreaterEq;
-    %left Plus Minus;
-    %left Mult Div;
-    %nonassoc Not;
 
     root ::= version_pragma translation_unit;
     version_pragma ::= Version IntConstant Identifier?;


### PR DESCRIPTION
Adds pomelo parser error handling for glsl.

Can now generate errors like:
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ParseError { kind: InvalidToken(Comma(TokenMetadata { line: 3, chars: 23..24 }))
 }', examples/convert.rs:58:25
```