### PR TITLE
Change ErrorKind::SemanticError to use Cow<'static, str> instead of &'static str

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -72,7 +72,7 @@ impl Program {
             &resolve_ctx,
         ) {
             //TODO: better error report
-            Err(_) => Err(ErrorKind::SemanticError("Can't resolve type")),
+            Err(_) => Err(ErrorKind::SemanticError("Can't resolve type".into())),
             Ok(()) => Ok(self.context.typifier.get(handle, &self.module.types)),
         }
     }

--- a/src/front/glsl/error.rs
+++ b/src/front/glsl/error.rs
@@ -1,6 +1,6 @@
 use super::parser::Token;
 use super::token::TokenMetadata;
-use std::{fmt, io};
+use std::{fmt, io, borrow::Cow};
 
 #[derive(Debug)]
 pub enum ErrorKind {
@@ -20,7 +20,7 @@ pub enum ErrorKind {
     #[cfg(feature = "glsl-validate")]
     VariableNotAvailable(String),
     ExpectedConstant,
-    SemanticError(&'static str),
+    SemanticError(Cow<'static, str>),
     PreprocessorError(String),
     WrongNumberArgs(String, usize, usize),
 }

--- a/src/front/glsl/error.rs
+++ b/src/front/glsl/error.rs
@@ -1,6 +1,6 @@
 use super::parser::Token;
 use super::token::TokenMetadata;
-use std::{fmt, io, borrow::Cow};
+use std::{borrow::Cow, fmt, io};
 
 #[derive(Debug)]
 pub enum ErrorKind {

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -11,7 +11,7 @@ impl Program {
             FunctionCallKind::TypeConstructor(ty) => {
                 let h = if fc.args.len() == 1 {
                     let kind = self.module.types[ty].inner.scalar_kind().ok_or(
-                        ErrorKind::SemanticError("Can only cast to scalar or vector"),
+                        ErrorKind::SemanticError("Can only cast to scalar or vector".into()),
                     )?;
                     self.context.expressions.append(Expression::As {
                         kind,
@@ -78,7 +78,7 @@ impl Program {
                                     .collect(),
                             })
                         } else {
-                            Err(ErrorKind::SemanticError("Bad call to texture"))
+                            Err(ErrorKind::SemanticError("Bad call to textur".into()))
                         }
                     }
                     "ceil" | "round" | "floor" | "fract" | "trunc" => {
@@ -107,7 +107,7 @@ impl Program {
                         let function = *self
                             .lookup_function
                             .get(func_name)
-                            .ok_or(ErrorKind::SemanticError("Unknown function"))?;
+                            .ok_or(ErrorKind::SemanticError(format!("Unknown function: {}", func_name).into()))?;
                         Ok(ExpressionRule {
                             expression: self.context.expressions.append(Expression::Call {
                                 function,

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -10,9 +10,9 @@ impl Program {
         match fc.kind {
             FunctionCallKind::TypeConstructor(ty) => {
                 let h = if fc.args.len() == 1 {
-                    let kind = self.module.types[ty].inner.scalar_kind().ok_or_else(||
-                        ErrorKind::SemanticError("Can only cast to scalar or vector".into()),
-                    )?;
+                    let kind = self.module.types[ty].inner.scalar_kind().ok_or_else(|| {
+                        ErrorKind::SemanticError("Can only cast to scalar or vector".into())
+                    })?;
                     self.context.expressions.append(Expression::As {
                         kind,
                         expr: fc.args[0].expression,
@@ -78,7 +78,7 @@ impl Program {
                                     .collect(),
                             })
                         } else {
-                            Err(ErrorKind::SemanticError("Bad call to textur".into()))
+                            Err(ErrorKind::SemanticError("Bad call to texture".into()))
                         }
                     }
                     "ceil" | "round" | "floor" | "fract" | "trunc" => {
@@ -104,11 +104,11 @@ impl Program {
                         })
                     }
                     func_name => {
-                        let function = *self.lookup_function.get(func_name).ok_or_else(||
+                        let function = *self.lookup_function.get(func_name).ok_or_else(|| {
                             ErrorKind::SemanticError(
                                 format!("Unknown function: {}", func_name).into(),
-                            ),
-                        )?;
+                            )
+                        })?;
                         Ok(ExpressionRule {
                             expression: self.context.expressions.append(Expression::Call {
                                 function,

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -104,10 +104,11 @@ impl Program {
                         })
                     }
                     func_name => {
-                        let function = *self
-                            .lookup_function
-                            .get(func_name)
-                            .ok_or(ErrorKind::SemanticError(format!("Unknown function: {}", func_name).into()))?;
+                        let function = *self.lookup_function.get(func_name).ok_or(
+                            ErrorKind::SemanticError(
+                                format!("Unknown function: {}", func_name).into(),
+                            ),
+                        )?;
                         Ok(ExpressionRule {
                             expression: self.context.expressions.append(Expression::Call {
                                 function,

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -10,7 +10,7 @@ impl Program {
         match fc.kind {
             FunctionCallKind::TypeConstructor(ty) => {
                 let h = if fc.args.len() == 1 {
-                    let kind = self.module.types[ty].inner.scalar_kind().ok_or(
+                    let kind = self.module.types[ty].inner.scalar_kind().ok_or_else(||
                         ErrorKind::SemanticError("Can only cast to scalar or vector".into()),
                     )?;
                     self.context.expressions.append(Expression::As {
@@ -104,7 +104,7 @@ impl Program {
                         })
                     }
                     func_name => {
-                        let function = *self.lookup_function.get(func_name).ok_or(
+                        let function = *self.lookup_function.get(func_name).ok_or_else(||
                             ErrorKind::SemanticError(
                                 format!("Unknown function: {}", func_name).into(),
                             ),

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -517,7 +517,7 @@ pomelo! {
     }
 
     single_declaration ::= fully_specified_type(t) {
-        let ty = t.1.ok_or(ErrorKind::SemanticError("Empty type for declaration".into()))?;
+        let ty = t.1.ok_or_else(||ErrorKind::SemanticError("Empty type for declaration".into()))?;
 
         VarDeclaration {
             type_qualifiers: t.0,
@@ -526,7 +526,7 @@ pomelo! {
         }
     }
     single_declaration ::= fully_specified_type(t) Identifier(i) {
-        let ty = t.1.ok_or(ErrorKind::SemanticError("Empty type for declaration".into()))?;
+        let ty = t.1.ok_or_else(|| ErrorKind::SemanticError("Empty type for declaration".into()))?;
 
         VarDeclaration {
             type_qualifiers: t.0,
@@ -537,7 +537,7 @@ pomelo! {
     // single_declaration ::= fully_specified_type Identifier array_specifier;
     // single_declaration ::= fully_specified_type Identifier array_specifier Equal initializer;
     single_declaration ::= fully_specified_type(t) Identifier(i) Equal initializer(init) {
-        let ty = t.1.ok_or(ErrorKind::SemanticError("Empty type for declaration".into()))?;
+        let ty = t.1.ok_or_else(|| ErrorKind::SemanticError("Empty type for declaration".into()))?;
 
         VarDeclaration {
             type_qualifiers: t.0,
@@ -707,7 +707,7 @@ pomelo! {
         // local variables
         if let Some(d) = d {
             for (id, initializer) in d.ids_initializers {
-                let id = id.ok_or(ErrorKind::SemanticError("Local var must be named".into()))?;
+                let id = id.ok_or_else(|| ErrorKind::SemanticError("Local var must be named".into()))?;
                 // check if already declared in current scope
                 #[cfg(feature = "glsl-validate")]
                 {
@@ -1002,7 +1002,7 @@ pomelo! {
         if let Some(d) = d {
             let class = d.type_qualifiers.iter().find_map(|tq| {
                 if let TypeQualifier::StorageClass(sc) = tq { Some(*sc) } else { None }
-            }).ok_or(ErrorKind::SemanticError(format!("Missing storage class for global var \"{:?}\"", d).into()))?;
+            }).ok_or_else(|| ErrorKind::SemanticError(format!("Missing storage class for global var \"{:?}\"", d).into()))?;
 
             let binding = d.type_qualifiers.iter().find_map(|tq| {
                 if let TypeQualifier::Binding(b) = tq { Some(b.clone()) } else { None }

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -517,7 +517,7 @@ pomelo! {
     }
 
     single_declaration ::= fully_specified_type(t) {
-        let ty = t.1.ok_or(ErrorKind::SemanticError("Empty type for declaration"))?;
+        let ty = t.1.ok_or(ErrorKind::SemanticError("Empty type for declaration".into()))?;
 
         VarDeclaration {
             type_qualifiers: t.0,
@@ -526,7 +526,7 @@ pomelo! {
         }
     }
     single_declaration ::= fully_specified_type(t) Identifier(i) {
-        let ty = t.1.ok_or(ErrorKind::SemanticError("Empty type for declaration"))?;
+        let ty = t.1.ok_or(ErrorKind::SemanticError("Empty type for declaration".into()))?;
 
         VarDeclaration {
             type_qualifiers: t.0,
@@ -537,7 +537,7 @@ pomelo! {
     // single_declaration ::= fully_specified_type Identifier array_specifier;
     // single_declaration ::= fully_specified_type Identifier array_specifier Equal initializer;
     single_declaration ::= fully_specified_type(t) Identifier(i) Equal initializer(init) {
-        let ty = t.1.ok_or(ErrorKind::SemanticError("Empty type for declaration"))?;
+        let ty = t.1.ok_or(ErrorKind::SemanticError("Empty type for declaration".into()))?;
 
         VarDeclaration {
             type_qualifiers: t.0,
@@ -676,7 +676,7 @@ pomelo! {
                 ty,
             }).collect()
         } else {
-            return Err(ErrorKind::SemanticError("Struct member can't be void"))
+            return Err(ErrorKind::SemanticError("Struct member can't be void".into()))
         }
     }
     //struct_declaration ::= type_qualifier type_specifier struct_declarator_list Semicolon;
@@ -707,7 +707,7 @@ pomelo! {
         // local variables
         if let Some(d) = d {
             for (id, initializer) in d.ids_initializers {
-                let id = id.ok_or(ErrorKind::SemanticError("local var must be named"))?;
+                let id = id.ok_or(ErrorKind::SemanticError("Local var must be named".into()))?;
                 // check if already declared in current scope
                 #[cfg(feature = "glsl-validate")]
                 {
@@ -1002,7 +1002,7 @@ pomelo! {
         if let Some(d) = d {
             let class = d.type_qualifiers.iter().find_map(|tq| {
                 if let TypeQualifier::StorageClass(sc) = tq { Some(*sc) } else { None }
-            }).ok_or(ErrorKind::SemanticError("Missing storage class for global var"))?;
+            }).ok_or(ErrorKind::SemanticError(format!("Missing storage class for global var \"{:?}\"", d).into()))?;
 
             let binding = d.type_qualifiers.iter().find_map(|tq| {
                 if let TypeQualifier::Binding(b) = tq { Some(b.clone()) } else { None }

--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -204,7 +204,7 @@ impl Program {
                                         4 => VectorSize::Quad,
                                         _ => {
                                             return Err(ErrorKind::SemanticError(
-                                                "Bad swizzle size",
+                                                format!("Bad swizzle size for \"{:?}\": {:?}", name, v).into(),
                                             ));
                                         }
                                     },
@@ -214,10 +214,10 @@ impl Program {
                         }))
                     }
                 } else {
-                    Err(ErrorKind::SemanticError("Invalid swizzle for vector"))
+                    Err(ErrorKind::SemanticError(format!("Invalid swizzle for vector \"{}\"", name).into()))
                 }
             }
-            _ => Err(ErrorKind::SemanticError("Can't lookup field on this type")),
+            _ => Err(ErrorKind::SemanticError(format!("Can't lookup field on this type \"{}\"", name).into())),
         }
     }
 }

--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -204,7 +204,11 @@ impl Program {
                                         4 => VectorSize::Quad,
                                         _ => {
                                             return Err(ErrorKind::SemanticError(
-                                                format!("Bad swizzle size for \"{:?}\": {:?}", name, v).into(),
+                                                format!(
+                                                    "Bad swizzle size for \"{:?}\": {:?}",
+                                                    name, v
+                                                )
+                                                .into(),
                                             ));
                                         }
                                     },
@@ -214,10 +218,14 @@ impl Program {
                         }))
                     }
                 } else {
-                    Err(ErrorKind::SemanticError(format!("Invalid swizzle for vector \"{}\"", name).into()))
+                    Err(ErrorKind::SemanticError(
+                        format!("Invalid swizzle for vector \"{}\"", name).into(),
+                    ))
                 }
             }
-            _ => Err(ErrorKind::SemanticError(format!("Can't lookup field on this type \"{}\"", name).into())),
+            _ => Err(ErrorKind::SemanticError(
+                format!("Can't lookup field on this type \"{}\"", name).into(),
+            )),
         }
     }
 }


### PR DESCRIPTION
I was messing around with migrating my build scripts for https://github.com/sotrh/learn-wgpu to use `naga` instead of `shaderc`, and I ran into issues with errors not having enough information. While this PR doesn't fix that issue entirely, it makes `SemanticError`s more flexible as they can now still borrow static strings, and they can be formatted to include additional details such as line numbers and names of variables.