### PR TITLE
Simplify bitshift IR

### DIFF
--- a/src/back/glsl.rs
+++ b/src/back/glsl.rs
@@ -1126,9 +1126,8 @@ fn write_expression<'a, 'b>(
                 BinaryOperator::InclusiveOr => "|",
                 BinaryOperator::LogicalAnd => "&&",
                 BinaryOperator::LogicalOr => "||",
-                BinaryOperator::ShiftLeftLogical => "<<",
-                BinaryOperator::ShiftRightLogical => todo!(),
-                BinaryOperator::ShiftRightArithmetic => ">>",
+                BinaryOperator::ShiftLeft => "<<",
+                BinaryOperator::ShiftRight => ">>",
             };
 
             Cow::Owned(format!("({} {} {})", left_expr, op_str, right_expr))

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -328,11 +328,10 @@ pomelo! {
     }
     shift_expression ::= additive_expression;
     shift_expression ::= shift_expression(left) LeftOp additive_expression(right) {
-        extra.binary_expr(BinaryOperator::ShiftLeftLogical, left, right)
+        extra.binary_expr(BinaryOperator::ShiftLeft, left, right)
     }
     shift_expression ::= shift_expression(left) RightOp additive_expression(right) {
-        //TODO: when to use ShiftRightArithmetic
-        extra.binary_expr(BinaryOperator::ShiftRightLogical, left, right)
+        extra.binary_expr(BinaryOperator::ShiftRight, left, right)
     }
     relational_expression ::= shift_expression;
     relational_expression ::= relational_expression(left) LeftAngle shift_expression(right) {
@@ -422,10 +421,10 @@ pomelo! {
         BinaryOperator::Subtract
     }
     assignment_operator ::= LeftAssign {
-        BinaryOperator::ShiftLeftLogical
+        BinaryOperator::ShiftLeft
     }
     assignment_operator ::= RightAssign {
-        BinaryOperator::ShiftRightLogical
+        BinaryOperator::ShiftRight
     }
     assignment_operator ::= AndAssign {
         BinaryOperator::And

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -852,6 +852,38 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                         },
                     );
                 }
+                // Bitwise instructions
+                Op::Not => {
+                    inst.expect(4)?;
+                    self.parse_expr_unary_op(expressions, crate::UnaryOperator::Not)?;
+                }
+                Op::BitwiseOr => {
+                    inst.expect(5)?;
+                    self.parse_expr_binary_op(expressions, crate::BinaryOperator::InclusiveOr)?;
+                }
+                Op::BitwiseXor => {
+                    inst.expect(5)?;
+                    self.parse_expr_binary_op(expressions, crate::BinaryOperator::ExclusiveOr)?;
+                }
+                Op::BitwiseAnd => {
+                    inst.expect(5)?;
+                    self.parse_expr_binary_op(expressions, crate::BinaryOperator::And)?;
+                }
+                Op::ShiftRightLogical => {
+                    inst.expect(5)?;
+                    //TODO: convert input and result to usigned
+                    self.parse_expr_binary_op(expressions, crate::BinaryOperator::ShiftRight)?;
+                }
+                Op::ShiftRightArithmetic => {
+                    inst.expect(5)?;
+                    //TODO: convert input and result to signed
+                    self.parse_expr_binary_op(expressions, crate::BinaryOperator::ShiftRight)?;
+                }
+                Op::ShiftLeftLogical => {
+                    inst.expect(5)?;
+                    self.parse_expr_binary_op(expressions, crate::BinaryOperator::ShiftLeft)?;
+                }
+                // Sampling
                 Op::SampledImage => {
                     inst.expect(5)?;
                     let _result_type_id = self.next()?;

--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -69,12 +69,7 @@ fn consume_token(mut input: &str) -> (Token<'_>, &str) {
             if next == Some('=') {
                 (Token::LogicalOperation(cur), chars.as_str())
             } else if next == Some(cur) {
-                input = chars.as_str();
-                if chars.next() == Some(cur) {
-                    (Token::ArithmeticShiftOperation(cur), chars.as_str())
-                } else {
-                    (Token::ShiftOperation(cur), input)
-                }
+                (Token::ShiftOperation(cur), chars.as_str())
             } else {
                 (Token::Paren(cur), input)
             }

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -26,7 +26,6 @@ pub enum Token<'a> {
     Operation(char),
     LogicalOperation(char),
     ShiftOperation(char),
-    ArithmeticShiftOperation(char),
     Arrow,
     Unknown(char),
     UnterminatedString,
@@ -790,13 +789,10 @@ impl Parser {
                             lexer,
                             |token| match token {
                                 Token::ShiftOperation('<') => {
-                                    Some(crate::BinaryOperator::ShiftLeftLogical)
+                                    Some(crate::BinaryOperator::ShiftLeft)
                                 }
                                 Token::ShiftOperation('>') => {
-                                    Some(crate::BinaryOperator::ShiftRightLogical)
-                                }
-                                Token::ArithmeticShiftOperation('>') => {
-                                    Some(crate::BinaryOperator::ShiftRightArithmetic)
+                                    Some(crate::BinaryOperator::ShiftRight)
                                 }
                                 _ => None,
                             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,9 +498,9 @@ pub enum BinaryOperator {
     InclusiveOr,
     LogicalAnd,
     LogicalOr,
-    ShiftLeftLogical,
-    ShiftRightLogical,
-    ShiftRightArithmetic,
+    ShiftLeft,
+    /// Right shift carries the sign of signed integers only.
+    ShiftRight,
 }
 
 /// Built-in shader function.

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -232,11 +232,8 @@ impl Typifier {
                 crate::BinaryOperator::And
                 | crate::BinaryOperator::ExclusiveOr
                 | crate::BinaryOperator::InclusiveOr
-                | crate::BinaryOperator::ShiftLeftLogical
-                | crate::BinaryOperator::ShiftRightLogical
-                | crate::BinaryOperator::ShiftRightArithmetic => {
-                    self.resolutions[left.index()].clone()
-                }
+                | crate::BinaryOperator::ShiftLeft
+                | crate::BinaryOperator::ShiftRight => self.resolutions[left.index()].clone(),
             },
             crate::Expression::Intrinsic { .. } => unimplemented!(),
             crate::Expression::Transpose(expr) => match *self.get(expr, types) {


### PR DESCRIPTION
Aligns our IR to WGSL according to https://github.com/gpuweb/gpuweb/pull/914
TL;DR: right shifts are always arithmetic for signed integer and logical for unsigned.
Fixes one of the points in https://github.com/gfx-rs/naga/issues/243