### PR TITLE
[glsl-in] Add initial texture handling

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -138,6 +138,7 @@ impl Context {
 pub struct ExpressionRule {
     pub expression: Handle<Expression>,
     pub statements: Vec<Statement>,
+    pub sampler: Option<Handle<Expression>>,
 }
 
 impl ExpressionRule {
@@ -145,6 +146,7 @@ impl ExpressionRule {
         ExpressionRule {
             expression,
             statements: vec![],
+            sampler: None,
         }
     }
 }
@@ -166,12 +168,11 @@ pub struct VarDeclaration {
 #[derive(Debug)]
 pub enum FunctionCallKind {
     TypeConstructor(Handle<Type>),
-    Function(Handle<Expression>),
+    Function(String),
 }
 
 #[derive(Debug)]
 pub struct FunctionCall {
     pub kind: FunctionCallKind,
-    pub args: Vec<Handle<Expression>>,
-    pub statements: Vec<Statement>,
+    pub args: Vec<ExpressionRule>,
 }

--- a/src/front/glsl/parser_tests.rs
+++ b/src/front/glsl/parser_tests.rs
@@ -162,3 +162,21 @@ fn control_flow() {
     )
     .unwrap();
 }
+
+#[test]
+fn textures() {
+    let _program = parse_program(
+        r#"
+        #version 450
+        layout(location = 0) in vec2 v_uv;
+        layout(location = 0) out vec4 o_color;
+        layout(set = 1, binding = 1) uniform texture2D tex;
+        layout(set = 1, binding = 2) uniform sampler tex_sampler;
+        void main() {
+            o_color = texture(sampler2D(tex, tex_sampler), v_uv);
+        }
+        "#,
+        ShaderStage::Fragment,
+    )
+    .unwrap();
+}

--- a/src/front/glsl/types.rs
+++ b/src/front/glsl/types.rs
@@ -37,6 +37,21 @@ pub fn parse_type(type_name: &str) -> Option<Type> {
                 width: 4,
             },
         }),
+        "texture2D" => Some(Type {
+            name: None,
+            inner: TypeInner::Image {
+                dim: crate::ImageDimension::D2,
+                arrayed: false,
+                class: crate::ImageClass::Sampled {
+                    kind: ScalarKind::Float,
+                    multi: false,
+                },
+            },
+        }),
+        "sampler" => Some(Type {
+            name: None,
+            inner: TypeInner::Sampler { comparison: false },
+        }),
         word => {
             fn kind_width_parse(ty: &str) -> Option<(ScalarKind, u8)> {
                 Some(match ty {


### PR DESCRIPTION
Managed to get simple form of texturing working. Parses stuff like:
```glsl
#version 450
layout(location = 0) in vec2 v_uv;
layout(location = 0) out vec4 o_color;
layout(set = 1, binding = 1) uniform texture2D tex;
layout(set = 1, binding = 2) uniform sampler tex_sampler;
void main() {
    o_color = texture(sampler2D(tex, tex_sampler), v_uv);
}
```