### PR TITLE
[wgsl-in] Fix constant initialization

### DIFF
--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1142,10 +1142,12 @@ impl Parser {
                             .append(crate::Expression::LocalVariable(var_id));
                         context.lookup_ident.insert(name, expr_id);
                         match init {
-                            Init::Variable(value) => crate::Statement::Store {
-                                pointer: expr_id,
-                                value,
-                            },
+                            Init::Variable(value) | Init::Uniform(value) => {
+                                crate::Statement::Store {
+                                    pointer: expr_id,
+                                    value,
+                                }
+                            }
                             _ => crate::Statement::Empty,
                         }
                     }

--- a/test-data/simple/simple.expected.ron
+++ b/test-data/simple/simple.expected.ron
@@ -94,7 +94,10 @@
                 ),
             ],
             body: [
-                Empty,
+                Store(
+                    pointer: 4,
+                    value: 3,
+                ),
                 Store(
                     pointer: 2,
                     value: 6,


### PR DESCRIPTION
Constant initalizations, e.g. would get a `Statement::Empty` in the IR:
```
fn main_vert() -> void {
	var test: f32 = 1.0;	
	return;
}
entry_point vertex as "main" = main_vert;
```

PR fixed this, and it will now get a `Statement::Store` in the IR.

Back-ends tested:
- [x] Spirv
- [x] Metal
- [x] GLSL