### PR TITLE
[spv-out] Handle ImageSample

### DIFF
--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -235,6 +235,13 @@ pub(super) fn instruction_type_sampler(id: Word) -> Instruction {
     instruction
 }
 
+pub(super) fn instruction_type_sampled_image(id: Word, image_type_id: Word) -> Instruction {
+    let mut instruction = Instruction::new(Op::TypeSampledImage);
+    instruction.set_result(id);
+    instruction.add_operand(image_type_id);
+    instruction
+}
+
 pub(super) fn instruction_type_array(
     id: Word,
     element_type_id: Word,
@@ -449,6 +456,33 @@ pub(super) fn instruction_function_call(
 //
 // Image Instructions
 //
+pub(super) fn instruction_sampled_image(
+    result_type_id: Word,
+    id: Word,
+    image: Word,
+    sampler: Word,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::SampledImage);
+    instruction.set_type(result_type_id);
+    instruction.set_result(id);
+    instruction.add_operand(image);
+    instruction.add_operand(sampler);
+    instruction
+}
+
+pub(super) fn instruction_image_sample_implicit_lod(
+    result_type_id: Word,
+    id: Word,
+    sampled_image: Word,
+    coordinates: Word,
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::ImageSampleImplicitLod);
+    instruction.set_type(result_type_id);
+    instruction.set_result(id);
+    instruction.add_operand(sampled_image);
+    instruction.add_operand(coordinates);
+    instruction
+}
 
 //
 // Conversion Instructions


### PR DESCRIPTION
Handles most simple case for `ImageSample`

Sample input (glsl)
```glsl
#version 450
layout(location = 0) out vec4 o_Target;
layout(set = 1, binding = 1) uniform texture2D ColorMaterial_texture;
layout(set = 1, binding = 2) uniform sampler ColorMaterial_texture_sampler;

void main() {
    o_Target = texture(
        sampler2D(ColorMaterial_texture, ColorMaterial_texture_sampler),
        vec2(0));
    return;
}
```

results in:
```spirv
; SPIR-V
; Version: 1.0
; Generator: Khronos; 0
; Bound: 25
; Schema: 0
               OpCapability ImageMSArray
               OpCapability Shader
               OpCapability Kernel
          %1 = OpExtInstImport "GLSL.std.450"
               OpMemoryModel Logical GLSL450
               OpEntryPoint Fragment %main "main" %o_Target %ColorMaterial_texture %ColorMaterial_texture_sampler
               OpExecutionMode %main OriginUpperLeft
               OpSource GLSL 450
               OpName %o_Target "o_Target"
               OpName %ColorMaterial_texture "ColorMaterial_texture"
               OpName %ColorMaterial_texture_sampler "ColorMaterial_texture_sampler"
               OpName %main "main"
               OpDecorate %o_Target Location 0
               OpDecorate %ColorMaterial_texture DescriptorSet 1
               OpDecorate %ColorMaterial_texture Binding 1
               OpDecorate %ColorMaterial_texture_sampler DescriptorSet 1
               OpDecorate %ColorMaterial_texture_sampler Binding 2
      %float = OpTypeFloat 32
    %v4float = OpTypeVector %float 4
          %4 = OpTypeImage %float 2D 0 0 0 1 Unknown
          %5 = OpTypeSampler
    %v2float = OpTypeVector %float 2
        %int = OpTypeInt 32 1
%_ptr_Output_v4float = OpTypePointer Output %v4float
   %o_Target = OpVariable %_ptr_Output_v4float Output
%_ptr_Uniform_4 = OpTypePointer Uniform %4
%ColorMaterial_texture = OpVariable %_ptr_Uniform_4 Uniform
%_ptr_Uniform_5 = OpTypePointer Uniform %5
%ColorMaterial_texture_sampler = OpVariable %_ptr_Uniform_5 Uniform
      %int_0 = OpConstant %int 0
       %void = OpTypeVoid
         %17 = OpTypeFunction %void
         %20 = OpTypeSampledImage %4
       %main = OpFunction %void None %17
         %18 = OpLabel
         %19 = OpLoad %4 %ColorMaterial_texture None
         %21 = OpLoad %5 %ColorMaterial_texture_sampler None
         %22 = OpCompositeConstruct %v2float %int_0
         %23 = OpSampledImage %20 %19 %21
         %24 = OpImageSampleImplicitLod %v4float %23 %22
               OpStore %o_Target %24 None
               OpReturn
               OpFunctionEnd
```

Introduces a couple new errors enum variants, and tries to avoid `.unwrap()`