### PR TITLE
Added support for matrix access on the typifier

### DIFF
--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -98,6 +98,12 @@ impl Typifier {
                     kind,
                     width,
                 } => Resolution::Value(crate::TypeInner::Scalar { kind, width }),
+                crate::TypeInner::Matrix {
+                    rows: size,
+                    columns: _,
+                    kind,
+                    width,
+                } => Resolution::Value(crate::TypeInner::Vector { size, kind, width }),
                 ref other => panic!("Can't access into {:?}", other),
             },
             crate::Expression::AccessIndex { base, index } => match *self.get(base, types) {


### PR DESCRIPTION
I talked about with kvark about this in the matrix room, we didn't reach any conclusion but i think it's supposed to be supported, here are some links
- https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#OpAccessChain
- https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#CompositeType