### PR TITLE
Refactor Switch statement, implement on WGSL

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1023,15 +1023,15 @@ impl<'a, W: Write> Writer<'a, W> {
                 writeln!(self.out, ") {{")?;
 
                 // Write all cases
-                for (label, (block, fallthrough)) in cases {
-                    writeln!(self.out, "{}case {}:", "\t".repeat(indent + 1), label)?;
+                for case in cases {
+                    writeln!(self.out, "{}case {}:", "\t".repeat(indent + 1), case.value)?;
 
-                    for sta in block {
+                    for sta in case.body.iter() {
                         self.write_stmt(sta, ctx, indent + 2)?;
                     }
 
                     // Write `break;` if the block isn't fallthrough
-                    if fallthrough.is_none() {
+                    if case.fall_through {
                         writeln!(self.out, "{}break;", "\t".repeat(indent + 2))?;
                     }
                 }

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -505,10 +505,10 @@ impl<W: Write> Writer<W> {
                     self.put_expression(selector, context)?;
                     writeln!(self.out, ") {{")?;
                     let lcase = level.next();
-                    for (&value, &(ref block, ref fall_through)) in cases.iter() {
-                        writeln!(self.out, "{}case {}: {{", lcase, value)?;
-                        self.put_block(lcase.next(), block, context, return_value)?;
-                        if fall_through.is_none() {
+                    for case in cases.iter() {
+                        writeln!(self.out, "{}case {}: {{", lcase, case.value)?;
+                        self.put_block(lcase.next(), &case.body, context, return_value)?;
+                        if case.fall_through {
                             writeln!(self.out, "{}break;", lcase.next())?;
                         }
                         writeln!(self.out, "{}}}", lcase)?;

--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -198,7 +198,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn _next_sint_literal(&mut self) -> Result<i32, Error<'a>> {
+    pub(super) fn next_sint_literal(&mut self) -> Result<i32, Error<'a>> {
         match self.next() {
             Token::Number(word) => word.parse().map_err(|err| Error::BadInteger(word, err)),
             other => Err(Error::Unexpected(other)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -666,12 +666,20 @@ pub enum Expression {
 /// A code block is just a vector of statements.
 pub type Block = Vec<Statement>;
 
-/// Marker type, used for falling through in a switch statement.
+/// A case for a switch statement.
 // Clone is used only for error reporting and is not intended for end users
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-pub struct FallThrough;
+pub struct SwitchCase {
+    /// Value, upon which the case is considered true.
+    pub value: i32,
+    /// Body of the cae.
+    pub body: Block,
+    /// If true, the control flow continues to the next case in the list,
+    /// or default.
+    pub fall_through: bool,
+}
 
 /// Instructions which make up an executable block.
 // Clone is used only for error reporting and is not intended for end users
@@ -690,7 +698,7 @@ pub enum Statement {
     /// Conditionally executes one of multiple blocks, based on the value of the selector.
     Switch {
         selector: Handle<Expression>, //int
-        cases: FastHashMap<i32, (Block, Option<FallThrough>)>,
+        cases: Vec<SwitchCase>,
         default: Block,
     },
     /// Executes a block repeatedly.

--- a/src/proc/interface.rs
+++ b/src/proc/interface.rs
@@ -148,8 +148,8 @@ where
                     ref default,
                 } => {
                     self.traverse_expr(selector);
-                    for &(ref case, _) in cases.values() {
-                        self.traverse(case);
+                    for case in cases.iter() {
+                        self.traverse(&case.body);
                     }
                     self.traverse(default);
                 }

--- a/src/proc/terminator.rs
+++ b/src/proc/terminator.rs
@@ -22,9 +22,9 @@ pub fn ensure_block_returns(block: &mut crate::Block) {
             ref mut cases,
             ref mut default,
         }) => {
-            for case in cases.values_mut() {
-                if let (ref mut b, None) = *case {
-                    ensure_block_returns(b);
+            for case in cases.iter_mut() {
+                if !case.fall_through {
+                    ensure_block_returns(&mut case.body);
                 }
             }
             ensure_block_returns(default);


### PR DESCRIPTION
Previous IR was unusable because the hashmap has no order, so "fallthrough" semantics was broken.
Now with an array it's usable, but we need to validate the array properly to not contain intersections.