### PR TITLE
[spv-out] Fix write_function returning block id

### DIFF
--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -311,23 +311,23 @@ impl Writer {
             parameter_type_ids,
         };
 
-        let id = self.generate_id();
+        let function_id = self.generate_id();
         let function_type =
             self.get_function_type(lookup_function_type, function_parameter_pointer_ids);
         function.signature = Some(super::instructions::instruction_function(
             return_type_id,
-            id,
+            function_id,
             spirv::FunctionControl::empty(),
             function_type,
         ));
 
-        let id = self.write_block(&ir_function.body, ir_module, ir_function, &mut function);
+        self.write_block(&ir_function.body, ir_module, ir_function, &mut function);
 
         function.to_words(&mut self.logical_layout.function_definitions);
         super::instructions::instruction_function_end()
             .to_words(&mut self.logical_layout.function_definitions);
 
-        id
+        function_id
     }
 
     // TODO Move to instructions module


### PR DESCRIPTION
The variable [`function_id`](https://github.com/gfx-rs/naga/blob/master/src/back/spv/writer.rs#L341) in `write_entry_point` was using a wrong id. Namely, the `write_function` method returned the block id instead of the function id. spirv-val tool told me it failed due to the entrypoint having a wrong id. 

At the same time, the `lookup_function` probably stopped working as block ids were inserted, instead of function ids.

This was introduced during the entry point refactor, due to the fact that it used to override variables, see [commit](https://github.com/gfx-rs/naga/commit/2ebaadaf0ca62e558ac027606f6f18c807308ee7#diff-4516391251ac170e6db90c0fa6f07022L1074).