### PR TITLE
Move storage class from image type into the global declaration

### DIFF
--- a/src/back/glsl.rs
+++ b/src/back/glsl.rs
@@ -254,7 +254,7 @@ pub fn write<'a>(module: &'a Module, out: &mut impl Write, options: Options) -> 
 
         let storage_format = match module.types[global.ty].inner {
             TypeInner::Image {
-                class: ImageClass::Storage(format, _),
+                class: ImageClass::Storage(format),
                 ..
             } => Some(format),
             _ => None,
@@ -280,16 +280,10 @@ pub fn write<'a>(module: &'a Module, out: &mut impl Write, options: Options) -> 
             write!(out, ") ")?;
         }
 
-        if let TypeInner::Image {
-            class: ImageClass::Storage(_, access),
-            ..
-        } = module.types[global.ty].inner
-        {
-            if access == StorageAccess::LOAD {
-                write!(out, "readonly ")?;
-            } else if access == StorageAccess::STORE {
-                write!(out, "writeonly ")?;
-            }
+        if global.storage_access == StorageAccess::LOAD {
+            write!(out, "readonly ")?;
+        } else if global.storage_access == StorageAccess::STORE {
+            write!(out, "writeonly ")?;
         }
 
         if let Some(interpolation) = global.interpolation {
@@ -950,9 +944,7 @@ fn write_expression<'a, 'b>(
                         )
                     }
                 }
-                ImageClass::Storage(_, _) => {
-                    format!("imageLoad({},{})", image_expr, coordinate_expr)
-                }
+                ImageClass::Storage(_) => format!("imageLoad({},{})", image_expr, coordinate_expr),
                 ImageClass::Depth => todo!(),
             };
 
@@ -1402,7 +1394,7 @@ fn write_type<'a>(
                         ))),
                 },
                 match class {
-                    ImageClass::Storage(_, _) => "image",
+                    ImageClass::Storage(_) => "image",
                     _ => "texture",
                 },
                 ImageDimension(dim),

--- a/src/back/msl.rs
+++ b/src/back/msl.rs
@@ -944,17 +944,23 @@ impl<W: Write> Writer<W> {
                     };
                     let array_str = if arrayed { "_array" } else { "" };
                     let access = match class {
-                        crate::ImageClass::Storage(_, access) => {
-                            if access
+                        crate::ImageClass::Storage(_) => {
+                            let (_, global) = module
+                                .global_variables
+                                .iter()
+                                .find(|(_, var)| var.ty == handle)
+                                .expect("Unable to find a global variable using the image type");
+                            if global
+                                .storage_access
                                 .contains(crate::StorageAccess::LOAD | crate::StorageAccess::STORE)
                             {
                                 "read_write"
-                            } else if access.contains(crate::StorageAccess::STORE) {
+                            } else if global.storage_access.contains(crate::StorageAccess::STORE) {
                                 "write"
-                            } else if access.contains(crate::StorageAccess::LOAD) {
+                            } else if global.storage_access.contains(crate::StorageAccess::LOAD) {
                                 "read"
                             } else {
-                                return Err(Error::InvalidImageAccess(access));
+                                return Err(Error::InvalidImageAccess(global.storage_access));
                             }
                         }
                         _ => "sample",

--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -187,59 +187,45 @@ pub(super) fn instruction_type_image(
         _ => 0,
     });
 
-    let (format, access) = match image_class {
-        crate::ImageClass::Storage(format, access) => {
-            let spv_format = match format {
-                crate::StorageFormat::R8Unorm => spirv::ImageFormat::R8,
-                crate::StorageFormat::R8Snorm => spirv::ImageFormat::R8Snorm,
-                crate::StorageFormat::R8Uint => spirv::ImageFormat::R8ui,
-                crate::StorageFormat::R8Sint => spirv::ImageFormat::R8i,
-                crate::StorageFormat::R16Uint => spirv::ImageFormat::R16ui,
-                crate::StorageFormat::R16Sint => spirv::ImageFormat::R16i,
-                crate::StorageFormat::R16Float => spirv::ImageFormat::R16f,
-                crate::StorageFormat::Rg8Unorm => spirv::ImageFormat::Rg8,
-                crate::StorageFormat::Rg8Snorm => spirv::ImageFormat::Rg8Snorm,
-                crate::StorageFormat::Rg8Uint => spirv::ImageFormat::Rg8ui,
-                crate::StorageFormat::Rg8Sint => spirv::ImageFormat::Rg8i,
-                crate::StorageFormat::R32Uint => spirv::ImageFormat::R32ui,
-                crate::StorageFormat::R32Sint => spirv::ImageFormat::R32i,
-                crate::StorageFormat::R32Float => spirv::ImageFormat::R32f,
-                crate::StorageFormat::Rg16Uint => spirv::ImageFormat::Rg16ui,
-                crate::StorageFormat::Rg16Sint => spirv::ImageFormat::Rg16i,
-                crate::StorageFormat::Rg16Float => spirv::ImageFormat::Rg16f,
-                crate::StorageFormat::Rgba8Unorm => spirv::ImageFormat::Rgba8,
-                crate::StorageFormat::Rgba8Snorm => spirv::ImageFormat::Rgba8Snorm,
-                crate::StorageFormat::Rgba8Uint => spirv::ImageFormat::Rgba8ui,
-                crate::StorageFormat::Rgba8Sint => spirv::ImageFormat::Rgba8i,
-                crate::StorageFormat::Rgb10a2Unorm => spirv::ImageFormat::Rgb10a2ui,
-                crate::StorageFormat::Rg11b10Float => spirv::ImageFormat::R11fG11fB10f,
-                crate::StorageFormat::Rg32Uint => spirv::ImageFormat::Rg32ui,
-                crate::StorageFormat::Rg32Sint => spirv::ImageFormat::Rg32i,
-                crate::StorageFormat::Rg32Float => spirv::ImageFormat::Rg32f,
-                crate::StorageFormat::Rgba16Uint => spirv::ImageFormat::Rgba16ui,
-                crate::StorageFormat::Rgba16Sint => spirv::ImageFormat::Rgba16i,
-                crate::StorageFormat::Rgba16Float => spirv::ImageFormat::Rgba16f,
-                crate::StorageFormat::Rgba32Uint => spirv::ImageFormat::Rgba32ui,
-                crate::StorageFormat::Rgba32Sint => spirv::ImageFormat::Rgba32i,
-                crate::StorageFormat::Rgba32Float => spirv::ImageFormat::Rgba32f,
-            };
-            (spv_format, access)
-        }
-        _ => (spirv::ImageFormat::Unknown, crate::StorageAccess::empty()),
+    let format = match image_class {
+        crate::ImageClass::Storage(format) => match format {
+            crate::StorageFormat::R8Unorm => spirv::ImageFormat::R8,
+            crate::StorageFormat::R8Snorm => spirv::ImageFormat::R8Snorm,
+            crate::StorageFormat::R8Uint => spirv::ImageFormat::R8ui,
+            crate::StorageFormat::R8Sint => spirv::ImageFormat::R8i,
+            crate::StorageFormat::R16Uint => spirv::ImageFormat::R16ui,
+            crate::StorageFormat::R16Sint => spirv::ImageFormat::R16i,
+            crate::StorageFormat::R16Float => spirv::ImageFormat::R16f,
+            crate::StorageFormat::Rg8Unorm => spirv::ImageFormat::Rg8,
+            crate::StorageFormat::Rg8Snorm => spirv::ImageFormat::Rg8Snorm,
+            crate::StorageFormat::Rg8Uint => spirv::ImageFormat::Rg8ui,
+            crate::StorageFormat::Rg8Sint => spirv::ImageFormat::Rg8i,
+            crate::StorageFormat::R32Uint => spirv::ImageFormat::R32ui,
+            crate::StorageFormat::R32Sint => spirv::ImageFormat::R32i,
+            crate::StorageFormat::R32Float => spirv::ImageFormat::R32f,
+            crate::StorageFormat::Rg16Uint => spirv::ImageFormat::Rg16ui,
+            crate::StorageFormat::Rg16Sint => spirv::ImageFormat::Rg16i,
+            crate::StorageFormat::Rg16Float => spirv::ImageFormat::Rg16f,
+            crate::StorageFormat::Rgba8Unorm => spirv::ImageFormat::Rgba8,
+            crate::StorageFormat::Rgba8Snorm => spirv::ImageFormat::Rgba8Snorm,
+            crate::StorageFormat::Rgba8Uint => spirv::ImageFormat::Rgba8ui,
+            crate::StorageFormat::Rgba8Sint => spirv::ImageFormat::Rgba8i,
+            crate::StorageFormat::Rgb10a2Unorm => spirv::ImageFormat::Rgb10a2ui,
+            crate::StorageFormat::Rg11b10Float => spirv::ImageFormat::R11fG11fB10f,
+            crate::StorageFormat::Rg32Uint => spirv::ImageFormat::Rg32ui,
+            crate::StorageFormat::Rg32Sint => spirv::ImageFormat::Rg32i,
+            crate::StorageFormat::Rg32Float => spirv::ImageFormat::Rg32f,
+            crate::StorageFormat::Rgba16Uint => spirv::ImageFormat::Rgba16ui,
+            crate::StorageFormat::Rgba16Sint => spirv::ImageFormat::Rgba16i,
+            crate::StorageFormat::Rgba16Float => spirv::ImageFormat::Rgba16f,
+            crate::StorageFormat::Rgba32Uint => spirv::ImageFormat::Rgba32ui,
+            crate::StorageFormat::Rgba32Sint => spirv::ImageFormat::Rgba32i,
+            crate::StorageFormat::Rgba32Float => spirv::ImageFormat::Rgba32f,
+        },
+        _ => spirv::ImageFormat::Unknown,
     };
 
     instruction.add_operand(format as u32);
-    // Access Qualifier
-    if !access.is_empty() {
-        instruction.add_operand(if access == crate::StorageAccess::all() {
-            2
-        } else if access.contains(crate::StorageAccess::STORE) {
-            1
-        } else {
-            0
-        });
-    }
-
     instruction
 }
 

--- a/src/front/glsl/mod.rs
+++ b/src/front/glsl/mod.rs
@@ -2,8 +2,8 @@
 use crate::{
     Arena, ArraySize, BinaryOperator, Binding, BuiltIn, Constant, ConstantInner, EntryPoint,
     Expression, FastHashMap, Function, GlobalVariable, Handle, Header, Interpolation,
-    LocalVariable, Module, ScalarKind, ShaderStage, StorageClass, StructMember, Type, TypeInner,
-    VectorSize,
+    LocalVariable, Module, ScalarKind, ShaderStage, StorageAccess, StorageClass, StructMember,
+    Type, TypeInner, VectorSize,
 };
 use glsl::{
     parser::{Parse, ParseError},
@@ -236,6 +236,7 @@ impl<'a> Parser<'a> {
                             name,
                             ty,
                             interpolation,
+                            storage_access: StorageAccess::empty(), //TODO
                         });
 
                         for (name, index) in reexports {
@@ -586,6 +587,7 @@ impl<'a> Parser<'a> {
                                 },
                             }),
                             interpolation: None,
+                            storage_access: StorageAccess::empty(),
                         }),
                     )),
                     "gl_InstanceIndex" => Ok(Expression::GlobalVariable(
@@ -601,6 +603,7 @@ impl<'a> Parser<'a> {
                                 },
                             }),
                             interpolation: None,
+                            storage_access: StorageAccess::empty(),
                         }),
                     )),
                     "gl_BaseVertex" => Ok(Expression::GlobalVariable(
@@ -616,6 +619,7 @@ impl<'a> Parser<'a> {
                                 },
                             }),
                             interpolation: None,
+                            storage_access: StorageAccess::empty(),
                         }),
                     )),
                     "gl_BaseInstance" => Ok(Expression::GlobalVariable(
@@ -631,6 +635,7 @@ impl<'a> Parser<'a> {
                                 },
                             }),
                             interpolation: None,
+                            storage_access: StorageAccess::empty(),
                         }),
                     )),
                     "gl_Position" => Ok(Expression::GlobalVariable(self.globals.fetch_or_append(
@@ -651,6 +656,7 @@ impl<'a> Parser<'a> {
                                 },
                             }),
                             interpolation: None,
+                            storage_access: StorageAccess::empty(),
                         },
                     ))),
                     "gl_PointSize" => Ok(Expression::GlobalVariable(self.globals.fetch_or_append(
@@ -666,6 +672,7 @@ impl<'a> Parser<'a> {
                                 },
                             }),
                             interpolation: None,
+                            storage_access: StorageAccess::empty(),
                         },
                     ))),
                     "gl_ClipDistance" => Ok(Expression::GlobalVariable(
@@ -681,6 +688,7 @@ impl<'a> Parser<'a> {
                                 },
                             }),
                             interpolation: None,
+                            storage_access: StorageAccess::empty(),
                         }),
                     )),
                     other => {
@@ -1090,6 +1098,7 @@ impl<'a> Parser<'a> {
             binding,
             ty,
             interpolation,
+            storage_access: StorageAccess::empty(), //TODO
         }))
     }
 

--- a/src/front/glsl_new/parser.rs
+++ b/src/front/glsl_new/parser.rs
@@ -7,7 +7,8 @@ pomelo! {
         use super::super::{error::ErrorKind, token::*, ast::*};
         use crate::{Arena, BinaryOperator, Binding, Block, BuiltIn, Constant, ConstantInner, Expression,
             Function, GlobalVariable, Handle, LocalVariable, ScalarKind,
-            ShaderStage, Statement, StorageClass, Type, TypeInner, VectorSize, Interpolation};
+            ShaderStage, Statement, StorageAccess, StorageClass, Type, TypeInner,
+            VectorSize, Interpolation};
     }
     %token #[derive(Debug)] pub enum Token {};
     %parser pub struct Parser<'a> {};
@@ -151,6 +152,7 @@ pomelo! {
                             },
                         }),
                         interpolation: None,
+                        storage_access: StorageAccess::empty(),
                     },
                 );
                 extra.lookup_global_variables.insert(v.1.clone(), h);
@@ -719,6 +721,7 @@ pomelo! {
                     binding: binding.clone(),
                     ty: d.ty,
                     interpolation,
+                    storage_access: StorageAccess::empty(), //TODO
                 },
             );
             extra.lookup_global_variables.insert(id, h);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ pub enum ImageClass {
     /// Depth comparison image.
     Depth,
     /// Storage image.
-    Storage(StorageFormat, StorageAccess),
+    Storage(StorageFormat),
 }
 
 /// A data type declared in the module.
@@ -450,6 +450,8 @@ pub struct GlobalVariable {
     /// or fragment input, `None` corresponds to the
     /// `smooth`/`perspective` interpolation qualifier.
     pub interpolation: Option<Interpolation>,
+    /// Access bit for storage types of images and buffers.
+    pub storage_access: StorageAccess,
 }
 
 /// Variable defined at function level.

--- a/test-data/simple/simple.expected.ron
+++ b/test-data/simple/simple.expected.ron
@@ -49,6 +49,9 @@
             binding: Some(Location(0)),
             ty: 1,
             interpolation: None,
+            storage_access: (
+                bits: 0,
+            ),
         ),
         (
             name: Some("o_pos"),
@@ -56,6 +59,9 @@
             binding: Some(Location(0)),
             ty: 2,
             interpolation: None,
+            storage_access: (
+                bits: 0,
+            ),
         ),
     ],
     functions: [


### PR DESCRIPTION
It appears that the access flags are not really a part of the image type in SPIR-V. The `ReadOnly` and `WriteOnly` flags are only for the "Kernel" shader model, which we don't use.
Therefore, it's totally controlled by the decorations `NonReadable` and `NonWritable`, which are put on the global variables. Therefore, it makes sense to have the `storage_access` on the global vars instead of the image types, and now it can apply to buffers as well!

Unresolved: perhaps, the flags should be a part of the `StorageClass::Uniform` variant? I'm hesitating because SPIR-V confusingly considers storage buffers and images in this class. Also, it has an extension for the `StorageBuffer` class, which confuses me even more...