### PR TITLE
[glsl-new] Fix expression ordering for compose

### DIFF
--- a/src/front/glsl_new/ast.rs
+++ b/src/front/glsl_new/ast.rs
@@ -112,3 +112,16 @@ pub struct VarDeclaration {
     pub ids_initializers: Vec<(String, Option<ExpressionRule>)>,
     pub ty: Handle<Type>,
 }
+
+#[derive(Debug)]
+pub enum FunctionCallKind {
+    TypeConstructor(Handle<Type>),
+    Function(Handle<Expression>),
+}
+
+#[derive(Debug)]
+pub struct FunctionCall {
+    pub kind: FunctionCallKind,
+    pub args: Vec<Handle<Expression>>,
+    pub statements: Vec<Statement>,
+}


### PR DESCRIPTION
Fix issue with `Compose` expression depending on later expressions.

Now `Compose` isn't generated until all args have been collected.