### PR TITLE
[msl] namespace and matrix fixes to get Skybox running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ Cargo.lock
 /*.metal
 /*.metallib
 /*.ron
+/*.spv
+/*.vert
+/*.frag
+/*.comp

--- a/src/back/glsl/features.rs
+++ b/src/back/glsl/features.rs
@@ -193,7 +193,7 @@ impl<'a, W> Writer<'a, W> {
             match ty.inner {
                 TypeInner::Scalar { kind, width } => self.scalar_required_features(kind, width),
                 TypeInner::Vector { kind, width, .. } => self.scalar_required_features(kind, width),
-                TypeInner::Matrix { .. } => self.scalar_required_features(ScalarKind::Float, 8),
+                TypeInner::Matrix { width, .. } => self.scalar_required_features(ScalarKind::Float, width),
                 TypeInner::Array { base, .. } => {
                     if let TypeInner::Array { .. } = self.module.types[base].inner {
                         self.features.request(Features::ARRAY_OF_ARRAYS)

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -1,3 +1,11 @@
+bitflags::bitflags! {
+    struct Language: u32 {
+        const SPIRV = 0x1;
+        const METAL = 0x2;
+        const GLSL = 0x4;
+    }
+}
+
 #[derive(Hash, PartialEq, Eq, serde::Deserialize)]
 enum Stage {
     Vertex,
@@ -37,14 +45,6 @@ struct Parameters {
     spv_capabilities: naga::FastHashSet<spirv::Capability>,
     #[cfg_attr(not(feature = "msl-out"), allow(dead_code))]
     mtl_bindings: naga::FastHashMap<BindSource, BindTarget>,
-}
-
-bitflags::bitflags! {
-    struct Language: u32 {
-        const SPIRV = 0x1;
-        const METAL = 0x2;
-        const GLSL = 0x4;
-    }
 }
 
 #[cfg(feature = "spv-out")]
@@ -169,4 +169,10 @@ fn converts_wgsl_simple() {
 #[test]
 fn converts_wgsl_boids() {
     convert_wgsl("boids", Language::METAL);
+}
+
+#[cfg(feature = "wgsl-in")]
+#[test]
+fn converts_wgsl_skybox() {
+    convert_wgsl("skybox", Language::all());
 }

--- a/tests/snapshots/in/skybox.param.ron
+++ b/tests/snapshots/in/skybox.param.ron
@@ -1,0 +1,9 @@
+(
+	spv_flow_dump_prefix: "",
+	spv_capabilities: [ Shader ],
+	mtl_bindings: {
+		(stage: Vertex, group: 0, binding: 0): (buffer: Some(0)),
+		(stage: Fragment, group: 0, binding: 1): (texture: Some(0)),
+		(stage: Fragment, group: 0, binding: 2): (sampler: Some(1)),
+	}
+)

--- a/tests/snapshots/in/skybox.wgsl
+++ b/tests/snapshots/in/skybox.wgsl
@@ -1,0 +1,43 @@
+[[builtin(position)]]
+var<out> out_position: vec4<f32>;
+[[location(0)]] var<out> out_uv: vec3<f32>;
+[[builtin(vertex_index)]] var<in> in_vertex_index: u32;
+
+#[[block]]
+struct Data {
+    [[offset(0)]] proj_inv: mat4x4<f32>;
+    [[offset(64)]] view: mat4x4<f32>;
+};
+[[group(0), binding(0)]]
+var r_data: Data;
+
+[[stage(vertex)]]
+fn vs_main() {
+    # hacky way to draw a large triangle
+    var tmp1: i32 = i32(in_vertex_index) / 2;
+    var tmp2: i32 = i32(in_vertex_index) & 1;
+    const pos: vec4<f32> = vec4<f32>(
+        f32(tmp1) * 4.0 - 1.0,
+        f32(tmp2) * 4.0 - 1.0,
+        0.0,
+        1.0
+    );
+
+    const inv_model_view: mat3x3<f32> = transpose(mat3x3<f32>(r_data.view.x.xyz, r_data.view.y.xyz, r_data.view.z.xyz));
+    var unprojected: vec4<f32> = r_data.proj_inv * pos; #TODO: const
+    out_uv = inv_model_view * unprojected.xyz;
+    out_position = pos;
+}
+
+[[group(0), binding(1)]]
+var r_texture: texture_cube<f32>;
+[[group(0), binding(2)]]
+var r_sampler: sampler;
+
+[[location(0)]] var<in> in_uv: vec3<f32>;
+[[location(0)]] var<out> out_color: vec4<f32>;
+
+[[stage(fragment)]]
+fn fs_main() {
+    out_color = textureSample(r_texture, r_sampler, in_uv);
+}

--- a/tests/snapshots/snapshots__boids.msl.snap
+++ b/tests/snapshots/snapshots__boids.msl.snap
@@ -5,8 +5,8 @@ expression: msl
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-typedef float2 type;
-typedef float4 type1;
+typedef metal::float2 type;
+typedef metal::float4 type1;
 typedef float type2;
 struct Particle {
 	type pos;
@@ -26,7 +26,7 @@ typedef Particle type4[5];
 struct Particles {
 	type4 particles;
 };
-typedef uint3 type5;
+typedef metal::uint3 type5;
 typedef int type6;
 
 struct main1Input {
@@ -41,7 +41,7 @@ vertex main1Output main1(
 	main1Input input [[stage_in]]
 ) {
 	main1Output output;
-	output.gl_Position = float4(float2(input.a_pos.x * metal::cos(-metal::atan2(input.a_particleVel.x, input.a_particleVel.y)) - input.a_pos.y * metal::sin(-metal::atan2(input.a_particleVel.x, input.a_particleVel.y)), input.a_pos.x * metal::sin(-metal::atan2(input.a_particleVel.x, input.a_particleVel.y)) + input.a_pos.y * metal::cos(-metal::atan2(input.a_particleVel.x, input.a_particleVel.y))) + input.a_particlePos, 0.0, 1.0);
+	output.gl_Position = metal::float4(metal::float2(input.a_pos.x * metal::cos(-metal::atan2(input.a_particleVel.x, input.a_particleVel.y)) - input.a_pos.y * metal::sin(-metal::atan2(input.a_particleVel.x, input.a_particleVel.y)), input.a_pos.x * metal::sin(-metal::atan2(input.a_particleVel.x, input.a_particleVel.y)) + input.a_pos.y * metal::cos(-metal::atan2(input.a_particleVel.x, input.a_particleVel.y))) + input.a_particlePos, 0.0, 1.0);
 	return output;
 }
 struct main2Input {
@@ -53,7 +53,7 @@ fragment main2Output main2(
 	main2Input input [[stage_in]]
 ) {
 	main2Output output;
-	output.fragColor = float4(1.0, 1.0, 1.0, 1.0);
+	output.fragColor = metal::float4(1.0, 1.0, 1.0, 1.0);
 	return output;
 }
 kernel void main3(
@@ -76,9 +76,9 @@ kernel void main3(
 	}
 	vPos = particlesA.particles[gl_GlobalInvocationID.x].pos;
 	vVel = particlesA.particles[gl_GlobalInvocationID.x].vel;
-	cMass = float2(0.0, 0.0);
-	cVel = float2(0.0, 0.0);
-	colVel = float2(0.0, 0.0);
+	cMass = metal::float2(0.0, 0.0);
+	cVel = metal::float2(0.0, 0.0);
+	colVel = metal::float2(0.0, 0.0);
 	while(true) {
 		if (i >= static_cast<uint>(5)) {
 			break;
@@ -86,8 +86,8 @@ kernel void main3(
 		if (i == gl_GlobalInvocationID.x) {
 			continue;
 		}
-		pos1 = float2(particlesA.particles[i].pos.x, particlesA.particles[i].pos.y);
-		vel1 = float2(particlesA.particles[i].vel.x, particlesA.particles[i].vel.y);
+		pos1 = metal::float2(particlesA.particles[i].pos.x, particlesA.particles[i].pos.y);
+		vel1 = metal::float2(particlesA.particles[i].vel.x, particlesA.particles[i].vel.y);
 		if (metal::distance(pos1, vPos) < params.rule1Distance) {
 			cMass = cMass + pos1;
 			cMassCount = cMassCount + 1;
@@ -101,10 +101,10 @@ kernel void main3(
 		}
 	}
 	if (cMassCount == 0) {
-		cMass = cMass / float2(cMassCount, cMassCount) + vPos;
+		cMass = cMass / metal::float2(cMassCount, cMassCount) + vPos;
 	}
 	if (cVelCount == 0) {
-		cVel = cVel / float2(cVelCount, cVelCount);
+		cVel = cVel / metal::float2(cVelCount, cVelCount);
 	}
 	vVel = vVel + cMass * params.rule1Scale + colVel * params.rule2Scale + cVel * params.rule3Scale;
 	vVel = metal::normalize(vVel) * metal::clamp(metal::length(vVel), 0.0, 0.1);

--- a/tests/snapshots/snapshots__quad.msl.snap
+++ b/tests/snapshots/snapshots__quad.msl.snap
@@ -6,11 +6,11 @@ expression: msl
 #include <simd/simd.h>
 
 typedef float type;
-typedef float2 type1;
-typedef float4 type2;
-typedef texture2d<float, access::sample> type3;
-typedef sampler type4;
-typedef int2 type5;
+typedef metal::float2 type1;
+typedef metal::float4 type2;
+typedef metal::texture2d<float, metal::access::sample> type3;
+typedef metal::sampler type4;
+typedef metal::int2 type5;
 
 struct main1Input {
 	type1 a_pos [[attribute(0)]];
@@ -25,7 +25,7 @@ vertex main1Output main1(
 ) {
 	main1Output output;
 	output.v_uv = input.a_uv;
-	output.o_position = float4(1.2 * input.a_pos, 0.0, 1.0);
+	output.o_position = metal::float4(1.2 * input.a_pos, 0.0, 1.0);
 	return output;
 }
 struct main2Input {

--- a/tests/snapshots/snapshots__simple.msl.snap
+++ b/tests/snapshots/snapshots__simple.msl.snap
@@ -5,7 +5,7 @@ expression: msl
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-typedef float4 type;
+typedef metal::float4 type;
 typedef int type1;
 
 struct main1Input {
@@ -17,7 +17,7 @@ vertex main1Output main1(
 	main1Input input [[stage_in]]
 ) {
 	main1Output output;
-	output.o_position = float4(1);
+	output.o_position = metal::float4(1);
 	return output;
 }
 

--- a/tests/snapshots/snapshots__skybox-Fragment.glsl.snap
+++ b/tests/snapshots/snapshots__skybox-Fragment.glsl.snap
@@ -1,0 +1,24 @@
+---
+source: tests/snapshots.rs
+expression: string
+---
+#version 310 es
+
+precision highp float;
+
+
+struct Data {
+	mat4x4 proj_inv;
+	mat4x4 view;
+};
+
+uniform samplerCube r_texture;
+in vec3 in_uv;
+out vec4 out_color;
+
+void main() {
+
+	out_color = texture(r_texture, vec3(in_uv));
+	return;
+}
+

--- a/tests/snapshots/snapshots__skybox-Vertex.glsl.snap
+++ b/tests/snapshots/snapshots__skybox-Vertex.glsl.snap
@@ -1,0 +1,30 @@
+---
+source: tests/snapshots.rs
+expression: string
+---
+#version 310 es
+
+precision highp float;
+
+
+struct Data {
+	mat4x4 proj_inv;
+	mat4x4 view;
+};
+
+out vec3 out_uv;
+uniform Data r_data;
+
+void main() {
+	int tmp1_;
+	int tmp2_;
+	vec4 unprojected;
+
+	tmp1_ = (int(gl_VertexID) / 2);
+	tmp2_ = (int(gl_VertexID) & 1);
+	unprojected = (r_data.proj_inv * vec4(((float(tmp1_) * 4.0) - 1.0), ((float(tmp2_) * 4.0) - 1.0), 0.0, 1.0));
+	out_uv = (transpose(mat3x3(vec3(r_data.view[0][0], r_data.view[0][1], r_data.view[0][2]), vec3(r_data.view[1][0], r_data.view[1][1], r_data.view[1][2]), vec3(r_data.view[2][0], r_data.view[2][1], r_data.view[2][2]))) * vec3(unprojected[0], unprojected[1], unprojected[2]));
+	gl_Position = vec4(((float(tmp1_) * 4.0) - 1.0), ((float(tmp2_) * 4.0) - 1.0), 0.0, 1.0);
+	return;
+}
+

--- a/tests/snapshots/snapshots__skybox.msl.snap
+++ b/tests/snapshots/snapshots__skybox.msl.snap
@@ -1,0 +1,60 @@
+---
+source: tests/snapshots.rs
+expression: msl
+---
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+typedef metal::float4 type;
+typedef metal::float3 type1;
+typedef uint type2;
+typedef metal::float4x4 type3;
+struct Data {
+	type3 proj_inv;
+	type3 view;
+};
+typedef int type4;
+typedef float type5;
+typedef metal::float3x3 type6;
+typedef metal::texturecube<float, metal::access::sample> type7;
+typedef metal::sampler type8;
+typedef metal::int3 type9;
+
+struct vs_mainInput {
+};
+struct vs_mainOutput {
+	type out_position [[position]];
+	type1 out_uv [[user(loc0)]];
+};
+vertex vs_mainOutput vs_main(
+	vs_mainInput input [[stage_in]],
+	type2 in_vertex_index [[vertex_id]],
+	constant Data& r_data [[buffer(0)]]
+) {
+	vs_mainOutput output;
+	type4 tmp1_;
+	type4 tmp2_;
+	type unprojected;
+	tmp1_ = static_cast<int>(in_vertex_index) / 2;
+	tmp2_ = static_cast<int>(in_vertex_index) & 1;
+	unprojected = r_data.proj_inv * metal::float4(static_cast<float>(tmp1_) * 4.0 - 1.0, static_cast<float>(tmp2_) * 4.0 - 1.0, 0.0, 1.0);
+	output.out_uv = metal::transpose(metal::float3x3(metal::float3(r_data.view[0].x, r_data.view[0].y, r_data.view[0].z), metal::float3(r_data.view[1].x, r_data.view[1].y, r_data.view[1].z), metal::float3(r_data.view[2].x, r_data.view[2].y, r_data.view[2].z))) * metal::float3(unprojected.x, unprojected.y, unprojected.z);
+	output.out_position = metal::float4(static_cast<float>(tmp1_) * 4.0 - 1.0, static_cast<float>(tmp2_) * 4.0 - 1.0, 0.0, 1.0);
+	return output;
+}
+struct fs_mainInput {
+	type1 in_uv [[user(loc0)]];
+};
+struct fs_mainOutput {
+	type out_color [[color(0)]];
+};
+fragment fs_mainOutput fs_main(
+	fs_mainInput input [[stage_in]],
+	type7 r_texture [[texture(0)]],
+	type8 r_sampler [[sampler(1)]]
+) {
+	fs_mainOutput output;
+	output.out_color = r_texture.sample(r_sampler, input.in_uv);
+	return output;
+}
+

--- a/tests/snapshots/snapshots__skybox.spvasm.snap
+++ b/tests/snapshots/snapshots__skybox.spvasm.snap
@@ -1,0 +1,218 @@
+---
+source: tests/snapshots.rs
+expression: dis
+---
+; SPIR-V
+; Version: 1.0
+; Generator: rspirv
+; Bound: 185
+OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %11 "vs_main" %157 %44 %15
+OpEntryPoint Fragment %168 "fs_main" %180 %170
+OpExecutionMode %168 OriginUpperLeft
+OpDecorate %15 BuiltIn VertexIndex
+OpDecorate %25 DescriptorSet 0
+OpDecorate %25 Binding 0
+OpDecorate %44 Location 0
+OpDecorate %157 BuiltIn Position
+OpDecorate %170 Location 0
+OpDecorate %171 DescriptorSet 0
+OpDecorate %171 Binding 1
+OpDecorate %176 DescriptorSet 0
+OpDecorate %176 Binding 2
+OpDecorate %180 Location 0
+%3 = OpTypeInt 32 1
+%4 = OpTypePointer Function %3
+%8 = OpTypeFloat 32
+%7 = OpTypeVector %8 4
+%9 = OpTypePointer Function %7
+%10 = OpTypeVoid
+%12 = OpTypeFunction %10
+%16 = OpTypeInt 32 0
+%17 = OpTypePointer Input %16
+%15 = OpVariable  %17  Input
+%19 = OpConstant  %3  2
+%22 = OpConstant  %3  1
+%27 = OpTypeMatrix %7 4
+%26 = OpTypeStruct %27 %27
+%28 = OpTypePointer Uniform %26
+%25 = OpVariable  %28  Uniform
+%29 = OpTypePointer Uniform %27
+%30 = OpConstant  %3  0
+%36 = OpConstant  %8  4.0
+%37 = OpConstant  %8  1.0
+%42 = OpConstant  %8  0.0
+%45 = OpTypeVector %8 3
+%46 = OpTypePointer Output %45
+%44 = OpVariable  %46  Output
+%48 = OpTypeMatrix %45 3
+%52 = OpTypePointer Uniform %27
+%53 = OpConstant  %3  1
+%54 = OpTypePointer Uniform %7
+%55 = OpConstant  %3  0
+%56 = OpTypePointer Uniform %8
+%57 = OpConstant  %3  0
+%62 = OpTypePointer Uniform %27
+%63 = OpConstant  %3  1
+%64 = OpTypePointer Uniform %7
+%65 = OpConstant  %3  0
+%66 = OpTypePointer Uniform %8
+%67 = OpConstant  %3  1
+%72 = OpTypePointer Uniform %27
+%73 = OpConstant  %3  1
+%74 = OpTypePointer Uniform %7
+%75 = OpConstant  %3  0
+%76 = OpTypePointer Uniform %8
+%77 = OpConstant  %3  2
+%83 = OpTypePointer Uniform %27
+%84 = OpConstant  %3  1
+%85 = OpTypePointer Uniform %7
+%86 = OpConstant  %3  1
+%87 = OpTypePointer Uniform %8
+%88 = OpConstant  %3  0
+%93 = OpTypePointer Uniform %27
+%94 = OpConstant  %3  1
+%95 = OpTypePointer Uniform %7
+%96 = OpConstant  %3  1
+%97 = OpTypePointer Uniform %8
+%98 = OpConstant  %3  1
+%103 = OpTypePointer Uniform %27
+%104 = OpConstant  %3  1
+%105 = OpTypePointer Uniform %7
+%106 = OpConstant  %3  1
+%107 = OpTypePointer Uniform %8
+%108 = OpConstant  %3  2
+%114 = OpTypePointer Uniform %27
+%115 = OpConstant  %3  1
+%116 = OpTypePointer Uniform %7
+%117 = OpConstant  %3  2
+%118 = OpTypePointer Uniform %8
+%119 = OpConstant  %3  0
+%124 = OpTypePointer Uniform %27
+%125 = OpConstant  %3  1
+%126 = OpTypePointer Uniform %7
+%127 = OpConstant  %3  2
+%128 = OpTypePointer Uniform %8
+%129 = OpConstant  %3  1
+%134 = OpTypePointer Uniform %27
+%135 = OpConstant  %3  1
+%136 = OpTypePointer Uniform %7
+%137 = OpConstant  %3  2
+%138 = OpTypePointer Uniform %8
+%139 = OpConstant  %3  2
+%145 = OpTypePointer Function %8
+%146 = OpConstant  %3  0
+%149 = OpTypePointer Function %8
+%150 = OpConstant  %3  1
+%153 = OpTypePointer Function %8
+%154 = OpConstant  %3  2
+%158 = OpTypePointer Output %7
+%157 = OpVariable  %158  Output
+%170 = OpVariable  %158  Output
+%172 = OpTypeImage %8 Cube 0 0 0 1 Unknown
+%173 = OpTypePointer UniformConstant %172
+%171 = OpVariable  %173  UniformConstant
+%175 = OpTypeSampledImage %172
+%177 = OpTypeSampler
+%178 = OpTypePointer UniformConstant %177
+%176 = OpVariable  %178  UniformConstant
+%181 = OpTypePointer Input %45
+%180 = OpVariable  %181  Input
+%11 = OpFunction  %10  None %12
+%13 = OpLabel
+%2 = OpVariable  %4  Function
+%5 = OpVariable  %4  Function
+%6 = OpVariable  %9  Function
+%18 = OpLoad  %16  %15
+%14 = OpSDiv  %3  %18 %19
+OpStore %2 %14
+%21 = OpLoad  %16  %15
+%20 = OpBitwiseAnd  %3  %21 %22
+OpStore %5 %20
+%24 = OpAccessChain  %29  %25 %30
+%31 = OpLoad  %27  %24
+%34 = OpLoad  %3  %2
+%35 = OpConvertSToF  %8  %34
+%33 = OpFMul  %8  %35 %36
+%32 = OpFSub  %8  %33 %37
+%40 = OpLoad  %3  %5
+%41 = OpConvertSToF  %8  %40
+%39 = OpFMul  %8  %41 %36
+%38 = OpFSub  %8  %39 %37
+%43 = OpCompositeConstruct  %7  %32 %38 %42 %37
+%23 = OpMatrixTimesVector  %7  %31 %43
+OpStore %6 %23
+%51 = OpAccessChain  %52  %25 %53
+%50 = OpAccessChain  %54  %51 %55
+%49 = OpAccessChain  %56  %50 %57
+%58 = OpLoad  %8  %49
+%61 = OpAccessChain  %62  %25 %63
+%60 = OpAccessChain  %64  %61 %65
+%59 = OpAccessChain  %66  %60 %67
+%68 = OpLoad  %8  %59
+%71 = OpAccessChain  %72  %25 %73
+%70 = OpAccessChain  %74  %71 %75
+%69 = OpAccessChain  %76  %70 %77
+%78 = OpLoad  %8  %69
+%79 = OpCompositeConstruct  %45  %58 %68 %78
+%82 = OpAccessChain  %83  %25 %84
+%81 = OpAccessChain  %85  %82 %86
+%80 = OpAccessChain  %87  %81 %88
+%89 = OpLoad  %8  %80
+%92 = OpAccessChain  %93  %25 %94
+%91 = OpAccessChain  %95  %92 %96
+%90 = OpAccessChain  %97  %91 %98
+%99 = OpLoad  %8  %90
+%102 = OpAccessChain  %103  %25 %104
+%101 = OpAccessChain  %105  %102 %106
+%100 = OpAccessChain  %107  %101 %108
+%109 = OpLoad  %8  %100
+%110 = OpCompositeConstruct  %45  %89 %99 %109
+%113 = OpAccessChain  %114  %25 %115
+%112 = OpAccessChain  %116  %113 %117
+%111 = OpAccessChain  %118  %112 %119
+%120 = OpLoad  %8  %111
+%123 = OpAccessChain  %124  %25 %125
+%122 = OpAccessChain  %126  %123 %127
+%121 = OpAccessChain  %128  %122 %129
+%130 = OpLoad  %8  %121
+%133 = OpAccessChain  %134  %25 %135
+%132 = OpAccessChain  %136  %133 %137
+%131 = OpAccessChain  %138  %132 %139
+%140 = OpLoad  %8  %131
+%141 = OpCompositeConstruct  %45  %120 %130 %140
+%142 = OpCompositeConstruct  %48  %79 %110 %141
+%143 = OpTranspose  %48  %142
+%144 = OpAccessChain  %145  %6 %146
+%147 = OpLoad  %8  %144
+%148 = OpAccessChain  %149  %6 %150
+%151 = OpLoad  %8  %148
+%152 = OpAccessChain  %153  %6 %154
+%155 = OpLoad  %8  %152
+%156 = OpCompositeConstruct  %45  %147 %151 %155
+%47 = OpMatrixTimesVector  %45  %143 %156
+OpStore %44 %47
+%161 = OpLoad  %3  %2
+%162 = OpConvertSToF  %8  %161
+%160 = OpFMul  %8  %162 %36
+%159 = OpFSub  %8  %160 %37
+%165 = OpLoad  %3  %5
+%166 = OpConvertSToF  %8  %165
+%164 = OpFMul  %8  %166 %36
+%163 = OpFSub  %8  %164 %37
+%167 = OpCompositeConstruct  %7  %159 %163 %42 %37
+OpStore %157 %167
+OpReturn
+OpFunctionEnd
+%168 = OpFunction  %10  None %12
+%169 = OpLabel
+%174 = OpLoad  %172  %171
+%179 = OpLoad  %177  %176
+%182 = OpLoad  %45  %180
+%183 = OpSampledImage  %175  %174 %179
+%184 = OpImageSampleImplicitLod  %7  %183 %182
+OpStore %170 %184
+OpReturn
+OpFunctionEnd


### PR DESCRIPTION
Based on #329, this PR gets us to a point where we can generate the MSL shader for the `skybox` example directly from IR 🎉 
(there is only one new commit here)
The things missing were:
  - inserting the namespace qualifier `metal::` before the types (we can discuss this on Matrix if there are concerns)
  - fixing matrix composition and indexing

Update: also got GLSL output working for this! And added it to the snapshot tests.