### PR TITLE
[spv-out] Add and implement i_sub and f_sub

### DIFF
--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -571,6 +571,38 @@ pub(super) fn instruction_composite_construct(
 //
 // Arithmetic Instructions
 //
+fn instruction_binary(
+    op: Op,
+    result_type_id: Word,
+    id: Word,
+    operand_1: Word,
+    operand_2: Word,
+) -> Instruction {
+    let mut instruction = Instruction::new(op);
+    instruction.set_type(result_type_id);
+    instruction.set_result(id);
+    instruction.add_operand(operand_1);
+    instruction.add_operand(operand_2);
+    instruction
+}
+
+pub(super) fn instruction_i_sub(
+    result_type_id: Word,
+    id: Word,
+    operand_1: Word,
+    operand_2: Word,
+) -> Instruction {
+    instruction_binary(Op::ISub, result_type_id, id, operand_1, operand_2)
+}
+
+pub(super) fn instruction_f_sub(
+    result_type_id: Word,
+    id: Word,
+    operand_1: Word,
+    operand_2: Word,
+) -> Instruction {
+    instruction_binary(Op::FSub, result_type_id, id, operand_1, operand_2)
+}
 
 pub(super) fn instruction_i_mul(
     result_type_id: Word,
@@ -578,12 +610,7 @@ pub(super) fn instruction_i_mul(
     operand_1: Word,
     operand_2: Word,
 ) -> Instruction {
-    let mut instruction = Instruction::new(Op::IMul);
-    instruction.set_type(result_type_id);
-    instruction.set_result(id);
-    instruction.add_operand(operand_1);
-    instruction.add_operand(operand_2);
-    instruction
+    instruction_binary(Op::IMul, result_type_id, id, operand_1, operand_2)
 }
 
 pub(super) fn instruction_f_mul(
@@ -592,12 +619,7 @@ pub(super) fn instruction_f_mul(
     operand_1: Word,
     operand_2: Word,
 ) -> Instruction {
-    let mut instruction = Instruction::new(Op::FMul);
-    instruction.set_type(result_type_id);
-    instruction.set_result(id);
-    instruction.add_operand(operand_1);
-    instruction.add_operand(operand_2);
-    instruction
+    instruction_binary(Op::FMul, result_type_id, id, operand_1, operand_2)
 }
 
 pub(super) fn instruction_vector_times_scalar(


### PR DESCRIPTION
- Add and implement i_sub and f_sub.
- Reduce DRY code from binary instructions.
- Move out binary operator logic out of `crate::BinaryOperator::Multiply` match to easily implement other binary instructions.

There is however an edge case, and I am not sure yet how we want to solve this. Both instructions are also compatible with vectors, but as the SPIR-V spec says: "The types of Operand 1 and Operand 2 both must be the same as Result Type.".

What this means, and I have checked this in the [shader playground](http://shader-playground.timjones.io/ce2a44d27e0012a232a04aa94fdda636), is that a float vector can be subtracted by an integer. This contradicts the SPIR-V spec, but it does work in the playground as follows:

1)  Convert integer to float
2) Create an CompositeConstruct (a vector) that matches the vector operand result type (in this case a vec2)
3) Syntax has now basically become `vec2(1.0)` which translates in GLSL to a vector with 2 elements set to the value of 1.0
4) As the result types are now equal, subtract them from each other

It gets weirder as it is not possible to do this same "trick" with an `ivec2`. So `ivec2 vector = ivec2(1, 1) - 1` is not valid, because apparently the integer is still converted to a float.

Do we also want to compile in this way? The problem is that I think that it is a fairly common case to substract a float vector with an integer, as the Hello-triangle example already uses this in its shader.