### PR TITLE
Add legend for supported end-points

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,5 @@ AIR             |                    |       |
 DXIR            |                    |       |
 DXIL            |                    |       |
 DXBC            |                    |       |
+
+:heavy_check_mark: = Primary support — :white_check_mark: = Secondary support — :construction: = Unsupported, but support in progress


### PR DESCRIPTION
There's no legend explaining what symbols mean for supported end-points, but it seems to be following the same format at wgpu. This PR copies wgpu's legend.