### PR TITLE
[spv-out] Fix annotations not getting added to output

### DIFF
--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1671,10 +1671,6 @@ impl Writer {
             ));
         }
 
-        for annotation in self.annotations.iter() {
-            annotation.to_words(&mut self.logical_layout.annotations);
-        }
-
         for (handle, ir_function) in ir_module.functions.iter() {
             let id = self.write_function(ir_function, ir_module);
             self.lookup_function.insert(handle, id);
@@ -1702,6 +1698,10 @@ impl Writer {
             for debug in self.debugs.iter() {
                 debug.to_words(&mut self.logical_layout.debugs);
             }
+        }
+
+        for annotation in self.annotations.iter() {
+            annotation.to_words(&mut self.logical_layout.annotations);
         }
     }
 


### PR DESCRIPTION
Moved the annotation loop to the bottom of the `write_logical_layout()`. Apparently it could happen that bindings of global variables for instance weren't getting added to the SPIR-V output as the loop over the annotation collection happened before even a binding was added as decorate to the annotations, resulting in no annotations being added.