### PR TITLE
[msl] refactor function call parsing

### DIFF
--- a/src/front/wgsl/conv.rs
+++ b/src/front/wgsl/conv.rs
@@ -107,11 +107,20 @@ pub fn get_intrinsic(word: &str) -> Option<crate::IntrinsicFunction> {
         _ => None,
     }
 }
+
 pub fn get_derivative(word: &str) -> Option<crate::DerivativeAxis> {
     match word {
         "dpdx" => Some(crate::DerivativeAxis::X),
         "dpdy" => Some(crate::DerivativeAxis::Y),
         "dwidth" => Some(crate::DerivativeAxis::Width),
+        _ => None,
+    }
+}
+
+// Returns argument count on success
+pub fn get_standard_fun(word: &str) -> Option<usize> {
+    match word {
+        "min" | "max" => Some(2),
         _ => None,
     }
 }

--- a/src/front/wgsl/tests.rs
+++ b/src/front/wgsl/tests.rs
@@ -13,7 +13,19 @@ fn parse_type_cast() {
         const a : i32 = 2;
         fn main() {
             var x: f32 = f32(a);
-            #x = f32(i32(a + 1) / 2); //TODO
+            x = f32(i32(a + 1) / 2);
+        }
+    ",
+    )
+    .unwrap();
+}
+
+#[test]
+fn parse_standard_fun() {
+    parse_str(
+        "
+        fn main() {
+            var x: i32 = min(max(1, 2), 3);
         }
     ",
     )


### PR DESCRIPTION
This allows writing things like `f32(i32(x) + 1)`, and also add more stdlib functions easily.