### PR TITLE
Tidy up constants IR

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -527,25 +527,30 @@ impl<W: Write> Writer<W> {
     ) -> Result<(), Error> {
         let constant = &module.constants[handle];
         match constant.inner {
-            crate::ConstantInner::Sint(value) => {
-                write!(self.out, "{}", value)?;
-            }
-            crate::ConstantInner::Uint(value) => {
-                write!(self.out, "{}", value)?;
-            }
-            crate::ConstantInner::Float(value) => {
-                write!(self.out, "{}", value)?;
-                if value.fract() == 0.0 {
-                    write!(self.out, ".0")?;
+            crate::ConstantInner::Scalar {
+                width: _,
+                ref value,
+            } => match *value {
+                crate::ScalarValue::Sint(value) => {
+                    write!(self.out, "{}", value)?;
                 }
-            }
-            crate::ConstantInner::Bool(value) => {
-                write!(self.out, "{}", value)?;
-            }
-            crate::ConstantInner::Composite(ref constituents) => {
-                let ty_name = &self.names[&NameKey::Type(constant.ty)];
+                crate::ScalarValue::Uint(value) => {
+                    write!(self.out, "{}", value)?;
+                }
+                crate::ScalarValue::Float(value) => {
+                    write!(self.out, "{}", value)?;
+                    if value.fract() == 0.0 {
+                        write!(self.out, ".0")?;
+                    }
+                }
+                crate::ScalarValue::Bool(value) => {
+                    write!(self.out, "{}", value)?;
+                }
+            },
+            crate::ConstantInner::Composite { ty, ref components } => {
+                let ty_name = &self.names[&NameKey::Type(ty)];
                 write!(self.out, "{}(", ty_name)?;
-                for (i, &handle) in constituents.iter().enumerate() {
+                for (i, &handle) in components.iter().enumerate() {
                     if i != 0 {
                         write!(self.out, ", ")?;
                     }

--- a/src/back/spv/layout.rs
+++ b/src/back/spv/layout.rs
@@ -1,4 +1,4 @@
-use crate::back::spv::{Instruction, LogicalLayout, PhysicalLayout};
+use super::{Instruction, LogicalLayout, PhysicalLayout};
 use spirv::*;
 use std::iter;
 

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1203,23 +1203,16 @@ impl Writer {
                             other => unreachable!("Mul {:?}", other),
                         }
                     }
-                    crate::BinaryOperator::Divide => match *left_ty_inner {
-                        crate::TypeInner::Scalar { kind, .. }
-                        | crate::TypeInner::Vector { kind, .. } => match kind {
-                            crate::ScalarKind::Sint => spirv::Op::SDiv,
-                            crate::ScalarKind::Uint => spirv::Op::UDiv,
-                            _ => unreachable!(),
-                        },
+                    crate::BinaryOperator::Divide => match left_ty_inner.scalar_kind() {
+                        Some(crate::ScalarKind::Sint) => spirv::Op::SDiv,
+                        Some(crate::ScalarKind::Uint) => spirv::Op::UDiv,
+                        Some(crate::ScalarKind::Float) => spirv::Op::FDiv,
                         _ => unreachable!(),
                     },
-                    crate::BinaryOperator::Modulo => match *left_ty_inner {
-                        crate::TypeInner::Scalar { kind, .. }
-                        | crate::TypeInner::Vector { kind, .. } => match kind {
-                            crate::ScalarKind::Sint => spirv::Op::SMod,
-                            crate::ScalarKind::Uint => spirv::Op::UMod,
-                            crate::ScalarKind::Float => spirv::Op::FMod,
-                            _ => unreachable!(),
-                        },
+                    crate::BinaryOperator::Modulo => match left_ty_inner.scalar_kind() {
+                        Some(crate::ScalarKind::Sint) => spirv::Op::SMod,
+                        Some(crate::ScalarKind::Uint) => spirv::Op::UMod,
+                        Some(crate::ScalarKind::Float) => spirv::Op::FMod,
                         _ => unreachable!(),
                     },
                     crate::BinaryOperator::And => spirv::Op::BitwiseAnd,

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -10,7 +10,7 @@ pomelo! {
             Arena, BinaryOperator, Binding, Block, Constant,
             ConstantInner, EntryPoint, Expression,
             Function, GlobalVariable, Handle, Interpolation,
-            LocalVariable, SampleLevel, ScalarKind,
+            LocalVariable, SampleLevel, ScalarValue,
             Statement, StorageAccess, StorageClass, StructMember,
             SwitchCase, Type, TypeInner, UnaryOperator,
         };
@@ -165,18 +165,13 @@ pomelo! {
 
     primary_expression ::= variable_identifier;
     primary_expression ::= IntConstant(i) {
-        let ty = extra.module.types.fetch_or_append(Type {
-            name: None,
-            inner: TypeInner::Scalar {
-                kind: ScalarKind::Sint,
-                width: 4,
-            }
-        });
         let ch = extra.module.constants.fetch_or_append(Constant {
             name: None,
             specialization: None,
-            ty,
-            inner: ConstantInner::Sint(i.1)
+            inner: ConstantInner::Scalar {
+                width: 4,
+                value: ScalarValue::Sint(i.1),
+            },
         });
         ExpressionRule::from_expression(
             extra.context.expressions.append(Expression::Constant(ch))
@@ -184,36 +179,26 @@ pomelo! {
     }
     // primary_expression ::= UintConstant;
     primary_expression ::= FloatConstant(f) {
-        let ty = extra.module.types.fetch_or_append(Type {
-            name: None,
-            inner: TypeInner::Scalar {
-                kind: ScalarKind::Float,
-                width: 4,
-            }
-        });
         let ch = extra.module.constants.fetch_or_append(Constant {
             name: None,
             specialization: None,
-            ty,
-            inner: ConstantInner::Float(f.1 as f64)
+            inner: ConstantInner::Scalar {
+                width: 4,
+                value: ScalarValue::Float(f.1 as f64),
+            },
         });
         ExpressionRule::from_expression(
             extra.context.expressions.append(Expression::Constant(ch))
         )
     }
     primary_expression ::= BoolConstant(b) {
-        let ty = extra.module.types.fetch_or_append(Type {
-            name: None,
-            inner: TypeInner::Scalar {
-                kind: ScalarKind::Bool,
-                width: 4,
-            }
-        });
         let ch = extra.module.constants.fetch_or_append(Constant {
             name: None,
             specialization: None,
-            ty,
-            inner: ConstantInner::Bool(b.1)
+            inner: ConstantInner::Scalar {
+                width: 1,
+                value: ScalarValue::Bool(b.1)
+            },
         });
         ExpressionRule::from_expression(
             extra.context.expressions.append(Expression::Constant(ch))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,7 +396,17 @@ pub struct Constant {
     pub name: Option<String>,
     pub specialization: Option<u32>,
     pub inner: ConstantInner,
-    pub ty: Handle<Type>,
+}
+
+/// A literal scalar value, used in constants.
+#[derive(Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+pub enum ScalarValue {
+    Sint(i64),
+    Uint(u64),
+    Float(f64),
+    Bool(bool),
 }
 
 /// Additional information, dependendent on the kind of constant.
@@ -404,11 +414,14 @@ pub struct Constant {
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub enum ConstantInner {
-    Sint(i64),
-    Uint(u64),
-    Float(f64),
-    Bool(bool),
-    Composite(Vec<Handle<Constant>>),
+    Scalar {
+        width: Bytes,
+        value: ScalarValue,
+    },
+    Composite {
+        ty: Handle<Type>,
+        components: Vec<Handle<Constant>>,
+    },
 }
 
 /// Describes how an input/output variable is to be bound.

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -15,7 +15,7 @@ pub use interface::{Interface, Visitor};
 pub use namer::{EntryPointIndex, NameKey, Namer};
 pub use sizer::Sizer;
 pub use terminator::ensure_block_returns;
-pub use typifier::{check_constant_type, ResolveContext, ResolveError, Typifier};
+pub use typifier::{ResolveContext, ResolveError, Typifier};
 pub use validator::{ValidationError, Validator};
 
 impl From<super::StorageFormat> for super::ScalarKind {
@@ -54,6 +54,17 @@ impl From<super::StorageFormat> for super::ScalarKind {
             Sf::Rgba32Uint => Sk::Uint,
             Sf::Rgba32Sint => Sk::Sint,
             Sf::Rgba32Float => Sk::Float,
+        }
+    }
+}
+
+impl crate::ScalarValue {
+    pub fn scalar_kind(&self) -> crate::ScalarKind {
+        match *self {
+            Self::Uint(_) => crate::ScalarKind::Uint,
+            Self::Sint(_) => crate::ScalarKind::Sint,
+            Self::Float(_) => crate::ScalarKind::Float,
+            Self::Bool(_) => crate::ScalarKind::Bool,
         }
     }
 }

--- a/src/proc/sizer.rs
+++ b/src/proc/sizer.rs
@@ -28,7 +28,10 @@ impl Sizer {
                 Ti::Array { base, size, stride } => {
                     let count = match size {
                         crate::ArraySize::Constant(handle) => match constants[handle].inner {
-                            crate::ConstantInner::Uint(value) => value as u32,
+                            crate::ConstantInner::Scalar {
+                                width: _,
+                                value: crate::ScalarValue::Uint(value),
+                            } => value as u32,
                             ref other => unreachable!("Unexpected array size {:?}", other),
                         },
                         crate::ArraySize::Dynamic => 1,

--- a/test-data/simple/module.ron
+++ b/test-data/simple/module.ron
@@ -32,14 +32,18 @@
         (
             name: None,
             specialization: None,
-            inner: Float(1),
-            ty: 3,
+            inner: Scalar(
+                width: 4,
+                value: Float(1),
+            ),
         ),
         (
             name: None,
             specialization: None,
-            inner: Float(0),
-            ty: 3,
+            inner: Scalar(
+                width: 4,
+                value: Float(0),
+            ),
         ),
     ],
     global_variables: [

--- a/tests/snapshots/snapshots__boids.msl.snap
+++ b/tests/snapshots/snapshots__boids.msl.snap
@@ -21,12 +21,12 @@ struct SimParams {
 	type2 rule2Scale;
 	type2 rule3Scale;
 };
-typedef uint type3;
-typedef Particle type4[5];
+typedef Particle type3[5];
 struct Particles {
-	type4 particles;
+	type3 particles;
 };
-typedef metal::uint3 type5;
+typedef metal::uint3 type4;
+typedef uint type5;
 typedef int type6;
 
 struct main1Input {
@@ -60,7 +60,7 @@ kernel void main3(
 	constant SimParams& params [[buffer(0)]],
 	constant Particles& particlesA [[buffer(1)]],
 	device Particles& particlesB [[buffer(2)]],
-	type5 gl_GlobalInvocationID [[thread_position_in_grid]]
+	type4 gl_GlobalInvocationID [[thread_position_in_grid]]
 ) {
 	type vPos;
 	type vVel;
@@ -71,7 +71,7 @@ kernel void main3(
 	type6 cVelCount = 0;
 	type pos1;
 	type vel1;
-	type3 i = 0;
+	type5 i = 0;
 	if (gl_GlobalInvocationID.x >= static_cast<uint>(5)) {
 	}
 	vPos = particlesA.particles[gl_GlobalInvocationID.x].pos;

--- a/tests/snapshots/snapshots__simple.msl.snap
+++ b/tests/snapshots/snapshots__simple.msl.snap
@@ -6,7 +6,6 @@ expression: msl
 #include <simd/simd.h>
 
 typedef metal::float4 type;
-typedef int type1;
 
 struct main1Input {
 };

--- a/tests/snapshots/snapshots__skybox.msl.snap
+++ b/tests/snapshots/snapshots__skybox.msl.snap
@@ -14,8 +14,8 @@ struct Data {
 	type3 view;
 };
 typedef int type4;
-typedef float type5;
-typedef metal::float3x3 type6;
+typedef metal::float3x3 type5;
+typedef float type6;
 typedef metal::texturecube<float, metal::access::sample> type7;
 typedef metal::sampler type8;
 typedef metal::int3 type9;


### PR DESCRIPTION
Another chapter in the series of IR refinements. Previously, we carried a type handle in every constant.
However, this is redundant for the scalar constants mostly. New API is more dense, more correct by constructions. It allows a clear 1:1 between `ScalarValue` and `ScalarKind`.

Note: in some cases it seems that moving the `Bool` variant out of `ScalarValue` into `ConstantInner` would be more convenient, but we'd lose this 1:1 relationship, so I didn't do it.