### PR TITLE
[spv-out] Refactor the load/store logic

### DIFF
--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -375,13 +375,13 @@ pub(super) fn instruction_variable(
 pub(super) fn instruction_load(
     result_type_id: Word,
     id: Word,
-    pointer_type_id: Word,
+    pointer_id: Word,
     memory_access: Option<spirv::MemoryAccess>,
 ) -> Instruction {
     let mut instruction = Instruction::new(Op::Load);
     instruction.set_type(result_type_id);
     instruction.set_result(id);
-    instruction.add_operand(pointer_type_id);
+    instruction.add_operand(pointer_id);
 
     if let Some(memory_access) = memory_access {
         instruction.add_operand(memory_access.bits());

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1130,48 +1130,8 @@ impl Writer {
                     )?;
                     constituent_ids.push(component_id);
                 }
-                let constituent_ids_slice = constituent_ids.as_slice();
 
-                let id = match ir_module.types[ty].inner {
-                    crate::TypeInner::Vector { .. } => {
-                        self.write_composite_construct(base_type_id, constituent_ids_slice, block)
-                    }
-                    crate::TypeInner::Matrix {
-                        rows,
-                        columns,
-                        width,
-                    } => {
-                        let vector_type_id = self.get_type_id(
-                            &ir_module.types,
-                            LookupType::Local(LocalType::Vector {
-                                width,
-                                kind: crate::ScalarKind::Float,
-                                size: columns,
-                            }),
-                        )?;
-
-                        let capacity = match rows {
-                            crate::VectorSize::Bi => 2,
-                            crate::VectorSize::Tri => 3,
-                            crate::VectorSize::Quad => 4,
-                        };
-
-                        let mut vector_ids = Vec::with_capacity(capacity);
-
-                        for _ in 0..capacity {
-                            let vector_id = self.write_composite_construct(
-                                vector_type_id,
-                                constituent_ids_slice,
-                                block,
-                            );
-                            vector_ids.push(vector_id);
-                        }
-
-                        self.write_composite_construct(base_type_id, vector_ids.as_slice(), block)
-                    }
-                    _ => unreachable!(),
-                };
-
+                let id = self.write_composite_construct(base_type_id, &constituent_ids, block);
                 Ok((RawExpression::Value(id), LookupType::Handle(ty)))
             }
             crate::Expression::Binary { op, left, right } => {


### PR DESCRIPTION
This PR brings a number of fixes and improvements to the SPIR-V backend.

The goal was to get both the `cube` and `skybox` wgpu-rs examples converted to WGSL with validated SPIR-V output.
The main improvement here is the consistent logic of inserting the Load/Store instructions. There is no code duplication any 
more, and all the meat is in one place (`write_expression_raw`).
Based on #328 . Please review stuff starting with "[spv]".