### PR TITLE
[glsl-in] Cast gl_VertexIndex to SInt

### DIFF
--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -24,29 +24,26 @@ impl Program {
                         return Err(ErrorKind::VariableNotAvailable(name.into()));
                     }
                 };
-                let h = self
-                    .module
-                    .global_variables
-                    .append(GlobalVariable {
-                        name: Some(name.into()),
-                        class: if self.shader_stage == ShaderStage::Vertex {
-                            StorageClass::Output
-                        } else {
-                            StorageClass::Input
+                let h = self.module.global_variables.append(GlobalVariable {
+                    name: Some(name.into()),
+                    class: if self.shader_stage == ShaderStage::Vertex {
+                        StorageClass::Output
+                    } else {
+                        StorageClass::Input
+                    },
+                    binding: Some(Binding::BuiltIn(BuiltIn::Position)),
+                    ty: self.module.types.fetch_or_append(Type {
+                        name: None,
+                        inner: TypeInner::Vector {
+                            size: VectorSize::Quad,
+                            kind: ScalarKind::Float,
+                            width: 4,
                         },
-                        binding: Some(Binding::BuiltIn(BuiltIn::Position)),
-                        ty: self.module.types.fetch_or_append(Type {
-                            name: None,
-                            inner: TypeInner::Vector {
-                                size: VectorSize::Quad,
-                                kind: ScalarKind::Float,
-                                width: 4,
-                            },
-                        }),
-                        init: None,
-                        interpolation: None,
-                        storage_access: StorageAccess::empty(),
-                    });
+                    }),
+                    init: None,
+                    interpolation: None,
+                    storage_access: StorageAccess::empty(),
+                });
                 self.lookup_global_variables.insert(name.into(), h);
                 let exp = self
                     .context
@@ -64,24 +61,21 @@ impl Program {
                         return Err(ErrorKind::VariableNotAvailable(name.into()));
                     }
                 };
-                let h = self
-                    .module
-                    .global_variables
-                    .append(GlobalVariable {
-                        name: Some(name.into()),
-                        class: StorageClass::Input,
-                        binding: Some(Binding::BuiltIn(BuiltIn::VertexIndex)),
-                        ty: self.module.types.fetch_or_append(Type {
-                            name: None,
-                            inner: TypeInner::Scalar {
-                                kind: ScalarKind::Uint,
-                                width: 4,
-                            },
-                        }),
-                        init: None,
-                        interpolation: None,
-                        storage_access: StorageAccess::empty(),
-                    });
+                let h = self.module.global_variables.append(GlobalVariable {
+                    name: Some(name.into()),
+                    class: StorageClass::Input,
+                    binding: Some(Binding::BuiltIn(BuiltIn::VertexIndex)),
+                    ty: self.module.types.fetch_or_append(Type {
+                        name: None,
+                        inner: TypeInner::Scalar {
+                            kind: ScalarKind::Uint,
+                            width: 4,
+                        },
+                    }),
+                    init: None,
+                    interpolation: None,
+                    storage_access: StorageAccess::empty(),
+                });
                 self.lookup_global_variables.insert(name.into(), h);
                 let mut expr = self
                     .context
@@ -106,24 +100,21 @@ impl Program {
                         return Err(ErrorKind::VariableNotAvailable(name.into()));
                     }
                 };
-                let h = self
-                    .module
-                    .global_variables
-                    .append(GlobalVariable {
-                        name: Some(name.into()),
-                        class: StorageClass::Input,
-                        binding: Some(Binding::BuiltIn(BuiltIn::InstanceIndex)),
-                        ty: self.module.types.fetch_or_append(Type {
-                            name: None,
-                            inner: TypeInner::Scalar {
-                                kind: ScalarKind::Uint,
-                                width: 4,
-                            },
-                        }),
-                        init: None,
-                        interpolation: None,
-                        storage_access: StorageAccess::empty(),
-                    });
+                let h = self.module.global_variables.append(GlobalVariable {
+                    name: Some(name.into()),
+                    class: StorageClass::Input,
+                    binding: Some(Binding::BuiltIn(BuiltIn::InstanceIndex)),
+                    ty: self.module.types.fetch_or_append(Type {
+                        name: None,
+                        inner: TypeInner::Scalar {
+                            kind: ScalarKind::Uint,
+                            width: 4,
+                        },
+                    }),
+                    init: None,
+                    interpolation: None,
+                    storage_access: StorageAccess::empty(),
+                });
                 self.lookup_global_variables.insert(name.into(), h);
                 let mut expr = self
                     .context
@@ -140,7 +131,7 @@ impl Program {
 
                 Ok(Some(expr))
             }
-            _ => Ok(None)
+            _ => Ok(None),
         }
     }
 

--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -91,7 +91,7 @@ impl Program {
                 expr = self.context.expressions.append(Expression::As {
                     expr,
                     kind: ScalarKind::Sint,
-                    convert: false,
+                    convert: true,
                 });
                 self.context
                     .lookup_global_var_exps
@@ -129,13 +129,20 @@ impl Program {
                         storage_access: StorageAccess::empty(),
                     });
                 self.lookup_global_variables.insert(name.into(), h);
-                let exp = self
+                let mut expr = self
                     .context
                     .expressions
                     .append(Expression::GlobalVariable(h));
-                self.context.lookup_global_var_exps.insert(name.into(), exp);
+                expr = self.context.expressions.append(Expression::As {
+                    expr,
+                    kind: ScalarKind::Sint,
+                    convert: true,
+                });
+                self.context
+                    .lookup_global_var_exps
+                    .insert(name.into(), expr);
 
-                expression = Some(exp);
+                expression = Some(expr);
             }
             _ => {}
         }

--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -19,6 +19,9 @@ impl Program {
                         return Err(ErrorKind::VariableNotAvailable(name.into()));
                     }
                 };
+                if let Some(global_var) = self.context.lookup_global_var_exps.get(name) {
+                    return Ok(Some(*global_var));
+                }
                 let h = self
                     .module
                     .global_variables
@@ -59,6 +62,9 @@ impl Program {
                         return Err(ErrorKind::VariableNotAvailable(name.into()));
                     }
                 };
+                if let Some(global_var) = self.context.lookup_global_var_exps.get(name) {
+                    return Ok(Some(*global_var));
+                }
                 let h = self
                     .module
                     .global_variables
@@ -78,13 +84,20 @@ impl Program {
                         storage_access: StorageAccess::empty(),
                     });
                 self.lookup_global_variables.insert(name.into(), h);
-                let exp = self
+                let mut expr = self
                     .context
                     .expressions
                     .append(Expression::GlobalVariable(h));
-                self.context.lookup_global_var_exps.insert(name.into(), exp);
+                expr = self.context.expressions.append(Expression::As {
+                    expr,
+                    kind: ScalarKind::Sint,
+                    convert: false,
+                });
+                self.context
+                    .lookup_global_var_exps
+                    .insert(name.into(), expr);
 
-                expression = Some(exp);
+                expression = Some(expr);
             }
             "gl_InstanceIndex" => {
                 #[cfg(feature = "glsl-validate")]
@@ -94,6 +107,9 @@ impl Program {
                         return Err(ErrorKind::VariableNotAvailable(name.into()));
                     }
                 };
+                if let Some(global_var) = self.context.lookup_global_var_exps.get(name) {
+                    return Ok(Some(*global_var));
+                }
                 let h = self
                     .module
                     .global_variables


### PR DESCRIPTION
Adds a cast to SInt (`Expression::As`), when `gl_VertexIndex` is used.

Now getting this kind of output:
```
...
         %14 = OpLoad %uint %gl_VertexIndex
         %10 = OpISub %int %14 %int_1
         %17 = OpConvertSToF %float %10            
               OpStore %2 %17 
         %21 = OpLoad %uint %gl_VertexIndex
         %20 = OpBitwiseAnd %int %21 %int_1
         %19 = OpIMul %int %20 %int_2                                                                             
         %18 = OpISub %int %19 %int_1
         %23 = OpConvertSToF %float %18                                                                           
               OpStore %5 %23
         %27 = OpLoad %float %2                                                                                   
         %28 = OpLoad %float %5
         %31 = OpCompositeConstruct %v4float %27 %28 %float_0 %float_1
               OpStore %gl_Position %31
               OpReturn
               OpFunctionEnd 
```