### PR TITLE
Interpolation support for wgsl, glsl, glsl-new, spirv (front and back), and glsl-out

### DIFF
--- a/examples/convert.rs
+++ b/examples/convert.rs
@@ -79,11 +79,37 @@ fn main() {
             }
             module.unwrap()
         }
-        #[cfg(feature = "glsl")]
+        #[cfg(any(feature = "glsl", feature = "glsl-new"))]
         "frag" => {
             let input = fs::read_to_string(&args[1]).unwrap();
-            naga::front::glsl::parse_str(&input, "main".to_string(), naga::ShaderStage::Fragment)
-                .unwrap()
+            let mut module = None;
+            if prefer_glsl_new {
+                #[cfg(feature = "glsl-new")]
+                {
+                    module = Some(
+                        naga::front::glsl_new::parse_str(
+                            &input,
+                            "main".to_string(),
+                            naga::ShaderStage::Fragment,
+                        )
+                        .unwrap(),
+                    )
+                }
+            }
+            if module.is_none() {
+                #[cfg(feature = "glsl")]
+                {
+                    module = Some(
+                        naga::front::glsl::parse_str(
+                            &input,
+                            "main".to_string(),
+                            naga::ShaderStage::Fragment,
+                        )
+                        .unwrap(),
+                    )
+                }
+            }
+            module.unwrap()
         }
         #[cfg(feature = "glsl")]
         "comp" => {

--- a/src/back/glsl.rs
+++ b/src/back/glsl.rs
@@ -81,9 +81,13 @@ pub fn write(module: &Module, out: &mut impl Write) -> Result<(), Error> {
 
                 writeln!(out, "struct {} {{", name)?;
                 for (idx, member) in members.iter().enumerate() {
+                    write!(out, "   ")?;
+                    if let Some(interpolation) = member.interpolation {
+                        write!(out, "{} ", write_interpolation(interpolation)?)?;
+                    }
                     writeln!(
                         out,
-                        "   {} {};",
+                        "{} {};",
                         write_type(member.ty, &module.types, &structs)?,
                         member.name.clone().unwrap_or_else(|| idx.to_string())
                     )?;

--- a/src/back/glsl.rs
+++ b/src/back/glsl.rs
@@ -81,13 +81,9 @@ pub fn write(module: &Module, out: &mut impl Write) -> Result<(), Error> {
 
                 writeln!(out, "struct {} {{", name)?;
                 for (idx, member) in members.iter().enumerate() {
-                    write!(out, "   ")?;
-                    if let Some(interpolation) = member.interpolation {
-                        write!(out, "{} ", write_interpolation(interpolation)?)?;
-                    }
                     writeln!(
                         out,
-                        "{} {};",
+                        "   {} {};",
                         write_type(member.ty, &module.types, &structs)?,
                         member.name.clone().unwrap_or_else(|| idx.to_string())
                     )?;
@@ -903,7 +899,8 @@ fn write_storage_class(class: StorageClass) -> Result<String, Error> {
 
 fn write_interpolation(interpolation: Interpolation) -> Result<&'static str, Error> {
     Ok(match interpolation {
-        Interpolation::NoPerspective => "noperspective",
+        Interpolation::Perspective => "smooth",
+        Interpolation::Linear => "noperspective",
         Interpolation::Flat => "flat",
         Interpolation::Centroid => "centroid",
         Interpolation::Sample => "sample",

--- a/src/back/glsl.rs
+++ b/src/back/glsl.rs
@@ -1,7 +1,8 @@
 use crate::{
     Arena, ArraySize, BinaryOperator, BuiltIn, Constant, ConstantInner, DerivativeAxis, Expression,
-    FastHashMap, Function, FunctionOrigin, GlobalVariable, Handle, ImageFlags, IntrinsicFunction,
-    LocalVariable, Module, ScalarKind, Statement, StorageClass, Type, TypeInner, UnaryOperator,
+    FastHashMap, Function, FunctionOrigin, GlobalVariable, Handle, ImageFlags, Interpolation,
+    IntrinsicFunction, LocalVariable, Module, ScalarKind, Statement, StorageClass, Type, TypeInner,
+    UnaryOperator,
 };
 use std::{
     borrow::Cow,
@@ -121,6 +122,10 @@ pub fn write(module: &Module, out: &mut impl Write) -> Result<(), Error> {
 
         if let Some(ref binding) = global.binding {
             write!(out, "layout({}) ", Binding(binding.clone()))?;
+        }
+
+        if let Some(interpolation) = global.interpolation {
+            write!(out, "{} ", write_interpolation(interpolation)?)?;
         }
 
         let name = namer(global.name.as_ref());
@@ -890,6 +895,20 @@ fn write_storage_class(class: StorageClass) -> Result<String, Error> {
         StorageClass::Uniform => "uniform ",
         StorageClass::WorkGroup => "shared ",
     }))
+}
+
+fn write_interpolation(interpolation: Interpolation) -> Result<&'static str, Error> {
+    Ok(match interpolation {
+        Interpolation::NoPerspective => "noperspective",
+        Interpolation::Flat => "flat",
+        Interpolation::Centroid => "centroid",
+        Interpolation::Sample => "sample",
+        Interpolation::Patch => {
+            return Err(Error::Custom(
+                "patch interpolation qualifier not supported".to_string(),
+            ))
+        }
+    })
 }
 
 fn write_array_size(size: ArraySize) -> Result<String, Error> {

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -233,6 +233,21 @@ impl Writer {
         instruction
     }
 
+    fn instruction_member_decorate(
+        &self,
+        target_id: Word,
+        member: Word,
+        decoration: spirv::Decoration,
+        operands: &[Word],
+    ) -> Instruction {
+        let mut instruction = Instruction::new(Op::MemberDecorate);
+        instruction.add_operand(target_id);
+        instruction.add_operand(member);
+        instruction.add_operand(decoration as u32);
+        instruction.add_operands(operands.into());
+        instruction
+    }
+
     ///
     /// Extension Instructions
     ///
@@ -824,8 +839,23 @@ impl Writer {
             }
             crate::TypeInner::Struct { ref members } => {
                 let mut member_ids = Vec::with_capacity(members.len());
-                for member in members {
+                for (member_index, member) in members.iter().enumerate() {
                     let member_id = self.get_type_id(arena, LookupType::Handle(member.ty));
+                    if let Some(interpolation) = member.interpolation {
+                        let decoration = match interpolation {
+                            crate::Interpolation::NoPerspective => spirv::Decoration::NoPerspective,
+                            crate::Interpolation::Flat => spirv::Decoration::Flat,
+                            crate::Interpolation::Patch => spirv::Decoration::Patch,
+                            crate::Interpolation::Centroid => spirv::Decoration::Centroid,
+                            crate::Interpolation::Sample => spirv::Decoration::Sample,
+                        };
+                        self.annotations.push(self.instruction_member_decorate(
+                            id,
+                            member_index as u32,
+                            decoration,
+                            &[],
+                        ));
+                    }
                     member_ids.push(member_id);
                 }
                 self.instruction_type_struct(id, member_ids)
@@ -954,6 +984,18 @@ impl Writer {
         if self.writer_flags.contains(WriterFlags::DEBUG) {
             self.debugs
                 .push(self.instruction_name(id, global_variable.name.as_ref().unwrap().as_str()));
+        }
+
+        if let Some(interpolation) = global_variable.interpolation {
+            let decoration = match interpolation {
+                crate::Interpolation::NoPerspective => spirv::Decoration::NoPerspective,
+                crate::Interpolation::Flat => spirv::Decoration::Flat,
+                crate::Interpolation::Patch => spirv::Decoration::Patch,
+                crate::Interpolation::Centroid => spirv::Decoration::Centroid,
+                crate::Interpolation::Sample => spirv::Decoration::Sample,
+            };
+            self.annotations
+                .push(self.instruction_decorate(id, decoration, &[]));
         }
 
         match global_variable.binding.as_ref().unwrap() {

--- a/src/front/glsl/mod.rs
+++ b/src/front/glsl/mod.rs
@@ -1243,12 +1243,10 @@ impl<'a> Parser<'a> {
                     }
                 }
                 TypeQualifierSpec::Interpolation(interpolation_qualifier) => {
-                    match interpolation_qualifier {
-                        InterpolationQualifier::NoPerspective => {
-                            interpolation = Interpolation::Linear
-                        }
-                        InterpolationQualifier::Flat => interpolation = Interpolation::Flat,
-                        InterpolationQualifier::Smooth => {}
+                    interpolation = match interpolation_qualifier {
+                        InterpolationQualifier::NoPerspective => Interpolation::Linear,
+                        InterpolationQualifier::Flat => Interpolation::Flat,
+                        InterpolationQualifier::Smooth => Interpolation::Perspective,
                     }
                 }
                 _ => unimplemented!(),

--- a/src/front/glsl/mod.rs
+++ b/src/front/glsl/mod.rs
@@ -196,7 +196,6 @@ impl<'a> Parser<'a> {
                                     } else {
                                         ty
                                     },
-                                    interpolation: None,
                                 });
 
                                 if name.is_none() {
@@ -1175,7 +1174,7 @@ impl<'a> Parser<'a> {
     ) -> (StorageClass, Option<Binding>, Option<Interpolation>) {
         let mut storage = None;
         let mut binding = None;
-        let mut interpolation = None;
+        let mut interpolation = Interpolation::Perspective;
 
         for qualifier in qualifier.qualifiers {
             match qualifier {
@@ -1244,12 +1243,11 @@ impl<'a> Parser<'a> {
                     }
                 }
                 TypeQualifierSpec::Interpolation(interpolation_qualifier) => {
-                    assert!(interpolation.is_none());
                     match interpolation_qualifier {
                         InterpolationQualifier::NoPerspective => {
-                            interpolation = Some(Interpolation::NoPerspective)
+                            interpolation = Interpolation::Linear
                         }
-                        InterpolationQualifier::Flat => interpolation = Some(Interpolation::Flat),
+                        InterpolationQualifier::Flat => interpolation = Interpolation::Flat,
                         InterpolationQualifier::Smooth => {}
                     }
                 }
@@ -1257,10 +1255,15 @@ impl<'a> Parser<'a> {
             }
         }
 
+        let class = storage.unwrap_or(StorageClass::Private);
+
         (
-            storage.unwrap_or(StorageClass::Private),
+            class,
             binding,
-            interpolation,
+            match class {
+                StorageClass::Input | StorageClass::Output => Some(interpolation),
+                _ => None,
+            },
         )
     }
 }

--- a/src/front/glsl/mod.rs
+++ b/src/front/glsl/mod.rs
@@ -1246,9 +1246,11 @@ impl<'a> Parser<'a> {
                 TypeQualifierSpec::Interpolation(interpolation_qualifier) => {
                     assert!(interpolation.is_none());
                     match interpolation_qualifier {
-                        InterpolationQualifier::NoPerspective => interpolation = Some(Interpolation::NoPerspective),
+                        InterpolationQualifier::NoPerspective => {
+                            interpolation = Some(Interpolation::NoPerspective)
+                        }
                         InterpolationQualifier::Flat => interpolation = Some(Interpolation::Flat),
-                        InterpolationQualifier::Smooth => {},
+                        InterpolationQualifier::Smooth => {}
                     }
                 }
                 _ => unimplemented!(),

--- a/src/front/glsl_new/ast.rs
+++ b/src/front/glsl_new/ast.rs
@@ -1,6 +1,6 @@
 use crate::{
     Arena, Binding, Constant, Expression, FastHashMap, Function, GlobalVariable, Handle,
-    LocalVariable, ShaderStage, Statement, StorageClass, Type,
+    Interpolation, LocalVariable, ShaderStage, Statement, StorageClass, Type,
 };
 
 #[derive(Debug)]
@@ -104,6 +104,7 @@ pub struct ExpressionRule {
 pub enum TypeQualifier {
     StorageClass(StorageClass),
     Binding(Binding),
+    Interpolation(Interpolation),
 }
 
 #[derive(Debug)]

--- a/src/front/glsl_new/lex.rs
+++ b/src/front/glsl_new/lex.rs
@@ -113,6 +113,26 @@ pub fn consume_token(mut input: &str) -> (Option<Token>, &str) {
                 "layout" => (Some(Token::Layout(meta)), rest),
                 "in" => (Some(Token::In(meta)), rest),
                 "out" => (Some(Token::Out(meta)), rest),
+                "flat" => (
+                    Some(Token::Interpolation((meta, crate::Interpolation::Flat))),
+                    rest,
+                ),
+                "noperspective" => (
+                    Some(Token::Interpolation((
+                        meta,
+                        crate::Interpolation::NoPerspective,
+                    ))),
+                    rest,
+                ),
+                "smooth" => (None, rest),
+                "centroid" => (
+                    Some(Token::Interpolation((meta, crate::Interpolation::Centroid))),
+                    rest,
+                ),
+                "sample" => (
+                    Some(Token::Interpolation((meta, crate::Interpolation::Sample))),
+                    rest,
+                ),
                 // types
                 "void" => (Some(Token::Void(meta)), rest),
                 "float" => (Some(Token::Float(meta)), rest),

--- a/src/front/glsl_new/lex.rs
+++ b/src/front/glsl_new/lex.rs
@@ -118,10 +118,7 @@ pub fn consume_token(mut input: &str) -> (Option<Token>, &str) {
                     rest,
                 ),
                 "noperspective" => (
-                    Some(Token::Interpolation((
-                        meta,
-                        crate::Interpolation::NoPerspective,
-                    ))),
+                    Some(Token::Interpolation((meta, crate::Interpolation::Linear))),
                     rest,
                 ),
                 "smooth" => (None, rest),

--- a/src/front/glsl_new/lex.rs
+++ b/src/front/glsl_new/lex.rs
@@ -121,7 +121,13 @@ pub fn consume_token(mut input: &str) -> (Option<Token>, &str) {
                     Some(Token::Interpolation((meta, crate::Interpolation::Linear))),
                     rest,
                 ),
-                "smooth" => (None, rest),
+                "smooth" => (
+                    Some(Token::Interpolation((
+                        meta,
+                        crate::Interpolation::Perspective,
+                    ))),
+                    rest,
+                ),
                 "centroid" => (
                     Some(Token::Interpolation((meta, crate::Interpolation::Centroid))),
                     rest,

--- a/src/front/glsl_new/parser.rs
+++ b/src/front/glsl_new/parser.rs
@@ -8,7 +8,7 @@ pomelo! {
         use super::super::{error::ErrorKind, token::*, ast::*};
         use crate::{Arena, BinaryOperator, Binding, Block, BuiltIn, Constant, ConstantInner, Expression,
             Function, GlobalVariable, Handle, LocalVariable, ScalarKind,
-            ShaderStage, Statement, StorageClass, Type, TypeInner, VectorSize, Bytes};
+            ShaderStage, Statement, StorageClass, Type, TypeInner, VectorSize, Bytes, Interpolation};
     }
     %token #[derive(Debug)] pub enum Token {};
     %parser pub struct Parser<'a> {};
@@ -99,6 +99,8 @@ pomelo! {
     %type type_qualifier Vec<TypeQualifier>;
     %type single_type_qualifier TypeQualifier;
     %type storage_qualifier StorageClass;
+    %type interpolation_qualifier Interpolation;
+    %type Interpolation Interpolation;
 
     // types
     %type fully_specified_type (Vec<TypeQualifier>, Option<Handle<Type>>);
@@ -151,6 +153,7 @@ pomelo! {
                             width: 4,
                         },
                     }),
+                    interpolation: None,
                 },
             );
             extra.lookup_global_variables.insert(v.1, h);
@@ -533,7 +536,9 @@ pomelo! {
         TypeQualifier::Binding(l)
     }
     // single_type_qualifier ::= precision_qualifier;
-    // single_type_qualifier ::= interpolation_qualifier;
+    single_type_qualifier ::= interpolation_qualifier(i) {
+        TypeQualifier::Interpolation(i)
+    }
     // single_type_qualifier ::= invariant_qualifier;
     // single_type_qualifier ::= precise_qualifier;
 
@@ -542,6 +547,7 @@ pomelo! {
     storage_qualifier ::= In {StorageClass::Input}
     storage_qualifier ::= Out {StorageClass::Output}
     //TODO: other storage qualifiers
+    interpolation_qualifier ::= Interpolation((_, i)) { i }
 
     initializer ::= assignment_expression;
     // initializer ::= LeftBrace initializer_list RightBrace;
@@ -735,6 +741,10 @@ pomelo! {
             if let TypeQualifier::Binding(b) = tq { Some(b.clone()) } else { None }
         });
 
+        let interpolation = d.type_qualifiers.iter().find_map(|tq| {
+            if let TypeQualifier::Interpolation(i) = tq { Some(i.clone()) } else { None }
+        });
+
         for (id, initializer) in d.ids_initializers {
             let h = extra.global_variables.fetch_or_append(
                 GlobalVariable {
@@ -742,6 +752,7 @@ pomelo! {
                     class,
                     binding: binding.clone(),
                     ty: d.ty,
+                    interpolation,
                 },
             );
             extra.lookup_global_variables.insert(id, h);

--- a/src/front/glsl_new/parser.rs
+++ b/src/front/glsl_new/parser.rs
@@ -743,6 +743,11 @@ pomelo! {
 
         let interpolation = d.type_qualifiers.iter().find_map(|tq| {
             if let TypeQualifier::Interpolation(i) = tq { Some(*i) } else { None }
+        }).or_else(|| match class {
+            StorageClass::Input | StorageClass::Output => {
+                Some(Interpolation::Perspective)
+            }
+            _ => None,
         });
 
         for (id, initializer) in d.ids_initializers {

--- a/src/front/glsl_new/parser.rs
+++ b/src/front/glsl_new/parser.rs
@@ -742,7 +742,7 @@ pomelo! {
         });
 
         let interpolation = d.type_qualifiers.iter().find_map(|tq| {
-            if let TypeQualifier::Interpolation(i) = tq { Some(i.clone()) } else { None }
+            if let TypeQualifier::Interpolation(i) = tq { Some(*i) } else { None }
         });
 
         for (id, initializer) in d.ids_initializers {

--- a/src/front/spv.rs
+++ b/src/front/spv.rs
@@ -497,20 +497,20 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                 inst.expect(base_words + 2)?;
                 dec.array_stride = NonZeroU32::new(self.next()?);
             }
-            spirv::Decoration::NoPerspective
-            | spirv::Decoration::Flat
-            | spirv::Decoration::Patch
-            | spirv::Decoration::Centroid
-            | spirv::Decoration::Sample => {
-                use spirv::Decoration::*;
-                dec.interpolation = Some(match dec_typed {
-                    NoPerspective => crate::Interpolation::Linear,
-                    Flat => crate::Interpolation::Flat,
-                    Patch => crate::Interpolation::Patch,
-                    Centroid => crate::Interpolation::Centroid,
-                    Sample => crate::Interpolation::Sample,
-                    _ => unreachable!(),
-                });
+            spirv::Decoration::NoPerspective => {
+                dec.interpolation = Some(crate::Interpolation::Linear);
+            }
+            spirv::Decoration::Flat => {
+                dec.interpolation = Some(crate::Interpolation::Flat);
+            }
+            spirv::Decoration::Patch => {
+                dec.interpolation = Some(crate::Interpolation::Patch);
+            }
+            spirv::Decoration::Centroid => {
+                dec.interpolation = Some(crate::Interpolation::Centroid);
+            }
+            spirv::Decoration::Sample => {
+                dec.interpolation = Some(crate::Interpolation::Sample);
             }
             other => {
                 log::warn!("Unknown decoration {:?}", other);

--- a/src/front/wgsl.rs
+++ b/src/front/wgsl.rs
@@ -999,17 +999,9 @@ impl Parser {
                             offset = lexer.next_uint_literal()?;
                             ready = false;
                         }
-                        Token::Word(word) if ready => {
-                            if let Ok(found) = Self::get_interpolation(word) {
-                                ready = false;
-                                if interpolation.is_none() {
-                                    interpolation = Some(found);
-                                } else {
-                                    return Err(Error::Unexpected(Token::Word(word)));
-                                }
-                            } else {
-                                return Err(Error::UnknownDecoration(word));
-                            }
+                        Token::Word("interpolate") if ready => {
+                            interpolation = Some(Self::get_interpolation(lexer.next_ident()?)?);
+                            ready = false;
                         }
                         other => return Err(Error::Unexpected(other)),
                     }
@@ -1454,14 +1446,10 @@ impl Parser {
                     "set" => {
                         bind_set = Some(lexer.next_uint_literal()?);
                     }
-                    word => {
-                        // if match expressions supported `if let`, this could be cleaner.
-                        if let Ok(found) = Self::get_interpolation(word) {
-                            interpolation = Some(found);
-                        } else {
-                            return Err(Error::UnknownDecoration(word));
-                        }
+                    "interpolate" => {
+                        interpolation = Some(Self::get_interpolation(lexer.next_ident()?)?);
                     }
+                    word => return Err(Error::UnknownDecoration(word)),
                 }
                 match lexer.next() {
                     Token::DoubleParen(']') => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,26 @@ pub enum MemberOrigin {
     Offset(u32),
 }
 
+/// The interpolation qualifier of a binding or struct field.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+pub enum Interpolation {
+    /// Indicates that linear, non-perspective, correct
+    //// interpolation must be used.
+    NoPerspective,
+    /// Indicates that no interpolation will be performed.
+    Flat,
+    /// Indicates a tessellation patch.
+    Patch,
+    /// When used with multi-sampling rasterization, allow
+    /// a single interpolation location for an entire pixel.
+    Centroid,
+    /// When used with multi-sampling rasterization, require
+    /// per-sample interpolation.
+    Sample,
+}
+
 /// Member of a user-defined structure.
 // Clone is used only for error reporting and is not intended for end users
 #[derive(Clone, Debug, PartialEq)]
@@ -162,6 +182,7 @@ pub struct StructMember {
     pub name: Option<String>,
     pub origin: MemberOrigin,
     pub ty: Handle<Type>,
+    pub interpolation: Option<Interpolation>,
 }
 
 /// The number of dimensions an image has.
@@ -316,6 +337,8 @@ pub struct GlobalVariable {
     pub binding: Option<Binding>,
     /// The type of this variable.
     pub ty: Handle<Type>,
+    /// The interpolation qualifier, if any.
+    pub interpolation: Option<Interpolation>,
 }
 
 /// Variable defined at function level.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,6 +342,8 @@ pub struct GlobalVariable {
     /// The type of this variable.
     pub ty: Handle<Type>,
     /// The interpolation qualifier, if any.
+    /// Required for global outputs in vertex shaders
+    /// and global inputs in fragment shaders.
     pub interpolation: Option<Interpolation>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,9 +158,13 @@ pub enum MemberOrigin {
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub enum Interpolation {
+    /// The value will be interpolated in a perspective-correct fashion.
+    /// Also known as "smooth" in glsl.
+    Perspective,
     /// Indicates that linear, non-perspective, correct
-    //// interpolation must be used.
-    NoPerspective,
+    /// interpolation must be used.
+    /// Also known as "no_perspective" in glsl.
+    Linear,
     /// Indicates that no interpolation will be performed.
     Flat,
     /// Indicates a tessellation patch.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,6 @@ pub struct StructMember {
     pub name: Option<String>,
     pub origin: MemberOrigin,
     pub ty: Handle<Type>,
-    pub interpolation: Option<Interpolation>,
 }
 
 /// The number of dimensions an image has.


### PR DESCRIPTION
This pr adds interpolation qualifier support to naga itself, as well as all frontends and all backends except `msl` (I don't know `msl` well enough). You may notice that includes `wgsl`. While there has been no official declaration of how interpolation qualifiers will make their way into wgsl, [this](https://github.com/gpuweb/gpuweb/issues/802) issue gave some good options, and I went with the one (the second) that seemed better to me. Easy enough to change down the line.

While I was able to test most of these, the spirv frontend was having issues that were unrelated to my changes and so I couldn't test it.