### PR TITLE
Local function calls in IR

### DIFF
--- a/src/back/msl.rs
+++ b/src/back/msl.rs
@@ -618,7 +618,7 @@ impl<W: Write> Writer<W> {
                 }))
             }
             crate::Expression::Call {
-                ref name,
+                origin: crate::FunctionOrigin::External(ref name),
                 ref arguments,
             } => match name.as_str() {
                 "cos" | "normalize" | "sin" => {

--- a/src/front/wgsl.rs
+++ b/src/front/wgsl.rs
@@ -328,7 +328,6 @@ impl<'a> ExpressionContext<'a, '_, '_> {
                 self.global_vars,
                 self.local_vars,
                 &Arena::new(),
-                &FastHashMap::default(),
             )
             .map_err(Error::InvalidResolve)
     }
@@ -548,7 +547,7 @@ impl Parser {
                         arguments.push(arg);
                     }
                     crate::Expression::Call {
-                        name: name.to_owned(),
+                        origin: crate::FunctionOrigin::External(name.to_owned()),
                         arguments,
                     }
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,6 +338,13 @@ pub enum DerivativeAxis {
     Width,
 }
 
+/// Origin of a function to call.
+#[derive(Clone, Debug, PartialEq)]
+pub enum FunctionOrigin {
+    Local(Handle<Function>),
+    External(String),
+}
+
 /// An expression that can be evaluated to obtain a value.
 #[derive(Clone, Debug)]
 pub enum Expression {
@@ -399,9 +406,9 @@ pub enum Expression {
         //modifier,
         expr: Handle<Expression>,
     },
-    /// Call a function defined in this module.
+    /// Call another function.
     Call {
-        name: String,
+        origin: FunctionOrigin,
         arguments: Vec<Handle<Expression>>,
     },
 }


### PR DESCRIPTION
Plus some SPV front-end refactor in preparation to the control flow graph.
Note that SPIR-V allows function calls into future-defined functions, so we have to do some gymnastics in order to handle that. We collect all the local function calls and resolve them at the end of the module parsing.