### PR TITLE
Added function pow for the spirv backend

### DIFF
--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1680,6 +1680,7 @@ impl Writer {
                         MathOp::Other(inst, result_lookup_ty)
                     }
                     Mf::Normalize => MathOp::Single(spirv::GLOp::Normalize),
+                    Mf::Pow => MathOp::Double(spirv::GLOp::Pow),
                     // computational
                     Mf::Transpose => {
                         let result_lookup_ty =


### PR DESCRIPTION
I consulted the specs of the extended instruction set https://www.khronos.org/registry/spir-v/specs/1.0/GLSL.std.450.html
and WGSL https://gpuweb.github.io/gpuweb/wgsl.html#float-builtin-functions

I didn't find any unit test around math function.

I tested with this WGSL shader:
```
var x: f32 = pow(1.0, 0.5);  // 1
var y: f32 = pow(2.0, 2.0) / 8.0; // 0.5
out_target = vec4<f32>(x, y, 0.0, 1.0);
```
