### PR TITLE
[clippy] Fix clippy issues after upgrading to 1.47

### DIFF
--- a/src/front/spv/error.rs
+++ b/src/front/spv/error.rs
@@ -51,4 +51,5 @@ pub enum Error {
     BadString,
     IncompleteData,
     InvalidTerminator,
+    UnexpectedComparisonType(Handle<crate::Type>),
 }

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -1477,7 +1477,9 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                     };
                     *comparison = true;
                 }
-                _ => panic!("Unexpected comparison type {:?}", ty),
+                _ => {
+                    return Err(Error::UnexpectedComparisonType(handle));
+                }
             }
         }
 

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1787,7 +1787,13 @@ impl Parser {
                 }
                 Ok(true) => {}
                 Ok(false) => {
-                    assert_eq!(self.scopes, Vec::new());
+                    if !self.scopes.is_empty() {
+                        return Err(ParseError {
+                            error: Error::Other,
+                            scopes: std::mem::replace(&mut self.scopes, Vec::new()),
+                            pos: (0, 0),
+                        });
+                    };
                     return Ok(module);
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,11 @@
 //!
 //! To improve performance and reduce memory usage, most structures are stored
 //! in an [`Arena`], and can be retrieved using the corresponding [`Handle`].
-#![allow(clippy::new_without_default, clippy::unneeded_field_pattern)]
+#![allow(
+    clippy::new_without_default,
+    clippy::unneeded_field_pattern,
+    clippy::match_like_matches_macro
+)]
 #![deny(clippy::panic)]
 
 mod arena;

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -53,9 +53,9 @@ pub enum ResolveError {
     TypeNotFound,
     #[error("Incompatible operand: {op} {operand}")]
     IncompatibleOperand { op: String, operand: String },
-    #[error("Incompatible operands: {left} {op:?} {right}")]
+    #[error("Incompatible operands: {left} {op} {right}")]
     IncompatibleOperands {
-        op: crate::Expression,
+        op: String,
         left: String,
         right: String,
     },
@@ -213,7 +213,7 @@ impl Typifier {
                             }),
                             _ => {
                                 return Err(ResolveError::IncompatibleOperands {
-                                    op: expr.clone(),
+                                    op: "x".to_string(),
                                     left: format!("{:?}", ty_left),
                                     right: format!("{:?}", ty_right),
                                 })

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -53,9 +53,9 @@ pub enum ResolveError {
     TypeNotFound,
     #[error("Incompatible operand: {op} {operand}")]
     IncompatibleOperand { op: String, operand: String },
-    #[error("Incompatible operands: {left} {op} {right}")]
+    #[error("Incompatible operands: {left} {op:?} {right}")]
     IncompatibleOperands {
-        op: String,
+        op: crate::Expression,
         left: String,
         right: String,
     },
@@ -213,7 +213,7 @@ impl Typifier {
                             }),
                             _ => {
                                 return Err(ResolveError::IncompatibleOperands {
-                                    op: "x".to_string(),
+                                    op: expr.clone(),
                                     left: format!("{:?}", ty_left),
                                     right: format!("{:?}", ty_right),
                                 })

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -51,8 +51,14 @@ pub enum ResolveError {
     FunctionReturnsVoid,
     #[error("Type is not found in the given immutable arena")]
     TypeNotFound,
-    #[error("{msg}")]
-    Other { msg: String },
+    #[error("Incompatible operand: {op} {operand}")]
+    IncompatibleOperand { op: String, operand: String },
+    #[error("Incompatible operands: {left} {op} {right}")]
+    IncompatibleOperands {
+        op: String,
+        left: String,
+        right: String,
+    },
 }
 
 pub struct ResolveContext<'a> {
@@ -109,8 +115,9 @@ impl Typifier {
                     width,
                 }),
                 ref other => {
-                    return Err(ResolveError::Other {
-                        msg: format!("Can't access into {:?}", other),
+                    return Err(ResolveError::IncompatibleOperand {
+                        op: "access".to_string(),
+                        operand: format!("{:?}", other),
                     })
                 }
             },
@@ -143,8 +150,9 @@ impl Typifier {
                     Resolution::Handle(member.ty)
                 }
                 ref other => {
-                    return Err(ResolveError::Other {
-                        msg: format!("Can't access into {:?}", other),
+                    return Err(ResolveError::IncompatibleOperand {
+                        op: "access index".to_string(),
+                        operand: format!("{:?}", other),
                     })
                 }
             },
@@ -204,11 +212,10 @@ impl Typifier {
                                 width,
                             }),
                             _ => {
-                                return Err(ResolveError::Other {
-                                    msg: format!(
-                                        "Incompatible arguments {:?} x {:?}",
-                                        ty_left, ty_right
-                                    ),
+                                return Err(ResolveError::IncompatibleOperands {
+                                    op: "x".to_string(),
+                                    left: format!("{:?}", ty_left),
+                                    right: format!("{:?}", ty_right),
                                 })
                             }
                         }
@@ -243,8 +250,9 @@ impl Typifier {
                     width,
                 }),
                 ref other => {
-                    return Err(ResolveError::Other {
-                        msg: format!("incompatible transpose of {:?}", other),
+                    return Err(ResolveError::IncompatibleOperand {
+                        op: "transpose".to_string(),
+                        operand: format!("{:?}", other),
                     })
                 }
             },
@@ -255,8 +263,9 @@ impl Typifier {
                     width,
                 } => Resolution::Value(crate::TypeInner::Scalar { kind, width }),
                 ref other => {
-                    return Err(ResolveError::Other {
-                        msg: format!("incompatible dot of {:?}", other),
+                    return Err(ResolveError::IncompatibleOperand {
+                        op: "dot product".to_string(),
+                        operand: format!("{:?}", other),
                     })
                 }
             },
@@ -275,8 +284,9 @@ impl Typifier {
                     width,
                 } => Resolution::Value(crate::TypeInner::Vector { kind, size, width }),
                 ref other => {
-                    return Err(ResolveError::Other {
-                        msg: format!("incompatible as of {:?}", other),
+                    return Err(ResolveError::IncompatibleOperand {
+                        op: "as".to_string(),
+                        operand: format!("{:?}", other),
                     })
                 }
             },
@@ -291,8 +301,9 @@ impl Typifier {
                         Resolution::Value(crate::TypeInner::Scalar { kind, width })
                     }
                     ref other => {
-                        return Err(ResolveError::Other {
-                            msg: format!("Unexpected argument {:?} on {}", other, name),
+                        return Err(ResolveError::IncompatibleOperand {
+                            op: name.clone(),
+                            operand: format!("{:?}", other),
                         })
                     }
                 },
@@ -301,8 +312,9 @@ impl Typifier {
                         Resolution::Value(crate::TypeInner::Scalar { kind, width })
                     }
                     ref other => {
-                        return Err(ResolveError::Other {
-                            msg: format!("Unexpected argument {:?} on {}", other, name),
+                        return Err(ResolveError::IncompatibleOperand {
+                            op: name.clone(),
+                            operand: format!("{:?}", other),
                         })
                     }
                 },


### PR DESCRIPTION
- Disable match_like_matches_macro for now

Still need to deal with `panic`s found in:
- [x] spv-out
  - [/src/back/spv/writer.rs](../tree/master/src/back/spv/writer.rs#L1035)
- [x] spv-in
  - [/src/front/spv/mod.rs](../tree/master/src/front/spv/mod.rs#L1480)
- [x] wgsl-in
  - [/src/front/wgsl/mod.rs](../tree/master/src/front/wgsl/mod.rs#L1790)
- [x] typifier
  - numerous