### PR TITLE
Improve WGSL error reporting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,12 @@ spv-in = ["petgraph", "spirv"]
 spv-out = ["spirv"]
 wgsl-in = []
 
+#Note: it would be nice to do `cargo run` for conversion.
+# Blocked on https://github.com/rust-lang/cargo/issues/4663
+
 [dev-dependencies]
 difference = "2.0"
-env_logger = "0.6"
+env_logger = "0.8"
 ron = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 spirv = { package = "spirv_headers", version = "1.5", features = ["deserialize"] }

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -39,17 +39,10 @@ pub enum Token<'a> {
     End,
 }
 
-impl<'a> Token<'a> {
-    fn unexpected<T, E: std::fmt::Debug>(self, expected: E) -> Result<T, Error<'a>> {
-        log::error!("Unmet expectation for {:?}", expected);
-        Err(Error::Unexpected(self))
-    }
-}
-
 #[derive(Clone, Debug, Error)]
 pub enum Error<'a> {
-    #[error("unexpected token: {0:?}")]
-    Unexpected(Token<'a>),
+    #[error("unexpected token {0:?}, expected {1}")]
+    Unexpected(Token<'a>, &'a str),
     #[error("unable to parse `{0}` as integer: {1}")]
     BadInteger(&'a str, std::num::ParseIntError),
     #[error("unable to parse `{1}` as float: {1}")]
@@ -698,7 +691,12 @@ impl Parser {
                                 match lexer.next() {
                                     Token::Paren(')') => break,
                                     Token::Separator(',') => (),
-                                    other => return other.unexpected("argument list separator"),
+                                    other => {
+                                        return Err(Error::Unexpected(
+                                            other,
+                                            "argument list separator",
+                                        ))
+                                    }
                                 }
                             }
                         }
@@ -847,7 +845,7 @@ impl Parser {
                     crate::Expression::Compose { ty, components }
                 }
             }
-            other => return other.unexpected("primary expression"),
+            other => return Err(Error::Unexpected(other, "primary expression")),
         };
         self.scopes.pop();
         Ok(ctx.expressions.append(expression))
@@ -1180,7 +1178,7 @@ impl Parser {
                             lexer.expect(Token::Paren(')'))?;
                             ready = false;
                         }
-                        other => return other.unexpected("decoration separator"),
+                        other => return Err(Error::Unexpected(other, "decoration separator")),
                     }
                 }
                 self.scopes.pop();
@@ -1188,7 +1186,7 @@ impl Parser {
             let name = match lexer.next() {
                 Token::Word(word) => word,
                 Token::Paren('}') => return Ok(members),
-                other => return other.unexpected("field name"),
+                other => return Err(Error::Unexpected(other, "field name")),
             };
             lexer.expect(Token::Separator(':'))?;
             let (ty, _access) = self.parse_type_decl(lexer, None, type_arena, const_arena)?;
@@ -1344,7 +1342,7 @@ impl Parser {
                         crate::ArraySize::Constant(const_handle)
                     }
                     Token::Paren('>') => crate::ArraySize::Dynamic,
-                    other => return other.unexpected("generic separator"),
+                    other => return Err(Error::Unexpected(other, "generic separator")),
                 };
 
                 crate::TypeInner::Array {
@@ -1523,7 +1521,7 @@ impl Parser {
                         lexer.expect(Token::Paren(')'))?;
                     }
                     Token::DoubleParen(']') => break,
-                    other => return other.unexpected("type decoration"),
+                    other => return Err(Error::Unexpected(other, "type decoration")),
                 }
             }
             self.scopes.pop();
@@ -1555,7 +1553,7 @@ impl Parser {
         let word = match lexer.next() {
             Token::Separator(';') => return Ok(None),
             Token::Word(word) => word,
-            other => return other.unexpected("statement"),
+            other => return Err(Error::Unexpected(other, "statement")),
         };
 
         self.scopes.push(Scope::Statement);
@@ -1664,7 +1662,9 @@ impl Parser {
                                         });
                                     }
                                     Token::Separator(':') => break value,
-                                    other => return other.unexpected("case separator"),
+                                    other => {
+                                        return Err(Error::Unexpected(other, "case separator"))
+                                    }
                                 }
                             };
 
@@ -1695,7 +1695,7 @@ impl Parser {
                             default = self.parse_block(lexer, context.reborrow())?;
                         }
                         Token::Paren('}') => break,
-                        other => return other.unexpected("switch item"),
+                        other => return Err(Error::Unexpected(other, "switch item")),
                     }
                 }
 
@@ -1909,7 +1909,12 @@ impl Parser {
                             match lexer.next() {
                                 Token::Paren(')') => break,
                                 Token::Separator(',') if i != 2 => (),
-                                other => return other.unexpected("workgroup size separator"),
+                                other => {
+                                    return Err(Error::Unexpected(
+                                        other,
+                                        "workgroup size separator",
+                                    ))
+                                }
                             }
                         }
                         for size in workgroup_size.iter_mut() {
@@ -1925,7 +1930,7 @@ impl Parser {
                         break;
                     }
                     Token::Separator(',') => {}
-                    other => return other.unexpected("decoration separator"),
+                    other => return Err(Error::Unexpected(other, "decoration separator")),
                 }
             }
             if let (Some(group), Some(index)) = (bind_group, bind_index) {
@@ -2044,7 +2049,7 @@ impl Parser {
                 }
             }
             Token::End => return Ok(false),
-            other => return other.unexpected("global item"),
+            other => return Err(Error::Unexpected(other, "global item")),
         }
 
         match binding {

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -17,6 +17,8 @@ use self::lexer::Lexer;
 use std::num::NonZeroU32;
 use thiserror::Error;
 
+const SPACE: &str = "                                                                                                    ";
+
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Token<'a> {
     Separator(char),
@@ -334,11 +336,12 @@ struct ParsedVariable<'a> {
 }
 
 #[derive(Clone, Debug, Error)]
-#[error("error while parsing WGSL in scopes {scopes:?} at position {pos:?}: {error}")]
+#[error("error while parsing WGSL in scopes {scopes:?} at line {line} pos {pos}: {error}")]
 pub struct ParseError<'a> {
     pub error: Error<'a>,
     pub scopes: Vec<Scope>,
-    pub pos: (usize, usize),
+    pub line: usize,
+    pub pos: usize,
 }
 
 pub struct Parser {
@@ -2071,23 +2074,38 @@ impl Parser {
                 Err(error) => {
                     let pos = lexer.offset_from(source);
                     let (mut rows, mut cols) = (0, 1);
+                    let (mut prev_line, mut cur_line) = ("", "");
                     for line in source[..pos].lines() {
                         rows += 1;
                         cols = line.len();
+                        prev_line = cur_line;
+                        cur_line = line;
+                    }
+                    log::error!("|\t{}", prev_line);
+                    log::error!(
+                        ">\t{}{}",
+                        cur_line,
+                        source[pos..].lines().next().unwrap_or_default()
+                    );
+                    if cols <= SPACE.len() {
+                        log::error!("|\t{}^", &SPACE[..cols]);
                     }
                     return Err(ParseError {
                         error,
                         scopes: std::mem::replace(&mut self.scopes, Vec::new()),
-                        pos: (rows, cols),
+                        line: rows,
+                        pos: cols,
                     });
                 }
                 Ok(true) => {}
                 Ok(false) => {
                     if !self.scopes.is_empty() {
+                        log::error!("Reached the end of file, but scopes are not closed");
                         return Err(ParseError {
                             error: Error::Other,
                             scopes: std::mem::replace(&mut self.scopes, Vec::new()),
-                            pos: (0, 0),
+                            line: 0,
+                            pos: 0,
                         });
                     };
                     return Ok(module);


### PR DESCRIPTION
Here is how it looks with the PR:
```
[2021-01-27T15:57:52Z ERROR naga::front::wgsl] |	fn vs_bake() {
[2021-01-27T15:57:52Z ERROR naga::front::wgsl] >	    out_position = u_globals.view_proj 1* u_entity.world * vec4<f32>(in_position);
[2021-01-27T15:57:52Z ERROR naga::front::wgsl] |	                                        ^
thread 'main' panicked at 'error while parsing WGSL in scopes [FunctionDecl, Block, Statement] at line 26 pos 40: unexpected token Number { value: "1", ty: 'i', width: "" }, expected separator', examples/convert.rs:54:31
```
Here is how it looks on master right now:
```
[2021-01-27T15:57:34Z ERROR naga::front::wgsl] Unmet expectation for Separator(';')
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ParseError { error: Unexpected(Number { value: "1", ty: 'i', width: "" }), scopes: [Function```