### PR TITLE
[glsl-in] Add initial pre-processor

### DIFF
--- a/examples/convert.rs
+++ b/examples/convert.rs
@@ -52,17 +52,19 @@ fn main() {
         #[cfg(feature = "glsl-in")]
         "vert" => {
             let input = fs::read_to_string(&args[1]).unwrap();
-            naga::front::glsl::parse_str(&input, "main", naga::ShaderStage::Vertex).unwrap()
+            naga::front::glsl::parse_str(&input, "main", naga::ShaderStage::Vertex, vec![]).unwrap()
         }
         #[cfg(feature = "glsl-in")]
         "frag" => {
             let input = fs::read_to_string(&args[1]).unwrap();
-            naga::front::glsl::parse_str(&input, "main", naga::ShaderStage::Fragment).unwrap()
+            naga::front::glsl::parse_str(&input, "main", naga::ShaderStage::Fragment, vec![])
+                .unwrap()
         }
         #[cfg(feature = "glsl-in")]
         "comp" => {
             let input = fs::read_to_string(&args[1]).unwrap();
-            naga::front::glsl::parse_str(&input, "main", naga::ShaderStage::Compute).unwrap()
+            naga::front::glsl::parse_str(&input, "main", naga::ShaderStage::Compute, vec![])
+                .unwrap()
         }
         #[cfg(feature = "deserialize")]
         "ron" => {

--- a/examples/convert.rs
+++ b/examples/convert.rs
@@ -52,19 +52,17 @@ fn main() {
         #[cfg(feature = "glsl-in")]
         "vert" => {
             let input = fs::read_to_string(&args[1]).unwrap();
-            naga::front::glsl::parse_str(&input, "main", naga::ShaderStage::Vertex, vec![]).unwrap()
+            naga::front::glsl::parse_str(&input, "main", naga::ShaderStage::Vertex, None).unwrap()
         }
         #[cfg(feature = "glsl-in")]
         "frag" => {
             let input = fs::read_to_string(&args[1]).unwrap();
-            naga::front::glsl::parse_str(&input, "main", naga::ShaderStage::Fragment, vec![])
-                .unwrap()
+            naga::front::glsl::parse_str(&input, "main", naga::ShaderStage::Fragment, None).unwrap()
         }
         #[cfg(feature = "glsl-in")]
         "comp" => {
             let input = fs::read_to_string(&args[1]).unwrap();
-            naga::front::glsl::parse_str(&input, "main", naga::ShaderStage::Compute, vec![])
-                .unwrap()
+            naga::front::glsl::parse_str(&input, "main", naga::ShaderStage::Compute, None).unwrap()
         }
         #[cfg(feature = "deserialize")]
         "ron" => {

--- a/examples/convert.rs
+++ b/examples/convert.rs
@@ -52,17 +52,35 @@ fn main() {
         #[cfg(feature = "glsl-in")]
         "vert" => {
             let input = fs::read_to_string(&args[1]).unwrap();
-            naga::front::glsl::parse_str(&input, "main", naga::ShaderStage::Vertex, None).unwrap()
+            naga::front::glsl::parse_str(
+                &input,
+                "main",
+                naga::ShaderStage::Vertex,
+                Default::default(),
+            )
+            .unwrap()
         }
         #[cfg(feature = "glsl-in")]
         "frag" => {
             let input = fs::read_to_string(&args[1]).unwrap();
-            naga::front::glsl::parse_str(&input, "main", naga::ShaderStage::Fragment, None).unwrap()
+            naga::front::glsl::parse_str(
+                &input,
+                "main",
+                naga::ShaderStage::Fragment,
+                Default::default(),
+            )
+            .unwrap()
         }
         #[cfg(feature = "glsl-in")]
         "comp" => {
             let input = fs::read_to_string(&args[1]).unwrap();
-            naga::front::glsl::parse_str(&input, "main", naga::ShaderStage::Compute, None).unwrap()
+            naga::front::glsl::parse_str(
+                &input,
+                "main",
+                naga::ShaderStage::Compute,
+                Default::default(),
+            )
+            .unwrap()
         }
         #[cfg(feature = "deserialize")]
         "ron" => {

--- a/src/front/glsl/error.rs
+++ b/src/front/glsl/error.rs
@@ -21,6 +21,7 @@ pub enum ErrorKind {
     VariableNotAvailable(String),
     ExpectedConstant,
     SemanticError(&'static str),
+    PreprocessorError(String),
 }
 
 impl fmt::Display for ErrorKind {
@@ -53,6 +54,7 @@ impl fmt::Display for ErrorKind {
             }
             ErrorKind::ExpectedConstant => write!(f, "Expected constant"),
             ErrorKind::SemanticError(msg) => write!(f, "Semantic error: {}", msg),
+            ErrorKind::PreprocessorError(val) => write!(f, "Preprocessor error: {}", val),
         }
     }
 }

--- a/src/front/glsl/mod.rs
+++ b/src/front/glsl/mod.rs
@@ -1,4 +1,4 @@
-use crate::{Module, ShaderStage};
+use crate::{FastHashMap, Module, ShaderStage};
 
 mod lex;
 #[cfg(test)]
@@ -25,13 +25,13 @@ pub fn parse_str(
     source: &str,
     entry: &str,
     stage: ShaderStage,
-    defines: Vec<(String, String)>,
+    defines: Option<FastHashMap<String, String>>,
 ) -> Result<Module, ParseError> {
     let mut program = Program::new(stage, entry);
 
     let mut lex = Lexer::new(source);
-    for (k, v) in defines {
-        lex.pp.defines.insert(k, v);
+    if let Some(defines) = defines {
+        lex.pp.defines = defines;
     }
 
     let mut parser = parser::Parser::new(&mut program);

--- a/src/front/glsl/mod.rs
+++ b/src/front/glsl/mod.rs
@@ -25,14 +25,12 @@ pub fn parse_str(
     source: &str,
     entry: &str,
     stage: ShaderStage,
-    defines: Option<FastHashMap<String, String>>,
+    defines: FastHashMap<String, String>,
 ) -> Result<Module, ParseError> {
     let mut program = Program::new(stage, entry);
 
     let mut lex = Lexer::new(source);
-    if let Some(defines) = defines {
-        lex.pp.defines = defines;
-    }
+    lex.pp.defines = defines;
 
     let mut parser = parser::Parser::new(&mut program);
 

--- a/src/front/glsl/mod.rs
+++ b/src/front/glsl/mod.rs
@@ -4,6 +4,10 @@ mod lex;
 #[cfg(test)]
 mod lex_tests;
 
+mod preprocess;
+#[cfg(test)]
+mod preprocess_tests;
+
 mod ast;
 use ast::Program;
 
@@ -17,11 +21,19 @@ mod token;
 mod types;
 mod variables;
 
-pub fn parse_str(source: &str, entry: &str, stage: ShaderStage) -> Result<Module, ParseError> {
-    log::debug!("------ GLSL-pomelo ------");
-
+pub fn parse_str(
+    source: &str,
+    entry: &str,
+    stage: ShaderStage,
+    defines: Vec<(String, String)>,
+) -> Result<Module, ParseError> {
     let mut program = Program::new(stage, entry);
-    let lex = Lexer::new(source);
+
+    let mut lex = Lexer::new(source);
+    for (k, v) in defines {
+        lex.pp.defines.insert(k, v);
+    }
+
     let mut parser = parser::Parser::new(&mut program);
 
     for token in lex {

--- a/src/front/glsl/preprocess.rs
+++ b/src/front/glsl/preprocess.rs
@@ -1,0 +1,145 @@
+use crate::FastHashMap;
+use thiserror::Error;
+
+#[derive(Clone, Debug, Error)]
+#[cfg_attr(test, derive(PartialEq))]
+pub enum Error {
+    #[error("unmatched else")]
+    UnmatchedElse,
+    #[error("unmatched endif")]
+    UnmatchedEndif,
+}
+
+#[derive(Clone, Debug)]
+pub struct LinePreProcessor {
+    pub defines: FastHashMap<String, String>,
+    if_stack: Vec<(bool, bool)>,
+    inside_comment: bool,
+    in_preprocess: bool,
+}
+
+impl LinePreProcessor {
+    pub fn new() -> Self {
+        LinePreProcessor {
+            defines: FastHashMap::default(),
+            if_stack: vec![],
+            inside_comment: false,
+            in_preprocess: false,
+        }
+    }
+
+    fn subst_defines(&self, input: &str) -> String {
+        //TODO: don't subst in commments, strings literals?
+        self.defines
+            .iter()
+            .fold(input.to_string(), |acc, (k, v)| acc.replace(k, v))
+    }
+
+    pub fn process_line(&mut self, line: &str) -> Result<Option<String>, Error> {
+        let mut skip = !self.if_stack.last().unwrap_or(&(true, false)).0;
+        let mut inside_comment = self.inside_comment;
+        let mut in_preprocess = inside_comment && self.in_preprocess;
+        // single-line comment
+        let mut processed = line;
+        if let Some(pos) = line.find("//") {
+            processed = line.split_at(pos).0;
+        }
+        // multi-line comment
+        let mut processed_string: String;
+        loop {
+            if inside_comment {
+                if let Some(pos) = processed.find("*/") {
+                    processed = processed.split_at(pos + 2).1;
+                    inside_comment = false;
+                    self.inside_comment = false;
+                    continue;
+                }
+            } else if let Some(pos) = processed.find("/*") {
+                if let Some(end_pos) = processed[pos + 2..].find("*/") {
+                    // comment ends during this line
+                    processed_string = processed.to_string();
+                    processed_string.replace_range(pos..pos + end_pos + 4, "");
+                    processed = &processed_string;
+                } else {
+                    processed = processed.split_at(pos).0;
+                    inside_comment = true;
+                }
+                continue;
+            }
+            break;
+        }
+        // strip leading whitespace
+        processed = processed.trim_start();
+        if processed.starts_with('#') && !self.inside_comment {
+            let mut iter = processed[1..]
+                .trim_start()
+                .splitn(2, |c: char| c.is_whitespace());
+            if let Some(directive) = iter.next() {
+                skip = true;
+                in_preprocess = true;
+                match directive {
+                    "version" => {
+                        skip = false;
+                    }
+                    "define" => {
+                        if let Some(rest) = iter.next() {
+                            let pos = rest
+                                .find(|c: char| !c.is_ascii_alphanumeric() && c != '_' && c != '(')
+                                .unwrap_or_else(|| rest.len());
+                            let (key, mut value) = rest.split_at(pos);
+                            value = value.trim();
+                            self.defines.insert(key.into(), self.subst_defines(value));
+                        }
+                    }
+                    "undef" => {
+                        if let Some(rest) = iter.next() {
+                            let key = rest.trim();
+                            self.defines.remove(key);
+                        }
+                    }
+                    "ifdef" => {
+                        if let Some(rest) = iter.next() {
+                            let key = rest.trim();
+                            self.if_stack.push((self.defines.contains_key(key), false));
+                        }
+                    }
+                    "ifndef" => {
+                        if let Some(rest) = iter.next() {
+                            let key = rest.trim();
+                            self.if_stack.push((!self.defines.contains_key(key), false));
+                        }
+                    }
+                    "else" => {
+                        if let Some(if_state) = self.if_stack.last_mut() {
+                            if !if_state.1 {
+                                // this is first else
+                                if_state.0 = !if_state.0;
+                                if_state.1 = true;
+                            } else {
+                                return Err(Error::UnmatchedElse);
+                            }
+                        }
+                    }
+                    "endif" => {
+                        if self.if_stack.pop().is_none() {
+                            return Err(Error::UnmatchedEndif);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        let res = if !skip && !self.inside_comment {
+            Ok(Some(self.subst_defines(&line)))
+        } else {
+            Ok(if in_preprocess && !self.in_preprocess {
+                Some("".to_string())
+            } else {
+                None
+            })
+        };
+        self.in_preprocess = in_preprocess || skip;
+        self.inside_comment = inside_comment;
+        res
+    }
+}

--- a/src/front/glsl/preprocess_tests.rs
+++ b/src/front/glsl/preprocess_tests.rs
@@ -1,0 +1,218 @@
+use super::preprocess::{Error, LinePreProcessor};
+use std::{iter::Enumerate, str::Lines};
+
+#[derive(Clone, Debug)]
+pub struct PreProcessor<'a> {
+    lines: Enumerate<Lines<'a>>,
+    input: String,
+    line: usize,
+    offset: usize,
+    line_pp: LinePreProcessor,
+}
+
+impl<'a> PreProcessor<'a> {
+    pub fn new(input: &'a str) -> Self {
+        let mut lexer = PreProcessor {
+            lines: input.lines().enumerate(),
+            input: "".to_string(),
+            line: 0,
+            offset: 0,
+            line_pp: LinePreProcessor::new(),
+        };
+        lexer.next_line();
+        lexer
+    }
+
+    fn next_line(&mut self) -> bool {
+        if let Some((line, input)) = self.lines.next() {
+            let mut input = String::from(input);
+
+            while input.ends_with('\\') {
+                if let Some((_, next)) = self.lines.next() {
+                    input.pop();
+                    input.push_str(next);
+                } else {
+                    break;
+                }
+            }
+
+            self.input = input;
+            self.line = line;
+            self.offset = 0;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn process(&mut self) -> Result<String, Error> {
+        let mut res = String::new();
+        loop {
+            let line = &self.line_pp.process_line(&self.input)?;
+            if let Some(line) = line {
+                res.push_str(line);
+            }
+            if !self.next_line() {
+                break;
+            }
+            if line.is_some() {
+                res.push_str("\n");
+            }
+        }
+        Ok(res)
+    }
+}
+
+#[test]
+fn preprocess() {
+    // line continuation
+    let mut pp = PreProcessor::new(
+        "void main my_\
+        func",
+    );
+    assert_eq!(pp.process().unwrap(), "void main my_func");
+
+    // preserve #version
+    let mut pp = PreProcessor::new(
+        "#version 450 core\n\
+        void main()",
+    );
+    assert_eq!(pp.process().unwrap(), "#version 450 core\nvoid main()");
+
+    // simple define
+    let mut pp = PreProcessor::new(
+        "#define FOO 42 \n\
+        fun=FOO",
+    );
+    assert_eq!(pp.process().unwrap(), "\nfun=42");
+
+    // ifdef with else
+    let mut pp = PreProcessor::new(
+        "#define FOO\n\
+        #ifdef FOO\n\
+            foo=42\n\
+        #endif\n\
+        some=17\n\
+        #ifdef BAR\n\
+            bar=88\n\
+        #else\n\
+            mm=49\n\
+        #endif\n\
+        done=1",
+    );
+    assert_eq!(
+        pp.process().unwrap(),
+        "\n\
+        foo=42\n\
+        \n\
+        some=17\n\
+        \n\
+        mm=49\n\
+        \n\
+        done=1"
+    );
+
+    // nested ifdef/ifndef
+    let mut pp = PreProcessor::new(
+        "#define FOO\n\
+        #define BOO\n\
+        #ifdef FOO\n\
+            foo=42\n\
+            #ifdef BOO\n\
+                boo=44\n\
+            #endif\n\
+                ifd=0\n\
+            #ifndef XYZ\n\
+                nxyz=8\n\
+            #endif\n\
+        #endif\n\
+        some=17\n\
+        #ifdef BAR\n\
+            bar=88\n\
+        #else\n\
+            mm=49\n\
+        #endif\n\
+        done=1",
+    );
+    assert_eq!(
+        pp.process().unwrap(),
+        "\n\
+        foo=42\n\
+        \n\
+        boo=44\n\
+        \n\
+        ifd=0\n\
+        \n\
+        nxyz=8\n\
+        \n\
+        some=17\n\
+        \n\
+        mm=49\n\
+        \n\
+        done=1"
+    );
+
+    // undef
+    let mut pp = PreProcessor::new(
+        "#define FOO\n\
+        #ifdef FOO\n\
+            foo=42\n\
+        #endif\n\
+        some=17\n\
+        #undef FOO\n\
+        #ifdef FOO\n\
+            foo=88\n\
+        #else\n\
+            nofoo=66\n\
+        #endif\n\
+        done=1",
+    );
+    assert_eq!(
+        pp.process().unwrap(),
+        "\n\
+        foo=42\n\
+        \n\
+        some=17\n\
+        \n\
+        nofoo=66\n\
+        \n\
+        done=1"
+    );
+
+    // single-line comment
+    let mut pp = PreProcessor::new(
+        "#define FOO 42//1234\n\
+        fun=FOO",
+    );
+    assert_eq!(pp.process().unwrap(), "\nfun=42");
+
+    // multi-line comments
+    let mut pp = PreProcessor::new(
+        "#define FOO 52/*/1234\n\
+        #define FOO 88\n\
+        end of comment*/ /* one more comment */ #define FOO 56\n\
+        fun=FOO",
+    );
+    assert_eq!(pp.process().unwrap(), "\nfun=56");
+
+    // unmatched endif
+    let mut pp = PreProcessor::new(
+        "#ifdef FOO\n\
+        foo=42\n\
+        #endif\n\
+        #endif",
+    );
+    assert_eq!(pp.process(), Err(Error::UnmatchedEndif));
+
+    // unmatched else
+    let mut pp = PreProcessor::new(
+        "#ifdef FOO\n\
+        foo=42\n\
+        #else\n\
+        bar=88\n\
+        #else\n\
+        bad=true\n\
+        #endif",
+    );
+    assert_eq!(pp.process(), Err(Error::UnmatchedElse));
+}

--- a/tests/convert.rs
+++ b/tests/convert.rs
@@ -20,7 +20,7 @@ fn load_spv(name: &str) -> naga::Module {
 #[cfg(feature = "glsl-in")]
 fn load_glsl(name: &str, entry: &str, stage: naga::ShaderStage) -> naga::Module {
     let input = load_test_data(name);
-    naga::front::glsl::parse_str(&input, entry, stage, None).unwrap()
+    naga::front::glsl::parse_str(&input, entry, stage, Default::default()).unwrap()
 }
 
 #[cfg(feature = "wgsl-in")]

--- a/tests/convert.rs
+++ b/tests/convert.rs
@@ -20,7 +20,7 @@ fn load_spv(name: &str) -> naga::Module {
 #[cfg(feature = "glsl-in")]
 fn load_glsl(name: &str, entry: &str, stage: naga::ShaderStage) -> naga::Module {
     let input = load_test_data(name);
-    naga::front::glsl::parse_str(&input, entry, stage, vec![]).unwrap()
+    naga::front::glsl::parse_str(&input, entry, stage, None).unwrap()
 }
 
 #[cfg(feature = "wgsl-in")]

--- a/tests/convert.rs
+++ b/tests/convert.rs
@@ -20,7 +20,7 @@ fn load_spv(name: &str) -> naga::Module {
 #[cfg(feature = "glsl-in")]
 fn load_glsl(name: &str, entry: &str, stage: naga::ShaderStage) -> naga::Module {
     let input = load_test_data(name);
-    naga::front::glsl::parse_str(&input, entry, stage).unwrap()
+    naga::front::glsl::parse_str(&input, entry, stage, vec![]).unwrap()
 }
 
 #[cfg(feature = "wgsl-in")]

--- a/tests/rosetta.rs
+++ b/tests/rosetta.rs
@@ -40,18 +40,33 @@ fn test_rosetta(dir_name: &str) {
         #[cfg(feature = "glsl-in")]
         {
             if let Ok(input) = fs::read_to_string(dir_path.join("x.vert")) {
-                let module =
-                    glsl::parse_str(&input, "main", naga::ShaderStage::Vertex, None).unwrap();
+                let module = glsl::parse_str(
+                    &input,
+                    "main",
+                    naga::ShaderStage::Vertex,
+                    Default::default(),
+                )
+                .unwrap();
                 check("vert", &module, &expected);
             }
             if let Ok(input) = fs::read_to_string(dir_path.join("x.frag")) {
-                let module =
-                    glsl::parse_str(&input, "main", naga::ShaderStage::Fragment, None).unwrap();
+                let module = glsl::parse_str(
+                    &input,
+                    "main",
+                    naga::ShaderStage::Fragment,
+                    Default::default(),
+                )
+                .unwrap();
                 check("frag", &module, &expected);
             }
             if let Ok(input) = fs::read_to_string(dir_path.join("x.comp")) {
-                let module =
-                    glsl::parse_str(&input, "main", naga::ShaderStage::Compute, None).unwrap();
+                let module = glsl::parse_str(
+                    &input,
+                    "main",
+                    naga::ShaderStage::Compute,
+                    Default::default(),
+                )
+                .unwrap();
                 check("comp", &module, &expected);
             }
         }

--- a/tests/rosetta.rs
+++ b/tests/rosetta.rs
@@ -41,17 +41,17 @@ fn test_rosetta(dir_name: &str) {
         {
             if let Ok(input) = fs::read_to_string(dir_path.join("x.vert")) {
                 let module =
-                    glsl::parse_str(&input, "main", naga::ShaderStage::Vertex, vec![]).unwrap();
+                    glsl::parse_str(&input, "main", naga::ShaderStage::Vertex, None).unwrap();
                 check("vert", &module, &expected);
             }
             if let Ok(input) = fs::read_to_string(dir_path.join("x.frag")) {
                 let module =
-                    glsl::parse_str(&input, "main", naga::ShaderStage::Fragment, vec![]).unwrap();
+                    glsl::parse_str(&input, "main", naga::ShaderStage::Fragment, None).unwrap();
                 check("frag", &module, &expected);
             }
             if let Ok(input) = fs::read_to_string(dir_path.join("x.comp")) {
                 let module =
-                    glsl::parse_str(&input, "main", naga::ShaderStage::Compute, vec![]).unwrap();
+                    glsl::parse_str(&input, "main", naga::ShaderStage::Compute, None).unwrap();
                 check("comp", &module, &expected);
             }
         }

--- a/tests/rosetta.rs
+++ b/tests/rosetta.rs
@@ -40,15 +40,18 @@ fn test_rosetta(dir_name: &str) {
         #[cfg(feature = "glsl-in")]
         {
             if let Ok(input) = fs::read_to_string(dir_path.join("x.vert")) {
-                let module = glsl::parse_str(&input, "main", naga::ShaderStage::Vertex).unwrap();
+                let module =
+                    glsl::parse_str(&input, "main", naga::ShaderStage::Vertex, vec![]).unwrap();
                 check("vert", &module, &expected);
             }
             if let Ok(input) = fs::read_to_string(dir_path.join("x.frag")) {
-                let module = glsl::parse_str(&input, "main", naga::ShaderStage::Fragment).unwrap();
+                let module =
+                    glsl::parse_str(&input, "main", naga::ShaderStage::Fragment, vec![]).unwrap();
                 check("frag", &module, &expected);
             }
             if let Ok(input) = fs::read_to_string(dir_path.join("x.comp")) {
-                let module = glsl::parse_str(&input, "main", naga::ShaderStage::Compute).unwrap();
+                let module =
+                    glsl::parse_str(&input, "main", naga::ShaderStage::Compute, vec![]).unwrap();
                 check("comp", &module, &expected);
             }
         }


### PR DESCRIPTION
Supported:
- `#define KEY VALUE`
- `#undef`
- `#ifdef`
- `#ifndef`
- `#else`
- `#endif`

Not supported (yet):
- `#define MACRO(x, y, z)`
- `#if` (need to handle const expressions)
- `#include`

Pre-configured defines can now also be passed in to the `parse_str` function as `Vec<String, String>` (key, value).

The preprocessor works on a line by line basis, and should be easy to apply to other front-ends if needed.

As the implementation is currently of reasonable size (<150 lines), this has not (yet) been feature gated.