### PR TITLE
Make TypeInner to be non-clonable

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -138,6 +138,14 @@ impl<T> Arena<T> {
         Handle::new(index)
     }
 
+    /// Fetch a handle to an existing type.
+    pub fn fetch_if<F: Fn(&T) -> bool>(&self, fun: F) -> Option<Handle<T>> {
+        self.data
+            .iter()
+            .position(fun)
+            .map(|index| Handle::new(unsafe { Index::new_unchecked((index + 1) as u32) }))
+    }
+
     /// Adds a value with a custom check for uniqueness:
     /// returns a handle pointing to
     /// an existing element if the check succeeds, or adds a new

--- a/src/back/mod.rs
+++ b/src/back/mod.rs
@@ -5,3 +5,26 @@ pub mod glsl;
 pub mod msl;
 #[cfg(feature = "spirv-out")]
 pub mod spv;
+
+#[derive(Debug)]
+pub enum MaybeOwned<'a, T: 'a> {
+    Borrowed(&'a T),
+    Owned(T),
+}
+
+impl<T> MaybeOwned<'_, T> {
+    fn borrow(&self) -> &T {
+        match *self {
+            MaybeOwned::Borrowed(inner) => inner,
+            MaybeOwned::Owned(ref inner) => inner,
+        }
+    }
+}
+
+pub type BorrowType<'a> = MaybeOwned<'a, crate::TypeInner>;
+
+impl crate::Module {
+    fn borrow_type(&self, handle: crate::Handle<crate::Type>) -> BorrowType {
+        MaybeOwned::Borrowed(&self.types[handle].inner)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,8 +254,7 @@ pub struct Type {
 }
 
 /// Enum with additional information, depending on the kind of type.
-// Clone is used only for error reporting and is not intended for end users
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub enum TypeInner {

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -4,5 +4,5 @@ mod interface;
 mod typifier;
 mod validator;
 
-pub use typifier::{check_constant_types, ResolveError, Typifier, UnexpectedConstantTypeError};
+pub use typifier::{check_constant_type, ResolveError, Typifier};
 pub use validator::{ValidationError, Validator};

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -1,7 +1,4 @@
-use crate::{
-    arena::{Arena, Handle},
-    Type, TypeInner, VectorSize,
-};
+use crate::arena::{Arena, Handle};
 
 use thiserror::Error;
 
@@ -29,29 +26,35 @@ impl Typifier {
         &mut self,
         expr_handle: Handle<crate::Expression>,
         expressions: &Arena<crate::Expression>,
-        types: &mut Arena<crate::Type>,
+        arena: &mut Arena<crate::Type>,
         constants: &Arena<crate::Constant>,
         global_vars: &Arena<crate::GlobalVariable>,
         local_vars: &Arena<crate::LocalVariable>,
         functions: &Arena<crate::Function>,
+        parameter_types: &[Handle<crate::Type>],
     ) -> Result<Handle<crate::Type>, ResolveError> {
+        #[derive(Debug)]
+        enum Resolution {
+            Handle(crate::Handle<crate::Type>),
+            Value(crate::TypeInner),
+        }
+
         if self.types.len() <= expr_handle.index() {
             for (eh, expr) in expressions.iter().skip(self.types.len()) {
-                let ty = match *expr {
+                let resolution = match *expr {
                     crate::Expression::Access { base, .. } => {
-                        match types[self.types[base.index()]].inner {
-                            crate::TypeInner::Array { base, .. } => base,
+                        match arena[self.types[base.index()]].inner {
+                            crate::TypeInner::Array { base, .. } => Resolution::Handle(base),
                             ref other => panic!("Can't access into {:?}", other),
                         }
                     }
                     crate::Expression::AccessIndex { base, index } => {
-                        match types[self.types[base.index()]].inner {
+                        match arena[self.types[base.index()]].inner {
                             crate::TypeInner::Vector { size, kind, width } => {
                                 if index >= size as u32 {
                                     return Err(ResolveError::InvalidAccessIndex);
                                 }
-                                let inner = crate::TypeInner::Scalar { kind, width };
-                                Self::deduce_type_handle(inner, types)
+                                Resolution::Value(crate::TypeInner::Scalar { kind, width })
                             }
                             crate::TypeInner::Matrix {
                                 columns,
@@ -62,89 +65,92 @@ impl Typifier {
                                 if index >= columns as u32 {
                                     return Err(ResolveError::InvalidAccessIndex);
                                 }
-                                let inner = crate::TypeInner::Vector {
+                                Resolution::Value(crate::TypeInner::Vector {
                                     size: rows,
                                     kind,
                                     width,
-                                };
-                                Self::deduce_type_handle(inner, types)
+                                })
                             }
-                            crate::TypeInner::Array { base, .. } => base,
+                            crate::TypeInner::Array { base, .. } => Resolution::Handle(base),
                             crate::TypeInner::Struct { ref members } => {
-                                members
+                                let member = members
                                     .get(index as usize)
-                                    .ok_or(ResolveError::InvalidAccessIndex)?
-                                    .ty
+                                    .ok_or(ResolveError::InvalidAccessIndex)?;
+                                Resolution::Handle(member.ty)
                             }
                             ref other => panic!("Can't access into {:?}", other),
                         }
                     }
-                    crate::Expression::Constant(h) => constants[h].ty,
-                    crate::Expression::Compose { ty, .. } => ty,
-                    crate::Expression::FunctionParameter(_) => unimplemented!(),
-                    crate::Expression::GlobalVariable(h) => global_vars[h].ty,
-                    crate::Expression::LocalVariable(h) => local_vars[h].ty,
+                    crate::Expression::Constant(h) => Resolution::Handle(constants[h].ty),
+                    crate::Expression::Compose { ty, .. } => Resolution::Handle(ty),
+                    crate::Expression::FunctionParameter(index) => {
+                        Resolution::Handle(parameter_types[index as usize])
+                    }
+                    crate::Expression::GlobalVariable(h) => Resolution::Handle(global_vars[h].ty),
+                    crate::Expression::LocalVariable(h) => Resolution::Handle(local_vars[h].ty),
                     crate::Expression::Load { .. } => unimplemented!(),
                     crate::Expression::ImageSample { image, .. }
                     | crate::Expression::ImageLoad { image, .. } => {
                         let image = self.resolve(
                             image,
                             expressions,
-                            types,
+                            arena,
                             constants,
                             global_vars,
                             local_vars,
                             functions,
+                            parameter_types,
                         )?;
 
-                        let inner = match types[image].inner {
-                            TypeInner::Image {
+                        Resolution::Value(match arena[image].inner {
+                            crate::TypeInner::Image {
                                 kind,
                                 class: crate::ImageClass::Depth,
                                 ..
-                            } => TypeInner::Scalar { kind, width: 4 },
-                            TypeInner::Image { kind, .. } => TypeInner::Vector {
+                            } => crate::TypeInner::Scalar { kind, width: 4 },
+                            crate::TypeInner::Image { kind, .. } => crate::TypeInner::Vector {
                                 kind,
                                 width: 4,
-                                size: VectorSize::Quad,
+                                size: crate::VectorSize::Quad,
                             },
                             _ => unreachable!(),
-                        };
-
-                        types.fetch_or_append(Type { name: None, inner })
+                        })
                     }
-                    crate::Expression::Unary { expr, .. } => self.types[expr.index()],
+                    crate::Expression::Unary { expr, .. } => {
+                        Resolution::Handle(self.types[expr.index()])
+                    }
                     crate::Expression::Binary { op, left, right } => match op {
                         crate::BinaryOperator::Add
                         | crate::BinaryOperator::Subtract
                         | crate::BinaryOperator::Divide
-                        | crate::BinaryOperator::Modulo => self.types[left.index()],
+                        | crate::BinaryOperator::Modulo => {
+                            Resolution::Handle(self.types[left.index()])
+                        }
                         crate::BinaryOperator::Multiply => {
                             let ty_left = self.types[left.index()];
                             let ty_right = self.types[right.index()];
                             if ty_left == ty_right {
-                                ty_left
-                            } else if let crate::TypeInner::Scalar { .. } = types[ty_right].inner {
-                                ty_left
-                            } else if let crate::TypeInner::Scalar { .. } = types[ty_left].inner {
-                                ty_right
+                                Resolution::Handle(ty_left)
+                            } else if let crate::TypeInner::Scalar { .. } = arena[ty_right].inner {
+                                Resolution::Handle(ty_left)
+                            } else if let crate::TypeInner::Scalar { .. } = arena[ty_left].inner {
+                                Resolution::Handle(ty_right)
                             } else if let crate::TypeInner::Matrix {
                                 columns,
                                 kind,
                                 width,
                                 ..
-                            } = types[ty_left].inner
+                            } = arena[ty_left].inner
                             {
-                                let inner = crate::TypeInner::Vector {
+                                Resolution::Value(crate::TypeInner::Vector {
                                     size: columns,
                                     kind,
                                     width,
-                                };
-                                Self::deduce_type_handle(inner, types)
+                                })
                             } else {
                                 panic!(
                                     "Incompatible arguments {:?} x {:?}",
-                                    types[ty_left], types[ty_right]
+                                    arena[ty_left], arena[ty_right]
                                 );
                             }
                         }
@@ -155,60 +161,61 @@ impl Typifier {
                         | crate::BinaryOperator::Greater
                         | crate::BinaryOperator::GreaterEqual
                         | crate::BinaryOperator::LogicalAnd
-                        | crate::BinaryOperator::LogicalOr => self.types[left.index()],
+                        | crate::BinaryOperator::LogicalOr => {
+                            Resolution::Handle(self.types[left.index()])
+                        }
                         crate::BinaryOperator::And
                         | crate::BinaryOperator::ExclusiveOr
                         | crate::BinaryOperator::InclusiveOr
                         | crate::BinaryOperator::ShiftLeftLogical
                         | crate::BinaryOperator::ShiftRightLogical
-                        | crate::BinaryOperator::ShiftRightArithmetic => self.types[left.index()],
+                        | crate::BinaryOperator::ShiftRightArithmetic => {
+                            Resolution::Handle(self.types[left.index()])
+                        }
                     },
                     crate::Expression::Intrinsic { .. } => unimplemented!(),
                     crate::Expression::Transpose(expr) => {
                         let ty_handle = self.types[expr.index()];
-                        let inner = match types[ty_handle].inner {
+                        match arena[ty_handle].inner {
                             crate::TypeInner::Matrix {
                                 columns,
                                 rows,
                                 kind,
                                 width,
-                            } => crate::TypeInner::Matrix {
+                            } => Resolution::Value(crate::TypeInner::Matrix {
                                 columns: rows,
                                 rows: columns,
                                 kind,
                                 width,
-                            },
+                            }),
                             ref other => panic!("incompatible transpose of {:?}", other),
-                        };
-                        types.fetch_or_append(Type { name: None, inner })
+                        }
                     }
                     crate::Expression::DotProduct(left_expr, _) => {
                         let left_ty = self.types[left_expr.index()];
-                        let inner = match types[left_ty].inner {
+                        match arena[left_ty].inner {
                             crate::TypeInner::Vector {
                                 kind,
                                 size: _,
                                 width,
-                            } => crate::TypeInner::Scalar { kind, width },
+                            } => Resolution::Value(crate::TypeInner::Scalar { kind, width }),
                             ref other => panic!("incompatible dot of {:?}", other),
-                        };
-                        types.fetch_or_append(Type { name: None, inner })
+                        }
                     }
                     crate::Expression::CrossProduct(_, _) => unimplemented!(),
                     crate::Expression::As(expr, kind) => {
                         let ty_handle = self.types[expr.index()];
-                        let inner = match types[ty_handle].inner {
+                        match arena[ty_handle].inner {
                             crate::TypeInner::Scalar { kind: _, width } => {
-                                crate::TypeInner::Scalar { kind, width }
+                                Resolution::Value(crate::TypeInner::Scalar { kind, width })
                             }
                             crate::TypeInner::Vector {
                                 kind: _,
                                 size,
                                 width,
-                            } => crate::TypeInner::Vector { kind, size, width },
+                            } => Resolution::Value(crate::TypeInner::Vector { kind, size, width }),
                             ref other => panic!("incompatible as of {:?}", other),
-                        };
-                        types.fetch_or_append(Type { name: None, inner })
+                        }
                     }
                     crate::Expression::Derivative { .. } => unimplemented!(),
                     crate::Expression::Call {
@@ -217,41 +224,39 @@ impl Typifier {
                     } => match name.as_str() {
                         "distance" | "length" | "dot" => {
                             let ty_handle = self.types[arguments[0].index()];
-                            let inner = match types[ty_handle].inner {
+                            match arena[ty_handle].inner {
                                 crate::TypeInner::Vector { kind, width, .. } => {
-                                    crate::TypeInner::Scalar { kind, width }
+                                    Resolution::Value(crate::TypeInner::Scalar { kind, width })
                                 }
                                 ref other => panic!("Unexpected argument {:?}", other),
-                            };
-                            Self::deduce_type_handle(inner, types)
+                            }
                         }
                         "normalize" | "fclamp" | "max" | "reflect" | "pow" | "clamp" | "mix" => {
-                            self.types[arguments[0].index()]
+                            Resolution::Handle(self.types[arguments[0].index()])
                         }
                         _ => return Err(ResolveError::FunctionNotDefined { name: name.clone() }),
                     },
                     crate::Expression::Call {
                         origin: crate::FunctionOrigin::Local(handle),
                         arguments: _,
-                    } => functions[handle]
-                        .return_type
-                        .ok_or(ResolveError::FunctionReturnsVoid)?,
+                    } => {
+                        let ty = functions[handle]
+                            .return_type
+                            .ok_or(ResolveError::FunctionReturnsVoid)?;
+                        Resolution::Handle(ty)
+                    }
                 };
-                log::debug!("Resolving {:?} = {:?} : {:?}", eh, expr, ty);
-                self.types.push(ty);
+                log::debug!("Resolving {:?} = {:?} : {:?}", eh, expr, resolution);
+                self.types.push(match resolution {
+                    Resolution::Handle(h) => h,
+                    Resolution::Value(inner) => arena
+                        .fetch_if_or_append(crate::Type { name: None, inner }, |a, b| {
+                            a.inner == b.inner
+                        }),
+                });
             }
         }
         Ok(self.types[expr_handle.index()])
-    }
-
-    pub fn deduce_type_handle(
-        inner: crate::TypeInner,
-        arena: &mut Arena<crate::Type>,
-    ) -> Handle<crate::Type> {
-        if let Some((token, _)) = arena.iter().find(|(_, ty)| ty.inner == inner) {
-            return token;
-        }
-        arena.append(crate::Type { name: None, inner })
     }
 }
 

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -14,11 +14,221 @@ pub enum ResolveError {
     FunctionNotDefined { name: String },
     #[error("Function without return type")]
     FunctionReturnsVoid,
+    #[error("Type is not found in the given immutable arena")]
+    TypeNotFound,
+}
+
+#[derive(Debug)]
+enum Resolution {
+    Handle(crate::Handle<crate::Type>),
+    Value(crate::TypeInner),
 }
 
 impl Typifier {
     pub fn new() -> Self {
         Typifier { types: Vec::new() }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn resolve_impl(
+        &self,
+        expr: &crate::Expression,
+        arena: &Arena<crate::Type>,
+        constants: &Arena<crate::Constant>,
+        global_vars: &Arena<crate::GlobalVariable>,
+        local_vars: &Arena<crate::LocalVariable>,
+        functions: &Arena<crate::Function>,
+        parameter_types: &[Handle<crate::Type>],
+    ) -> Result<Resolution, ResolveError> {
+        Ok(match *expr {
+            crate::Expression::Access { base, .. } => match arena[self.types[base.index()]].inner {
+                crate::TypeInner::Array { base, .. } => Resolution::Handle(base),
+                ref other => panic!("Can't access into {:?}", other),
+            },
+            crate::Expression::AccessIndex { base, index } => {
+                match arena[self.types[base.index()]].inner {
+                    crate::TypeInner::Vector { size, kind, width } => {
+                        if index >= size as u32 {
+                            return Err(ResolveError::InvalidAccessIndex);
+                        }
+                        Resolution::Value(crate::TypeInner::Scalar { kind, width })
+                    }
+                    crate::TypeInner::Matrix {
+                        columns,
+                        rows,
+                        kind,
+                        width,
+                    } => {
+                        if index >= columns as u32 {
+                            return Err(ResolveError::InvalidAccessIndex);
+                        }
+                        Resolution::Value(crate::TypeInner::Vector {
+                            size: rows,
+                            kind,
+                            width,
+                        })
+                    }
+                    crate::TypeInner::Array { base, .. } => Resolution::Handle(base),
+                    crate::TypeInner::Struct { ref members } => {
+                        let member = members
+                            .get(index as usize)
+                            .ok_or(ResolveError::InvalidAccessIndex)?;
+                        Resolution::Handle(member.ty)
+                    }
+                    ref other => panic!("Can't access into {:?}", other),
+                }
+            }
+            crate::Expression::Constant(h) => Resolution::Handle(constants[h].ty),
+            crate::Expression::Compose { ty, .. } => Resolution::Handle(ty),
+            crate::Expression::FunctionParameter(index) => {
+                Resolution::Handle(parameter_types[index as usize])
+            }
+            crate::Expression::GlobalVariable(h) => Resolution::Handle(global_vars[h].ty),
+            crate::Expression::LocalVariable(h) => Resolution::Handle(local_vars[h].ty),
+            crate::Expression::Load { .. } => unimplemented!(),
+            crate::Expression::ImageSample { image, .. }
+            | crate::Expression::ImageLoad { image, .. } => {
+                let image_ty = self.types[image.index()];
+                match arena[image_ty].inner {
+                    crate::TypeInner::Image {
+                        kind,
+                        class: crate::ImageClass::Depth,
+                        ..
+                    } => Resolution::Value(crate::TypeInner::Scalar { kind, width: 4 }),
+                    crate::TypeInner::Image { kind, .. } => {
+                        Resolution::Value(crate::TypeInner::Vector {
+                            kind,
+                            width: 4,
+                            size: crate::VectorSize::Quad,
+                        })
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            crate::Expression::Unary { expr, .. } => Resolution::Handle(self.types[expr.index()]),
+            crate::Expression::Binary { op, left, right } => match op {
+                crate::BinaryOperator::Add
+                | crate::BinaryOperator::Subtract
+                | crate::BinaryOperator::Divide
+                | crate::BinaryOperator::Modulo => Resolution::Handle(self.types[left.index()]),
+                crate::BinaryOperator::Multiply => {
+                    let ty_left = self.types[left.index()];
+                    let ty_right = self.types[right.index()];
+                    if ty_left == ty_right {
+                        Resolution::Handle(ty_left)
+                    } else if let crate::TypeInner::Scalar { .. } = arena[ty_right].inner {
+                        Resolution::Handle(ty_left)
+                    } else if let crate::TypeInner::Scalar { .. } = arena[ty_left].inner {
+                        Resolution::Handle(ty_right)
+                    } else if let crate::TypeInner::Matrix {
+                        columns,
+                        kind,
+                        width,
+                        ..
+                    } = arena[ty_left].inner
+                    {
+                        Resolution::Value(crate::TypeInner::Vector {
+                            size: columns,
+                            kind,
+                            width,
+                        })
+                    } else {
+                        panic!(
+                            "Incompatible arguments {:?} x {:?}",
+                            arena[ty_left], arena[ty_right]
+                        );
+                    }
+                }
+                crate::BinaryOperator::Equal
+                | crate::BinaryOperator::NotEqual
+                | crate::BinaryOperator::Less
+                | crate::BinaryOperator::LessEqual
+                | crate::BinaryOperator::Greater
+                | crate::BinaryOperator::GreaterEqual
+                | crate::BinaryOperator::LogicalAnd
+                | crate::BinaryOperator::LogicalOr => Resolution::Handle(self.types[left.index()]),
+                crate::BinaryOperator::And
+                | crate::BinaryOperator::ExclusiveOr
+                | crate::BinaryOperator::InclusiveOr
+                | crate::BinaryOperator::ShiftLeftLogical
+                | crate::BinaryOperator::ShiftRightLogical
+                | crate::BinaryOperator::ShiftRightArithmetic => {
+                    Resolution::Handle(self.types[left.index()])
+                }
+            },
+            crate::Expression::Intrinsic { .. } => unimplemented!(),
+            crate::Expression::Transpose(expr) => {
+                let ty_handle = self.types[expr.index()];
+                match arena[ty_handle].inner {
+                    crate::TypeInner::Matrix {
+                        columns,
+                        rows,
+                        kind,
+                        width,
+                    } => Resolution::Value(crate::TypeInner::Matrix {
+                        columns: rows,
+                        rows: columns,
+                        kind,
+                        width,
+                    }),
+                    ref other => panic!("incompatible transpose of {:?}", other),
+                }
+            }
+            crate::Expression::DotProduct(left_expr, _) => {
+                let left_ty = self.types[left_expr.index()];
+                match arena[left_ty].inner {
+                    crate::TypeInner::Vector {
+                        kind,
+                        size: _,
+                        width,
+                    } => Resolution::Value(crate::TypeInner::Scalar { kind, width }),
+                    ref other => panic!("incompatible dot of {:?}", other),
+                }
+            }
+            crate::Expression::CrossProduct(_, _) => unimplemented!(),
+            crate::Expression::As(expr, kind) => {
+                let ty_handle = self.types[expr.index()];
+                match arena[ty_handle].inner {
+                    crate::TypeInner::Scalar { kind: _, width } => {
+                        Resolution::Value(crate::TypeInner::Scalar { kind, width })
+                    }
+                    crate::TypeInner::Vector {
+                        kind: _,
+                        size,
+                        width,
+                    } => Resolution::Value(crate::TypeInner::Vector { kind, size, width }),
+                    ref other => panic!("incompatible as of {:?}", other),
+                }
+            }
+            crate::Expression::Derivative { .. } => unimplemented!(),
+            crate::Expression::Call {
+                origin: crate::FunctionOrigin::External(ref name),
+                ref arguments,
+            } => match name.as_str() {
+                "distance" | "length" | "dot" => {
+                    let ty_handle = self.types[arguments[0].index()];
+                    match arena[ty_handle].inner {
+                        crate::TypeInner::Vector { kind, width, .. } => {
+                            Resolution::Value(crate::TypeInner::Scalar { kind, width })
+                        }
+                        ref other => panic!("Unexpected argument {:?}", other),
+                    }
+                }
+                "normalize" | "fclamp" | "max" | "reflect" | "pow" | "clamp" | "mix" => {
+                    Resolution::Handle(self.types[arguments[0].index()])
+                }
+                _ => return Err(ResolveError::FunctionNotDefined { name: name.clone() }),
+            },
+            crate::Expression::Call {
+                origin: crate::FunctionOrigin::Local(handle),
+                arguments: _,
+            } => {
+                let ty = functions[handle]
+                    .return_type
+                    .ok_or(ResolveError::FunctionReturnsVoid)?;
+                Resolution::Handle(ty)
+            }
+        })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -33,219 +243,17 @@ impl Typifier {
         functions: &Arena<crate::Function>,
         parameter_types: &[Handle<crate::Type>],
     ) -> Result<Handle<crate::Type>, ResolveError> {
-        #[derive(Debug)]
-        enum Resolution {
-            Handle(crate::Handle<crate::Type>),
-            Value(crate::TypeInner),
-        }
-
         if self.types.len() <= expr_handle.index() {
             for (eh, expr) in expressions.iter().skip(self.types.len()) {
-                let resolution = match *expr {
-                    crate::Expression::Access { base, .. } => {
-                        match arena[self.types[base.index()]].inner {
-                            crate::TypeInner::Array { base, .. } => Resolution::Handle(base),
-                            ref other => panic!("Can't access into {:?}", other),
-                        }
-                    }
-                    crate::Expression::AccessIndex { base, index } => {
-                        match arena[self.types[base.index()]].inner {
-                            crate::TypeInner::Vector { size, kind, width } => {
-                                if index >= size as u32 {
-                                    return Err(ResolveError::InvalidAccessIndex);
-                                }
-                                Resolution::Value(crate::TypeInner::Scalar { kind, width })
-                            }
-                            crate::TypeInner::Matrix {
-                                columns,
-                                rows,
-                                kind,
-                                width,
-                            } => {
-                                if index >= columns as u32 {
-                                    return Err(ResolveError::InvalidAccessIndex);
-                                }
-                                Resolution::Value(crate::TypeInner::Vector {
-                                    size: rows,
-                                    kind,
-                                    width,
-                                })
-                            }
-                            crate::TypeInner::Array { base, .. } => Resolution::Handle(base),
-                            crate::TypeInner::Struct { ref members } => {
-                                let member = members
-                                    .get(index as usize)
-                                    .ok_or(ResolveError::InvalidAccessIndex)?;
-                                Resolution::Handle(member.ty)
-                            }
-                            ref other => panic!("Can't access into {:?}", other),
-                        }
-                    }
-                    crate::Expression::Constant(h) => Resolution::Handle(constants[h].ty),
-                    crate::Expression::Compose { ty, .. } => Resolution::Handle(ty),
-                    crate::Expression::FunctionParameter(index) => {
-                        Resolution::Handle(parameter_types[index as usize])
-                    }
-                    crate::Expression::GlobalVariable(h) => Resolution::Handle(global_vars[h].ty),
-                    crate::Expression::LocalVariable(h) => Resolution::Handle(local_vars[h].ty),
-                    crate::Expression::Load { .. } => unimplemented!(),
-                    crate::Expression::ImageSample { image, .. }
-                    | crate::Expression::ImageLoad { image, .. } => {
-                        let image = self.resolve(
-                            image,
-                            expressions,
-                            arena,
-                            constants,
-                            global_vars,
-                            local_vars,
-                            functions,
-                            parameter_types,
-                        )?;
-
-                        Resolution::Value(match arena[image].inner {
-                            crate::TypeInner::Image {
-                                kind,
-                                class: crate::ImageClass::Depth,
-                                ..
-                            } => crate::TypeInner::Scalar { kind, width: 4 },
-                            crate::TypeInner::Image { kind, .. } => crate::TypeInner::Vector {
-                                kind,
-                                width: 4,
-                                size: crate::VectorSize::Quad,
-                            },
-                            _ => unreachable!(),
-                        })
-                    }
-                    crate::Expression::Unary { expr, .. } => {
-                        Resolution::Handle(self.types[expr.index()])
-                    }
-                    crate::Expression::Binary { op, left, right } => match op {
-                        crate::BinaryOperator::Add
-                        | crate::BinaryOperator::Subtract
-                        | crate::BinaryOperator::Divide
-                        | crate::BinaryOperator::Modulo => {
-                            Resolution::Handle(self.types[left.index()])
-                        }
-                        crate::BinaryOperator::Multiply => {
-                            let ty_left = self.types[left.index()];
-                            let ty_right = self.types[right.index()];
-                            if ty_left == ty_right {
-                                Resolution::Handle(ty_left)
-                            } else if let crate::TypeInner::Scalar { .. } = arena[ty_right].inner {
-                                Resolution::Handle(ty_left)
-                            } else if let crate::TypeInner::Scalar { .. } = arena[ty_left].inner {
-                                Resolution::Handle(ty_right)
-                            } else if let crate::TypeInner::Matrix {
-                                columns,
-                                kind,
-                                width,
-                                ..
-                            } = arena[ty_left].inner
-                            {
-                                Resolution::Value(crate::TypeInner::Vector {
-                                    size: columns,
-                                    kind,
-                                    width,
-                                })
-                            } else {
-                                panic!(
-                                    "Incompatible arguments {:?} x {:?}",
-                                    arena[ty_left], arena[ty_right]
-                                );
-                            }
-                        }
-                        crate::BinaryOperator::Equal
-                        | crate::BinaryOperator::NotEqual
-                        | crate::BinaryOperator::Less
-                        | crate::BinaryOperator::LessEqual
-                        | crate::BinaryOperator::Greater
-                        | crate::BinaryOperator::GreaterEqual
-                        | crate::BinaryOperator::LogicalAnd
-                        | crate::BinaryOperator::LogicalOr => {
-                            Resolution::Handle(self.types[left.index()])
-                        }
-                        crate::BinaryOperator::And
-                        | crate::BinaryOperator::ExclusiveOr
-                        | crate::BinaryOperator::InclusiveOr
-                        | crate::BinaryOperator::ShiftLeftLogical
-                        | crate::BinaryOperator::ShiftRightLogical
-                        | crate::BinaryOperator::ShiftRightArithmetic => {
-                            Resolution::Handle(self.types[left.index()])
-                        }
-                    },
-                    crate::Expression::Intrinsic { .. } => unimplemented!(),
-                    crate::Expression::Transpose(expr) => {
-                        let ty_handle = self.types[expr.index()];
-                        match arena[ty_handle].inner {
-                            crate::TypeInner::Matrix {
-                                columns,
-                                rows,
-                                kind,
-                                width,
-                            } => Resolution::Value(crate::TypeInner::Matrix {
-                                columns: rows,
-                                rows: columns,
-                                kind,
-                                width,
-                            }),
-                            ref other => panic!("incompatible transpose of {:?}", other),
-                        }
-                    }
-                    crate::Expression::DotProduct(left_expr, _) => {
-                        let left_ty = self.types[left_expr.index()];
-                        match arena[left_ty].inner {
-                            crate::TypeInner::Vector {
-                                kind,
-                                size: _,
-                                width,
-                            } => Resolution::Value(crate::TypeInner::Scalar { kind, width }),
-                            ref other => panic!("incompatible dot of {:?}", other),
-                        }
-                    }
-                    crate::Expression::CrossProduct(_, _) => unimplemented!(),
-                    crate::Expression::As(expr, kind) => {
-                        let ty_handle = self.types[expr.index()];
-                        match arena[ty_handle].inner {
-                            crate::TypeInner::Scalar { kind: _, width } => {
-                                Resolution::Value(crate::TypeInner::Scalar { kind, width })
-                            }
-                            crate::TypeInner::Vector {
-                                kind: _,
-                                size,
-                                width,
-                            } => Resolution::Value(crate::TypeInner::Vector { kind, size, width }),
-                            ref other => panic!("incompatible as of {:?}", other),
-                        }
-                    }
-                    crate::Expression::Derivative { .. } => unimplemented!(),
-                    crate::Expression::Call {
-                        origin: crate::FunctionOrigin::External(ref name),
-                        ref arguments,
-                    } => match name.as_str() {
-                        "distance" | "length" | "dot" => {
-                            let ty_handle = self.types[arguments[0].index()];
-                            match arena[ty_handle].inner {
-                                crate::TypeInner::Vector { kind, width, .. } => {
-                                    Resolution::Value(crate::TypeInner::Scalar { kind, width })
-                                }
-                                ref other => panic!("Unexpected argument {:?}", other),
-                            }
-                        }
-                        "normalize" | "fclamp" | "max" | "reflect" | "pow" | "clamp" | "mix" => {
-                            Resolution::Handle(self.types[arguments[0].index()])
-                        }
-                        _ => return Err(ResolveError::FunctionNotDefined { name: name.clone() }),
-                    },
-                    crate::Expression::Call {
-                        origin: crate::FunctionOrigin::Local(handle),
-                        arguments: _,
-                    } => {
-                        let ty = functions[handle]
-                            .return_type
-                            .ok_or(ResolveError::FunctionReturnsVoid)?;
-                        Resolution::Handle(ty)
-                    }
-                };
+                let resolution = self.resolve_impl(
+                    expr,
+                    arena,
+                    constants,
+                    global_vars,
+                    local_vars,
+                    functions,
+                    parameter_types,
+                )?;
                 log::debug!("Resolving {:?} = {:?} : {:?}", eh, expr, resolution);
                 self.types.push(match resolution {
                     Resolution::Handle(h) => h,
@@ -260,14 +268,7 @@ impl Typifier {
     }
 }
 
-#[derive(Clone, Debug, Error)]
-#[error("mismatched constant type {0:?} expected {1:?}")]
-pub struct UnexpectedConstantTypeError(crate::ConstantInner, crate::TypeInner);
-
-pub fn check_constant_types(
-    inner: &crate::ConstantInner,
-    type_inner: &crate::TypeInner,
-) -> Result<(), UnexpectedConstantTypeError> {
+pub fn check_constant_type(inner: &crate::ConstantInner, type_inner: &crate::TypeInner) -> bool {
     match (inner, type_inner) {
         (
             crate::ConstantInner::Sint(_),
@@ -275,32 +276,29 @@ pub fn check_constant_types(
                 kind: crate::ScalarKind::Sint,
                 width: _,
             },
-        ) => Ok(()),
+        ) => true,
         (
             crate::ConstantInner::Uint(_),
             crate::TypeInner::Scalar {
                 kind: crate::ScalarKind::Uint,
                 width: _,
             },
-        ) => Ok(()),
+        ) => true,
         (
             crate::ConstantInner::Float(_),
             crate::TypeInner::Scalar {
                 kind: crate::ScalarKind::Float,
                 width: _,
             },
-        ) => Ok(()),
+        ) => true,
         (
             crate::ConstantInner::Bool(_),
             crate::TypeInner::Scalar {
                 kind: crate::ScalarKind::Bool,
                 width: _,
             },
-        ) => Ok(()),
-        (crate::ConstantInner::Composite(_inner), _) => Ok(()), // TODO recursively check composite types
-        (other_inner, other_type_inner) => Err(UnexpectedConstantTypeError(
-            other_inner.clone(),
-            other_type_inner.clone(),
-        )),
+        ) => true,
+        (crate::ConstantInner::Composite(_inner), _) => true, // TODO recursively check composite types
+        (_, _) => false,
     }
 }


### PR DESCRIPTION
`TypeInner` generally can have heap allocation. Cloning it is not something that I expect we need, ever. It's stored in an arena, and it can always be referenced from it.
Previously, we derived `Clone` with a comment saying this is only meant to be used for error reporting. However, the genie gets out of the box, and it's tempting to use this clone universally once it's available.

So this PR puts the genie back into the box! In particular, it makes the `Error` of the backends to return references to types, and it makes both GLSL and MSL backends to share the same `MaybeOwned` type.