### PR TITLE
[spv-out] Add scalar conversion support

### DIFF
--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -453,7 +453,49 @@ pub(super) fn instruction_function_call(
 //
 // Conversion Instructions
 //
+fn instruction_unary(op: Op, result_type_id: Word, id: Word, value: Word) -> Instruction {
+    let mut instruction = Instruction::new(op);
+    instruction.set_type(result_type_id);
+    instruction.set_result(id);
+    instruction.add_operand(value);
+    instruction
+}
 
+pub(super) fn instruction_convert_f_to_u(
+    result_type_id: Word,
+    id: Word,
+    float_value: Word,
+) -> Instruction {
+    instruction_unary(Op::ConvertFToU, result_type_id, id, float_value)
+}
+
+pub(super) fn instruction_convert_f_to_s(
+    result_type_id: Word,
+    id: Word,
+    float_value: Word,
+) -> Instruction {
+    instruction_unary(Op::ConvertFToS, result_type_id, id, float_value)
+}
+
+pub(super) fn instruction_convert_s_to_f(
+    result_type_id: Word,
+    id: Word,
+    signed_value: Word,
+) -> Instruction {
+    instruction_unary(Op::ConvertSToF, result_type_id, id, signed_value)
+}
+
+pub(super) fn instruction_convert_u_to_f(
+    result_type_id: Word,
+    id: Word,
+    unsigned_value: Word,
+) -> Instruction {
+    instruction_unary(Op::ConvertUToF, result_type_id, id, unsigned_value)
+}
+
+pub(super) fn instruction_bit_cast(result_type_id: Word, id: Word, operand: Word) -> Instruction {
+    instruction_unary(Op::Bitcast, result_type_id, id, operand)
+}
 //
 // Composite Instructions
 //


### PR DESCRIPTION
Add support for scalar conversions via `Expression::As`.

Following conversions are implemented:
- `OpConvertFToU` (float to unsigned int)
- `OpConvertFToS` (float to signed int)
- `OpConvertSToF` (signed int to float)
- `OpConvertUToF` (unsigned int to float)

Tested with the following WGSL:
```
[[stage(fragment)]]
fn main() -> void {
  var uint_1: u32 = u32(1.0);
  var int_1: i32 = i32(1.0);

  var float_1: f32 = f32(1);
  var temp_uint_2: u32 = u32(1);
  var float_2: f32 = f32(temp_uint_2);
  # var float_2: f32 = f32(u32(1));
  return;
}
```

I've commented out two particular cases where double casting didn't result in a double `Expression::As` expression, so I had to use an temp variable to hold the first conversion in, see #222.