### PR TITLE
Add support for initialization of local variables to glsl backend

### DIFF
--- a/src/back/glsl.rs
+++ b/src/back/glsl.rs
@@ -186,24 +186,18 @@ pub fn write(module: &Module, out: &mut impl Write) -> Result<(), Error> {
         };
 
         for (handle, name) in locals.iter() {
+            let ty = write_type(func.local_variables[*handle].ty, &module.types, &structs)?;
             let init = func.local_variables[*handle].init;
             if let Some(init) = init {
-                let expr = &func.expressions[init];
-
                 writeln!(
                     out,
-                    "{ty} {name} = {init};",
-                    ty = write_type(func.local_variables[*handle].ty, &module.types, &structs)?,
-                    name = name,
-                    init = write_expression(expr, &module, &mut builder)?.0,
+                    "{} {} = {init};",
+                    ty,
+                    name,
+                    init = write_expression(&func.expressions[init], &module, &mut builder)?.0,
                 )?;
             } else {
-                writeln!(
-                    out,
-                    "{} {};",
-                    write_type(func.local_variables[*handle].ty, &module.types, &structs)?,
-                    name
-                )?;
+                writeln!(out, "{} {};", ty, name,)?;
             }
         }
 


### PR DESCRIPTION
Add support for local variable initialization to glsl backend.

Input glsl:

```glsl
#version 450 core

layout(location = 0) in vec2 position;

void main() {
    float w = 1.0;
    gl_Position = vec4(position, 0.0, w);
}
```

Before patch, converted to:

```glsl
#version 450 core
layout(location=0) in vec2 position;
void main() {
float w;
gl_position = vec4(position,0,w);
}
```

After patch, converted to:

```glsl
#version 450 core
layout(location=0) in vec2 position;
void main() {
float w = 1;
gl_position = vec4(position,0,w);
}
```