### PR TITLE
[wgsl] support simple block statements

### DIFF
--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1557,6 +1557,17 @@ impl Parser {
     ) -> Result<Option<crate::Statement>, Error<'a>> {
         let word = match lexer.next() {
             Token::Separator(';') => return Ok(None),
+            Token::Paren('{') => {
+                self.scopes.push(Scope::Block);
+                let mut statements = Vec::new();
+                while !lexer.skip(Token::Paren('}')) {
+                    let s = self.parse_statement(lexer, context.reborrow())?;
+                    statements.extend(s);
+                }
+                self.scopes.pop();
+                let block = crate::Statement::Block(statements);
+                return Ok(Some(block));
+            }
             Token::Word(word) => word,
             other => return other.unexpected("statement"),
         };

--- a/src/front/wgsl/tests.rs
+++ b/src/front/wgsl/tests.rs
@@ -74,6 +74,20 @@ fn parse_standard_fun() {
 }
 
 #[test]
+fn parse_statement() {
+    parse_str(
+        "
+        fn main() {
+            ;
+            {}
+            {;}
+        }
+    ",
+    )
+    .unwrap();
+}
+
+#[test]
 fn parse_if() {
     parse_str(
         "


### PR DESCRIPTION
The code is mostly a copy-paste from `parse_block`, but sharing it would be more trouble than it's worth.