### PR TITLE
[spv-out] Add multiply instructions

### DIFF
--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -520,6 +520,34 @@ pub(super) fn instruction_composite_construct(
 // Arithmetic Instructions
 //
 
+pub(super) fn instruction_i_mul(
+    result_type_id: Word,
+    id: Word,
+    operand_1: Word,
+    operand_2: Word,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::IMul);
+    instruction.set_type(result_type_id);
+    instruction.set_result(id);
+    instruction.add_operand(operand_1);
+    instruction.add_operand(operand_2);
+    instruction
+}
+
+pub(super) fn instruction_f_mul(
+    result_type_id: Word,
+    id: Word,
+    operand_1: Word,
+    operand_2: Word,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::FMul);
+    instruction.set_type(result_type_id);
+    instruction.set_result(id);
+    instruction.add_operand(operand_1);
+    instruction.add_operand(operand_2);
+    instruction
+}
+
 pub(super) fn instruction_vector_times_scalar(
     result_type_id: Word,
     id: Word,
@@ -531,6 +559,62 @@ pub(super) fn instruction_vector_times_scalar(
     instruction.set_result(id);
     instruction.add_operand(vector_type_id);
     instruction.add_operand(scalar_type_id);
+    instruction
+}
+
+pub(super) fn instruction_matrix_times_scalar(
+    result_type_id: Word,
+    id: Word,
+    matrix_id: Word,
+    scalar_id: Word,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::MatrixTimesScalar);
+    instruction.set_type(result_type_id);
+    instruction.set_result(id);
+    instruction.add_operand(matrix_id);
+    instruction.add_operand(scalar_id);
+    instruction
+}
+
+pub(super) fn instruction_vector_times_matrix(
+    result_type_id: Word,
+    id: Word,
+    vector_id: Word,
+    matrix_id: Word,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::VectorTimesMatrix);
+    instruction.set_type(result_type_id);
+    instruction.set_result(id);
+    instruction.add_operand(vector_id);
+    instruction.add_operand(matrix_id);
+    instruction
+}
+
+pub(super) fn instruction_matrix_times_vector(
+    result_type_id: Word,
+    id: Word,
+    matrix_id: Word,
+    vector_id: Word,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::MatrixTimesVector);
+    instruction.set_type(result_type_id);
+    instruction.set_result(id);
+    instruction.add_operand(matrix_id);
+    instruction.add_operand(vector_id);
+    instruction
+}
+
+pub(super) fn instruction_matrix_times_matrix(
+    result_type_id: Word,
+    id: Word,
+    left_matrix: Word,
+    right_matrix: Word,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::MatrixTimesMatrix);
+    instruction.set_type(result_type_id);
+    instruction.set_result(id);
+    instruction.add_operand(left_matrix);
+    instruction.add_operand(right_matrix);
     instruction
 }
 


### PR DESCRIPTION
Add support for the long-awaited multiply instructions:
- OpIMul
- OpFMul
- OpVectorTimesScalar
- OpVectorTimesMatrix
- OpMatrixTimesVector
- OpMatrixTimesScalar
- OpMatrixTimesMatrix

Tested with the following WGSL:
```
[[stage(fragment)]]
fn main() -> void {
    # OpIMul
    var int_1: i32 = 1;
    var int_2: i32 = int_1 * int_1;

    # OpFMul
    var float_1: f32 = 1.0;
    var float_2: f32 = float_1 * float_1;

    # OpVectorTimesScalar
    var vec_1: vec2<f32> = vec2<f32>(1.0, 1.0);
    var vec_2: vec2<f32> = vec_1 * float_1;

    # OpVectorTimesMatrix
    var mat_1: mat2x2<f32> = mat2x2<f32>(1.0, 1.0);
    var vec_3: vec2<f32> = vec_2 * mat_1;

    # OpMatrixTimesVector
    var vec_4: vec2<f32> = mat_1 * vec_3;

    # OpMatrixTimesScalar
    var mat_2: mat2x2<f32> = mat_1 * float_2;

    # OpMatrixTimesMatrix
    var mat_3: mat2x2<f32> = mat_2 * mat_2;

    return;
}
```
