### PR TITLE
Add support for other matrices keywords

### DIFF
--- a/src/front/wgsl.rs
+++ b/src/front/wgsl.rs
@@ -1046,10 +1046,64 @@ impl Parser {
                     width,
                 }
             }
+            Token::Word("mat2x3") => {
+                let (kind, width) = lexer.next_scalar_generic()?;
+                crate::TypeInner::Matrix {
+                    columns: crate::VectorSize::Bi,
+                    rows: crate::VectorSize::Tri,
+                    kind,
+                    width,
+                }
+            }
+            Token::Word("mat2x4") => {
+                let (kind, width) = lexer.next_scalar_generic()?;
+                crate::TypeInner::Matrix {
+                    columns: crate::VectorSize::Bi,
+                    rows: crate::VectorSize::Quad,
+                    kind,
+                    width,
+                }
+            }
+            Token::Word("mat3x2") => {
+                let (kind, width) = lexer.next_scalar_generic()?;
+                crate::TypeInner::Matrix {
+                    columns: crate::VectorSize::Tri,
+                    rows: crate::VectorSize::Bi,
+                    kind,
+                    width,
+                }
+            }
             Token::Word("mat3x3") => {
                 let (kind, width) = lexer.next_scalar_generic()?;
                 crate::TypeInner::Matrix {
                     columns: crate::VectorSize::Tri,
+                    rows: crate::VectorSize::Tri,
+                    kind,
+                    width,
+                }
+            }
+            Token::Word("mat3x4") => {
+                let (kind, width) = lexer.next_scalar_generic()?;
+                crate::TypeInner::Matrix {
+                    columns: crate::VectorSize::Tri,
+                    rows: crate::VectorSize::Quad,
+                    kind,
+                    width,
+                }
+            }
+            Token::Word("mat4x2") => {
+                let (kind, width) = lexer.next_scalar_generic()?;
+                crate::TypeInner::Matrix {
+                    columns: crate::VectorSize::Quad,
+                    rows: crate::VectorSize::Bi,
+                    kind,
+                    width,
+                }
+            }
+            Token::Word("mat4x3") => {
+                let (kind, width) = lexer.next_scalar_generic()?;
+                crate::TypeInner::Matrix {
+                    columns: crate::VectorSize::Quad,
                     rows: crate::VectorSize::Tri,
                     kind,
                     width,


### PR DESCRIPTION
Add mat2x3, mat2x4, mat3x2, mat3x4, mat4x2, and mat4x3 keywords.

Updating the WGSL front-end to support all the matrices keywords, see [keywords](https://gpuweb.github.io/gpuweb/wgsl.html#keywords).