### PR TITLE
WGSL const and function call refactor

### DIFF
--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -981,7 +981,11 @@ pomelo! {
     }
 
     statement_list ::= statement(s) {
-        vec![s]
+        //TODO: catch this earlier and don't populate the statements
+        match s {
+            Statement::Block(ref block) if block.is_empty() => vec![],
+            _ => vec![s],
+        }
     }
     statement_list ::= statement_list(mut ss) statement(s) { ss.push(s); ss }
 

--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -163,8 +163,7 @@ impl<'a> Lexer<'a> {
         if token == expected {
             Ok(())
         } else {
-            log::trace!("expect {:?}, got {:?}", expected, token);
-            Err(Error::Unexpected(token))
+            token.unexpected(expected)
         }
     }
 
@@ -181,28 +180,28 @@ impl<'a> Lexer<'a> {
     pub(super) fn next_ident(&mut self) -> Result<&'a str, Error<'a>> {
         match self.next() {
             Token::Word(word) => Ok(word),
-            other => Err(Error::Unexpected(other)),
+            other => other.unexpected("ident"),
         }
     }
 
     fn _next_float_literal(&mut self) -> Result<f32, Error<'a>> {
         match self.next() {
             Token::Number(word) => word.parse().map_err(|err| Error::BadFloat(word, err)),
-            other => Err(Error::Unexpected(other)),
+            other => other.unexpected("float literal"),
         }
     }
 
     pub(super) fn next_uint_literal(&mut self) -> Result<u32, Error<'a>> {
         match self.next() {
             Token::Number(word) => word.parse().map_err(|err| Error::BadInteger(word, err)),
-            other => Err(Error::Unexpected(other)),
+            other => other.unexpected("uint literal"),
         }
     }
 
     pub(super) fn next_sint_literal(&mut self) -> Result<i32, Error<'a>> {
         match self.next() {
             Token::Number(word) => word.parse().map_err(|err| Error::BadInteger(word, err)),
-            other => Err(Error::Unexpected(other)),
+            other => other.unexpected("sint literal"),
         }
     }
 

--- a/test-data/boids.wgsl
+++ b/test-data/boids.wgsl
@@ -23,12 +23,11 @@ import "GLSL.std.450" as std;
 
 [[stage(vertex)]]
 fn main() -> void {
-  var angle : f32 = -atan2(a_particleVel.x, a_particleVel.y);
-  var pos : vec2<f32> = vec2<f32>(
+  const angle : f32 = -atan2(a_particleVel.x, a_particleVel.y);
+  const pos : vec2<f32> = vec2<f32>(
       (a_pos.x * cos(angle)) - (a_pos.y * sin(angle)),
       (a_pos.x * sin(angle)) + (a_pos.y * cos(angle)));
   gl_Position = vec4<f32>(pos + a_particlePos, 0.0, 1.0);
-  return;
 }
 
 # fragment shader
@@ -37,7 +36,6 @@ fn main() -> void {
 [[stage(fragment)]]
 fn main() -> void {
   fragColor = vec4<f32>(1.0, 1.0, 1.0, 1.0);
-  return;
 }
 
 # compute shader
@@ -69,7 +67,7 @@ type Particles = struct {
 # https://github.com/austinEng/Project6-Vulkan-Flocking/blob/master/data/shaders/computeparticles/particle.comp
 [[stage(compute), workgroup_size(1)]]
 fn main() -> void {
-  var index : u32 = gl_GlobalInvocationID.x;
+  const index : u32 = gl_GlobalInvocationID.x;
   if (index >= u32(5)) {
     return;
   }
@@ -146,6 +144,4 @@ fn main() -> void {
   # Write back
   particlesB.particles[index].pos = vPos;
   particlesB.particles[index].vel = vVel;
-
-  return;
 }

--- a/test-data/function.wgsl
+++ b/test-data/function.wgsl
@@ -1,11 +1,9 @@
-import "GLSL.std.450" as std::glsl;
-
 fn test_function(test: f32) -> f32 {
     return test;
 }
 
 [[stage(vertex)]]
 fn main() -> void {
-    var foo: f32 = std::glsl::distance(0.0, 1.0);
+    var foo: f32 = distance(0.0, 1.0);
     var test: f32 = test_function(1.0);
 }

--- a/test-data/simple/module.ron
+++ b/test-data/simple/module.ron
@@ -106,7 +106,6 @@
                     ),
                 ],
                 body: [
-                    Block([]),
                     Store(
                         pointer: 2,
                         value: 6,

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -29,6 +29,7 @@ struct BindTarget {
 #[derive(Default, Deserialize)]
 struct Parameters {
     #[serde(default)]
+    #[allow(dead_code)]
     spv_flow_dump_prefix: String,
     #[cfg_attr(not(feature = "spv-out"), allow(dead_code))]
     spv_capabilities: naga::FastHashSet<spirv::Capability>,


### PR DESCRIPTION
This PR brings a bag of improvements to WGSL frontend:
  - `const` inside functions
  - avoid generating meaningless/empty statements
  - more neat DRY
  - less backups of the lexer