### PR TITLE
Add spv::write_vec helper

### DIFF
--- a/examples/convert.rs
+++ b/examples/convert.rs
@@ -159,7 +159,7 @@ fn main() {
                 spirv_cross_compatibility: false,
                 binding_map,
             };
-            let msl = msl::write_string(&module, &options).unwrap();
+            let (msl, _) = msl::write_string(&module, &options).unwrap();
             fs::write(&args[2], msl).unwrap();
         }
         #[cfg(feature = "spv-out")]

--- a/examples/convert.rs
+++ b/examples/convert.rs
@@ -174,7 +174,7 @@ fn main() {
                 }
             });
 
-            let spv = spv::Writer::new(&module.header, debug_flag).write(&module);
+            let spv = spv::write_vec(&module, debug_flag);
 
             let bytes = spv
                 .iter()

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -204,8 +204,20 @@ impl ResolvedBinding {
     }
 }
 
-pub fn write_string(module: &crate::Module, options: &Options) -> Result<String, Error> {
+/// Information about a translated module that is required
+/// for the use of the result.
+pub struct TranslationInfo {
+    /// Mapping of the entry point names. Each item in the array
+    /// corresponds to an entry point in `module.entry_points.iter()`.
+    pub entry_point_names: Vec<String>,
+}
+
+pub fn write_string(
+    module: &crate::Module,
+    options: &Options,
+) -> Result<(String, TranslationInfo), Error> {
     let mut w = writer::Writer::new(Vec::new());
-    w.write(module, options)?;
-    Ok(String::from_utf8(w.finish())?)
+    let info = w.write(module, options)?;
+    let string = String::from_utf8(w.finish())?;
+    Ok((string, info))
 }

--- a/src/back/spv/mod.rs
+++ b/src/back/spv/mod.rs
@@ -50,3 +50,10 @@ pub(self) struct Instruction {
     result_id: Option<Word>,
     operands: Vec<Word>,
 }
+
+pub fn write_vec(module: &crate::Module, flags: WriterFlags) -> Vec<u32> {
+    let mut words = Vec::new();
+    let mut w = Writer::new(&module.header, flags);
+    w.write(module, &mut words);
+    words
+}

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1720,15 +1720,12 @@ impl Writer {
         }
     }
 
-    pub fn write(&mut self, ir_module: &crate::Module) -> Vec<Word> {
-        let mut words: Vec<Word> = vec![];
-
+    pub fn write(&mut self, ir_module: &crate::Module, words: &mut Vec<Word>) {
         self.write_logical_layout(ir_module);
         self.write_physical_layout();
 
-        self.physical_layout.in_words(&mut words);
-        self.logical_layout.in_words(&mut words);
-        words
+        self.physical_layout.in_words(words);
+        self.logical_layout.in_words(words);
     }
 }
 

--- a/tests/convert.rs
+++ b/tests/convert.rs
@@ -198,13 +198,8 @@ fn convert_phong_lighting() {
 
     #[cfg(feaure = "spv-out")]
     {
-        let header = naga::Header {
-            version: (1, 0, 0),
-            generator: 1234,
-        };
-        let writer_flags = naga::back::spv::WriterFlags::empty();
-        let mut w = naga::back::spv::Writer::new(&header, writer_flags);
-        w.write(&module);
+        let flags = naga::back::spv::WriterFlags::empty();
+        let _ = naga::back::spv::write_vec(&module, flags);
     }
 }
 

--- a/tests/rosetta.rs
+++ b/tests/rosetta.rs
@@ -13,7 +13,7 @@ fn test_rosetta(dir_name: &str) {
 
         #[cfg(feature = "spv-out")]
         {
-            let spv = spv::Writer::new(&module.header, spv::WriterFlags::NONE).write(&module);
+            let spv = spv::write_vec(&module, spv::WriterFlags::NONE);
             assert!(spv.len() > 0);
         }
     }


### PR DESCRIPTION
~~All my prior resistance to making it cloneable was futile. Yes, we get away from clone internally. But this is IR, it's a part of API, and for the users it's just convenient to be able to clone it. For example, `gfx` would need a copy for its purposes, and `wgpu` needs a copy for validation.~~