### PR TITLE
Clean up the storage classes

### DIFF
--- a/src/back/msl.rs
+++ b/src/back/msl.rs
@@ -254,9 +254,7 @@ impl<'a> TypedGlobalVariable<'a> {
 
         let (space_qualifier, reference) = match ty.inner {
             crate::TypeInner::Struct { .. } => match var.class {
-                crate::StorageClass::Constant
-                | crate::StorageClass::Uniform
-                | crate::StorageClass::StorageBuffer => {
+                crate::StorageClass::Uniform | crate::StorageClass::Storage => {
                     let space = if self.usage.contains(crate::GlobalUse::STORE) {
                         "device "
                     } else {
@@ -837,9 +835,13 @@ impl<W: Write> Writer<W> {
                     let base_name = module.types[base].name.or_index(base);
                     let class_name = match class {
                         Sc::Input | Sc::Output => continue,
-                        Sc::Constant | Sc::Uniform => "constant",
-                        Sc::StorageBuffer => "device",
-                        Sc::Private | Sc::Function | Sc::WorkGroup => "",
+                        Sc::Uniform => "constant",
+                        Sc::Storage => "device",
+                        Sc::Handle
+                        | Sc::Private
+                        | Sc::Function
+                        | Sc::WorkGroup
+                        | Sc::PushConstant => "",
                     };
                     write!(self.out, "typedef {} {} *{}", class_name, base_name, name)?;
                 }

--- a/src/back/spv/layout.rs
+++ b/src/back/spv/layout.rs
@@ -24,6 +24,10 @@ impl PhysicalLayout {
         sink.extend(iter::once(self.bound));
         sink.extend(iter::once(self.instruction_schema));
     }
+
+    pub(super) fn supports_storage_buffers(&self) -> bool {
+        self.version >= 0x10300
+    }
 }
 
 impl LogicalLayout {

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -417,14 +417,19 @@ impl Writer {
 
     fn parse_to_spirv_storage_class(&self, class: crate::StorageClass) -> spirv::StorageClass {
         match class {
-            crate::StorageClass::Constant => spirv::StorageClass::UniformConstant,
+            crate::StorageClass::Handle => spirv::StorageClass::UniformConstant,
             crate::StorageClass::Function => spirv::StorageClass::Function,
             crate::StorageClass::Input => spirv::StorageClass::Input,
             crate::StorageClass::Output => spirv::StorageClass::Output,
             crate::StorageClass::Private => spirv::StorageClass::Private,
-            crate::StorageClass::StorageBuffer => spirv::StorageClass::StorageBuffer,
-            crate::StorageClass::Uniform => spirv::StorageClass::Uniform,
+            crate::StorageClass::Storage if self.physical_layout.supports_storage_buffers() => {
+                spirv::StorageClass::StorageBuffer
+            }
+            crate::StorageClass::Storage | crate::StorageClass::Uniform => {
+                spirv::StorageClass::Uniform
+            }
             crate::StorageClass::WorkGroup => spirv::StorageClass::Workgroup,
+            crate::StorageClass::PushConstant => spirv::StorageClass::PushConstant,
         }
     }
 

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -596,9 +596,7 @@ pomelo! {
     // single_type_qualifier ::= invariant_qualifier;
     // single_type_qualifier ::= precise_qualifier;
 
-    storage_qualifier ::= Const {
-        StorageClass::Constant
-    }
+    // storage_qualifier ::= Const
     // storage_qualifier ::= InOut;
     storage_qualifier ::= In {
         StorageClass::Input

--- a/src/front/spv/convert.rs
+++ b/src/front/spv/convert.rs
@@ -43,21 +43,6 @@ pub fn map_vector_size(word: spirv::Word) -> Result<crate::VectorSize, Error> {
     }
 }
 
-pub fn map_storage_class(word: spirv::Word) -> Result<crate::StorageClass, Error> {
-    use spirv::StorageClass as Sc;
-    match Sc::from_u32(word) {
-        Some(Sc::UniformConstant) => Ok(crate::StorageClass::Constant),
-        Some(Sc::Function) => Ok(crate::StorageClass::Function),
-        Some(Sc::Input) => Ok(crate::StorageClass::Input),
-        Some(Sc::Output) => Ok(crate::StorageClass::Output),
-        Some(Sc::Private) => Ok(crate::StorageClass::Private),
-        Some(Sc::StorageBuffer) => Ok(crate::StorageClass::StorageBuffer),
-        Some(Sc::Uniform) => Ok(crate::StorageClass::Uniform),
-        Some(Sc::Workgroup) => Ok(crate::StorageClass::WorkGroup),
-        _ => Err(Error::UnsupportedStorageClass(word)),
-    }
-}
-
 pub fn map_image_dim(word: spirv::Word) -> Result<crate::ImageDimension, Error> {
     use spirv::Dim as D;
     match D::from_u32(word) {

--- a/src/front/wgsl/conv.rs
+++ b/src/front/wgsl/conv.rs
@@ -4,8 +4,9 @@ pub fn map_storage_class(word: &str) -> Result<crate::StorageClass, Error<'_>> {
     match word {
         "in" => Ok(crate::StorageClass::Input),
         "out" => Ok(crate::StorageClass::Output),
+        "private" => Ok(crate::StorageClass::Private),
         "uniform" => Ok(crate::StorageClass::Uniform),
-        "storage_buffer" => Ok(crate::StorageClass::StorageBuffer),
+        "storage" => Ok(crate::StorageClass::Storage),
         _ => Err(Error::UnknownStorageClass(word)),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,14 +108,24 @@ pub enum ShaderStage {
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[allow(missing_docs)] // The names are self evident
 pub enum StorageClass {
-    Constant,
+    /// Function locals.
     Function,
+    /// Pipeline input, per invocation.
     Input,
+    /// Pipeline output, per invocation, mutable.
     Output,
+    /// Private data, per invocation, mutable.
     Private,
-    StorageBuffer,
-    Uniform,
+    /// Workgroup shared data, mutable.
     WorkGroup,
+    /// Uniform buffer data.
+    Uniform,
+    /// Storage buffer data, potentially mutable.
+    Storage,
+    /// Opaque handles, such as samplers and images.
+    Handle,
+    /// Push constants.
+    PushConstant,
 }
 
 /// Built-in inputs and outputs.

--- a/src/proc/interface.rs
+++ b/src/proc/interface.rs
@@ -218,7 +218,7 @@ mod tests {
     fn global_use_scan() {
         let test_global = GlobalVariable {
             name: None,
-            class: StorageClass::Constant,
+            class: StorageClass::Uniform,
             binding: None,
             ty: Handle::new(std::num::NonZeroU32::new(1).unwrap()),
             interpolation: None,

--- a/test-data/boids.wgsl
+++ b/test-data/boids.wgsl
@@ -61,8 +61,8 @@ type Particles = struct {
 };
 
 [[group(0), binding(0)]] var<uniform> params : SimParams;
-[[group(0), binding(1)]] var<storage_buffer> particlesA : Particles;
-[[group(0), binding(2)]] var<storage_buffer> particlesB : Particles;
+[[group(0), binding(1)]] var<storage> particlesA : Particles;
+[[group(0), binding(2)]] var<storage> particlesB : Particles;
 
 [[builtin(global_invocation_id)]] var gl_GlobalInvocationID : vec3<u32>;
 

--- a/test-data/quad.wgsl
+++ b/test-data/quad.wgsl
@@ -14,8 +14,8 @@ fn main() -> void {
 
 # fragment
 [[location(0)]] var<in> v_uv : vec2<f32>;
-[[group(0), binding(0)]] var<uniform> u_texture : texture_sampled_2d<f32>;
-[[group(0), binding(1)]] var<uniform> u_sampler : sampler;
+[[group(0), binding(0)]] var u_texture : texture_sampled_2d<f32>;
+[[group(0), binding(1)]] var u_sampler : sampler;
 [[location(0)]] var<out> o_color : vec4<f32>;
 
 [[stage(fragment)]]


### PR DESCRIPTION
Mostly aligns us to https://github.com/gpuweb/gpuweb/pull/1093

I think the storage classes were one of the most confusing parts of the IR, and I've long wanted to make them understandable. I believe, they are now.

The push constant class is not really supported, but we'll need it for future expansion (outside of WebGPU).

See https://github.com/KhronosGroup/SPIRV-Reflect/pull/96 for the logic about where SPIR-V chooses which classes.