### PR TITLE
[Spirv-out] Move instructions to own module

### DIFF
--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -619,7 +619,6 @@ mod tests {
             result_id: true,
             operands: true,
         };
-
         validate_spec_requirements(requirements, &instruction);
 
         instruction.to_words(&mut output);
@@ -635,6 +634,25 @@ mod tests {
         let requirements = SpecRequirements {
             op: Op::MemoryModel,
             wc: 3,
+            type_id: false,
+            result_id: false,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_entry_point() {
+        let instruction =
+            super::instruction_entry_point(spirv::ExecutionModel::Fragment, 1, "main", &[1, 2]);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::EntryPoint,
+            wc: 4,
             type_id: false,
             result_id: false,
             operands: true,
@@ -675,7 +693,408 @@ mod tests {
             result_id: false,
             operands: true,
         };
+        validate_spec_requirements(requirements, &instruction);
 
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_type_void() {
+        let instruction = super::instruction_type_void(1);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::TypeVoid,
+            wc: 2,
+            type_id: false,
+            result_id: true,
+            operands: false,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_type_bool() {
+        let instruction = super::instruction_type_bool(1);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::TypeBool,
+            wc: 2,
+            type_id: false,
+            result_id: true,
+            operands: false,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_type_int() {
+        let instruction = super::instruction_type_int(1, 32, super::Signedness::Signed);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::TypeInt,
+            wc: 4,
+            type_id: false,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_type_float() {
+        let instruction = super::instruction_type_float(1, 32);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::TypeFloat,
+            wc: 3,
+            type_id: false,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_type_vector() {
+        let instruction = super::instruction_type_vector(1, 1, crate::VectorSize::Bi);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::TypeVector,
+            wc: 4,
+            type_id: false,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_type_matrix() {
+        let instruction = super::instruction_type_matrix(1, 1, crate::VectorSize::Bi);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::TypeMatrix,
+            wc: 4,
+            type_id: false,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_type_image() {
+        let instruction = super::instruction_type_image(
+            1,
+            1,
+            spirv::Dim::Dim3D,
+            true,
+            crate::ImageClass::Multisampled,
+        );
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::TypeImage,
+            wc: 9,
+            type_id: false,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_type_sampler() {
+        let instruction = super::instruction_type_sampler(1);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::TypeSampler,
+            wc: 2,
+            type_id: false,
+            result_id: true,
+            operands: false,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_type_array() {
+        let instruction = super::instruction_type_array(1, 1, 1);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::TypeArray,
+            wc: 4,
+            type_id: false,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_type_runtime_array() {
+        let instruction = super::instruction_type_runtime_array(1, 1);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::TypeRuntimeArray,
+            wc: 3,
+            type_id: false,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_type_struct() {
+        let instruction = super::instruction_type_struct(1, &[1, 2]);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::TypeStruct,
+            wc: 2,
+            type_id: false,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_type_pointer() {
+        let instruction = super::instruction_type_pointer(1, spirv::StorageClass::Function, 1);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::TypePointer,
+            wc: 4,
+            type_id: false,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_type_function() {
+        let instruction = super::instruction_type_function(1, 1, &[1, 2]);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::TypeFunction,
+            wc: 3,
+            type_id: false,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_constant_true() {
+        let instruction = super::instruction_constant_true(1, 1);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::ConstantTrue,
+            wc: 3,
+            type_id: true,
+            result_id: true,
+            operands: false,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_constant_false() {
+        let instruction = super::instruction_constant_false(1, 1);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::ConstantFalse,
+            wc: 3,
+            type_id: true,
+            result_id: true,
+            operands: false,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_constant() {
+        let instruction = super::instruction_constant(1, 1, &[1, 2]);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::Constant,
+            wc: 3,
+            type_id: true,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_constant_composite() {
+        let instruction = super::instruction_constant_composite(1, 1, &[1, 2]);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::ConstantComposite,
+            wc: 3,
+            type_id: true,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_variable() {
+        let instruction = super::instruction_variable(1, 1, spirv::StorageClass::Function, Some(1));
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::Variable,
+            wc: 4,
+            type_id: true,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_load() {
+        let instruction = super::instruction_load(1, 1, 1, None);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::Load,
+            wc: 4,
+            type_id: true,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_store() {
+        let instruction = super::instruction_store(1, 1, None);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::Store,
+            wc: 3,
+            type_id: false,
+            result_id: false,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_function() {
+        let instruction = super::instruction_function(1, 1, spirv::FunctionControl::NONE, 1);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::Function,
+            wc: 5,
+            type_id: true,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_function_parameter() {
+        let instruction = super::instruction_function_parameter(1, 1);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::FunctionParameter,
+            wc: 3,
+            type_id: true,
+            result_id: true,
+            operands: false,
+        };
         validate_spec_requirements(requirements, &instruction);
 
         instruction.to_words(&mut output);
@@ -701,6 +1120,60 @@ mod tests {
     }
 
     #[test]
+    fn test_instruction_function_call() {
+        let instruction = super::instruction_function_call(1, 1, 1, &[1, 2]);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::FunctionCall,
+            wc: 4,
+            type_id: true,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_composite_construct() {
+        let instruction = super::instruction_composite_construct(1, 1, &[1, 2]);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::CompositeConstruct,
+            wc: 3,
+            type_id: true,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_vector_times_scalar() {
+        let instruction = super::instruction_vector_times_scalar(1, 1, 1, 1);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::VectorTimesScalar,
+            wc: 5,
+            type_id: true,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
     fn test_instruction_label() {
         let instruction = super::instruction_label(1);
         let mut output = vec![];
@@ -711,6 +1184,42 @@ mod tests {
             type_id: false,
             result_id: true,
             operands: false,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_return() {
+        let instruction = super::instruction_return();
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::Return,
+            wc: 1,
+            type_id: false,
+            result_id: false,
+            operands: false,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_return_value() {
+        let instruction = super::instruction_return_value(1);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::ReturnValue,
+            wc: 2,
+            type_id: false,
+            result_id: false,
+            operands: true,
         };
         validate_spec_requirements(requirements, &instruction);
 

--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -578,7 +578,7 @@ mod tests {
 
         let requirements = SpecRequirements {
             op: Op::ExtInstImport,
-            wc: 2,
+            wc: 3,
             type_id: false,
             result_id: true,
             operands: true,

--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -552,18 +552,54 @@ mod tests {
     use spirv::*;
 
     #[test]
-    fn test_instruction_capability() {
-        let instruction = super::instruction_capability(Capability::Shader);
+    fn test_instruction_source() {
+        let version = 450;
+        let instruction = super::instruction_source(SourceLanguage::GLSL, version);
         let mut output = vec![];
 
         let requirements = SpecRequirements {
-            op: Op::Capability,
-            wc: 2,
+            op: Op::Source,
+            wc: 3,
             type_id: false,
             result_id: false,
             operands: true,
         };
+        validate_spec_requirements(requirements, &instruction);
 
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_name() {
+        let instruction = super::instruction_name(1, "Test");
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::Name,
+            wc: 3,
+            type_id: false,
+            result_id: false,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_decorate() {
+        let instruction = super::instruction_decorate(1, Decoration::Location, &[1]);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::Decorate,
+            wc: 3,
+            type_id: false,
+            result_id: false,
+            operands: true,
+        };
         validate_spec_requirements(requirements, &instruction);
 
         instruction.to_words(&mut output);
@@ -610,24 +646,6 @@ mod tests {
     }
 
     #[test]
-    fn test_instruction_name() {
-        let instruction = super::instruction_name(1, "Test");
-        let mut output = vec![];
-
-        let requirements = SpecRequirements {
-            op: Op::Name,
-            wc: 3,
-            type_id: false,
-            result_id: false,
-            operands: true,
-        };
-        validate_spec_requirements(requirements, &instruction);
-
-        instruction.to_words(&mut output);
-        validate_instruction(output.as_slice(), &instruction);
-    }
-
-    #[test]
     fn test_instruction_execution_mode() {
         let instruction = super::instruction_execution_mode(1, ExecutionMode::OriginUpperLeft);
         let mut output = vec![];
@@ -646,36 +664,18 @@ mod tests {
     }
 
     #[test]
-    fn test_instruction_source() {
-        let version = 450;
-        let instruction = super::instruction_source(SourceLanguage::GLSL, version);
+    fn test_instruction_capability() {
+        let instruction = super::instruction_capability(Capability::Shader);
         let mut output = vec![];
 
         let requirements = SpecRequirements {
-            op: Op::Source,
-            wc: 3,
+            op: Op::Capability,
+            wc: 2,
             type_id: false,
             result_id: false,
             operands: true,
         };
-        validate_spec_requirements(requirements, &instruction);
 
-        instruction.to_words(&mut output);
-        validate_instruction(output.as_slice(), &instruction);
-    }
-
-    #[test]
-    fn test_instruction_label() {
-        let instruction = super::instruction_label(1);
-        let mut output = vec![];
-
-        let requirements = SpecRequirements {
-            op: Op::Label,
-            wc: 2,
-            type_id: false,
-            result_id: true,
-            operands: false,
-        };
         validate_spec_requirements(requirements, &instruction);
 
         instruction.to_words(&mut output);
@@ -701,16 +701,16 @@ mod tests {
     }
 
     #[test]
-    fn test_instruction_decorate() {
-        let instruction = super::instruction_decorate(1, Decoration::Location, &[1]);
+    fn test_instruction_label() {
+        let instruction = super::instruction_label(1);
         let mut output = vec![];
 
         let requirements = SpecRequirements {
-            op: Op::Decorate,
-            wc: 3,
+            op: Op::Label,
+            wc: 2,
             type_id: false,
-            result_id: false,
-            operands: true,
+            result_id: true,
+            operands: false,
         };
         validate_spec_requirements(requirements, &instruction);
 

--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -1,0 +1,683 @@
+use crate::back::spv::{helpers, Instruction};
+use spirv::{Op, Word};
+
+pub(super) enum Signedness {
+    Unsigned = 0,
+    Signed = 1,
+}
+
+//
+// Debug Instructions
+//
+
+pub(super) fn instruction_source(
+    source_language: spirv::SourceLanguage,
+    version: u32,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::Source);
+    instruction.add_operand(source_language as u32);
+    instruction.add_operands(helpers::bytes_to_words(&version.to_le_bytes()));
+    instruction
+}
+
+pub(super) fn instruction_name(target_id: Word, name: &str) -> Instruction {
+    let mut instruction = Instruction::new(Op::Name);
+    instruction.set_result(target_id);
+    instruction.add_operands(helpers::string_to_words(name));
+    instruction
+}
+
+//
+// Annotation Instructions
+//
+
+pub(super) fn instruction_decorate(
+    target_id: Word,
+    decoration: spirv::Decoration,
+    operands: &[Word],
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::Decorate);
+    instruction.add_operand(target_id);
+    instruction.add_operand(decoration as u32);
+    instruction.add_operands(Vec::from(operands));
+    instruction
+}
+
+//
+// Extension Instructions
+//
+
+pub(super) fn instruction_ext_inst_import(id: Word, name: &str) -> Instruction {
+    let mut instruction = Instruction::new(Op::ExtInstImport);
+    instruction.set_result(id);
+    instruction.add_operands(helpers::string_to_words(name));
+    instruction
+}
+
+//
+// Mode-Setting Instructions
+//
+
+pub(super) fn instruction_memory_model(
+    addressing_model: spirv::AddressingModel,
+    memory_model: spirv::MemoryModel,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::MemoryModel);
+    instruction.add_operand(addressing_model as u32);
+    instruction.add_operand(memory_model as u32);
+    instruction
+}
+
+pub(super) fn instruction_entry_point(
+    execution_model: spirv::ExecutionModel,
+    entry_point_id: Word,
+    name: &str,
+    interface_ids: Vec<Word>,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::EntryPoint);
+    instruction.add_operand(execution_model as u32);
+    instruction.add_operand(entry_point_id);
+    instruction.add_operands(helpers::string_to_words(name));
+    instruction.add_operands(interface_ids);
+    instruction
+}
+
+pub(super) fn instruction_execution_mode(
+    function_id: Word,
+    execution_mode: spirv::ExecutionMode,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::ExecutionMode);
+    instruction.add_operand(function_id);
+    instruction.add_operand(execution_mode as u32);
+    instruction
+}
+
+pub(super) fn instruction_capability(capability: spirv::Capability) -> Instruction {
+    let mut instruction = Instruction::new(Op::Capability);
+    instruction.add_operand(capability as u32);
+    instruction
+}
+
+//
+// Type-Declaration Instructions
+//
+
+pub(super) fn instruction_type_void(id: Word) -> Instruction {
+    let mut instruction = Instruction::new(Op::TypeVoid);
+    instruction.set_result(id);
+    instruction
+}
+
+pub(super) fn instruction_type_bool(id: Word) -> Instruction {
+    let mut instruction = Instruction::new(Op::TypeBool);
+    instruction.set_result(id);
+    instruction
+}
+
+pub(super) fn instruction_type_int(id: Word, width: Word, signedness: Signedness) -> Instruction {
+    let mut instruction = Instruction::new(Op::TypeInt);
+    instruction.set_result(id);
+    instruction.add_operand(width);
+    instruction.add_operand(signedness as u32);
+    instruction
+}
+
+pub(super) fn instruction_type_float(id: Word, width: Word) -> Instruction {
+    let mut instruction = Instruction::new(Op::TypeFloat);
+    instruction.set_result(id);
+    instruction.add_operand(width);
+    instruction
+}
+
+pub(super) fn instruction_type_vector(
+    id: Word,
+    component_type_id: Word,
+    component_count: crate::VectorSize,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::TypeVector);
+    instruction.set_result(id);
+    instruction.add_operand(component_type_id);
+    instruction.add_operand(component_count as u32);
+    instruction
+}
+
+pub(super) fn instruction_type_matrix(
+    id: Word,
+    column_type_id: Word,
+    column_count: crate::VectorSize,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::TypeMatrix);
+    instruction.set_result(id);
+    instruction.add_operand(column_type_id);
+    instruction.add_operand(column_count as u32);
+    instruction
+}
+
+pub(super) fn instruction_type_image(
+    id: Word,
+    sampled_type_id: Word,
+    dim: spirv::Dim,
+    arrayed: bool,
+    class: crate::ImageClass,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::TypeImage);
+    instruction.set_result(id);
+    instruction.add_operand(sampled_type_id);
+    instruction.add_operand(dim as u32);
+
+    instruction.add_operand(match class {
+        crate::ImageClass::Depth => 1,
+        _ => 0,
+    });
+    instruction.add_operand(if arrayed { 1 } else { 0 });
+    instruction.add_operand(match class {
+        crate::ImageClass::Multisampled => 1,
+        _ => 0,
+    });
+    instruction.add_operand(match class {
+        crate::ImageClass::Sampled => 1,
+        _ => 0,
+    });
+
+    let (format, access) = match class {
+        crate::ImageClass::Storage(format, access) => {
+            let spv_format = match format {
+                crate::StorageFormat::R8Unorm => spirv::ImageFormat::R8,
+                crate::StorageFormat::R8Snorm => spirv::ImageFormat::R8Snorm,
+                crate::StorageFormat::R8Uint => spirv::ImageFormat::R8ui,
+                crate::StorageFormat::R8Sint => spirv::ImageFormat::R8i,
+                crate::StorageFormat::R16Uint => spirv::ImageFormat::R16ui,
+                crate::StorageFormat::R16Sint => spirv::ImageFormat::R16i,
+                crate::StorageFormat::R16Float => spirv::ImageFormat::R16f,
+                crate::StorageFormat::Rg8Unorm => spirv::ImageFormat::Rg8,
+                crate::StorageFormat::Rg8Snorm => spirv::ImageFormat::Rg8Snorm,
+                crate::StorageFormat::Rg8Uint => spirv::ImageFormat::Rg8ui,
+                crate::StorageFormat::Rg8Sint => spirv::ImageFormat::Rg8i,
+                crate::StorageFormat::R32Uint => spirv::ImageFormat::R32ui,
+                crate::StorageFormat::R32Sint => spirv::ImageFormat::R32i,
+                crate::StorageFormat::R32Float => spirv::ImageFormat::R32f,
+                crate::StorageFormat::Rg16Uint => spirv::ImageFormat::Rg16ui,
+                crate::StorageFormat::Rg16Sint => spirv::ImageFormat::Rg16i,
+                crate::StorageFormat::Rg16Float => spirv::ImageFormat::Rg16f,
+                crate::StorageFormat::Rgba8Unorm => spirv::ImageFormat::Rgba8,
+                crate::StorageFormat::Rgba8Snorm => spirv::ImageFormat::Rgba8Snorm,
+                crate::StorageFormat::Rgba8Uint => spirv::ImageFormat::Rgba8ui,
+                crate::StorageFormat::Rgba8Sint => spirv::ImageFormat::Rgba8i,
+                crate::StorageFormat::Rgb10a2Unorm => spirv::ImageFormat::Rgb10a2ui,
+                crate::StorageFormat::Rg11b10Float => spirv::ImageFormat::R11fG11fB10f,
+                crate::StorageFormat::Rg32Uint => spirv::ImageFormat::Rg32ui,
+                crate::StorageFormat::Rg32Sint => spirv::ImageFormat::Rg32i,
+                crate::StorageFormat::Rg32Float => spirv::ImageFormat::Rg32f,
+                crate::StorageFormat::Rgba16Uint => spirv::ImageFormat::Rgba16ui,
+                crate::StorageFormat::Rgba16Sint => spirv::ImageFormat::Rgba16i,
+                crate::StorageFormat::Rgba16Float => spirv::ImageFormat::Rgba16f,
+                crate::StorageFormat::Rgba32Uint => spirv::ImageFormat::Rgba32ui,
+                crate::StorageFormat::Rgba32Sint => spirv::ImageFormat::Rgba32i,
+                crate::StorageFormat::Rgba32Float => spirv::ImageFormat::Rgba32f,
+            };
+            (spv_format, access)
+        }
+        _ => (spirv::ImageFormat::Unknown, crate::StorageAccess::empty()),
+    };
+
+    instruction.add_operand(format as u32);
+    // Access Qualifier
+    if !access.is_empty() {
+        instruction.add_operand(if access == crate::StorageAccess::all() {
+            2
+        } else if access.contains(crate::StorageAccess::STORE) {
+            1
+        } else {
+            0
+        });
+    }
+
+    instruction
+}
+
+pub(super) fn instruction_type_sampler(id: Word) -> Instruction {
+    let mut instruction = Instruction::new(Op::TypeSampler);
+    instruction.set_result(id);
+    instruction
+}
+
+pub(super) fn instruction_type_array(
+    id: Word,
+    element_type_id: Word,
+    length_id: Word,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::TypeArray);
+    instruction.set_result(id);
+    instruction.add_operand(element_type_id);
+    instruction.add_operand(length_id);
+    instruction
+}
+
+pub(super) fn instruction_type_runtime_array(id: Word, element_type_id: Word) -> Instruction {
+    let mut instruction = Instruction::new(Op::TypeRuntimeArray);
+    instruction.set_result(id);
+    instruction.add_operand(element_type_id);
+    instruction
+}
+
+pub(super) fn instruction_type_struct(id: Word, member_ids: Vec<Word>) -> Instruction {
+    let mut instruction = Instruction::new(Op::TypeStruct);
+    instruction.set_result(id);
+    instruction.add_operands(member_ids);
+    instruction
+}
+
+pub(super) fn instruction_type_pointer(
+    id: Word,
+    storage_class: spirv::StorageClass,
+    type_id: Word,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::TypePointer);
+    instruction.set_result(id);
+    instruction.add_operand(storage_class as u32);
+    instruction.add_operand(type_id);
+    instruction
+}
+
+pub(super) fn instruction_type_function(
+    id: Word,
+    return_type_id: Word,
+    parameter_ids: Vec<Word>,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::TypeFunction);
+    instruction.set_result(id);
+    instruction.add_operand(return_type_id);
+    instruction.add_operands(parameter_ids);
+    instruction
+}
+
+//
+// Constant-Creation Instructions
+//
+
+pub(super) fn instruction_constant_true(scalar_constant_id: Word, id: Word) -> Instruction {
+    let mut instruction = Instruction::new(Op::ConstantTrue);
+    instruction.set_type(scalar_constant_id);
+    instruction.set_result(id);
+    instruction
+}
+
+pub(super) fn instruction_constant_false(scalar_constant_id: Word, id: Word) -> Instruction {
+    let mut instruction = Instruction::new(Op::ConstantFalse);
+    instruction.set_type(scalar_constant_id);
+    instruction.set_result(id);
+    instruction
+}
+
+pub(super) fn instruction_constant(
+    scalar_constant_id: Word,
+    id: Word,
+    values: &[Word],
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::Constant);
+    instruction.set_type(scalar_constant_id);
+    instruction.set_result(id);
+    for value in values {
+        instruction.add_operand(*value);
+    }
+    instruction
+}
+
+pub(super) fn instruction_constant_composite(
+    composite_type_id: Word,
+    id: Word,
+    constituent_ids: Vec<Word>,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::ConstantComposite);
+    instruction.set_type(composite_type_id);
+    instruction.set_result(id);
+    instruction.add_operands(constituent_ids);
+    instruction
+}
+
+//
+// Memory Instructions
+//
+
+pub(super) fn instruction_variable(
+    result_type_id: Word,
+    result_id: Word,
+    storage_class: spirv::StorageClass,
+    initializer_id: Option<Word>,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::Variable);
+    instruction.set_type(result_type_id);
+    instruction.set_result(result_id);
+    instruction.add_operand(storage_class as u32);
+
+    if let Some(initializer_id) = initializer_id {
+        instruction.add_operand(initializer_id);
+    }
+
+    instruction
+}
+
+pub(super) fn instruction_load(
+    type_id: Word,
+    id: Word,
+    pointer_type_id: Word,
+    memory_access: Option<spirv::MemoryAccess>,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::Load);
+    instruction.set_type(type_id);
+    instruction.set_result(id);
+    instruction.add_operand(pointer_type_id);
+
+    instruction.add_operand(if let Some(memory_access) = memory_access {
+        memory_access.bits()
+    } else {
+        spirv::MemoryAccess::NONE.bits()
+    });
+
+    instruction
+}
+
+pub(super) fn instruction_store(pointer_type_id: Word, object_id: Word) -> Instruction {
+    let mut instruction = Instruction::new(Op::Store);
+    instruction.set_type(pointer_type_id);
+    instruction.add_operand(object_id);
+    instruction
+}
+
+//
+// Function Instructions
+//
+
+pub(super) fn instruction_function(
+    return_type_id: Word,
+    id: Word,
+    function_control: spirv::FunctionControl,
+    function_type_id: Word,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::Function);
+    instruction.set_type(return_type_id);
+    instruction.set_result(id);
+    instruction.add_operand(function_control.bits());
+    instruction.add_operand(function_type_id);
+    instruction
+}
+
+pub(super) fn instruction_function_parameter(result_type_id: Word, id: Word) -> Instruction {
+    let mut instruction = Instruction::new(Op::FunctionParameter);
+    instruction.set_type(result_type_id);
+    instruction.set_result(id);
+    instruction
+}
+
+pub(super) fn instruction_function_end() -> Instruction {
+    Instruction::new(Op::FunctionEnd)
+}
+
+pub(super) fn instruction_function_call(
+    result_type_id: Word,
+    id: Word,
+    function_id: Word,
+    argument_ids: Vec<Word>,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::FunctionCall);
+    instruction.set_type(result_type_id);
+    instruction.set_result(id);
+    instruction.add_operand(function_id);
+    instruction.add_operands(argument_ids);
+    instruction
+}
+
+//
+// Image Instructions
+//
+
+//
+// Conversion Instructions
+//
+
+//
+// Composite Instructions
+//
+
+pub(super) fn instruction_composite_construct(
+    composite_type_id: Word,
+    id: Word,
+    constituent_ids: Vec<Word>,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::CompositeConstruct);
+    instruction.set_type(composite_type_id);
+    instruction.set_result(id);
+    instruction.add_operands(constituent_ids);
+    instruction
+}
+
+//
+// Arithmetic Instructions
+//
+
+pub(super) fn instruction_vector_times_scalar(
+    float_type_id: Word,
+    id: Word,
+    vector_type_id: Word,
+    scalar_type_id: Word,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::VectorTimesScalar);
+    instruction.set_type(float_type_id);
+    instruction.set_result(id);
+    instruction.add_operand(vector_type_id);
+    instruction.add_operand(scalar_type_id);
+    instruction
+}
+
+//
+// Bit Instructions
+//
+
+//
+// Relational and Logical Instructions
+//
+
+//
+// Derivative Instructions
+//
+
+//
+// Control-Flow Instructions
+//
+
+pub(super) fn instruction_label(id: Word) -> Instruction {
+    let mut instruction = Instruction::new(Op::Label);
+    instruction.set_result(id);
+    instruction
+}
+
+pub(super) fn instruction_return() -> Instruction {
+    Instruction::new(Op::Return)
+}
+
+pub(super) fn instruction_return_value(value_id: Word) -> Instruction {
+    let mut instruction = Instruction::new(Op::ReturnValue);
+    instruction.add_operand(value_id);
+    instruction
+}
+
+//
+// Atomic Instructions
+//
+
+//
+// Primitive Instructions
+//
+
+#[cfg(test)]
+mod tests {
+    use crate::back::spv::test_framework::*;
+    use spirv::*;
+
+    #[test]
+    fn test_instruction_capability() {
+        let instruction = super::instruction_capability(Capability::Shader);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::Capability,
+            wc: 2,
+            type_id: false,
+            result_id: false,
+            operands: true,
+        };
+
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_ext_inst_import() {
+        let import_name = "GLSL.std.450";
+        let instruction = super::instruction_ext_inst_import(1, import_name);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::ExtInstImport,
+            wc: 2,
+            type_id: false,
+            result_id: true,
+            operands: true,
+        };
+
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_memory_model() {
+        let instruction =
+            super::instruction_memory_model(AddressingModel::Logical, MemoryModel::GLSL450);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::MemoryModel,
+            wc: 3,
+            type_id: false,
+            result_id: false,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_name() {
+        let instruction = super::instruction_name(1, "Test");
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::Name,
+            wc: 3,
+            type_id: false,
+            result_id: true,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_execution_mode() {
+        let instruction = super::instruction_execution_mode(1, ExecutionMode::OriginUpperLeft);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::ExecutionMode,
+            wc: 3,
+            type_id: false,
+            result_id: false,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_source() {
+        let version = 450;
+        let instruction = super::instruction_source(SourceLanguage::GLSL, version);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::Source,
+            wc: 3,
+            type_id: false,
+            result_id: false,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_label() {
+        let instruction = super::instruction_label(1);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::Label,
+            wc: 2,
+            type_id: false,
+            result_id: true,
+            operands: false,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_function_end() {
+        let instruction = super::instruction_function_end();
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::FunctionEnd,
+            wc: 1,
+            type_id: false,
+            result_id: false,
+            operands: false,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+
+    #[test]
+    fn test_instruction_decorate() {
+        let instruction = super::instruction_decorate(1, Decoration::Location, &[1]);
+        let mut output = vec![];
+
+        let requirements = SpecRequirements {
+            op: Op::Decorate,
+            wc: 3,
+            type_id: false,
+            result_id: false,
+            operands: true,
+        };
+        validate_spec_requirements(requirements, &instruction);
+
+        instruction.to_words(&mut output);
+        validate_instruction(output.as_slice(), &instruction);
+    }
+}

--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -22,7 +22,7 @@ pub(super) fn instruction_source(
 
 pub(super) fn instruction_name(target_id: Word, name: &str) -> Instruction {
     let mut instruction = Instruction::new(Op::Name);
-    instruction.set_result(target_id);
+    instruction.add_operand(target_id);
     instruction.add_operands(helpers::string_to_words(name));
     instruction
 }
@@ -377,10 +377,21 @@ pub(super) fn instruction_load(
     instruction
 }
 
-pub(super) fn instruction_store(pointer_type_id: Word, object_id: Word) -> Instruction {
+pub(super) fn instruction_store(
+    pointer_type_id: Word,
+    object_id: Word,
+    memory_access: Option<spirv::MemoryAccess>,
+) -> Instruction {
     let mut instruction = Instruction::new(Op::Store);
-    instruction.set_type(pointer_type_id);
+    instruction.add_operand(pointer_type_id);
     instruction.add_operand(object_id);
+
+    instruction.add_operand(if let Some(memory_access) = memory_access {
+        memory_access.bits()
+    } else {
+        spirv::MemoryAccess::NONE.bits()
+    });
+
     instruction
 }
 

--- a/src/back/spv/mod.rs
+++ b/src/back/spv/mod.rs
@@ -1,4 +1,5 @@
 mod helpers;
+mod instructions;
 mod layout;
 mod writer;
 

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -869,7 +869,7 @@ impl Writer {
                         });
                         block
                             .body
-                            .push(super::instructions::instruction_store(variable_id, id));
+                            .push(super::instructions::instruction_store(variable_id, id, None));
                         argument_ids.push(variable_id);
                     }
 
@@ -955,7 +955,7 @@ impl Writer {
 
                 block
                     .body
-                    .push(super::instructions::instruction_store(pointer_id, value_id));
+                    .push(super::instructions::instruction_store(pointer_id, value_id,None));
             }
             crate::Statement::Empty => {}
             _ => unimplemented!("{:?}", statement),
@@ -1129,10 +1129,8 @@ impl Writer {
 
 #[cfg(test)]
 mod tests {
-    use crate::back::spv::test_framework::*;
     use crate::back::spv::{Writer, WriterFlags};
     use crate::Header;
-    use spirv::*;
 
     #[test]
     fn test_writer_generate_id() {

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1,6 +1,6 @@
 /*! Standard Portable Intermediate Representation (SPIR-V) backend !*/
-use super::{helpers, Instruction, LogicalLayout, PhysicalLayout, WriterFlags};
-use spirv::{Op, Word};
+use super::{Instruction, LogicalLayout, PhysicalLayout, WriterFlags};
+use spirv::Word;
 use std::collections::hash_map::Entry;
 
 const BITS_PER_BYTE: crate::Bytes = 8;
@@ -62,11 +62,6 @@ impl Function {
             block.termination.as_ref().unwrap().to_words(sink);
         }
     }
-}
-
-enum Signedness {
-    Unsigned = 0,
-    Signed = 1,
 }
 
 #[derive(Debug, PartialEq, Hash, Eq, Copy, Clone)]
@@ -208,7 +203,7 @@ impl Writer {
                 None => {
                     let id = self.generate_id();
                     self.void_type = Some(id);
-                    self.instruction_type_void(id)
+                    super::instructions::instruction_type_void(id)
                         .to_words(&mut self.logical_layout.declarations);
                     id
                 }
@@ -236,7 +231,8 @@ impl Writer {
                     Entry::Occupied(e) => *e.get(),
                     _ => {
                         let pointer_id = self.generate_id();
-                        let instruction = self.instruction_type_pointer(pointer_id, class, ty_id);
+                        let instruction =
+                            super::instructions::instruction_type_pointer(pointer_id, class, ty_id);
                         instruction.to_words(&mut self.logical_layout.declarations);
                         self.lookup_type.insert(
                             LookupType::Local(LocalType::Pointer {
@@ -252,80 +248,12 @@ impl Writer {
         }
     }
 
-    ///
-    /// Debug Instructions
-    ///
-
-    fn instruction_source(
-        &self,
-        source_language: spirv::SourceLanguage,
-        version: u32,
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::Source);
-        instruction.add_operand(source_language as u32);
-        instruction.add_operands(helpers::bytes_to_words(&version.to_le_bytes()));
-        instruction
-    }
-
-    fn instruction_name(&self, target_id: Word, name: &str) -> Instruction {
-        let mut instruction = Instruction::new(Op::Name);
-        instruction.set_result(target_id);
-        instruction.add_operands(helpers::string_to_words(name));
-        instruction
-    }
-
-    ///
-    /// Annotation Instructions
-    ///
-
-    fn instruction_decorate(
-        &self,
-        target_id: Word,
-        decoration: spirv::Decoration,
-        operands: &[Word],
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::Decorate);
-        instruction.add_operand(target_id);
-        instruction.add_operand(decoration as u32);
-        instruction.add_operands(Vec::from(operands));
-        instruction
-    }
-
-    ///
-    /// Extension Instructions
-    ///
-
-    fn instruction_ext_inst_import(&mut self, name: &str) -> Instruction {
-        let mut instruction = Instruction::new(Op::ExtInstImport);
-        let id = self.generate_id();
-        instruction.set_result(id);
-        instruction.add_operands(helpers::string_to_words(name));
-        instruction
-    }
-
-    ///
-    /// Mode-Setting Instructions
-    ///
-
-    fn instruction_memory_model(&mut self) -> Instruction {
-        let mut instruction = Instruction::new(Op::MemoryModel);
-        let addressing_model = spirv::AddressingModel::Logical;
-        let memory_model = spirv::MemoryModel::GLSL450;
-        self.try_add_capabilities(addressing_model.required_capabilities());
-        self.try_add_capabilities(memory_model.required_capabilities());
-
-        instruction.add_operand(addressing_model as u32);
-        instruction.add_operand(memory_model as u32);
-        instruction
-    }
-
-    fn instruction_entry_point(
+    // TODO Move to instructions module
+    fn write_entry_point(
         &mut self,
         entry_point: &crate::EntryPoint,
         ir_module: &crate::Module,
     ) -> Instruction {
-        let mut instruction = Instruction::new(Op::EntryPoint);
-
         let function_id = *self.lookup_function.get(&entry_point.function).unwrap();
 
         let exec_model = match entry_point.stage {
@@ -334,10 +262,7 @@ impl Writer {
             crate::ShaderStage::Compute { .. } => spirv::ExecutionModel::GLCompute,
         };
 
-        instruction.add_operand(exec_model as u32);
-        instruction.add_operand(function_id);
-        instruction.add_operands(helpers::string_to_words(entry_point.name.as_str()));
-
+        let mut interface_ids = vec![];
         let function = &ir_module.functions[entry_point.function];
         for ((handle, _), &usage) in ir_module
             .global_variables
@@ -350,7 +275,7 @@ impl Writer {
                     &ir_module.global_variables,
                     handle,
                 );
-                instruction.add_operand(id);
+                interface_ids.push(id);
             }
         }
 
@@ -360,469 +285,42 @@ impl Writer {
             crate::ShaderStage::Fragment { .. } => {
                 let execution_mode = spirv::ExecutionMode::OriginUpperLeft;
                 self.try_add_capabilities(execution_mode.required_capabilities());
-                self.instruction_execution_mode(function_id, execution_mode)
+                super::instructions::instruction_execution_mode(function_id, execution_mode)
                     .to_words(&mut self.logical_layout.execution_modes);
             }
             crate::ShaderStage::Compute { .. } => {}
         }
 
         if self.writer_flags.contains(WriterFlags::DEBUG) {
-            self.debugs
-                .push(self.instruction_name(function_id, entry_point.name.as_str()));
+            self.debugs.push(super::instructions::instruction_name(
+                function_id,
+                entry_point.name.as_str(),
+            ));
         }
 
-        instruction
+        super::instructions::instruction_entry_point(
+            exec_model,
+            function_id,
+            entry_point.name.as_str(),
+            interface_ids,
+        )
     }
-
-    fn instruction_execution_mode(
-        &self,
-        function_id: Word,
-        execution_mode: spirv::ExecutionMode,
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::ExecutionMode);
-        instruction.add_operand(function_id);
-        instruction.add_operand(execution_mode as u32);
-        instruction
-    }
-
-    fn instruction_capability(&self, capability: spirv::Capability) -> Instruction {
-        let mut instruction = Instruction::new(Op::Capability);
-        instruction.add_operand(capability as u32);
-        instruction
-    }
-
-    ///
-    /// Type-Declaration Instructions
-    ///
-
-    fn instruction_type_void(&self, id: Word) -> Instruction {
-        let mut instruction = Instruction::new(Op::TypeVoid);
-        instruction.set_result(id);
-        instruction
-    }
-
-    fn instruction_type_bool(&self, id: Word) -> Instruction {
-        let mut instruction = Instruction::new(Op::TypeBool);
-        instruction.set_result(id);
-        instruction
-    }
-
-    fn instruction_type_int(&self, id: Word, width: Word, signedness: Signedness) -> Instruction {
-        let mut instruction = Instruction::new(Op::TypeInt);
-        instruction.set_result(id);
-        instruction.add_operand(width);
-        instruction.add_operand(signedness as u32);
-        instruction
-    }
-
-    fn instruction_type_float(&self, id: Word, width: Word) -> Instruction {
-        let mut instruction = Instruction::new(Op::TypeFloat);
-        instruction.set_result(id);
-        instruction.add_operand(width);
-        instruction
-    }
-
-    fn instruction_type_vector(
-        &self,
-        id: Word,
-        component_type_id: Word,
-        component_count: crate::VectorSize,
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::TypeVector);
-        instruction.set_result(id);
-        instruction.add_operand(component_type_id);
-        instruction.add_operand(component_count as u32);
-        instruction
-    }
-
-    fn instruction_type_matrix(
-        &self,
-        id: Word,
-        column_type_id: Word,
-        column_count: crate::VectorSize,
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::TypeMatrix);
-        instruction.set_result(id);
-        instruction.add_operand(column_type_id);
-        instruction.add_operand(column_count as u32);
-        instruction
-    }
-
-    fn instruction_type_image(
-        &self,
-        id: Word,
-        sampled_type_id: Word,
-        dim: spirv::Dim,
-        arrayed: bool,
-        class: crate::ImageClass,
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::TypeImage);
-        instruction.set_result(id);
-        instruction.add_operand(sampled_type_id);
-        instruction.add_operand(dim as u32);
-
-        instruction.add_operand(match class {
-            crate::ImageClass::Depth => 1,
-            _ => 0,
-        });
-        instruction.add_operand(if arrayed { 1 } else { 0 });
-        instruction.add_operand(match class {
-            crate::ImageClass::Multisampled => 1,
-            _ => 0,
-        });
-        instruction.add_operand(match class {
-            crate::ImageClass::Sampled => 1,
-            _ => 0,
-        });
-
-        let (format, access) = match class {
-            crate::ImageClass::Storage(format, access) => {
-                let spv_format = match format {
-                    crate::StorageFormat::R8Unorm => spirv::ImageFormat::R8,
-                    crate::StorageFormat::R8Snorm => spirv::ImageFormat::R8Snorm,
-                    crate::StorageFormat::R8Uint => spirv::ImageFormat::R8ui,
-                    crate::StorageFormat::R8Sint => spirv::ImageFormat::R8i,
-                    crate::StorageFormat::R16Uint => spirv::ImageFormat::R16ui,
-                    crate::StorageFormat::R16Sint => spirv::ImageFormat::R16i,
-                    crate::StorageFormat::R16Float => spirv::ImageFormat::R16f,
-                    crate::StorageFormat::Rg8Unorm => spirv::ImageFormat::Rg8,
-                    crate::StorageFormat::Rg8Snorm => spirv::ImageFormat::Rg8Snorm,
-                    crate::StorageFormat::Rg8Uint => spirv::ImageFormat::Rg8ui,
-                    crate::StorageFormat::Rg8Sint => spirv::ImageFormat::Rg8i,
-                    crate::StorageFormat::R32Uint => spirv::ImageFormat::R32ui,
-                    crate::StorageFormat::R32Sint => spirv::ImageFormat::R32i,
-                    crate::StorageFormat::R32Float => spirv::ImageFormat::R32f,
-                    crate::StorageFormat::Rg16Uint => spirv::ImageFormat::Rg16ui,
-                    crate::StorageFormat::Rg16Sint => spirv::ImageFormat::Rg16i,
-                    crate::StorageFormat::Rg16Float => spirv::ImageFormat::Rg16f,
-                    crate::StorageFormat::Rgba8Unorm => spirv::ImageFormat::Rgba8,
-                    crate::StorageFormat::Rgba8Snorm => spirv::ImageFormat::Rgba8Snorm,
-                    crate::StorageFormat::Rgba8Uint => spirv::ImageFormat::Rgba8ui,
-                    crate::StorageFormat::Rgba8Sint => spirv::ImageFormat::Rgba8i,
-                    crate::StorageFormat::Rgb10a2Unorm => spirv::ImageFormat::Rgb10a2ui,
-                    crate::StorageFormat::Rg11b10Float => spirv::ImageFormat::R11fG11fB10f,
-                    crate::StorageFormat::Rg32Uint => spirv::ImageFormat::Rg32ui,
-                    crate::StorageFormat::Rg32Sint => spirv::ImageFormat::Rg32i,
-                    crate::StorageFormat::Rg32Float => spirv::ImageFormat::Rg32f,
-                    crate::StorageFormat::Rgba16Uint => spirv::ImageFormat::Rgba16ui,
-                    crate::StorageFormat::Rgba16Sint => spirv::ImageFormat::Rgba16i,
-                    crate::StorageFormat::Rgba16Float => spirv::ImageFormat::Rgba16f,
-                    crate::StorageFormat::Rgba32Uint => spirv::ImageFormat::Rgba32ui,
-                    crate::StorageFormat::Rgba32Sint => spirv::ImageFormat::Rgba32i,
-                    crate::StorageFormat::Rgba32Float => spirv::ImageFormat::Rgba32f,
-                };
-                (spv_format, access)
-            }
-            _ => (spirv::ImageFormat::Unknown, crate::StorageAccess::empty()),
-        };
-
-        instruction.add_operand(format as u32);
-        // Access Qualifier
-        if !access.is_empty() {
-            instruction.add_operand(if access == crate::StorageAccess::all() {
-                2
-            } else if access.contains(crate::StorageAccess::STORE) {
-                1
-            } else {
-                0
-            });
-        }
-
-        instruction
-    }
-
-    fn instruction_type_sampler(&self, id: Word) -> Instruction {
-        let mut instruction = Instruction::new(Op::TypeSampler);
-        instruction.set_result(id);
-        instruction
-    }
-
-    fn instruction_type_array(
-        &self,
-        id: Word,
-        element_type_id: Word,
-        length_id: Word,
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::TypeArray);
-        instruction.set_result(id);
-        instruction.add_operand(element_type_id);
-        instruction.add_operand(length_id);
-        instruction
-    }
-
-    fn instruction_type_runtime_array(&self, id: Word, element_type_id: Word) -> Instruction {
-        let mut instruction = Instruction::new(Op::TypeRuntimeArray);
-        instruction.set_result(id);
-        instruction.add_operand(element_type_id);
-        instruction
-    }
-
-    fn instruction_type_struct(&self, id: Word, member_ids: Vec<Word>) -> Instruction {
-        let mut instruction = Instruction::new(Op::TypeStruct);
-        instruction.set_result(id);
-        instruction.add_operands(member_ids);
-        instruction
-    }
-
-    fn instruction_type_pointer(
-        &self,
-        id: Word,
-        storage_class: spirv::StorageClass,
-        type_id: Word,
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::TypePointer);
-        instruction.set_result(id);
-        instruction.add_operand(storage_class as u32);
-        instruction.add_operand(type_id);
-        instruction
-    }
-
-    fn instruction_type_function(
-        &self,
-        id: Word,
-        return_type_id: Word,
-        parameter_ids: Vec<Word>,
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::TypeFunction);
-        instruction.set_result(id);
-        instruction.add_operand(return_type_id);
-        instruction.add_operands(parameter_ids);
-        instruction
-    }
-
-    ///
-    /// Constant-Creation Instructions
-    ///
-
-    fn instruction_constant_true(&self, scalar_constant_id: Word, id: Word) -> Instruction {
-        let mut instruction = Instruction::new(Op::ConstantTrue);
-        instruction.set_type(scalar_constant_id);
-        instruction.set_result(id);
-        instruction
-    }
-
-    fn instruction_constant_false(&self, scalar_constant_id: Word, id: Word) -> Instruction {
-        let mut instruction = Instruction::new(Op::ConstantFalse);
-        instruction.set_type(scalar_constant_id);
-        instruction.set_result(id);
-        instruction
-    }
-
-    fn instruction_constant(
-        &self,
-        scalar_constant_id: Word,
-        id: Word,
-        values: &[Word],
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::Constant);
-        instruction.set_type(scalar_constant_id);
-        instruction.set_result(id);
-        for value in values {
-            instruction.add_operand(*value);
-        }
-        instruction
-    }
-
-    fn instruction_constant_composite(
-        &self,
-        composite_type_id: Word,
-        id: Word,
-        constituent_ids: Vec<Word>,
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::ConstantComposite);
-        instruction.set_type(composite_type_id);
-        instruction.set_result(id);
-        instruction.add_operands(constituent_ids);
-        instruction
-    }
-
-    ///
-    /// Memory Instructions
-    ///
-
-    fn instruction_variable(
-        &self,
-        result_type_id: Word,
-        result_id: Word,
-        storage_class: spirv::StorageClass,
-        initializer_id: Option<Word>,
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::Variable);
-        instruction.set_type(result_type_id);
-        instruction.set_result(result_id);
-        instruction.add_operand(storage_class as u32);
-
-        if let Some(initializer_id) = initializer_id {
-            instruction.add_operand(initializer_id);
-        }
-
-        instruction
-    }
-
-    fn instruction_load(
-        &self,
-        type_id: Word,
-        id: Word,
-        pointer_type_id: Word,
-        memory_access: Option<spirv::MemoryAccess>,
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::Load);
-        instruction.set_type(type_id);
-        instruction.set_result(id);
-        instruction.add_operand(pointer_type_id);
-
-        instruction.add_operand(if let Some(memory_access) = memory_access {
-            memory_access.bits()
-        } else {
-            spirv::MemoryAccess::NONE.bits()
-        });
-
-        instruction
-    }
-
-    fn instruction_store(&self, pointer_type_id: Word, object_id: Word) -> Instruction {
-        let mut instruction = Instruction::new(Op::Store);
-        instruction.set_type(pointer_type_id);
-        instruction.add_operand(object_id);
-        instruction
-    }
-
-    ///
-    /// Function Instructions
-    ///
-
-    fn instruction_function(
-        &self,
-        return_type_id: Word,
-        id: Word,
-        function_control: spirv::FunctionControl,
-        function_type_id: Word,
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::Function);
-        instruction.set_type(return_type_id);
-        instruction.set_result(id);
-        instruction.add_operand(function_control.bits());
-        instruction.add_operand(function_type_id);
-        instruction
-    }
-
-    fn instruction_function_parameter(&self, result_type_id: Word, id: Word) -> Instruction {
-        let mut instruction = Instruction::new(Op::FunctionParameter);
-        instruction.set_type(result_type_id);
-        instruction.set_result(id);
-        instruction
-    }
-
-    fn instruction_function_end(&self) -> Instruction {
-        Instruction::new(Op::FunctionEnd)
-    }
-
-    fn instruction_function_call(
-        &self,
-        result_type_id: Word,
-        id: Word,
-        function_id: Word,
-        argument_ids: Vec<Word>,
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::FunctionCall);
-        instruction.set_type(result_type_id);
-        instruction.set_result(id);
-        instruction.add_operand(function_id);
-        instruction.add_operands(argument_ids);
-        instruction
-    }
-
-    ///
-    /// Image Instructions
-    ///
-
-    ///
-    /// Conversion Instructions
-    ///
-
-    ///
-    /// Composite Instructions
-    ///
-
-    fn instruction_composite_construct(
-        &self,
-        composite_type_id: Word,
-        id: Word,
-        constituent_ids: Vec<Word>,
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::CompositeConstruct);
-        instruction.set_type(composite_type_id);
-        instruction.set_result(id);
-        instruction.add_operands(constituent_ids);
-        instruction
-    }
-
-    ///
-    /// Arithmetic Instructions
-    ///
-
-    fn instruction_vector_times_scalar(
-        &self,
-        float_type_id: Word,
-        id: Word,
-        vector_type_id: Word,
-        scalar_type_id: Word,
-    ) -> Instruction {
-        let mut instruction = Instruction::new(Op::VectorTimesScalar);
-        instruction.set_type(float_type_id);
-        instruction.set_result(id);
-        instruction.add_operand(vector_type_id);
-        instruction.add_operand(scalar_type_id);
-        instruction
-    }
-
-    ///
-    /// Bit Instructions
-    ///
-
-    ///
-    /// Relational and Logical Instructions
-    ///
-
-    ///
-    /// Derivative Instructions
-    ///
-
-    ///
-    /// Control-Flow Instructions
-    ///
-
-    fn instruction_label(&self, id: Word) -> Instruction {
-        let mut instruction = Instruction::new(Op::Label);
-        instruction.set_result(id);
-        instruction
-    }
-
-    fn instruction_return(&self) -> Instruction {
-        Instruction::new(Op::Return)
-    }
-
-    fn instruction_return_value(&self, value_id: Word) -> Instruction {
-        let mut instruction = Instruction::new(Op::ReturnValue);
-        instruction.add_operand(value_id);
-        instruction
-    }
-
-    ///
-    /// Atomic Instructions
-    ///
-
-    ///
-    /// Primitive Instructions
-    ///
 
     fn write_scalar(&self, id: Word, kind: crate::ScalarKind, width: crate::Bytes) -> Instruction {
         let bits = (width * BITS_PER_BYTE) as u32;
         match kind {
-            crate::ScalarKind::Sint => self.instruction_type_int(id, bits, Signedness::Signed),
-            crate::ScalarKind::Uint => self.instruction_type_int(id, bits, Signedness::Unsigned),
-            crate::ScalarKind::Float => self.instruction_type_float(id, bits),
-            crate::ScalarKind::Bool => self.instruction_type_bool(id),
+            crate::ScalarKind::Sint => super::instructions::instruction_type_int(
+                id,
+                bits,
+                super::instructions::Signedness::Signed,
+            ),
+            crate::ScalarKind::Uint => super::instructions::instruction_type_int(
+                id,
+                bits,
+                super::instructions::Signedness::Unsigned,
+            ),
+            crate::ScalarKind::Float => super::instructions::instruction_type_float(id, bits),
+            crate::ScalarKind::Bool => super::instructions::instruction_type_bool(id),
         }
     }
 
@@ -849,7 +347,7 @@ impl Writer {
             LocalType::Scalar { kind, width } => self.write_scalar(id, kind, width),
             LocalType::Vector { size, .. } => {
                 let scalar_id = self.get_type_id(arena, LookupType::Local(local_ty));
-                self.instruction_type_vector(id, scalar_id, size)
+                super::instructions::instruction_type_vector(id, scalar_id, size)
             }
             LocalType::Pointer { .. } => unimplemented!(),
         };
@@ -880,7 +378,7 @@ impl Writer {
                     LookupType::Local(LocalType::Vector { size, kind, width }),
                     id,
                 );
-                self.instruction_type_vector(id, scalar_id, size)
+                super::instructions::instruction_type_vector(id, scalar_id, size)
             }
             crate::TypeInner::Matrix {
                 columns,
@@ -896,7 +394,7 @@ impl Writer {
                         width,
                     }),
                 );
-                self.instruction_type_matrix(id, vector_id, columns)
+                super::instructions::instruction_type_matrix(id, vector_id, columns)
             }
             crate::TypeInner::Image {
                 kind,
@@ -914,24 +412,29 @@ impl Writer {
                 );
                 let dim = map_dim(dim);
                 self.try_add_capabilities(dim.required_capabilities());
-                self.instruction_type_image(id, type_id, dim, arrayed, class)
+                super::instructions::instruction_type_image(id, type_id, dim, arrayed, class)
             }
-            crate::TypeInner::Sampler { comparison: _ } => self.instruction_type_sampler(id),
+            crate::TypeInner::Sampler { comparison: _ } => {
+                super::instructions::instruction_type_sampler(id)
+            }
             crate::TypeInner::Array { size, stride, .. } => {
                 if let Some(array_stride) = stride {
-                    self.annotations.push(self.instruction_decorate(
-                        id,
-                        spirv::Decoration::ArrayStride,
-                        &[array_stride.get()],
-                    ));
+                    self.annotations
+                        .push(super::instructions::instruction_decorate(
+                            id,
+                            spirv::Decoration::ArrayStride,
+                            &[array_stride.get()],
+                        ));
                 }
 
                 let type_id = self.get_type_id(arena, LookupType::Handle(handle));
                 match size {
                     crate::ArraySize::Static(length) => {
-                        self.instruction_type_array(id, type_id, length)
+                        super::instructions::instruction_type_array(id, type_id, length)
                     }
-                    crate::ArraySize::Dynamic => self.instruction_type_runtime_array(id, type_id),
+                    crate::ArraySize::Dynamic => {
+                        super::instructions::instruction_type_runtime_array(id, type_id)
+                    }
                 }
             }
             crate::TypeInner::Struct { ref members } => {
@@ -940,7 +443,7 @@ impl Writer {
                     let member_id = self.get_type_id(arena, LookupType::Handle(member.ty));
                     member_ids.push(member_id);
                 }
-                self.instruction_type_struct(id, member_ids)
+                super::instructions::instruction_type_struct(id, member_ids)
             }
             crate::TypeInner::Pointer { base, class } => {
                 let type_id = self.get_type_id(arena, LookupType::Handle(base));
@@ -951,7 +454,11 @@ impl Writer {
                     }),
                     id,
                 );
-                self.instruction_type_pointer(id, self.parse_to_spirv_storage_class(class), type_id)
+                super::instructions::instruction_type_pointer(
+                    id,
+                    self.parse_to_spirv_storage_class(class),
+                    type_id,
+                )
             }
         };
 
@@ -977,10 +484,10 @@ impl Writer {
 
                 let instruction = match ty.inner {
                     crate::TypeInner::Scalar { kind: _, width } => match width {
-                        4 => self.instruction_constant(type_id, id, &[val as u32]),
+                        4 => super::instructions::instruction_constant(type_id, id, &[val as u32]),
                         8 => {
                             let (low, high) = ((val >> 32) as u32, val as u32);
-                            self.instruction_constant(type_id, id, &[low, high])
+                            super::instructions::instruction_constant(type_id, id, &[low, high])
                         }
                         _ => unreachable!(),
                     },
@@ -994,10 +501,10 @@ impl Writer {
 
                 let instruction = match ty.inner {
                     crate::TypeInner::Scalar { kind: _, width } => match width {
-                        4 => self.instruction_constant(type_id, id, &[val as u32]),
+                        4 => super::instructions::instruction_constant(type_id, id, &[val as u32]),
                         8 => {
                             let (low, high) = ((val >> 32) as u32, val as u32);
-                            self.instruction_constant(type_id, id, &[low, high])
+                            super::instructions::instruction_constant(type_id, id, &[low, high])
                         }
                         _ => unreachable!(),
                     },
@@ -1012,11 +519,15 @@ impl Writer {
 
                 let instruction = match ty.inner {
                     crate::TypeInner::Scalar { kind: _, width } => match width {
-                        4 => self.instruction_constant(type_id, id, &[(val as f32).to_bits()]),
+                        4 => super::instructions::instruction_constant(
+                            type_id,
+                            id,
+                            &[(val as f32).to_bits()],
+                        ),
                         8 => {
                             let bits = f64::to_bits(val);
                             let (low, high) = ((bits >> 32) as u32, bits as u32);
-                            self.instruction_constant(type_id, id, &[low, high])
+                            super::instructions::instruction_constant(type_id, id, &[low, high])
                         }
                         _ => unreachable!(),
                     },
@@ -1028,9 +539,9 @@ impl Writer {
                 let type_id = self.get_type_id(arena, LookupType::Handle(constant.ty));
 
                 let instruction = if val {
-                    self.instruction_constant_true(type_id, id)
+                    super::instructions::instruction_constant_true(type_id, id)
                 } else {
-                    self.instruction_constant_false(type_id, id)
+                    super::instructions::instruction_constant_false(type_id, id)
                 };
 
                 (instruction, id)
@@ -1043,7 +554,11 @@ impl Writer {
                 }
 
                 let type_id = self.get_type_id(arena, LookupType::Handle(constant.ty));
-                let instruction = self.instruction_constant_composite(type_id, id, constituent_ids);
+                let instruction = super::instructions::instruction_constant_composite(
+                    type_id,
+                    id,
+                    constituent_ids,
+                );
                 (instruction, id)
             }
         }
@@ -1061,11 +576,13 @@ impl Writer {
         self.try_add_capabilities(class.required_capabilities());
 
         let pointer_id = self.get_pointer_id(arena, global_variable.ty, class);
-        let instruction = self.instruction_variable(pointer_id, id, class, None);
+        let instruction = super::instructions::instruction_variable(pointer_id, id, class, None);
 
         if self.writer_flags.contains(WriterFlags::DEBUG) {
-            self.debugs
-                .push(self.instruction_name(id, global_variable.name.as_ref().unwrap().as_str()));
+            self.debugs.push(super::instructions::instruction_name(
+                id,
+                global_variable.name.as_ref().unwrap().as_str(),
+            ));
         }
 
         if let Some(interpolation) = global_variable.interpolation {
@@ -1079,29 +596,36 @@ impl Writer {
             };
             if let Some(decoration) = decoration {
                 self.annotations
-                    .push(self.instruction_decorate(id, decoration, &[]));
+                    .push(super::instructions::instruction_decorate(
+                        id,
+                        decoration,
+                        &[],
+                    ));
             }
         }
 
         match global_variable.binding.as_ref().unwrap() {
             crate::Binding::Location(location) => {
-                self.annotations.push(self.instruction_decorate(
-                    id,
-                    spirv::Decoration::Location,
-                    &[*location],
-                ));
+                self.annotations
+                    .push(super::instructions::instruction_decorate(
+                        id,
+                        spirv::Decoration::Location,
+                        &[*location],
+                    ));
             }
             crate::Binding::Descriptor { set, binding } => {
-                self.annotations.push(self.instruction_decorate(
-                    id,
-                    spirv::Decoration::DescriptorSet,
-                    &[*set],
-                ));
-                self.annotations.push(self.instruction_decorate(
-                    id,
-                    spirv::Decoration::Binding,
-                    &[*binding],
-                ));
+                self.annotations
+                    .push(super::instructions::instruction_decorate(
+                        id,
+                        spirv::Decoration::DescriptorSet,
+                        &[*set],
+                    ));
+                self.annotations
+                    .push(super::instructions::instruction_decorate(
+                        id,
+                        spirv::Decoration::Binding,
+                        &[*binding],
+                    ));
             }
             crate::Binding::BuiltIn(built_in) => {
                 let built_in = match built_in {
@@ -1122,11 +646,12 @@ impl Writer {
                     crate::BuiltIn::WorkGroupId => spirv::BuiltIn::WorkgroupId,
                 };
 
-                self.annotations.push(self.instruction_decorate(
-                    id,
-                    spirv::Decoration::BuiltIn,
-                    &[built_in as u32],
-                ));
+                self.annotations
+                    .push(super::instructions::instruction_decorate(
+                        id,
+                        spirv::Decoration::BuiltIn,
+                        &[built_in as u32],
+                    ));
             }
         }
 
@@ -1148,7 +673,7 @@ impl Writer {
             Entry::Occupied(e) => *e.get(),
             _ => {
                 let id = self.generate_id();
-                let instruction = self.instruction_type_function(
+                let instruction = super::instructions::instruction_type_function(
                     id,
                     lookup_function_type.return_type_id,
                     parameter_pointer_ids,
@@ -1196,8 +721,11 @@ impl Writer {
                     constituent_ids.push(component_id);
                 }
 
-                let instruction =
-                    self.instruction_composite_construct(type_id, id, constituent_ids);
+                let instruction = super::instructions::instruction_composite_construct(
+                    type_id,
+                    id,
+                    constituent_ids,
+                );
                 block.body.push(instruction);
                 Some((id, Some(*ty)))
             }
@@ -1258,11 +786,15 @@ impl Writer {
                             };
 
                         let load_id = self.generate_id();
-                        let load_instruction =
-                            self.instruction_load(result_type_id, load_id, vector_id, None);
+                        let load_instruction = super::instructions::instruction_load(
+                            result_type_id,
+                            load_id,
+                            vector_id,
+                            None,
+                        );
                         block.body.push(load_instruction);
 
-                        let instruction = self.instruction_vector_times_scalar(
+                        let instruction = super::instructions::instruction_vector_times_scalar(
                             result_type_id,
                             id,
                             load_id,
@@ -1294,7 +826,7 @@ impl Writer {
                 let type_id = self.get_type_id(&ir_module.types, LookupType::Handle(*handle));
                 let load_id = self.generate_id();
 
-                block.body.push(self.instruction_load(
+                block.body.push(super::instructions::instruction_load(
                     type_id,
                     load_id,
                     function.parameters[*index as usize].result_id.unwrap(),
@@ -1328,26 +860,30 @@ impl Writer {
                         function.variables.push(LocalVariable {
                             id: variable_id,
                             name: None,
-                            instruction: self.instruction_variable(
+                            instruction: super::instructions::instruction_variable(
                                 pointer_id,
                                 variable_id,
                                 spirv::StorageClass::Function,
                                 None,
                             ),
                         });
-                        block.body.push(self.instruction_store(variable_id, id));
+                        block
+                            .body
+                            .push(super::instructions::instruction_store(variable_id, id));
                         argument_ids.push(variable_id);
                     }
 
                     let return_type_id = self
                         .get_function_return_type(origin_function.return_type, &ir_module.types);
 
-                    block.body.push(self.instruction_function_call(
-                        return_type_id,
-                        id,
-                        *self.lookup_function.get(local_function).unwrap(),
-                        argument_ids,
-                    ));
+                    block
+                        .body
+                        .push(super::instructions::instruction_function_call(
+                            return_type_id,
+                            id,
+                            *self.lookup_function.get(local_function).unwrap(),
+                            argument_ids,
+                        ));
                     Some((id, None))
                 }
                 _ => unimplemented!("{:?}", origin),
@@ -1375,9 +911,9 @@ impl Writer {
                     let id = match expression {
                         crate::Expression::LocalVariable(_) => {
                             let load_id = self.generate_id();
-                            let value_ty_id = self
-                                .get_type_id(&ir_module.types, LookupType::Handle(ty.unwrap()));
-                            block.body.push(self.instruction_load(
+                            let value_ty_id =
+                                self.get_type_id(&ir_module.types, LookupType::Handle(ty.unwrap()));
+                            block.body.push(super::instructions::instruction_load(
                                 value_ty_id,
                                 load_id,
                                 id,
@@ -1385,11 +921,11 @@ impl Writer {
                             ));
                             load_id
                         }
-                        _ => id
+                        _ => id,
                     };
-                    block.termination = Some(self.instruction_return_value(id));
+                    block.termination = Some(super::instructions::instruction_return_value(id));
                 }
-                None => block.termination = Some(self.instruction_return()),
+                None => block.termination = Some(super::instructions::instruction_return()),
             },
             crate::Statement::Store { pointer, value } => {
                 let pointer_expression = &ir_function.expressions[*pointer];
@@ -1406,7 +942,7 @@ impl Writer {
                         let load_id = self.generate_id();
                         let value_ty_id = self
                             .get_type_id(&ir_module.types, LookupType::Handle(value_ty.unwrap()));
-                        block.body.push(self.instruction_load(
+                        block.body.push(super::instructions::instruction_load(
                             value_ty_id,
                             load_id,
                             value_id,
@@ -1419,7 +955,7 @@ impl Writer {
 
                 block
                     .body
-                    .push(self.instruction_store(pointer_id, value_id));
+                    .push(super::instructions::instruction_store(pointer_id, value_id));
             }
             crate::Statement::Empty => {}
             _ => unimplemented!("{:?}", statement),
@@ -1431,12 +967,15 @@ impl Writer {
     }
 
     fn write_logical_layout(&mut self, ir_module: &crate::Module) {
-        self.instruction_ext_inst_import("GLSL.std.450")
+        let id = self.generate_id();
+        super::instructions::instruction_ext_inst_import(id, "GLSL.std.450")
             .to_words(&mut self.logical_layout.ext_inst_imports);
 
         if self.writer_flags.contains(WriterFlags::DEBUG) {
-            self.debugs
-                .push(self.instruction_source(spirv::SourceLanguage::GLSL, 450));
+            self.debugs.push(super::instructions::instruction_source(
+                spirv::SourceLanguage::GLSL,
+                450,
+            ));
         }
 
         // Looking through all global variable, types, constants.
@@ -1482,7 +1021,7 @@ impl Writer {
                 function.variables.push(LocalVariable {
                     id,
                     name: variable.name.clone(),
-                    instruction: self.instruction_variable(
+                    instruction: super::instructions::instruction_variable(
                         pointer_id,
                         id,
                         spirv::StorageClass::Function,
@@ -1510,7 +1049,9 @@ impl Writer {
                     .push(self.get_type_id(&ir_module.types, LookupType::Handle(*parameter_type)));
                 function
                     .parameters
-                    .push(self.instruction_function_parameter(pointer_id, id));
+                    .push(super::instructions::instruction_function_parameter(
+                        pointer_id, id,
+                    ));
             }
 
             let lookup_function_type = LookupFunctionType {
@@ -1521,7 +1062,7 @@ impl Writer {
             let id = self.generate_id();
             let function_type =
                 self.get_function_type(lookup_function_type, function_parameter_pointer_ids);
-            function.signature = Some(self.instruction_function(
+            function.signature = Some(super::instructions::instruction_function(
                 return_type_id,
                 id,
                 spirv::FunctionControl::empty(),
@@ -1532,7 +1073,7 @@ impl Writer {
 
             let mut block = Block::new();
             let id = self.generate_id();
-            block.label = Some(self.instruction_label(id));
+            block.label = Some(super::instructions::instruction_label(id));
             for statement in ir_function.body.iter() {
                 self.write_function_statement(
                     ir_module,
@@ -1545,21 +1086,26 @@ impl Writer {
             function.blocks.push(block);
 
             function.to_words(&mut self.logical_layout.function_definitions);
-            self.instruction_function_end()
+            super::instructions::instruction_function_end()
                 .to_words(&mut self.logical_layout.function_definitions);
         }
 
         for entry_point in ir_module.entry_points.iter() {
-            let entry_point_instruction = self.instruction_entry_point(entry_point, ir_module);
+            let entry_point_instruction = self.write_entry_point(entry_point, ir_module);
             entry_point_instruction.to_words(&mut self.logical_layout.entry_points);
         }
 
         for capability in self.capabilities.iter() {
-            self.instruction_capability(*capability)
+            super::instructions::instruction_capability(*capability)
                 .to_words(&mut self.logical_layout.capabilities);
         }
 
-        self.instruction_memory_model()
+        let addressing_model = spirv::AddressingModel::Logical;
+        let memory_model = spirv::MemoryModel::GLSL450;
+        self.try_add_capabilities(addressing_model.required_capabilities());
+        self.try_add_capabilities(memory_model.required_capabilities());
+
+        super::instructions::instruction_memory_model(addressing_model, memory_model)
             .to_words(&mut self.logical_layout.memory_model);
 
         if self.writer_flags.contains(WriterFlags::DEBUG) {
@@ -1607,181 +1153,6 @@ mod tests {
 
         writer.try_add_capabilities(&[spirv::Capability::Shader]);
         assert_eq!(writer.capabilities.len(), 1);
-    }
-
-    #[test]
-    fn test_instruction_capability() {
-        let writer = create_writer();
-        let instruction = writer.instruction_capability(spirv::Capability::Shader);
-        let mut output = vec![];
-
-        let requirements = SpecRequirements {
-            op: Op::Capability,
-            wc: 2,
-            type_id: false,
-            result_id: false,
-            operands: true,
-        };
-
-        validate_spec_requirements(requirements, &instruction);
-
-        instruction.to_words(&mut output);
-        validate_instruction(output.as_slice(), &instruction);
-    }
-
-    #[test]
-    fn test_instruction_ext_inst_import() {
-        let mut writer = create_writer();
-        let import_name = "GLSL.std.450";
-        let instruction = writer.instruction_ext_inst_import(import_name);
-        let mut output = vec![];
-
-        let requirements = SpecRequirements {
-            op: Op::ExtInstImport,
-            wc: 2,
-            type_id: false,
-            result_id: true,
-            operands: true,
-        };
-
-        validate_spec_requirements(requirements, &instruction);
-
-        instruction.to_words(&mut output);
-        validate_instruction(output.as_slice(), &instruction);
-    }
-
-    #[test]
-    fn test_instruction_memory_model() {
-        let mut writer = create_writer();
-        let instruction = writer.instruction_memory_model();
-        let mut output = vec![];
-
-        let requirements = SpecRequirements {
-            op: Op::MemoryModel,
-            wc: 3,
-            type_id: false,
-            result_id: false,
-            operands: true,
-        };
-        validate_spec_requirements(requirements, &instruction);
-
-        instruction.to_words(&mut output);
-        validate_instruction(output.as_slice(), &instruction);
-    }
-
-    #[test]
-    fn test_instruction_name() {
-        let writer = create_writer();
-        let instruction = writer.instruction_name(1, "Test");
-        let mut output = vec![];
-
-        let requirements = SpecRequirements {
-            op: Op::Name,
-            wc: 3,
-            type_id: false,
-            result_id: true,
-            operands: true,
-        };
-        validate_spec_requirements(requirements, &instruction);
-
-        instruction.to_words(&mut output);
-        validate_instruction(output.as_slice(), &instruction);
-    }
-
-    #[test]
-    fn test_instruction_execution_mode() {
-        let writer = create_writer();
-        let instruction = writer.instruction_execution_mode(1, ExecutionMode::OriginUpperLeft);
-        let mut output = vec![];
-
-        let requirements = SpecRequirements {
-            op: Op::ExecutionMode,
-            wc: 3,
-            type_id: false,
-            result_id: false,
-            operands: true,
-        };
-        validate_spec_requirements(requirements, &instruction);
-
-        instruction.to_words(&mut output);
-        validate_instruction(output.as_slice(), &instruction);
-    }
-
-    #[test]
-    fn test_instruction_source() {
-        let writer = create_writer();
-        let version = 450;
-        let instruction = writer.instruction_source(SourceLanguage::GLSL, version);
-        let mut output = vec![];
-
-        let requirements = SpecRequirements {
-            op: Op::Source,
-            wc: 3,
-            type_id: false,
-            result_id: false,
-            operands: true,
-        };
-        validate_spec_requirements(requirements, &instruction);
-
-        instruction.to_words(&mut output);
-        validate_instruction(output.as_slice(), &instruction);
-    }
-
-    #[test]
-    fn test_instruction_label() {
-        let writer = create_writer();
-        let instruction = writer.instruction_label(1);
-        let mut output = vec![];
-
-        let requirements = SpecRequirements {
-            op: Op::Label,
-            wc: 2,
-            type_id: false,
-            result_id: true,
-            operands: false,
-        };
-        validate_spec_requirements(requirements, &instruction);
-
-        instruction.to_words(&mut output);
-        validate_instruction(output.as_slice(), &instruction);
-    }
-
-    #[test]
-    fn test_instruction_function_end() {
-        let writer = create_writer();
-        let instruction = writer.instruction_function_end();
-        let mut output = vec![];
-
-        let requirements = SpecRequirements {
-            op: Op::FunctionEnd,
-            wc: 1,
-            type_id: false,
-            result_id: false,
-            operands: false,
-        };
-        validate_spec_requirements(requirements, &instruction);
-
-        instruction.to_words(&mut output);
-        validate_instruction(output.as_slice(), &instruction);
-    }
-
-    #[test]
-    fn test_instruction_decorate() {
-        let writer = create_writer();
-        let instruction = writer.instruction_decorate(1, Decoration::Location, &[1]);
-        let mut output = vec![];
-
-        let requirements = SpecRequirements {
-            op: Op::Decorate,
-            wc: 3,
-            type_id: false,
-            result_id: false,
-            operands: true,
-        };
-        validate_spec_requirements(requirements, &instruction);
-
-        instruction.to_words(&mut output);
-        validate_instruction(output.as_slice(), &instruction);
     }
 
     #[test]

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -302,7 +302,7 @@ impl Writer {
             exec_model,
             function_id,
             entry_point.name.as_str(),
-            interface_ids,
+            interface_ids.as_slice(),
         )
     }
 
@@ -443,7 +443,7 @@ impl Writer {
                     let member_id = self.get_type_id(arena, LookupType::Handle(member.ty));
                     member_ids.push(member_id);
                 }
-                super::instructions::instruction_type_struct(id, member_ids)
+                super::instructions::instruction_type_struct(id, member_ids.as_slice())
             }
             crate::TypeInner::Pointer { base, class } => {
                 let type_id = self.get_type_id(arena, LookupType::Handle(base));
@@ -557,7 +557,7 @@ impl Writer {
                 let instruction = super::instructions::instruction_constant_composite(
                     type_id,
                     id,
-                    constituent_ids,
+                    constituent_ids.as_slice(),
                 );
                 (instruction, id)
             }
@@ -676,7 +676,7 @@ impl Writer {
                 let instruction = super::instructions::instruction_type_function(
                     id,
                     lookup_function_type.return_type_id,
-                    parameter_pointer_ids,
+                    parameter_pointer_ids.as_slice(),
                 );
                 instruction.to_words(&mut self.logical_layout.declarations);
                 self.lookup_function_type.insert(lookup_function_type, id);
@@ -724,7 +724,7 @@ impl Writer {
                 let instruction = super::instructions::instruction_composite_construct(
                     type_id,
                     id,
-                    constituent_ids,
+                    constituent_ids.as_slice(),
                 );
                 block.body.push(instruction);
                 Some((id, Some(*ty)))
@@ -867,9 +867,11 @@ impl Writer {
                                 None,
                             ),
                         });
-                        block
-                            .body
-                            .push(super::instructions::instruction_store(variable_id, id, None));
+                        block.body.push(super::instructions::instruction_store(
+                            variable_id,
+                            id,
+                            None,
+                        ));
                         argument_ids.push(variable_id);
                     }
 
@@ -882,7 +884,7 @@ impl Writer {
                             return_type_id,
                             id,
                             *self.lookup_function.get(local_function).unwrap(),
-                            argument_ids,
+                            argument_ids.as_slice(),
                         ));
                     Some((id, None))
                 }
@@ -953,9 +955,9 @@ impl Writer {
                     _ => value_id,
                 };
 
-                block
-                    .body
-                    .push(super::instructions::instruction_store(pointer_id, value_id,None));
+                block.body.push(super::instructions::instruction_store(
+                    pointer_id, value_id, None,
+                ));
             }
             crate::Statement::Empty => {}
             _ => unimplemented!("{:?}", statement),


### PR DESCRIPTION
The [writer.rs](https://github.com/gfx-rs/naga/blob/master/src/back/spv/writer.rs#L255) in the spirv back-end was becoming a little bit too cluttered with instructions, especially after I wanted to add even more of them.  So I decided to move them to their own module. This is done for maintainability, as the instructions module will reach a point where it will always be correct (as the spirv spec doesn't really change).

- [x] Move all instructions to the instructions module.
- [x] Remove the instructions_ prefix of the instructions.
- [x] Move all current instruction unit tests to the instructions module.
- [x] Consistent parameter naming and order for each instruction (sometimes its `result_id`, sometimes `id`).
- [x] Check if all the correct Instruction methods are called (there are some cases where an instruction doesn't have an `result_id`, but it is still called).
- [x] Check compliance with spirv v1 spec (as when I implemented the spirv back-end, I was implementing it via the unified spec, instead of v1).
- [x] Update all current instruction unit tests.
- [x] Add instruction unit tests for all current instructions that don't have a test yet.

After this, the spirv back-end will be ready for its growth towards compiling more complex shaders (boids).