### PR TITLE
Fix SPIR-V global binding check, add GLES 320 support

### DIFF
--- a/src/back/glsl/features.rs
+++ b/src/back/glsl/features.rs
@@ -193,7 +193,9 @@ impl<'a, W> Writer<'a, W> {
             match ty.inner {
                 TypeInner::Scalar { kind, width } => self.scalar_required_features(kind, width),
                 TypeInner::Vector { kind, width, .. } => self.scalar_required_features(kind, width),
-                TypeInner::Matrix { width, .. } => self.scalar_required_features(ScalarKind::Float, width),
+                TypeInner::Matrix { width, .. } => {
+                    self.scalar_required_features(ScalarKind::Float, width)
+                }
                 TypeInner::Array { base, .. } => {
                     if let TypeInner::Array { .. } = self.module.types[base].inner {
                         self.features.request(Features::ARRAY_OF_ARRAYS)

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -67,9 +67,9 @@ mod features;
 mod keywords;
 
 /// List of supported core glsl versions
-const SUPPORTED_CORE_VERSIONS: &[u16] = &[330, 400, 410, 420, 430, 440, 450];
+pub const SUPPORTED_CORE_VERSIONS: &[u16] = &[330, 400, 410, 420, 430, 440, 450];
 /// List of supported es glsl versions
-const SUPPORTED_ES_VERSIONS: &[u16] = &[300, 310];
+pub const SUPPORTED_ES_VERSIONS: &[u16] = &[300, 310, 320];
 
 /// glsl version
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -287,6 +287,7 @@ impl<'a, W: Write> Writer<'a, W> {
     pub fn new(out: W, module: &'a Module, options: &'a Options) -> Result<Self, Error> {
         // Check if the requested version is supported
         if !options.version.is_supported() {
+            log::error!("Version {}", options.version);
             return Err(Error::VersionNotSupported);
         }
 

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -822,8 +822,8 @@ impl Writer {
             }
         }
 
-        match global_variable.binding.clone().unwrap() {
-            crate::Binding::Location(location) => {
+        match global_variable.binding {
+            Some(crate::Binding::Location(location)) => {
                 self.annotations
                     .push(super::instructions::instruction_decorate(
                         id,
@@ -831,7 +831,7 @@ impl Writer {
                         &[location],
                     ));
             }
-            crate::Binding::Resource { group, binding } => {
+            Some(crate::Binding::Resource { group, binding }) => {
                 self.annotations
                     .push(super::instructions::instruction_decorate(
                         id,
@@ -845,7 +845,7 @@ impl Writer {
                         &[binding],
                     ));
             }
-            crate::Binding::BuiltIn(built_in) => {
+            Some(crate::Binding::BuiltIn(built_in)) => {
                 let built_in = match built_in {
                     crate::BuiltIn::BaseInstance => spirv::BuiltIn::BaseInstance,
                     crate::BuiltIn::BaseVertex => spirv::BuiltIn::BaseVertex,
@@ -872,6 +872,7 @@ impl Writer {
                         &[built_in as u32],
                     ));
             }
+            None => {}
         }
 
         // TODO Initializer is optional and not (yet) included in the IR


### PR DESCRIPTION
For SPIR-V - the global variable can be in `Private` storage class, for which there isn't necessarily a binding.
For GLSL - the ES 320 target exists, although we may need to re-think the target version checks in the future anyway.