### PR TITLE
[rosetta] Add explicit return

### DIFF
--- a/test-data/simple/simple.expected.ron
+++ b/test-data/simple/simple.expected.ron
@@ -99,6 +99,9 @@
                     pointer: 2,
                     value: 6,
                 ),
+                Return(
+                    value: None,
+                ),
             ],
         ),
     ],

--- a/test-data/simple/simple.vert
+++ b/test-data/simple/simple.vert
@@ -6,4 +6,5 @@ layout(location = 0) out vec4 o_pos;
 void main() {
     float w = 1.0;
     o_pos = vec4(a_pos, 0.0, w);
+    return;
 }

--- a/test-data/simple/simple.wgsl
+++ b/test-data/simple/simple.wgsl
@@ -5,5 +5,6 @@
 fn main() -> void {
   var w: f32 = 1.0;
   o_pos = vec4<f32>(a_pos, 0.0, w);
+  return;
 }
 entry_point vertex as "main" = main;


### PR DESCRIPTION
Temporary add explicit return to Rosetta test, until we handle this in intermediary step between front and back-end.