### PR TITLE
Complete MSL, refactor WGSL, and remove Statement::Empty

### DIFF
--- a/src/back/glsl.rs
+++ b/src/back/glsl.rs
@@ -756,7 +756,6 @@ fn write_statement<'a, 'b>(
     indent: usize,
 ) -> Result<String, Error> {
     Ok(match sta {
-        Statement::Empty => String::new(),
         Statement::Block(block) => block
             .iter()
             .map(|sta| write_statement(sta, module, builder, indent))
@@ -1173,12 +1172,19 @@ fn write_expression<'a, 'b>(
             let value_expr = write_expression(&builder.expressions[expr], module, builder)?;
 
             let (source_kind, ty_expr) = match *builder.typifier.get(expr, &module.types) {
-                TypeInner::Scalar { width, kind } => (
-                    kind,
+                TypeInner::Scalar {
+                    width,
+                    kind: source_kind,
+                } => (
+                    source_kind,
                     Cow::Borrowed(map_scalar(kind, width, builder.manager)?.full),
                 ),
-                TypeInner::Vector { width, kind, size } => (
-                    kind,
+                TypeInner::Vector {
+                    width,
+                    kind: source_kind,
+                    size,
+                } => (
+                    source_kind,
                     Cow::Owned(format!(
                         "{}vec{}",
                         map_scalar(kind, width, builder.manager)?.prefix,

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -726,7 +726,6 @@ pomelo! {
             extra.context.add_local_var(id, exp);
         }
         match statements.len() {
-            0 => Statement::Empty,
             1 => statements.remove(0),
             _ => Statement::Block(statements),
         }
@@ -774,7 +773,7 @@ pomelo! {
     statement_list ::= statement_list(mut ss) statement(s) { ss.push(s); ss }
 
     expression_statement ::= Semicolon  {
-        Statement::Empty
+        Statement::Block(Vec::new())
     }
     expression_statement ::= expression(mut e) Semicolon {
         match e.statements.len() {

--- a/src/front/wgsl/conv.rs
+++ b/src/front/wgsl/conv.rs
@@ -1,0 +1,116 @@
+use super::Error;
+
+pub fn map_storage_class(word: &str) -> Result<crate::StorageClass, Error<'_>> {
+    match word {
+        "in" => Ok(crate::StorageClass::Input),
+        "out" => Ok(crate::StorageClass::Output),
+        "uniform" => Ok(crate::StorageClass::Uniform),
+        "storage_buffer" => Ok(crate::StorageClass::StorageBuffer),
+        _ => Err(Error::UnknownStorageClass(word)),
+    }
+}
+
+pub fn map_built_in(word: &str) -> Result<crate::BuiltIn, Error<'_>> {
+    Ok(match word {
+        // vertex
+        "position" => crate::BuiltIn::Position,
+        "vertex_idx" => crate::BuiltIn::VertexIndex,
+        "instance_idx" => crate::BuiltIn::InstanceIndex,
+        // fragment
+        "front_facing" => crate::BuiltIn::FrontFacing,
+        "frag_coord" => crate::BuiltIn::FragCoord,
+        "frag_depth" => crate::BuiltIn::FragDepth,
+        // compute
+        "global_invocation_id" => crate::BuiltIn::GlobalInvocationId,
+        "local_invocation_id" => crate::BuiltIn::LocalInvocationId,
+        "local_invocation_idx" => crate::BuiltIn::LocalInvocationIndex,
+        _ => return Err(Error::UnknownBuiltin(word)),
+    })
+}
+
+pub fn map_shader_stage(word: &str) -> Result<crate::ShaderStage, Error<'_>> {
+    match word {
+        "vertex" => Ok(crate::ShaderStage::Vertex),
+        "fragment" => Ok(crate::ShaderStage::Fragment),
+        "compute" => Ok(crate::ShaderStage::Compute),
+        _ => Err(Error::UnknownShaderStage(word)),
+    }
+}
+
+pub fn map_interpolation(word: &str) -> Result<crate::Interpolation, Error<'_>> {
+    match word {
+        "linear" => Ok(crate::Interpolation::Linear),
+        "flat" => Ok(crate::Interpolation::Flat),
+        "centroid" => Ok(crate::Interpolation::Centroid),
+        "sample" => Ok(crate::Interpolation::Sample),
+        "perspective" => Ok(crate::Interpolation::Perspective),
+        _ => Err(Error::UnknownDecoration(word)),
+    }
+}
+
+pub fn map_storage_format(word: &str) -> Result<crate::StorageFormat, Error<'_>> {
+    use crate::StorageFormat as Sf;
+    Ok(match word {
+        "r8unorm" => Sf::R8Unorm,
+        "r8snorm" => Sf::R8Snorm,
+        "r8uint" => Sf::R8Uint,
+        "r8sint" => Sf::R8Sint,
+        "r16uint" => Sf::R16Uint,
+        "r16sint" => Sf::R16Sint,
+        "r16float" => Sf::R16Float,
+        "rg8unorm" => Sf::Rg8Unorm,
+        "rg8snorm" => Sf::Rg8Snorm,
+        "rg8uint" => Sf::Rg8Uint,
+        "rg8sint" => Sf::Rg8Sint,
+        "r32uint" => Sf::R32Uint,
+        "r32sint" => Sf::R32Sint,
+        "r32float" => Sf::R32Float,
+        "rg16uint" => Sf::Rg16Uint,
+        "rg16sint" => Sf::Rg16Sint,
+        "rg16float" => Sf::Rg16Float,
+        "rgba8unorm" => Sf::Rgba8Unorm,
+        "rgba8snorm" => Sf::Rgba8Snorm,
+        "rgba8uint" => Sf::Rgba8Uint,
+        "rgba8sint" => Sf::Rgba8Sint,
+        "rgb10a2unorm" => Sf::Rgb10a2Unorm,
+        "rg11b10float" => Sf::Rg11b10Float,
+        "rg32uint" => Sf::Rg32Uint,
+        "rg32sint" => Sf::Rg32Sint,
+        "rg32float" => Sf::Rg32Float,
+        "rgba16uint" => Sf::Rgba16Uint,
+        "rgba16sint" => Sf::Rgba16Sint,
+        "rgba16float" => Sf::Rgba16Float,
+        "rgba32uint" => Sf::Rgba32Uint,
+        "rgba32sint" => Sf::Rgba32Sint,
+        "rgba32float" => Sf::Rgba32Float,
+        _ => return Err(Error::UnknownStorageFormat(word)),
+    })
+}
+
+pub fn get_scalar_type(word: &str) -> Option<(crate::ScalarKind, crate::Bytes)> {
+    match word {
+        "f32" => Some((crate::ScalarKind::Float, 4)),
+        "i32" => Some((crate::ScalarKind::Sint, 4)),
+        "u32" => Some((crate::ScalarKind::Uint, 4)),
+        _ => None,
+    }
+}
+
+pub fn get_intrinsic(word: &str) -> Option<crate::IntrinsicFunction> {
+    match word {
+        "any" => Some(crate::IntrinsicFunction::Any),
+        "all" => Some(crate::IntrinsicFunction::All),
+        "is_nan" => Some(crate::IntrinsicFunction::IsNan),
+        "is_inf" => Some(crate::IntrinsicFunction::IsInf),
+        "is_normal" => Some(crate::IntrinsicFunction::IsNormal),
+        _ => None,
+    }
+}
+pub fn get_derivative(word: &str) -> Option<crate::DerivativeAxis> {
+    match word {
+        "dpdx" => Some(crate::DerivativeAxis::X),
+        "dpdy" => Some(crate::DerivativeAxis::Y),
+        "dwidth" => Some(crate::DerivativeAxis::Width),
+        _ => None,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -645,7 +645,7 @@ pub type Block = Vec<Statement>;
 
 /// Marker type, used for falling through in a switch statement.
 // Clone is used only for error reporting and is not intended for end users
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub struct FallThrough;
@@ -656,8 +656,6 @@ pub struct FallThrough;
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub enum Statement {
-    /// Empty statement, does nothing.
-    Empty,
     /// A block containing more statements, to be executed sequentially.
     Block(Block),
     /// Conditionally executes one of two blocks, based on the value of the condition.

--- a/src/proc/interface.rs
+++ b/src/proc/interface.rs
@@ -119,7 +119,7 @@ where
         for statement in block {
             use crate::Statement as S;
             match *statement {
-                S::Empty | S::Break | S::Continue | S::Kill => (),
+                S::Break | S::Continue | S::Kill => (),
                 S::Block(ref b) => {
                     self.traverse(b);
                 }

--- a/test-data/boids.wgsl
+++ b/test-data/boids.wgsl
@@ -70,7 +70,7 @@ type Particles = struct {
 [[stage(compute), workgroup_size(1)]]
 fn main() -> void {
   var index : u32 = gl_GlobalInvocationID.x;
-  if (index >= 5) {
+  if (index >= u32(5)) {
     return;
   }
 
@@ -87,7 +87,7 @@ fn main() -> void {
   var vel : vec2<f32>;
   var i : u32 = 0;
   loop {
-    if (i >= 5) {
+    if (i >= u32(5)) {
       break;
     }
     if (i == index) {
@@ -110,7 +110,7 @@ fn main() -> void {
     }
 
     continuing {
-      i = i + 1;
+      i = i + u32(1);
     }
   }
   if (cMassCount > 0) {

--- a/test-data/simple/module.ron
+++ b/test-data/simple/module.ron
@@ -104,7 +104,7 @@
                     ),
                 ],
                 body: [
-                    Empty,
+                    Block([]),
                     Store(
                         pointer: 2,
                         value: 6,


### PR DESCRIPTION
This is another bag of good stuff.
- IR: remove `Statement::Empty` variant
- "glsl-out": fix `As` expression
- "msl-out": refactor call syntax, implement all the expressions and statements (yay!)
- "spv-out": block writing refactor and support for `Statement::Block`
- "wgsl-in": introduce the convert module

Most importantly, the `boids` shader is now successfully converted through `WGSL -> IR -> GLSL` and validated on that end (with `glslangValidator`) 🎉 