### PR TITLE
Make glsl dep more specific

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ fxhash = "0.2"
 log = "0.4"
 num-traits = "0.2"
 spirv = { package = "spirv_headers", version = "1.4.2", optional = true }
-glsl = { version = "4", optional = true }
+glsl = { version = "4.1", optional = true }
 pomelo = { version = "0.1.4", optional = true }
 thiserror = "1.0"
 


### PR DESCRIPTION
- Require 4.1 as 4.0 now gives compile errors