### PR TITLE
Refactor entry point IR

### DIFF
--- a/examples/convert.rs
+++ b/examples/convert.rs
@@ -3,7 +3,7 @@ use std::{env, fs, path::Path};
 
 #[derive(Hash, PartialEq, Eq, Serialize, Deserialize)]
 struct BindSource {
-    set: u32,
+    group: u32,
     binding: u32,
 }
 
@@ -54,26 +54,14 @@ fn main() {
         #[cfg(feature = "glsl-in")]
         "frag" => {
             let input = fs::read_to_string(&args[1]).unwrap();
-            naga::front::glsl::parse_str(
-                &input,
-                "main".to_string(),
-                naga::ShaderStage::Fragment {
-                    early_depth_test: None,
-                },
-            )
-            .unwrap()
+            naga::front::glsl::parse_str(&input, "main".to_string(), naga::ShaderStage::Fragment)
+                .unwrap()
         }
         #[cfg(feature = "glsl-in")]
         "comp" => {
             let input = fs::read_to_string(&args[1]).unwrap();
-            naga::front::glsl::parse_str(
-                &input,
-                "main".to_string(),
-                naga::ShaderStage::Compute {
-                    local_size: (0, 0, 0),
-                },
-            )
-            .unwrap()
+            naga::front::glsl::parse_str(&input, "main".to_string(), naga::ShaderStage::Compute)
+                .unwrap()
         }
         #[cfg(feature = "deserialize")]
         "ron" => {
@@ -113,7 +101,7 @@ fn main() {
             for (key, value) in params.metal_bindings {
                 binding_map.insert(
                     msl::BindSource {
-                        set: key.set,
+                        group: key.group,
                         binding: key.binding,
                     },
                     msl::BindTarget {
@@ -170,17 +158,13 @@ fn main() {
             let options = Options {
                 version: Version::Embedded(310),
                 entry_point: (
-                    String::from("main"),
                     match stage {
                         "vert" => ShaderStage::Vertex,
-                        "frag" => ShaderStage::Fragment {
-                            early_depth_test: None,
-                        },
-                        "comp" => ShaderStage::Compute {
-                            local_size: (0, 0, 0),
-                        },
+                        "frag" => ShaderStage::Fragment,
+                        "comp" => ShaderStage::Compute,
                         _ => unreachable!(),
                     },
+                    String::from("main"),
                 ),
             };
 

--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Arena, BinaryOperator, Binding, Constant, Expression, FastHashMap, Function, GlobalVariable,
-    Handle, Interpolation, LocalVariable, ShaderStage, Statement, StorageClass, Type,
+    Arena, BinaryOperator, Binding, Expression, FastHashMap, Function, GlobalVariable, Handle,
+    Interpolation, LocalVariable, Module, ShaderStage, Statement, StorageClass, Type,
 };
 
 #[derive(Debug)]
@@ -8,28 +8,23 @@ pub struct Program {
     pub version: u16,
     pub profile: Profile,
     pub shader_stage: ShaderStage,
+    pub entry: Option<String>,
     pub lookup_function: FastHashMap<String, Handle<Function>>,
-    pub functions: Arena<Function>,
     pub lookup_type: FastHashMap<String, Handle<Type>>,
-    pub types: Arena<Type>,
-    pub constants: Arena<Constant>,
-    pub global_variables: Arena<GlobalVariable>,
     pub lookup_global_variables: FastHashMap<String, Handle<GlobalVariable>>,
     pub context: Context,
+    pub module: Module,
 }
 
 impl Program {
-    pub fn new(shader_stage: ShaderStage) -> Program {
+    pub fn new(shader_stage: ShaderStage, entry: String) -> Program {
         Program {
             version: 0,
             profile: Profile::Core,
             shader_stage,
+            entry: Some(entry),
             lookup_function: FastHashMap::default(),
-            functions: Arena::<Function>::new(),
             lookup_type: FastHashMap::default(),
-            types: Arena::<Type>::new(),
-            constants: Arena::<Constant>::new(),
-            global_variables: Arena::<GlobalVariable>::new(),
             lookup_global_variables: FastHashMap::default(),
             context: Context {
                 expressions: Arena::<Expression>::new(),
@@ -37,6 +32,7 @@ impl Program {
                 scopes: vec![FastHashMap::default()],
                 lookup_global_var_exps: FastHashMap::default(),
             },
+            module: Module::generate_empty(),
         }
     }
 

--- a/src/front/glsl/mod.rs
+++ b/src/front/glsl/mod.rs
@@ -1,4 +1,4 @@
-use crate::{EntryPoint, Module, ShaderStage};
+use crate::{Module, ShaderStage};
 
 mod lex;
 #[cfg(test)]
@@ -23,7 +23,7 @@ mod rosetta_tests;
 pub fn parse_str(source: &str, entry: String, stage: ShaderStage) -> Result<Module, ParseError> {
     log::debug!("------ GLSL-pomelo ------");
 
-    let mut program = Program::new(stage);
+    let mut program = Program::new(stage, entry);
     let lex = Lexer::new(source);
     let mut parser = parser::Parser::new(&mut program);
 
@@ -32,20 +32,5 @@ pub fn parse_str(source: &str, entry: String, stage: ShaderStage) -> Result<Modu
     }
     parser.end_of_input()?;
 
-    let mut module = Module::generate_empty();
-    module.functions = program.functions;
-    module.types = program.types;
-    module.constants = program.constants;
-    module.global_variables = program.global_variables;
-
-    // find entry point
-    if let Some(entry_handle) = program.lookup_function.get(&entry) {
-        module.entry_points.push(EntryPoint {
-            stage,
-            name: entry,
-            function: *entry_handle,
-        });
-    }
-
-    Ok(module)
+    Ok(program.module)
 }

--- a/src/front/glsl/parser_tests.rs
+++ b/src/front/glsl/parser_tests.rs
@@ -5,7 +5,7 @@ use super::parser;
 use crate::ShaderStage;
 
 fn parse_program(source: &str, stage: ShaderStage) -> Result<Program, ErrorKind> {
-    let mut program = Program::new(stage);
+    let mut program = Program::new(stage, "".to_string());
     let lex = Lexer::new(source);
     let mut parser = parser::Parser::new(&mut program);
 

--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -18,25 +18,28 @@ impl Program {
                         return Err(ErrorKind::VariableNotAvailable(name.into()));
                     }
                 };
-                let h = self.global_variables.fetch_or_append(GlobalVariable {
-                    name: Some(name.into()),
-                    class: if self.shader_stage == ShaderStage::Vertex {
-                        StorageClass::Output
-                    } else {
-                        StorageClass::Input
-                    },
-                    binding: Some(Binding::BuiltIn(BuiltIn::Position)),
-                    ty: self.types.fetch_or_append(Type {
-                        name: None,
-                        inner: TypeInner::Vector {
-                            size: VectorSize::Quad,
-                            kind: ScalarKind::Float,
-                            width: 4,
+                let h = self
+                    .module
+                    .global_variables
+                    .fetch_or_append(GlobalVariable {
+                        name: Some(name.into()),
+                        class: if self.shader_stage == ShaderStage::Vertex {
+                            StorageClass::Output
+                        } else {
+                            StorageClass::Input
                         },
-                    }),
-                    interpolation: None,
-                    storage_access: StorageAccess::empty(),
-                });
+                        binding: Some(Binding::BuiltIn(BuiltIn::Position)),
+                        ty: self.module.types.fetch_or_append(Type {
+                            name: None,
+                            inner: TypeInner::Vector {
+                                size: VectorSize::Quad,
+                                kind: ScalarKind::Float,
+                                width: 4,
+                            },
+                        }),
+                        interpolation: None,
+                        storage_access: StorageAccess::empty(),
+                    });
                 self.lookup_global_variables.insert(name.into(), h);
                 let exp = self
                     .context
@@ -54,20 +57,23 @@ impl Program {
                         return Err(ErrorKind::VariableNotAvailable(name.into()));
                     }
                 };
-                let h = self.global_variables.fetch_or_append(GlobalVariable {
-                    name: Some(name.into()),
-                    class: StorageClass::Input,
-                    binding: Some(Binding::BuiltIn(BuiltIn::VertexIndex)),
-                    ty: self.types.fetch_or_append(Type {
-                        name: None,
-                        inner: TypeInner::Scalar {
-                            kind: ScalarKind::Uint,
-                            width: 4,
-                        },
-                    }),
-                    interpolation: None,
-                    storage_access: StorageAccess::empty(),
-                });
+                let h = self
+                    .module
+                    .global_variables
+                    .fetch_or_append(GlobalVariable {
+                        name: Some(name.into()),
+                        class: StorageClass::Input,
+                        binding: Some(Binding::BuiltIn(BuiltIn::VertexIndex)),
+                        ty: self.module.types.fetch_or_append(Type {
+                            name: None,
+                            inner: TypeInner::Scalar {
+                                kind: ScalarKind::Uint,
+                                width: 4,
+                            },
+                        }),
+                        interpolation: None,
+                        storage_access: StorageAccess::empty(),
+                    });
                 self.lookup_global_variables.insert(name.into(), h);
                 let exp = self
                     .context

--- a/src/front/mod.rs
+++ b/src/front/mod.rs
@@ -19,7 +19,7 @@ impl crate::Module {
             constants: Arena::new(),
             global_variables: Arena::new(),
             functions: Arena::new(),
-            entry_points: Vec::new(),
+            entry_points: crate::FastHashMap::default(),
         }
     }
 

--- a/src/front/spv/function.rs
+++ b/src/front/spv/function.rs
@@ -49,123 +49,142 @@ pub enum Terminator {
     Unreachable,
 }
 
-pub fn parse_function<I: Iterator<Item = u32>>(
-    parser: &mut super::Parser<I>,
-    inst: Instruction,
-    module: &mut crate::Module,
-) -> Result<(), Error> {
-    parser.switch(ModuleState::Function, inst.op)?;
-    inst.expect(5)?;
-    let result_type = parser.next()?;
-    let fun_id = parser.next()?;
-    let _fun_control = parser.next()?;
-    let fun_type = parser.next()?;
-    let mut fun = {
-        let ft = parser.lookup_function_type.lookup(fun_type)?;
-        if ft.return_type_id != result_type {
-            return Err(Error::WrongFunctionResultType(result_type));
-        }
-        crate::Function {
-            name: parser.future_decor.remove(&fun_id).and_then(|dec| dec.name),
-            parameter_types: Vec::with_capacity(ft.parameter_type_ids.len()),
-            return_type: if parser.lookup_void_type.contains(&result_type) {
-                None
-            } else {
-                Some(parser.lookup_type.lookup(result_type)?.handle)
-            },
-            global_usage: Vec::new(),
-            local_variables: Arena::new(),
-            expressions: parser.make_expression_storage(),
-            body: Vec::new(),
-        }
-    };
+impl<I: Iterator<Item = u32>> super::Parser<I> {
+    pub fn parse_function(
+        &mut self,
+        inst: Instruction,
+        module: &mut crate::Module,
+    ) -> Result<(), Error> {
+        self.switch(ModuleState::Function, inst.op)?;
+        inst.expect(5)?;
+        let result_type = self.next()?;
+        let fun_id = self.next()?;
+        let _fun_control = self.next()?;
+        let fun_type = self.next()?;
 
-    // read parameters
-    for i in 0..fun.parameter_types.capacity() {
-        match parser.next_inst()? {
-            Instruction {
-                op: spirv::Op::FunctionParameter,
-                wc: 3,
-            } => {
-                let type_id = parser.next()?;
-                let id = parser.next()?;
-                let handle = fun
-                    .expressions
-                    .append(crate::Expression::FunctionParameter(i as u32));
-                parser
-                    .lookup_expression
-                    .insert(id, LookupExpression { type_id, handle });
-                //Note: we redo the lookup in order to work around `parser` borrowing
+        let mut fun = {
+            let ft = self.lookup_function_type.lookup(fun_type)?;
+            if ft.return_type_id != result_type {
+                return Err(Error::WrongFunctionResultType(result_type));
+            }
+            crate::Function {
+                name: self.future_decor.remove(&fun_id).and_then(|dec| dec.name),
+                parameter_types: Vec::with_capacity(ft.parameter_type_ids.len()),
+                return_type: if self.lookup_void_type.contains(&result_type) {
+                    None
+                } else {
+                    Some(self.lookup_type.lookup(result_type)?.handle)
+                },
+                global_usage: Vec::new(),
+                local_variables: Arena::new(),
+                expressions: self.make_expression_storage(),
+                body: Vec::new(),
+            }
+        };
 
-                if type_id
-                    != parser
-                        .lookup_function_type
-                        .lookup(fun_type)?
-                        .parameter_type_ids[i]
-                {
-                    return Err(Error::WrongFunctionParameterType(type_id));
+        // read parameters
+        for i in 0..fun.parameter_types.capacity() {
+            match self.next_inst()? {
+                Instruction {
+                    op: spirv::Op::FunctionParameter,
+                    wc: 3,
+                } => {
+                    let type_id = self.next()?;
+                    let id = self.next()?;
+                    let handle = fun
+                        .expressions
+                        .append(crate::Expression::FunctionParameter(i as u32));
+                    self.lookup_expression
+                        .insert(id, LookupExpression { type_id, handle });
+                    //Note: we redo the lookup in order to work around `self` borrowing
+
+                    if type_id
+                        != self
+                            .lookup_function_type
+                            .lookup(fun_type)?
+                            .parameter_type_ids[i]
+                    {
+                        return Err(Error::WrongFunctionParameterType(type_id));
+                    }
+                    let ty = self.lookup_type.lookup(type_id)?.handle;
+                    fun.parameter_types.push(ty);
                 }
-                let ty = parser.lookup_type.lookup(type_id)?.handle;
-                fun.parameter_types.push(ty);
-            }
-            Instruction { op, .. } => return Err(Error::InvalidParameter(op)),
-        }
-    }
-
-    // Read body
-    let mut local_function_calls = FastHashMap::default();
-    let mut flow_graph = FlowGraph::new();
-
-    // Scan the blocks and add them as nodes
-    loop {
-        let fun_inst = parser.next_inst()?;
-        log::debug!("{:?}", fun_inst.op);
-        match fun_inst.op {
-            spirv::Op::Label => {
-                // Read the label ID
-                fun_inst.expect(2)?;
-                let block_id = parser.next()?;
-
-                let node = parser.next_block(
-                    block_id,
-                    &mut fun.expressions,
-                    &mut fun.local_variables,
-                    &module.types,
-                    &module.constants,
-                    &module.global_variables,
-                    &mut local_function_calls,
-                )?;
-
-                flow_graph.add_node(node);
-            }
-            spirv::Op::FunctionEnd => {
-                fun_inst.expect(1)?;
-                break;
-            }
-            _ => {
-                return Err(Error::UnsupportedInstruction(parser.state, fun_inst.op));
+                Instruction { op, .. } => return Err(Error::InvalidParameter(op)),
             }
         }
+
+        // Read body
+        let mut local_function_calls = FastHashMap::default();
+        let mut flow_graph = FlowGraph::new();
+
+        // Scan the blocks and add them as nodes
+        loop {
+            let fun_inst = self.next_inst()?;
+            log::debug!("{:?}", fun_inst.op);
+            match fun_inst.op {
+                spirv::Op::Label => {
+                    // Read the label ID
+                    fun_inst.expect(2)?;
+                    let block_id = self.next()?;
+
+                    let node = self.next_block(
+                        block_id,
+                        &mut fun.expressions,
+                        &mut fun.local_variables,
+                        &module.types,
+                        &module.constants,
+                        &module.global_variables,
+                        &mut local_function_calls,
+                    )?;
+
+                    flow_graph.add_node(node);
+                }
+                spirv::Op::FunctionEnd => {
+                    fun_inst.expect(1)?;
+                    break;
+                }
+                _ => {
+                    return Err(Error::UnsupportedInstruction(self.state, fun_inst.op));
+                }
+            }
+        }
+
+        flow_graph.classify();
+        flow_graph.remove_phi_instructions(&self.lookup_expression);
+        fun.body = flow_graph.to_naga()?;
+
+        // done
+        fun.fill_global_use(&module.global_variables);
+
+        let source = match self.lookup_entry_point.remove(&fun_id) {
+            Some(ep) => {
+                module.entry_points.insert(
+                    (ep.stage, ep.name.clone()),
+                    crate::EntryPoint {
+                        early_depth_test: ep.early_depth_test,
+                        workgroup_size: ep.workgroup_size,
+                        function: fun,
+                    },
+                );
+                DeferredSource::EntryPoint(ep.stage, ep.name)
+            }
+            None => {
+                let handle = module.functions.append(fun);
+                self.lookup_function.insert(fun_id, handle);
+                DeferredSource::Function(handle)
+            }
+        };
+
+        for (expr_handle, dst_id) in local_function_calls {
+            self.deferred_function_calls.push(DeferredFunctionCall {
+                source: source.clone(),
+                expr_handle,
+                dst_id,
+            });
+        }
+
+        self.lookup_expression.clear();
+        self.lookup_sampled_image.clear();
+        Ok(())
     }
-
-    flow_graph.classify();
-    flow_graph.remove_phi_instructions(&parser.lookup_expression);
-    fun.body = flow_graph.to_naga()?;
-
-    // done
-    fun.global_usage =
-        crate::GlobalUse::scan(&fun.expressions, &fun.body, &module.global_variables);
-    let handle = module.functions.append(fun);
-    for (expr_handle, dst_id) in local_function_calls {
-        parser.deferred_function_calls.push(DeferredFunctionCall {
-            source_handle: handle,
-            expr_handle,
-            dst_id,
-        });
-    }
-
-    parser.lookup_function.insert(fun_id, handle);
-    parser.lookup_expression.clear();
-    parser.lookup_sampled_image.clear();
-    Ok(())
 }

--- a/test-data/boids.param.ron
+++ b/test-data/boids.param.ron
@@ -1,7 +1,7 @@
 (
 	metal_bindings: {
-		(set: 0, binding: 0): (buffer: Some(0), texture: None, sampler: None, mutable: false),
-		(set: 0, binding: 1): (buffer: Some(1), texture: None, sampler: None, mutable: true),
-		(set: 0, binding: 2): (buffer: Some(2), texture: None, sampler: None, mutable: true),
+		(group: 0, binding: 0): (buffer: Some(0), texture: None, sampler: None, mutable: false),
+		(group: 0, binding: 1): (buffer: Some(1), texture: None, sampler: None, mutable: true),
+		(group: 0, binding: 2): (buffer: Some(2), texture: None, sampler: None, mutable: true),
 	}
 )

--- a/test-data/boids.wgsl
+++ b/test-data/boids.wgsl
@@ -16,12 +16,13 @@ import "GLSL.std.450" as std;
 
 # vertex shader
 
-[[location 0]] var<in> a_particlePos : vec2<f32>;
-[[location 1]] var<in> a_particleVel : vec2<f32>;
-[[location 2]] var<in> a_pos : vec2<f32>;
-[[builtin position]] var gl_Position : vec4<f32>;
+[[location(0)]] var<in> a_particlePos : vec2<f32>;
+[[location(1)]] var<in> a_particleVel : vec2<f32>;
+[[location(2)]] var<in> a_pos : vec2<f32>;
+[[builtin(position)]] var gl_Position : vec4<f32>;
 
-fn vtx_main() -> void {
+[[stage(vertex)]]
+fn main() -> void {
   var angle : f32 = -std::atan2(a_particleVel.x, a_particleVel.y);
   var pos : vec2<f32> = vec2<f32>(
       (a_pos.x * std::cos(angle)) - (a_pos.y * std::sin(angle)),
@@ -29,45 +30,45 @@ fn vtx_main() -> void {
   gl_Position = vec4<f32>(pos + a_particlePos, 0.0, 1.0);
   return;
 }
-entry_point vertex as "main" = vtx_main;
 
 # fragment shader
-[[location 0]] var<out> fragColor : vec4<f32>;
+[[location(0)]] var<out> fragColor : vec4<f32>;
 
-fn frag_main() -> void {
+[[stage(fragment)]]
+fn main() -> void {
   fragColor = vec4<f32>(1.0, 1.0, 1.0, 1.0);
   return;
 }
-entry_point fragment as "main" = frag_main;
 
 # compute shader
 type Particle = struct {
-  [[offset 0]] pos : vec2<f32>;
-  [[offset 8]] vel : vec2<f32>;
+  [[offset(0)]] pos : vec2<f32>;
+  [[offset(8)]] vel : vec2<f32>;
 };
 
 type SimParams = struct {
-  [[offset 0]] deltaT : f32;
-  [[offset 4]] rule1Distance : f32;
-  [[offset 8]] rule2Distance : f32;
-  [[offset 12]] rule3Distance : f32;
-  [[offset 16]] rule1Scale : f32;
-  [[offset 20]] rule2Scale : f32;
-  [[offset 24]] rule3Scale : f32;
+  [[offset(0)]] deltaT : f32;
+  [[offset(4)]] rule1Distance : f32;
+  [[offset(8)]] rule2Distance : f32;
+  [[offset(12)]] rule3Distance : f32;
+  [[offset(16)]] rule1Scale : f32;
+  [[offset(20)]] rule2Scale : f32;
+  [[offset(24)]] rule3Scale : f32;
 };
 
 type Particles = struct {
-  [[offset 0]] particles : [[stride 16]] array<Particle, 5>;
+  [[offset(0)]] particles : [[stride 16]] array<Particle, 5>;
 };
 
-[[binding 0, set 0]] var<uniform> params : SimParams;
-[[binding 1, set 0]] var<storage_buffer> particlesA : Particles;
-[[binding 2, set 0]] var<storage_buffer> particlesB : Particles;
+[[group(0), binding(0)]] var<uniform> params : SimParams;
+[[group(0), binding(1)]] var<storage_buffer> particlesA : Particles;
+[[group(0), binding(2)]] var<storage_buffer> particlesB : Particles;
 
-[[builtin global_invocation_id]] var gl_GlobalInvocationID : vec3<u32>;
+[[builtin(global_invocation_id)]] var gl_GlobalInvocationID : vec3<u32>;
 
 # https://github.com/austinEng/Project6-Vulkan-Flocking/blob/master/data/shaders/computeparticles/particle.comp
-fn compute_main() -> void {
+[[stage(compute)]]
+fn main() -> void {
   var index : u32 = gl_GlobalInvocationID.x;
   if (index >= 5) {
     return;
@@ -148,5 +149,3 @@ fn compute_main() -> void {
 
   return;
 }
-entry_point compute as "main" = compute_main;
-

--- a/test-data/function.wgsl
+++ b/test-data/function.wgsl
@@ -4,9 +4,8 @@ fn test_function(test: f32) -> f32 {
     return test;
 }
 
-fn main_vert() -> void {
+[[stage(vertex)]]
+fn main() -> void {
     var foo: f32 = std::glsl::distance(0.0, 1.0);
     var test: f32 = test_function(1.0);
 }
-
-entry_point vertex as "main" = main_vert;

--- a/test-data/quad.wgsl
+++ b/test-data/quad.wgsl
@@ -1,24 +1,24 @@
 # vertex
 const c_scale: f32 = 1.2;
-[[location 0]] var<in> a_pos : vec2<f32>;
-[[location 1]] var<in> a_uv : vec2<f32>;
-[[location 0]] var<out> v_uv : vec2<f32>;
-[[builtin position]] var<out> o_position : vec4<f32>;
+[[location(0)]] var<in> a_pos : vec2<f32>;
+[[location(1)]] var<in> a_uv : vec2<f32>;
+[[location(0)]] var<out> v_uv : vec2<f32>;
+[[builtin(position)]] var<out> o_position : vec4<f32>;
 
-fn main_vert() -> void {
+[[stage(vertex)]]
+fn main() -> void {
   o_position = vec4<f32>(c_scale * a_pos, 0.0, 1.0);
   return;
 }
-entry_point vertex as "main" = main_vert;
 
 # fragment
-[[location 0]] var<in> a_uv : vec2<f32>;
+[[location(0)]] var<in> a_uv : vec2<f32>;
 #layout(set = 0, binding = 0) uniform texture2D u_texture;
 #layout(set = 0, binding = 1) uniform sampler u_sampler;
-[[location 0]] var<out> o_color : vec4<f32>;
+[[location(0)]] var<out> o_color : vec4<f32>;
 
-fn main_frag() -> void {
+[[stage(fragment)]]
+fn main() -> void {
   o_color = vec4<f32>(1.0, 0.0, 0.0, 1.0); #TODO: sample
   return;
 }
-entry_point fragment as "main" = main_frag;

--- a/test-data/simple/simple.expected.ron
+++ b/test-data/simple/simple.expected.ron
@@ -64,58 +64,56 @@
             ),
         ),
     ],
-    functions: [
-        (
-            name: Some("main"),
-            parameter_types: [],
-            return_type: None,
-            global_usage: [
-                (
-                    bits: 1,
-                ),
-                (
-                    bits: 2,
-                ),
-            ],
-            local_variables: [
-                (
-                    name: Some("w"),
-                    ty: 3,
-                    init: Some(3),
-                ),
-            ],
-            expressions: [
-                GlobalVariable(1),
-                GlobalVariable(2),
-                Constant(1),
-                LocalVariable(1),
-                Constant(2),
-                Compose(
-                    ty: 2,
-                    components: [
-                        1,
-                        5,
-                        4,
-                    ],
-                ),
-            ],
-            body: [
-                Empty,
-                Store(
-                    pointer: 2,
-                    value: 6,
-                ),
-                Return(
-                    value: None,
-                ),
-            ],
+    functions: [],
+    entry_points: {
+        (Vertex, "main"): (
+            early_depth_test: None,
+            workgroup_size: (1, 1, 1),
+            function: (
+                name: Some("main"),
+                parameter_types: [],
+                return_type: None,
+                global_usage: [
+                    (
+                        bits: 1,
+                    ),
+                    (
+                        bits: 2,
+                    ),
+                ],
+                local_variables: [
+                    (
+                        name: Some("w"),
+                        ty: 3,
+                        init: Some(3),
+                    ),
+                ],
+                expressions: [
+                    GlobalVariable(1),
+                    GlobalVariable(2),
+                    Constant(1),
+                    LocalVariable(1),
+                    Constant(2),
+                    Compose(
+                        ty: 2,
+                        components: [
+                            1,
+                            5,
+                            4,
+                        ],
+                    ),
+                ],
+                body: [
+                    Empty,
+                    Store(
+                        pointer: 2,
+                        value: 6,
+                    ),
+                    Return(
+                        value: None,
+                    ),
+                ],
+            ),
         ),
-    ],
-    entry_points: [
-        (
-            stage: Vertex,
-            name: "main",
-            function: 1,
-        ),
-    ],
+    },
 )

--- a/test-data/simple/simple.wgsl
+++ b/test-data/simple/simple.wgsl
@@ -1,10 +1,10 @@
 # vertex
-[[location 0]] var<in> a_pos : vec2<f32>;
-[[location 0]] var<out> o_pos : vec4<f32>;
+[[location(0)]] var<in> a_pos : vec2<f32>;
+[[location(0)]] var<out> o_pos : vec4<f32>;
 
+[[stage(vertex)]]
 fn main() -> void {
   var w: f32 = 1.0;
   o_pos = vec4<f32>(a_pos, 0.0, w);
   return;
 }
-entry_point vertex as "main" = main;

--- a/tests/convert.rs
+++ b/tests/convert.rs
@@ -33,7 +33,10 @@ fn convert_quad() {
         use naga::back::msl;
         let mut binding_map = msl::BindingMap::default();
         binding_map.insert(
-            msl::BindSource { set: 0, binding: 0 },
+            msl::BindSource {
+                group: 0,
+                binding: 0,
+            },
             msl::BindTarget {
                 buffer: None,
                 texture: Some(1),
@@ -42,7 +45,10 @@ fn convert_quad() {
             },
         );
         binding_map.insert(
-            msl::BindSource { set: 0, binding: 1 },
+            msl::BindSource {
+                group: 0,
+                binding: 1,
+            },
             msl::BindTarget {
                 buffer: None,
                 texture: None,
@@ -67,7 +73,10 @@ fn convert_boids() {
         use naga::back::msl;
         let mut binding_map = msl::BindingMap::default();
         binding_map.insert(
-            msl::BindSource { set: 0, binding: 0 },
+            msl::BindSource {
+                group: 0,
+                binding: 0,
+            },
             msl::BindTarget {
                 buffer: Some(0),
                 texture: None,
@@ -76,7 +85,10 @@ fn convert_boids() {
             },
         );
         binding_map.insert(
-            msl::BindSource { set: 0, binding: 1 },
+            msl::BindSource {
+                group: 0,
+                binding: 1,
+            },
             msl::BindTarget {
                 buffer: Some(1),
                 texture: None,
@@ -85,7 +97,10 @@ fn convert_boids() {
             },
         );
         binding_map.insert(
-            msl::BindSource { set: 0, binding: 2 },
+            msl::BindSource {
+                group: 0,
+                binding: 2,
+            },
             msl::BindTarget {
                 buffer: Some(2),
                 texture: None,
@@ -113,7 +128,10 @@ fn convert_cube() {
         use naga::back::msl;
         let mut binding_map = msl::BindingMap::default();
         binding_map.insert(
-            msl::BindSource { set: 0, binding: 0 },
+            msl::BindSource {
+                group: 0,
+                binding: 0,
+            },
             msl::BindTarget {
                 buffer: Some(0),
                 texture: None,
@@ -122,7 +140,10 @@ fn convert_cube() {
             },
         );
         binding_map.insert(
-            msl::BindSource { set: 0, binding: 1 },
+            msl::BindSource {
+                group: 0,
+                binding: 1,
+            },
             msl::BindTarget {
                 buffer: None,
                 texture: Some(1),
@@ -131,7 +152,10 @@ fn convert_cube() {
             },
         );
         binding_map.insert(
-            msl::BindSource { set: 0, binding: 2 },
+            msl::BindSource {
+                group: 0,
+                binding: 2,
+            },
             msl::BindTarget {
                 buffer: None,
                 texture: None,
@@ -154,9 +178,7 @@ fn convert_phong_lighting() {
     let module = load_glsl(
         "glsl_phong_lighting.frag",
         "main",
-        naga::ShaderStage::Fragment {
-            early_depth_test: None,
-        },
+        naga::ShaderStage::Fragment,
     );
     naga::proc::Validator::new().validate(&module).unwrap();
 
@@ -176,9 +198,7 @@ fn convert_phong_lighting() {
 //     let module = load_glsl(
 //         "glsl_constant_expression.vert",
 //         "main",
-//         naga::ShaderStage::Fragment {
-//             early_depth_test: None,
-//         },
+//         naga::ShaderStage::Fragment,
 //     );
 //     naga::proc::Validator::new().validate(&module).unwrap();
 // }


### PR DESCRIPTION
Another innocent change that turned out to be rather big. I actually was just trying to update WGSL, and the changes started being contagious...

On the IR side, this changes entry points to:
  - be a map, so no collisions by construction
  - store the function directly instead of a handle, so that nothing can call this function

It also renames the "set" to "group" in the decorations.

And it updates WGSL attribute syntax to the one that just got accepted.