### PR TITLE
[wgsl] fix and update storage load

### DIFF
--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -665,12 +665,12 @@ impl Parser {
                         None
                     };
                     let index = match class {
-                        crate::ImageClass::Storage(_) => {
+                        crate::ImageClass::Storage(_) => None,
+                        // it's the MSAA index for multi-sampled, and LOD for the others
+                        crate::ImageClass::Sampled { .. } | crate::ImageClass::Depth => {
                             lexer.expect(Token::Separator(','))?;
-                            let index_name = lexer.next_ident()?;
-                            Some(ctx.lookup_ident.lookup(index_name)?)
+                            Some(self.parse_general_expression(lexer, ctx.reborrow())?)
                         }
-                        crate::ImageClass::Sampled { .. } | crate::ImageClass::Depth => None,
                     };
                     lexer.expect(Token::Paren(')'))?;
                     Some(crate::Expression::ImageLoad {
@@ -1408,6 +1408,14 @@ impl Parser {
                 crate::TypeInner::Image {
                     dim: crate::ImageDimension::D2,
                     arrayed: false,
+                    class: crate::ImageClass::Sampled { kind, multi: true },
+                }
+            }
+            "texture_multisampled_2d_array" => {
+                let (kind, _) = lexer.next_scalar_generic()?;
+                crate::TypeInner::Image {
+                    dim: crate::ImageDimension::D2,
+                    arrayed: true,
                     class: crate::ImageClass::Sampled { kind, multi: true },
                 }
             }

--- a/src/front/wgsl/tests.rs
+++ b/src/front/wgsl/tests.rs
@@ -116,3 +116,34 @@ fn parse_switch() {
     )
     .unwrap();
 }
+
+#[test]
+fn parse_texture_load() {
+    parse_str(
+        "
+        var t: texture_3d<u32>;
+        fn foo() {
+            const r: vec4<u32> = textureLoad(t, vec3<u32>(0.0, 1.0, 2.0), 1);
+        }
+    ",
+    )
+    .unwrap();
+    parse_str(
+        "
+        var t: texture_multisampled_2d_array<i32>;
+        fn foo() {
+        const r: vec4<i32> = textureLoad(t, vec2<i32>(10, 20), 2, 3);
+        }
+    ",
+    )
+    .unwrap();
+    parse_str(
+        "
+        var t: [[access(read)]] texture_storage_1d_array<r32float>;
+        fn foo() {
+            const r: vec4<f32> = textureLoad(t, 10, 2);
+        }
+    ",
+    )
+    .unwrap();
+}


### PR DESCRIPTION
The old implementation was the *opposite* of what we need: it only read the index for storages, and expected an identifier.