### PR TITLE
[wgsl] support vector type casts

### DIFF
--- a/src/front/wgsl/tests.rs
+++ b/src/front/wgsl/tests.rs
@@ -37,6 +37,15 @@ fn parse_type_cast() {
     ",
     )
     .unwrap();
+    parse_str(
+        "
+        fn main() {
+            const x: vec2<f32> = vec2<f32>(1.0, 2.0);
+            const y: vec2<u32> = vec2<u32>(x);
+        }
+    ",
+    )
+    .unwrap();
 }
 
 #[test]

--- a/tests/snapshots/snapshots__skybox.msl.snap
+++ b/tests/snapshots/snapshots__skybox.msl.snap
@@ -20,9 +20,9 @@ struct Data {
 
 typedef int type4;
 
-typedef metal::float3x3 type5;
+typedef float type5;
 
-typedef float type6;
+typedef metal::float3x3 type6;
 
 typedef metal::texturecube<float, metal::access::sample> type7;
 


### PR DESCRIPTION
Enables type casts like `vec2<i32>(other_vec)` in WGSL