### PR TITLE
Make type handling more generic in glsl-new

### DIFF
--- a/src/front/glsl_new/lex.rs
+++ b/src/front/glsl_new/lex.rs
@@ -119,23 +119,82 @@ pub fn consume_token(mut input: &str) -> (Option<Token>, &str) {
                 "double" => (Some(Token::Double(meta)), rest),
                 "int" => (Some(Token::Int(meta)), rest),
                 "uint" => (Some(Token::Uint(meta)), rest),
-                "vec2" => (Some(Token::Vec2(meta)), rest),
-                "bvec2" => (Some(Token::Bvec2(meta)), rest),
-                "ivec2" => (Some(Token::Ivec2(meta)), rest),
-                "uvec2" => (Some(Token::Uvec2(meta)), rest),
-                "dvec2" => (Some(Token::Dvec2(meta)), rest),
-                "vec3" => (Some(Token::Vec3(meta)), rest),
-                "bvec3" => (Some(Token::Bvec3(meta)), rest),
-                "ivec3" => (Some(Token::Ivec3(meta)), rest),
-                "uvec3" => (Some(Token::Uvec3(meta)), rest),
-                "dvec3" => (Some(Token::Dvec3(meta)), rest),
-                "vec4" => (Some(Token::Vec4(meta)), rest),
-                "bvec4" => (Some(Token::Bvec4(meta)), rest),
-                "ivec4" => (Some(Token::Ivec4(meta)), rest),
-                "uvec4" => (Some(Token::Uvec4(meta)), rest),
-                "dvec4" => (Some(Token::Dvec4(meta)), rest),
+                // "vec2" => (Some(Token::Vec2(meta)), rest),
+                // "bvec2" => (Some(Token::Bvec2(meta)), rest),
+                // "ivec2" => (Some(Token::Ivec2(meta)), rest),
+                // "uvec2" => (Some(Token::Uvec2(meta)), rest),
+                // "dvec2" => (Some(Token::Dvec2(meta)), rest),
+                // "vec3" => (Some(Token::Vec3(meta)), rest),
+                // "bvec3" => (Some(Token::Bvec3(meta)), rest),
+                // "ivec3" => (Some(Token::Ivec3(meta)), rest),
+                // "uvec3" => (Some(Token::Uvec3(meta)), rest),
+                // "dvec3" => (Some(Token::Dvec3(meta)), rest),
+                // "vec4" => (Some(Token::Vec4(meta)), rest),
+                // "bvec4" => (Some(Token::Bvec4(meta)), rest),
+                // "ivec4" => (Some(Token::Ivec4(meta)), rest),
+                // "uvec4" => (Some(Token::Uvec4(meta)), rest),
+                // "dvec4" => (Some(Token::Dvec4(meta)), rest),
                 //TODO: remaining types
-                _ => (Some(Token::Identifier((meta, String::from(word)))), rest),
+                word => {
+                    use crate::{ScalarKind, VectorSize};
+
+                    fn kind_width_parse(ty: &str) -> Option<(ScalarKind, u8)> {
+                        Some(match ty {
+                            "" => (ScalarKind::Float, 4),
+                            "b" => (ScalarKind::Bool, 4),
+                            "i" => (ScalarKind::Sint, 4),
+                            "u" => (ScalarKind::Uint, 4),
+                            "d" => (ScalarKind::Float, 8),
+                            _ => return None,
+                        })
+                    }
+
+                    fn size_parse(n: &str) -> Option<VectorSize> {
+                        Some(match n {
+                            "2" => VectorSize::Bi,
+                            "3" => VectorSize::Tri,
+                            "4" => VectorSize::Quad,
+                            _ => return None,
+                        })
+                    }
+
+                    let vec_parse = |word: &str| {
+                        let mut iter = word.split("vec");
+
+                        let kind = iter.next()?;
+                        let size = iter.next()?;
+                        let (kind, width) = kind_width_parse(kind)?;
+                        let size = size_parse(size)?;
+
+                        Some(Token::Vec((meta.clone(), (size, kind, width))))
+                    };
+
+                    let mat_parse = |word: &str| {
+                        let mut iter = word.split("mat");
+
+                        let kind = iter.next()?;
+                        let size = iter.next()?;
+                        let (kind, width) = kind_width_parse(kind)?;
+
+                        let (col, row) = if let Some(size) = size_parse(size) {
+                            (size, size)
+                        } else {
+                            let mut iter = size.split('x');
+                            match (iter.next()?, iter.next()?, iter.next()) {
+                                (col, row, None) => (size_parse(col)?, size_parse(row)?),
+                                _ => return None,
+                            }
+                        };
+
+                        Some(Token::Mat((meta.clone(), (col, row, kind, width))))
+                    };
+
+                    let token = vec_parse(word)
+                        .or_else(|| mat_parse(word))
+                        .unwrap_or_else(|| Token::Identifier((meta, String::from(word))));
+
+                    (Some(token), rest)
+                }
             }
         }
 

--- a/src/front/glsl_new/lex.rs
+++ b/src/front/glsl_new/lex.rs
@@ -119,22 +119,6 @@ pub fn consume_token(mut input: &str) -> (Option<Token>, &str) {
                 "double" => (Some(Token::Double(meta)), rest),
                 "int" => (Some(Token::Int(meta)), rest),
                 "uint" => (Some(Token::Uint(meta)), rest),
-                // "vec2" => (Some(Token::Vec2(meta)), rest),
-                // "bvec2" => (Some(Token::Bvec2(meta)), rest),
-                // "ivec2" => (Some(Token::Ivec2(meta)), rest),
-                // "uvec2" => (Some(Token::Uvec2(meta)), rest),
-                // "dvec2" => (Some(Token::Dvec2(meta)), rest),
-                // "vec3" => (Some(Token::Vec3(meta)), rest),
-                // "bvec3" => (Some(Token::Bvec3(meta)), rest),
-                // "ivec3" => (Some(Token::Ivec3(meta)), rest),
-                // "uvec3" => (Some(Token::Uvec3(meta)), rest),
-                // "dvec3" => (Some(Token::Dvec3(meta)), rest),
-                // "vec4" => (Some(Token::Vec4(meta)), rest),
-                // "bvec4" => (Some(Token::Bvec4(meta)), rest),
-                // "ivec4" => (Some(Token::Ivec4(meta)), rest),
-                // "uvec4" => (Some(Token::Uvec4(meta)), rest),
-                // "dvec4" => (Some(Token::Dvec4(meta)), rest),
-                //TODO: remaining types
                 word => {
                     use crate::{ScalarKind, VectorSize};
 

--- a/src/front/glsl_new/parser.rs
+++ b/src/front/glsl_new/parser.rs
@@ -8,7 +8,7 @@ pomelo! {
         use super::super::{error::ErrorKind, token::*, ast::*};
         use crate::{Arena, BinaryOperator, Binding, Block, BuiltIn, Constant, ConstantInner, Expression,
             Function, GlobalVariable, Handle, LocalVariable, ScalarKind,
-            ShaderStage, Statement, StorageClass, Type, TypeInner, VectorSize};
+            ShaderStage, Statement, StorageClass, Type, TypeInner, VectorSize, Bytes};
     }
     %token #[derive(Debug)] pub enum Token {};
     %parser pub struct Parser<'a> {};
@@ -104,6 +104,9 @@ pomelo! {
     %type fully_specified_type (Vec<TypeQualifier>, Option<Handle<Type>>);
     %type type_specifier Option<Handle<Type>>;
     %type type_specifier_nonarray Option<Type>;
+
+    %type Vec (VectorSize, ScalarKind, Bytes);
+    %type Mat (VectorSize, VectorSize, ScalarKind, Bytes);
 
 
     root ::= version_pragma translation_unit;
@@ -689,161 +692,27 @@ pomelo! {
             }
         })
     }
-    // Vectors (2)
-    type_specifier_nonarray ::= Vec2 {
+    type_specifier_nonarray ::= Vec((_, (size, kind, width))) {
         Some(Type {
             name: None,
             inner: TypeInner::Vector {
-                size: VectorSize::Bi,
-                kind: ScalarKind::Float,
-                width: 4,
+                size,
+                kind,
+                width,
             }
         })
     }
-    type_specifier_nonarray ::= Bvec2 {
+    type_specifier_nonarray ::= Mat((_, (columns, rows, kind, width))) {
         Some(Type {
             name: None,
-            inner: TypeInner::Vector {
-                size: VectorSize::Bi,
-                kind: ScalarKind::Bool,
-                width: 4,
+            inner: TypeInner::Matrix {
+                columns,
+                rows,
+                kind,
+                width,
             }
         })
     }
-    type_specifier_nonarray ::= Ivec2 {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Vector {
-                size: VectorSize::Bi,
-                kind: ScalarKind::Sint,
-                width: 4,
-            }
-        })
-    }
-    type_specifier_nonarray ::= Uvec2 {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Vector {
-                size: VectorSize::Bi,
-                kind: ScalarKind::Uint,
-                width: 4,
-            }
-        })
-    }
-    type_specifier_nonarray ::= Dvec2 {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Vector {
-                size: VectorSize::Bi,
-                kind: ScalarKind::Float,
-                width: 8,
-            }
-        })
-    }
-    // Vectors (3)
-    type_specifier_nonarray ::= Vec3 {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Vector {
-                size: VectorSize::Bi,
-                kind: ScalarKind::Float,
-                width: 4,
-            }
-        })
-    }
-    type_specifier_nonarray ::= Bvec3 {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Vector {
-                size: VectorSize::Bi,
-                kind: ScalarKind::Bool,
-                width: 4,
-            }
-        })
-    }
-    type_specifier_nonarray ::= Ivec3 {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Vector {
-                size: VectorSize::Bi,
-                kind: ScalarKind::Sint,
-                width: 4,
-            }
-        })
-    }
-    type_specifier_nonarray ::= Uvec3 {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Vector {
-                size: VectorSize::Bi,
-                kind: ScalarKind::Uint,
-                width: 4,
-            }
-        })
-    }
-    type_specifier_nonarray ::= Dvec3 {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Vector {
-                size: VectorSize::Bi,
-                kind: ScalarKind::Float,
-                width: 8,
-            }
-        })
-    }
-    // Vectors (4)
-    type_specifier_nonarray ::= Vec4 {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Vector {
-                size: VectorSize::Bi,
-                kind: ScalarKind::Float,
-                width: 4,
-            }
-        })
-    }
-    type_specifier_nonarray ::= Bvec4 {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Vector {
-                size: VectorSize::Bi,
-                kind: ScalarKind::Bool,
-                width: 4,
-            }
-        })
-    }
-    type_specifier_nonarray ::= Ivec4 {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Vector {
-                size: VectorSize::Bi,
-                kind: ScalarKind::Sint,
-                width: 4,
-            }
-        })
-    }
-    type_specifier_nonarray ::= Uvec4 {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Vector {
-                size: VectorSize::Bi,
-                kind: ScalarKind::Uint,
-                width: 4,
-            }
-        })
-    }
-    type_specifier_nonarray ::= Dvec4 {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Vector {
-                size: VectorSize::Bi,
-                kind: ScalarKind::Float,
-                width: 8,
-            }
-        })
-    }
-
-    //TODO: remaining types
 
     // misc
     translation_unit ::= external_declaration;


### PR DESCRIPTION
Redesign of the previous patch (sorry about that) that makes type handling more generic and adds support for matrices.