### PR TITLE
[ir] select expression

### DIFF
--- a/src/back/glsl.rs
+++ b/src/back/glsl.rs
@@ -1208,6 +1208,22 @@ fn write_expression<'a, 'b>(
 
             Cow::Owned(format!("({} {} {})", left_expr, op_str, right_expr))
         }
+        Expression::Select {
+            condition,
+            accept,
+            reject,
+        } => {
+            let cond_expr =
+                write_expression(&builder.expressions[condition], module, builder, manager)?;
+            let accept_expr =
+                write_expression(&builder.expressions[accept], module, builder, manager)?;
+            let reject_expr =
+                write_expression(&builder.expressions[reject], module, builder, manager)?;
+            Cow::Owned(format!(
+                "({} ? {} : {})",
+                cond_expr, accept_expr, reject_expr
+            ))
+        }
         Expression::Intrinsic { fun, argument } => {
             let expr = write_expression(&builder.expressions[argument], module, builder, manager)?;
 

--- a/src/back/msl.rs
+++ b/src/back/msl.rs
@@ -524,6 +524,19 @@ impl<W: Write> Writer<W> {
                     //write!(self.out, ")")?;
                 }
             }
+            crate::Expression::Select {
+                condition,
+                accept,
+                reject,
+            } => {
+                write!(self.out, "(")?;
+                self.put_expression(condition, context)?;
+                write!(self.out, " ? ")?;
+                self.put_expression(accept, context)?;
+                write!(self.out, " : ")?;
+                self.put_expression(reject, context)?;
+                write!(self.out, ")")?;
+            }
             crate::Expression::Intrinsic { fun, argument } => {
                 let op = match fun {
                     crate::IntrinsicFunction::Any => "any",

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -1067,6 +1067,31 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                         },
                     );
                 }
+                Op::Select => {
+                    inst.expect(6)?;
+                    let result_type_id = self.next()?;
+                    let result_id = self.next()?;
+                    let condition = self.next()?;
+                    let o1_id = self.next()?;
+                    let o2_id = self.next()?;
+
+                    let cond_lexp = self.lookup_expression.lookup(condition)?;
+                    let o1_lexp = self.lookup_expression.lookup(o1_id)?;
+                    let o2_lexp = self.lookup_expression.lookup(o2_id)?;
+
+                    let expr = crate::Expression::Select {
+                        condition: cond_lexp.handle,
+                        accept: o1_lexp.handle,
+                        reject: o2_lexp.handle,
+                    };
+                    self.lookup_expression.insert(
+                        result_id,
+                        LookupExpression {
+                            handle: expressions.append(expr),
+                            type_id: result_type_id,
+                        },
+                    );
+                }
                 Op::VectorShuffle => {
                     inst.expect_at_least(5)?;
                     let result_type_id = self.next()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -619,6 +619,13 @@ pub enum Expression {
         left: Handle<Expression>,
         right: Handle<Expression>,
     },
+    /// Select between two values based on a condition.
+    Select {
+        /// Boolean expression
+        condition: Handle<Expression>,
+        accept: Handle<Expression>,
+        reject: Handle<Expression>,
+    },
     /// Call an intrinsic function.
     Intrinsic {
         fun: IntrinsicFunction,

--- a/src/proc/interface.rs
+++ b/src/proc/interface.rs
@@ -79,6 +79,15 @@ where
                 self.traverse_expr(left);
                 self.traverse_expr(right);
             }
+            E::Select {
+                condition,
+                accept,
+                reject,
+            } => {
+                self.traverse_expr(condition);
+                self.traverse_expr(accept);
+                self.traverse_expr(reject);
+            }
             E::Intrinsic { argument, .. } => {
                 self.traverse_expr(argument);
             }

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -245,6 +245,7 @@ impl Typifier {
                 | crate::BinaryOperator::ShiftLeft
                 | crate::BinaryOperator::ShiftRight => self.resolutions[left.index()].clone(),
             },
+            crate::Expression::Select { accept, .. } => self.resolutions[accept.index()].clone(),
             crate::Expression::Intrinsic { .. } => unimplemented!(),
             crate::Expression::Transpose(expr) => match *self.get(expr, types) {
                 crate::TypeInner::Matrix {


### PR DESCRIPTION
I figured this to be require to support `OpSelect` from SPIR-V, which is used in WebGPU samples.
An alternative would involve splitting the expressions into statements, blocks, and merging with `OpPhi` - the whole eternal pain :)