### PR TITLE
[glsl-new] Refactor type handling

### DIFF
--- a/src/front/glsl_new/mod.rs
+++ b/src/front/glsl_new/mod.rs
@@ -14,6 +14,7 @@ mod parser;
 #[cfg(test)]
 mod parser_tests;
 mod token;
+mod types;
 
 #[cfg(all(test, feature = "serialize"))]
 mod rosetta_tests;

--- a/src/front/glsl_new/parser.rs
+++ b/src/front/glsl_new/parser.rs
@@ -7,7 +7,7 @@ pomelo! {
         use super::super::{error::ErrorKind, token::*, ast::*};
         use crate::{Arena, BinaryOperator, Binding, Block, BuiltIn, Constant, ConstantInner, Expression,
             Function, GlobalVariable, Handle, LocalVariable, ScalarKind,
-            ShaderStage, Statement, StorageClass, Type, TypeInner, VectorSize, Bytes, Interpolation};
+            ShaderStage, Statement, StorageClass, Type, TypeInner, VectorSize, Interpolation};
     }
     %token #[derive(Debug)] pub enum Token {};
     %parser pub struct Parser<'a> {};

--- a/src/front/glsl_new/parser.rs
+++ b/src/front/glsl_new/parser.rs
@@ -106,9 +106,7 @@ pomelo! {
     %type type_specifier Option<Handle<Type>>;
     %type type_specifier_nonarray Option<Type>;
 
-    %type Vec (VectorSize, ScalarKind, Bytes);
-    %type Mat (VectorSize, VectorSize, ScalarKind, Bytes);
-
+    %type TypeName Type;
 
     root ::= version_pragma translation_unit;
     version_pragma ::= Version IntConstant(V) Identifier?(P) {
@@ -670,73 +668,7 @@ pomelo! {
     }
 
     type_specifier_nonarray ::= Void { None }
-    // Scalars
-    type_specifier_nonarray ::= Bool {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Scalar {
-                kind: ScalarKind::Bool,
-                width: 4, // https://stackoverflow.com/questions/9419781/what-is-the-size-of-glsl-boolean
-            }
-        })
-    }
-    type_specifier_nonarray ::= Float {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Scalar {
-                kind: ScalarKind::Float,
-                width: 4,
-            }
-        })
-    }
-    type_specifier_nonarray ::= Double {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Scalar {
-                kind: ScalarKind::Float,
-                width: 8,
-            }
-        })
-    }
-    type_specifier_nonarray ::= Int {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Scalar {
-                kind: ScalarKind::Sint,
-                width: 4,
-            }
-        })
-    }
-    type_specifier_nonarray ::= Uint {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Scalar {
-                kind: ScalarKind::Uint,
-                width: 4,
-            }
-        })
-    }
-    type_specifier_nonarray ::= Vec((_, (size, kind, width))) {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Vector {
-                size,
-                kind,
-                width,
-            }
-        })
-    }
-    type_specifier_nonarray ::= Mat((_, (columns, rows, kind, width))) {
-        Some(Type {
-            name: None,
-            inner: TypeInner::Matrix {
-                columns,
-                rows,
-                kind,
-                width,
-            }
-        })
-    }
+    type_specifier_nonarray ::= TypeName(t) {Some(t.1)};
 
     // misc
     translation_unit ::= external_declaration;

--- a/src/front/glsl_new/types.rs
+++ b/src/front/glsl_new/types.rs
@@ -1,0 +1,106 @@
+use crate::{ScalarKind, Type, TypeInner, VectorSize};
+
+pub fn parse_type(type_name: &str) -> Option<Type> {
+    match type_name {
+        "bool" => Some(Type {
+            name: None,
+            inner: TypeInner::Scalar {
+                kind: ScalarKind::Bool,
+                width: 4, // https://stackoverflow.com/questions/9419781/what-is-the-size-of-glsl-boolean
+            },
+        }),
+        "float" => Some(Type {
+            name: None,
+            inner: TypeInner::Scalar {
+                kind: ScalarKind::Float,
+                width: 4,
+            },
+        }),
+        "double" => Some(Type {
+            name: None,
+            inner: TypeInner::Scalar {
+                kind: ScalarKind::Float,
+                width: 8,
+            },
+        }),
+        "int" => Some(Type {
+            name: None,
+            inner: TypeInner::Scalar {
+                kind: ScalarKind::Sint,
+                width: 4,
+            },
+        }),
+        "uint" => Some(Type {
+            name: None,
+            inner: TypeInner::Scalar {
+                kind: ScalarKind::Uint,
+                width: 4,
+            },
+        }),
+        word => {
+            fn kind_width_parse(ty: &str) -> Option<(ScalarKind, u8)> {
+                Some(match ty {
+                    "" => (ScalarKind::Float, 4),
+                    "b" => (ScalarKind::Bool, 4),
+                    "i" => (ScalarKind::Sint, 4),
+                    "u" => (ScalarKind::Uint, 4),
+                    "d" => (ScalarKind::Float, 8),
+                    _ => return None,
+                })
+            }
+
+            fn size_parse(n: &str) -> Option<VectorSize> {
+                Some(match n {
+                    "2" => VectorSize::Bi,
+                    "3" => VectorSize::Tri,
+                    "4" => VectorSize::Quad,
+                    _ => return None,
+                })
+            }
+
+            let vec_parse = |word: &str| {
+                let mut iter = word.split("vec");
+
+                let kind = iter.next()?;
+                let size = iter.next()?;
+                let (kind, width) = kind_width_parse(kind)?;
+                let size = size_parse(size)?;
+
+                Some(Type {
+                    name: None,
+                    inner: TypeInner::Vector { size, kind, width },
+                })
+            };
+
+            let mat_parse = |word: &str| {
+                let mut iter = word.split("mat");
+
+                let kind = iter.next()?;
+                let size = iter.next()?;
+                let (kind, width) = kind_width_parse(kind)?;
+
+                let (columns, rows) = if let Some(size) = size_parse(size) {
+                    (size, size)
+                } else {
+                    let mut iter = size.split('x');
+                    match (iter.next()?, iter.next()?, iter.next()) {
+                        (col, row, None) => (size_parse(col)?, size_parse(row)?),
+                        _ => return None,
+                    }
+                };
+
+                Some(Type {
+                    name: None,
+                    inner: TypeInner::Matrix {
+                        columns,
+                        rows,
+                        kind,
+                        width,
+                    },
+                })
+            };
+
+            vec_parse(word).or_else(|| mat_parse(word))
+        }
+    }
+}


### PR DESCRIPTION
Basically takes moves type handling out of `parser.rs` and `lex.rs` into `types.rs` in order to reduce their complexity