### PR TITLE
[spv-out] Fix duplicate scalar OpType

### DIFF
--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -189,7 +189,16 @@ impl Writer {
             *e.get()
         } else {
             match lookup_ty {
-                LookupType::Handle(handle) => self.write_type_declaration_arena(arena, handle),
+                LookupType::Handle(handle) => match arena[handle].inner {
+                    crate::TypeInner::Scalar { kind, width } => self.get_type_id(
+                        arena,
+                        LookupType::Local(LocalType::Scalar {
+                            kind,
+                            width,
+                        }),
+                    ),
+                    _ => self.write_type_declaration_arena(arena, handle),
+                },
                 LookupType::Local(local_ty) => self.write_type_declaration_local(arena, local_ty),
             }
         }


### PR DESCRIPTION
When the following WGSL input was used:
```
[[stage(vertex)]]
fn main() -> void {
  var vector: vec2<f32> = vec2<f32>(1.0, 1.0);
  return;
}
```

You would get a validation error when validating the SPIR-V output. The reason was because there would be a duplicate `OpTypeFloat` is because the vector implicitly uses OpTypeFloat here.

If you would first explicity add a float variable, it would work:
```
[[stage(vertex)]]
fn main() -> void {
  var float: f32 = 1.0;
  var vector: vec2<f32> = vec2<f32>(1.0, 1.0);
  return;
}
```

The reason this works is as there is an explicit `f32` declaration and that is getting parsed correctly.

### Technical
This is due to how LookupTypes work and I am not entirely sure how it is caused, but it something has to do that the implicit `f32` don't have a handle and aren't recognized when looking up.

### Conclusion
 For now, this "quick" fix should push the code forward, so we can focus on getting in more support for more shaders. The Lookup system works fine for now, but it can use some refactor a little later down the road.

This PR is one step closer to successfully parse the quad.wgsl