### PR TITLE
[spv-out] Add check for global variables if name is set

### DIFF
--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -670,10 +670,10 @@ impl Writer {
         let instruction = super::instructions::instruction_variable(pointer_id, id, class, None);
 
         if self.writer_flags.contains(WriterFlags::DEBUG) {
-            self.debugs.push(super::instructions::instruction_name(
-                id,
-                global_variable.name.as_ref().unwrap().as_str(),
-            ));
+            if let Some(ref name) = global_variable.name {
+                self.debugs
+                    .push(super::instructions::instruction_name(id, name.as_str()));
+            }
         }
 
         if let Some(interpolation) = global_variable.interpolation {


### PR DESCRIPTION
Add check if name for global variables is set. When the debug flag is set for spv-out, `OpName` would be added for the global variable. It can happen, for instance when having a uniform variable, that the name is not set. 

As the code always called `unwrap` when the debug flag was enabled, the code crashed.

This bug was found in issue: #210.