### PR TITLE
[spv-out] Add access and access index support

### DIFF
--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -406,6 +406,24 @@ pub(super) fn instruction_store(
     instruction
 }
 
+pub(super) fn instruction_access_chain(
+    result_type_id: Word,
+    id: Word,
+    base_id: Word,
+    index_ids: &[Word],
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::AccessChain);
+    instruction.set_type(result_type_id);
+    instruction.set_result(id);
+    instruction.add_operand(base_id);
+
+    for index_id in index_ids {
+        instruction.add_operand(*index_id);
+    }
+
+    instruction
+}
+
 //
 // Function Instructions
 //


### PR DESCRIPTION
# Description
Add support for `Expression::Access` and `Expression::AccessIndex`.

`Expression::Access`:
- [x] Vector
- ~~Matrix~~ - Will be done at a later moment.
- ~~Array~~ - Will be done at a later moment.

`Expression::AccessIndex`:
- [x] Vector
- ~~Matrix~~ - Will be done at a later moment.
- ~~Array~~ - Will be done at a later moment.
- [x] Struct


# WGSL test file
```
type Data = struct{
    [[offset(0)]] e: f32;
};

[[group(0), binding(0)]] var<uniform> u_data: Data;

[[stage(vertex)]]
fn main() -> void {
  var a: vec2<f32> = vec2<f32>(1.0, 1.0);
  
  # Expression::Access - Vector
  var b: f32 = a[0];
  
  # Expression::AccessIndex - Vector
  var c: f32 = a.x;
  
  # Expression::AccessIndex - Struct
  #var d: f32 = u_data.k;
  
  return;
}
```