### PR TITLE
glsl-out: Less allocations, handle struct member origin and correctly handle empty names

### DIFF
--- a/src/back/glsl.rs
+++ b/src/back/glsl.rs
@@ -1408,10 +1408,10 @@ fn write_struct(
 }
 
 fn is_valid_ident(ident: &str) -> bool {
-    !(ident.starts_with(|c: char| !(c.is_ascii_alphabetic() || c == '_'))
-        || ident.contains(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
-        || ident.starts_with("gl_")
-        || ident == "main")
+    ident.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_')
+        || ident.contains(|c: char| c.is_ascii_alphanumeric() || c == '_')
+        || !ident.starts_with("gl_")
+        || ident != "main"
 }
 
 fn builtin_to_glsl(builtin: BuiltIn) -> &'static str {


### PR DESCRIPTION
This PR reduces the calls to `clone` in half and replaces it with a `Cow`, the use of `beef` here could probably speed up things and save some bytes.

It also handles `MemberOrigin` in structs so that `BuiltIn` works and detects empty names (`""`) as invalid idents