### PR TITLE
[spv-out] Add support for vector with vector multiplication

### DIFF
--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1194,7 +1194,8 @@ impl Writer {
                             ),
                             left_lookup_ty,
                         ),
-                        (Dimension::Scalar, Dimension::Scalar)
+                        (Dimension::Vector, Dimension::Vector)
+                        | (Dimension::Scalar, Dimension::Scalar)
                             if left_ty_inner.scalar_kind() == Some(crate::ScalarKind::Float) =>
                         {
                             (
@@ -1207,7 +1208,8 @@ impl Writer {
                                 left_lookup_ty,
                             )
                         }
-                        (Dimension::Scalar, Dimension::Scalar) => (
+                        (Dimension::Vector, Dimension::Vector)
+                        | (Dimension::Scalar, Dimension::Scalar) => (
                             super::instructions::instruction_i_mul(
                                 left_result_type_id,
                                 id,


### PR DESCRIPTION
I went through the Bevy shader thread (#210) and a requirement for a shader to work was vector with vector multiplication. I have used the same strategy as we came up with the normal multiplication: if it is not a float vector times float vector, we will default to an `ivec`/`uvec multiplication.

There are however two other vector types in GLSL at least: `bvec` and `dvec`, but I don't think they are that commonly used, but that is just an assumption?