### PR TITLE
Implement Execution Modes

### DIFF
--- a/examples/convert.rs
+++ b/examples/convert.rs
@@ -91,7 +91,9 @@ fn main() {
                         naga::front::glsl_new::parse_str(
                             &input,
                             "main".to_string(),
-                            naga::ShaderStage::Fragment,
+                            naga::ShaderStage::Fragment {
+                                early_depth_test: None,
+                            },
                         )
                         .unwrap(),
                     )
@@ -104,7 +106,9 @@ fn main() {
                         naga::front::glsl::parse_str(
                             &input,
                             "main".to_string(),
-                            naga::ShaderStage::Fragment,
+                            naga::ShaderStage::Fragment {
+                                early_depth_test: None,
+                            },
                         )
                         .unwrap(),
                     )
@@ -115,8 +119,14 @@ fn main() {
         #[cfg(feature = "glsl")]
         "comp" => {
             let input = fs::read_to_string(&args[1]).unwrap();
-            naga::front::glsl::parse_str(&input, "main".to_string(), naga::ShaderStage::Compute)
-                .unwrap()
+            naga::front::glsl::parse_str(
+                &input,
+                "main".to_string(),
+                naga::ShaderStage::Compute {
+                    local_size: (0, 0, 0),
+                },
+            )
+            .unwrap()
         }
         #[cfg(feature = "deserialize")]
         "ron" => {
@@ -209,8 +219,12 @@ fn main() {
                     String::from("main"),
                     match stage {
                         "vert" => ShaderStage::Vertex,
-                        "frag" => ShaderStage::Fragment,
-                        "comp" => ShaderStage::Compute,
+                        "frag" => ShaderStage::Fragment {
+                            early_depth_test: None,
+                        },
+                        "comp" => ShaderStage::Compute {
+                            local_size: (0, 0, 0),
+                        },
                         _ => unreachable!(),
                     },
                 ),

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -271,8 +271,8 @@ impl Writer {
 
         let exec_model = match entry_point.stage {
             crate::ShaderStage::Vertex => spirv::ExecutionModel::Vertex,
-            crate::ShaderStage::Fragment => spirv::ExecutionModel::Fragment,
-            crate::ShaderStage::Compute => spirv::ExecutionModel::GLCompute,
+            crate::ShaderStage::Fragment { .. } => spirv::ExecutionModel::Fragment,
+            crate::ShaderStage::Compute { .. } => spirv::ExecutionModel::GLCompute,
         };
 
         instruction.add_operand(exec_model as u32);
@@ -298,13 +298,13 @@ impl Writer {
         self.try_add_capabilities(exec_model.required_capabilities());
         match entry_point.stage {
             crate::ShaderStage::Vertex => {}
-            crate::ShaderStage::Fragment => {
+            crate::ShaderStage::Fragment { .. } => {
                 let execution_mode = spirv::ExecutionMode::OriginUpperLeft;
                 self.try_add_capabilities(execution_mode.required_capabilities());
                 self.instruction_execution_mode(function_id, execution_mode)
                     .to_words(&mut self.logical_layout.execution_modes);
             }
-            crate::ShaderStage::Compute => {}
+            crate::ShaderStage::Compute { .. } => {}
         }
 
         if self.writer_flags.contains(WriterFlags::DEBUG) {

--- a/src/front/glsl/mod.rs
+++ b/src/front/glsl/mod.rs
@@ -638,7 +638,7 @@ impl<'a> Parser<'a> {
                             name: Some(name),
                             class: match self.shader_stage {
                                 ShaderStage::Vertex => StorageClass::Output,
-                                ShaderStage::Fragment => StorageClass::Input,
+                                ShaderStage::Fragment { .. } => StorageClass::Input,
                                 _ => panic!(),
                             },
                             binding: Some(Binding::BuiltIn(BuiltIn::Position)),
@@ -1327,7 +1327,13 @@ mod tests {
 
         println!(
             "{:#?}",
-            parse_str(data, String::from("main"), crate::ShaderStage::Fragment)
+            parse_str(
+                data,
+                String::from("main"),
+                crate::ShaderStage::Fragment {
+                    early_depth_test: None
+                }
+            )
         );
     }
 

--- a/src/front/spv/error.rs
+++ b/src/front/spv/error.rs
@@ -15,6 +15,7 @@ pub enum Error {
     UnsupportedExtInst(spirv::Word),
     UnsupportedType(Handle<crate::Type>),
     UnsupportedExecutionModel(spirv::Word),
+    UnsupportedExecutionMode(spirv::Word),
     UnsupportedStorageClass(spirv::Word),
     UnsupportedImageDim(spirv::Word),
     UnsupportedImageFormat(spirv::Word),

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -265,8 +265,12 @@ impl Parser {
     fn get_shader_stage(word: &str) -> Result<crate::ShaderStage, Error<'_>> {
         match word {
             "vertex" => Ok(crate::ShaderStage::Vertex),
-            "fragment" => Ok(crate::ShaderStage::Fragment),
-            "compute" => Ok(crate::ShaderStage::Compute),
+            "fragment" => Ok(crate::ShaderStage::Fragment {
+                early_depth_test: None,
+            }),
+            "compute" => Ok(crate::ShaderStage::Compute {
+                local_size: (0, 0, 0),
+            }),
             _ => Err(Error::UnknownShaderStage(word)),
         }
     }

--- a/tests/convert.rs
+++ b/tests/convert.rs
@@ -114,7 +114,9 @@ fn convert_phong_lighting() {
     let module = load_glsl(
         "glsl_phong_lighting.frag",
         "main",
-        naga::ShaderStage::Fragment,
+        naga::ShaderStage::Fragment {
+            early_depth_test: None,
+        },
     );
     naga::proc::Validator::new().validate(&module).unwrap();
 
@@ -133,7 +135,9 @@ fn constant_expressions() {
     let module = load_glsl(
         "glsl_constant_expression.vert",
         "main",
-        naga::ShaderStage::Fragment,
+        naga::ShaderStage::Fragment {
+            early_depth_test: None,
+        },
     );
     naga::proc::Validator::new().validate(&module).unwrap();
 }


### PR DESCRIPTION
This is a draft design for inclusion of **Execution Modes** (Options of shader stages. See [1]) into Naga's IR. This is necessary to support all basic fragment and compute shaders.

Unresolved:
- [ ] Non-exhaustive? 
- [ ] Rosetta testing vs optionality of some fields. 
    Some fields do not have to be specified in frontend languages like GLSL while always being defined in SPIR-V, like ```coordinate_origin```. This could lead to a situation where on a testing path GLSL -> Naga -> GLSL we would emit functionally the same code but with additional declarations not explicitly written in the original.

  The question is whether to pollute the code with additional Options just for the testing or expect tests to be written with always explicitly declared defaults. The latter might break with expansion of the ```ShaderStage``` enum.

The enum currently has only SPIR-V 1.0 and It is also limited by what is supported by WebGPU. That turns out to be everything for compute and fragment shaders. I expect It to expand with tesselation and mesh shaders in the near future.

[1]: https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#_a_id_execution_mode_a_execution_mode