### PR TITLE
[glsl-new] Add bool consts, update logical exprs

### DIFF
--- a/src/front/glsl_new/ast.rs
+++ b/src/front/glsl_new/ast.rs
@@ -102,6 +102,15 @@ pub struct ExpressionRule {
     pub statements: Vec<Statement>,
 }
 
+impl ExpressionRule {
+    pub fn from_expression(expression: Handle<Expression>) -> ExpressionRule {
+        ExpressionRule {
+            expression,
+            statements: vec![],
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum TypeQualifier {
     StorageClass(StorageClass),

--- a/src/front/glsl_new/lex.rs
+++ b/src/front/glsl_new/lex.rs
@@ -136,6 +136,9 @@ pub fn consume_token(mut input: &str) -> (Option<Token>, &str) {
                     Some(Token::Interpolation((meta, crate::Interpolation::Sample))),
                     rest,
                 ),
+                // values
+                "true" => (Some(Token::BoolConstant((meta, true))), rest),
+                "false" => (Some(Token::BoolConstant((meta, false))), rest),
                 // types
                 "void" => (Some(Token::Void(meta)), rest),
                 word => {


### PR DESCRIPTION
Handle "true" and "false" constants.

Refactor logical expression rules in parser to use `ExpressionRule`.

Still need to change remaining expressions to `ExpressionRule`.