### PR TITLE
Assorted MSL fixes

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -305,7 +305,7 @@ impl<'a, W: Write> Writer<'a, W> {
 
         // Generate a map with names required to write the module
         let mut names = FastHashMap::default();
-        Namer::process(module, keywords::RESERVED_KEYWORDS, &mut names);
+        Namer::default().reset(module, keywords::RESERVED_KEYWORDS, &mut names);
 
         // Generate a call graph for the entry point
         let call_graph = CallGraphBuilder {

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -286,7 +286,7 @@ impl<W: Write> Writer<W> {
                 match level {
                     crate::SampleLevel::Auto => {}
                     crate::SampleLevel::Zero => {
-                        write!(self.out, ", level(0)")?;
+                        //TODO: do we support Zero on `Sampled` image classes?
                     }
                     crate::SampleLevel::Exact(h) => {
                         write!(self.out, ", level(")?;
@@ -538,7 +538,7 @@ impl<W: Write> Writer<W> {
                     write!(self.out, "{}", value)?;
                 }
                 crate::ScalarValue::Uint(value) => {
-                    write!(self.out, "{}", value)?;
+                    write!(self.out, "{}u", value)?;
                 }
                 crate::ScalarValue::Float(value) => {
                     write!(self.out, "{}", value)?;

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -182,3 +182,9 @@ fn convert_wgsl_skybox() {
 fn convert_wgsl_collatz() {
     convert_wgsl("collatz", Language::METAL | Language::SPIRV);
 }
+
+#[cfg(feature = "wgsl-in")]
+#[test]
+fn convert_wgsl_shadow() {
+    convert_wgsl("shadow", Language::METAL | Language::SPIRV);
+}

--- a/tests/snapshots/in/boids.wgsl
+++ b/tests/snapshots/in/boids.wgsl
@@ -1,46 +1,9 @@
-// Copyright 2020 The Tint Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+const NUM_PARTICLES: u32 = 1500;
 
-// vertex shader
-
-[[location(0)]] var<in> a_particlePos : vec2<f32>;
-[[location(1)]] var<in> a_particleVel : vec2<f32>;
-[[location(2)]] var<in> a_pos : vec2<f32>;
-[[builtin(position)]] var gl_Position : vec4<f32>;
-
-[[stage(vertex)]]
-fn main() {
-  const angle : f32 = -atan2(a_particleVel.x, a_particleVel.y);
-  const pos : vec2<f32> = vec2<f32>(
-      (a_pos.x * cos(angle)) - (a_pos.y * sin(angle)),
-      (a_pos.x * sin(angle)) + (a_pos.y * cos(angle)));
-  gl_Position = vec4<f32>(pos + a_particlePos, 0.0, 1.0);
-}
-
-// fragment shader
-[[location(0)]] var<out> fragColor : vec4<f32>;
-
-[[stage(fragment)]]
-fn main() {
-  fragColor = vec4<f32>(1.0, 1.0, 1.0, 1.0);
-}
-
-// compute shader
 [[block]]
 struct Particle {
-  [[span(8)]] pos : vec2<f32>;
-  [[span(8)]] vel : vec2<f32>;
+  pos : vec2<f32>;
+  vel : vec2<f32>;
 };
 
 [[block]]
@@ -56,25 +19,25 @@ struct SimParams {
 
 [[block]]
 struct Particles {
-  particles : [[stride(16)]] array<Particle, 5>;
+  particles : [[stride(16)]] array<Particle>;
 };
 
 [[group(0), binding(0)]] var<uniform> params : SimParams;
-[[group(0), binding(1)]] var<storage> particlesA : [[access(read_write)]] Particles;
-[[group(0), binding(2)]] var<storage> particlesB : [[access(read_write)]] Particles;
+[[group(0), binding(1)]] var<storage> particlesSrc : [[access(read)]] Particles;
+[[group(0), binding(2)]] var<storage> particlesDst : [[access(read_write)]] Particles;
 
 [[builtin(global_invocation_id)]] var gl_GlobalInvocationID : vec3<u32>;
 
 // https://github.com/austinEng/Project6-Vulkan-Flocking/blob/master/data/shaders/computeparticles/particle.comp
-[[stage(compute), workgroup_size(1)]]
+[[stage(compute), workgroup_size(64)]]
 fn main() {
   const index : u32 = gl_GlobalInvocationID.x;
-  if (index >= 5u) {
+  if (index >= NUM_PARTICLES) {
     return;
   }
 
-  var vPos : vec2<f32> = particlesA.particles[index].pos;
-  var vVel : vec2<f32> = particlesA.particles[index].vel;
+  var vPos : vec2<f32> = particlesSrc.particles[index].pos;
+  var vVel : vec2<f32> = particlesSrc.particles[index].vel;
 
   var cMass : vec2<f32> = vec2<f32>(0.0, 0.0);
   var cVel : vec2<f32> = vec2<f32>(0.0, 0.0);
@@ -86,15 +49,15 @@ fn main() {
   var vel : vec2<f32>;
   var i : u32 = 0u;
   loop {
-    if (i >= 5u) {
+    if (i >= NUM_PARTICLES) {
       break;
     }
     if (i == index) {
       continue;
     }
 
-    pos = particlesA.particles[i].pos.xy;
-    vel = particlesA.particles[i].vel.xy;
+    pos = particlesSrc.particles[i].pos;
+    vel = particlesSrc.particles[i].vel;
 
     if (distance(pos, vPos) < params.rule1Distance) {
       cMass = cMass + pos;
@@ -113,13 +76,14 @@ fn main() {
     }
   }
   if (cMassCount > 0) {
-    cMass = (cMass / vec2<f32>(vec2<i32>(cMassCount, cMassCount))) + vPos;
+    cMass = cMass * (1.0 / f32(cMassCount)) - vPos;
   }
   if (cVelCount > 0) {
-    cVel = cVel / vec2<f32>(vec2<i32>(cVelCount, cVelCount));
+    cVel = cVel * (1.0 / f32(cVelCount));
   }
 
-  vVel = vVel + (cMass * params.rule1Scale) + (colVel * params.rule2Scale) +
+  vVel = vVel + (cMass * params.rule1Scale) +
+      (colVel * params.rule2Scale) +
       (cVel * params.rule3Scale);
 
   // clamp velocity for a more pleasing simulation
@@ -143,6 +107,6 @@ fn main() {
   }
 
   // Write back
-  particlesB.particles[index].pos = vPos;
-  particlesB.particles[index].vel = vVel;
+  particlesDst.particles[index].pos = vPos;
+  particlesDst.particles[index].vel = vVel;
 }

--- a/tests/snapshots/in/shadow.param.ron
+++ b/tests/snapshots/in/shadow.param.ron
@@ -1,0 +1,10 @@
+(
+    spv_flow_dump_prefix: "",
+    spv_capabilities: [ Shader ],
+    mtl_bindings: {
+        (stage: Fragment, group: 0, binding: 0): (buffer: Some(0), mutable: false),
+        (stage: Fragment, group: 0, binding: 1): (buffer: Some(1), mutable: false),
+        (stage: Fragment, group: 0, binding: 2): (texture: Some(0), mutable: false),
+        (stage: Fragment, group: 0, binding: 3): (sampler: Some(0), mutable: false),
+    }
+)

--- a/tests/snapshots/in/shadow.wgsl
+++ b/tests/snapshots/in/shadow.wgsl
@@ -1,0 +1,69 @@
+[[block]]
+struct Globals {
+    num_lights: vec4<u32>;
+};
+
+[[group(0), binding(0)]]
+var<uniform> u_globals: Globals;
+
+[[block]]
+struct Light {
+    proj: mat4x4<f32>;
+    pos: vec4<f32>;
+    color: vec4<f32>;
+};
+
+[[block]]
+struct Lights {
+    data: [[stride(96)]] array<Light>;
+};
+
+[[group(0), binding(1)]]
+var<storage> s_lights: [[access(read)]] Lights;
+[[group(0), binding(2)]]
+var t_shadow: texture_depth_2d_array;
+[[group(0), binding(3)]]
+var sampler_shadow: sampler;
+
+fn fetch_shadow(light_id: u32, homogeneous_coords: vec4<f32>) -> f32 {
+    if (homogeneous_coords.w <= 0.0) {
+        return 1.0;
+    }
+    const flip_correction: vec2<f32> = vec2<f32>(0.5, -0.5);
+    const proj_correction: f32 = 1.0 / homogeneous_coords.w;
+    const light_local: vec2<f32> = homogeneous_coords.xy * flip_correction * proj_correction + vec2<f32>(0.5, 0.5);
+    return textureSampleCompare(t_shadow, sampler_shadow, light_local, i32(light_id), homogeneous_coords.z * proj_correction);
+}
+
+[[location(0)]]
+var<in> in_normal_fs: vec3<f32>;
+[[location(1)]]
+var<in> in_position_fs: vec4<f32>;
+[[location(0)]]
+var<out> out_color_fs: vec4<f32>;
+
+const c_ambient: vec3<f32> = vec3<f32>(0.05, 0.05, 0.05);
+const c_max_lights: u32 = 10u;
+
+[[stage(fragment)]]
+fn fs_main() {
+    const normal: vec3<f32> = normalize(in_normal_fs);
+    // accumulate color
+    var color: vec3<f32> = c_ambient;
+    var i: u32 = 0u;
+    loop {
+        if (i >= min(u_globals.num_lights.x, c_max_lights)) {
+            break;
+        }
+        const light: Light = s_lights.data[i];
+        const shadow: f32 = fetch_shadow(i, light.proj * in_position_fs);
+        const light_dir: vec3<f32> = normalize(light.pos.xyz - in_position_fs.xyz);
+        const diffuse: f32 = max(0.0, dot(normal, light_dir));
+        color = color + shadow * diffuse * light.color.xyz;
+        continuing {
+            i = i + 1u;
+        }
+    }
+    // multiply the light by material color
+    out_color_fs = vec4<f32>(color, 1.0);
+}

--- a/tests/snapshots/snapshots__boids.msl.snap
+++ b/tests/snapshots/snapshots__boids.msl.snap
@@ -51,7 +51,7 @@ kernel void main1(
     type5 cVelCount = 0;
     type1 pos1;
     type1 vel1;
-    type i = 0;
+    type i = 0u;
     if ((gl_GlobalInvocationID.x >= 1500)) {
         return ;
     }
@@ -63,7 +63,7 @@ kernel void main1(
     bool loop_init = true;
     while(true) {
         if (!loop_init) {
-            i = (i + 1);
+            i = (i + 1u);
         }
         loop_init = false;
         if ((i >= 1500)) {

--- a/tests/snapshots/snapshots__boids.msl.snap
+++ b/tests/snapshots/snapshots__boids.msl.snap
@@ -5,16 +5,16 @@ expression: msl
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-typedef metal::float2 type;
+typedef uint type;
 
-typedef metal::float4 type1;
-
-typedef float type2;
+typedef metal::float2 type1;
 
 struct Particle {
-    type pos;
-    type vel;
+    type1 pos;
+    type1 vel;
 };
+
+typedef float type2;
 
 struct SimParams {
     type2 deltaT;
@@ -26,7 +26,7 @@ struct SimParams {
     type2 rule3Scale;
 };
 
-typedef Particle type3[5];
+typedef Particle type3[1];
 
 struct Particles {
     type3 particles;
@@ -34,111 +34,81 @@ struct Particles {
 
 typedef metal::uint3 type4;
 
-typedef uint type5;
+typedef int type5;
 
-typedef int type6;
-
-typedef metal::int2 type7;
-
-struct main1Input {
-    type a_particlePos [[attribute(0)]];
-    type a_particleVel [[attribute(1)]];
-    type a_pos [[attribute(2)]];
-};
-
-struct main1Output {
-    type1 gl_Position [[position]];
-};
-
-vertex main1Output main1(
-    main1Input input [[stage_in]]
-) {
-    main1Output output;
-    output.gl_Position = metal::float4(metal::float2(input.a_pos.x * metal::cos(-metal::atan2(input.a_particleVel.x, input.a_particleVel.y)) - input.a_pos.y * metal::sin(-metal::atan2(input.a_particleVel.x, input.a_particleVel.y)), input.a_pos.x * metal::sin(-metal::atan2(input.a_particleVel.x, input.a_particleVel.y)) + input.a_pos.y * metal::cos(-metal::atan2(input.a_particleVel.x, input.a_particleVel.y))) + input.a_particlePos, 0.0, 1.0);
-    return output;
-}
-
-struct main2Input {
-};
-
-struct main2Output {
-    type1 fragColor [[color(0)]];
-};
-
-fragment main2Output main2(
-    main2Input input [[stage_in]]
-) {
-    main2Output output;
-    output.fragColor = metal::float4(1.0, 1.0, 1.0, 1.0);
-    return output;
-}
-
-kernel void main3(
+kernel void main1(
     constant SimParams& params [[buffer(0)]],
-    constant Particles& particlesA [[buffer(1)]],
-    device Particles& particlesB [[buffer(2)]],
+    constant Particles& particlesSrc [[buffer(1)]],
+    device Particles& particlesDst [[buffer(2)]],
     type4 gl_GlobalInvocationID [[thread_position_in_grid]]
 ) {
-    type vPos;
-    type vVel;
-    type cMass;
-    type cVel;
-    type colVel;
-    type6 cMassCount = 0;
-    type6 cVelCount = 0;
-    type pos1;
-    type vel1;
-    type5 i = 0;
-    if (gl_GlobalInvocationID.x >= 5) {
+    type1 vPos;
+    type1 vVel;
+    type1 cMass;
+    type1 cVel;
+    type1 colVel;
+    type5 cMassCount = 0;
+    type5 cVelCount = 0;
+    type1 pos1;
+    type1 vel1;
+    type i = 0;
+    if ((gl_GlobalInvocationID.x >= 1500)) {
+        return ;
     }
-    vPos = particlesA.particles[gl_GlobalInvocationID.x].pos;
-    vVel = particlesA.particles[gl_GlobalInvocationID.x].vel;
+    vPos = particlesSrc.particles[gl_GlobalInvocationID.x].pos;
+    vVel = particlesSrc.particles[gl_GlobalInvocationID.x].vel;
     cMass = metal::float2(0.0, 0.0);
     cVel = metal::float2(0.0, 0.0);
     colVel = metal::float2(0.0, 0.0);
+    bool loop_init = true;
     while(true) {
-        if (i >= 5) {
+        if (!loop_init) {
+            i = (i + 1);
+        }
+        loop_init = false;
+        if ((i >= 1500)) {
             break;
         }
-        if (i == gl_GlobalInvocationID.x) {
+        if ((i == gl_GlobalInvocationID.x)) {
             continue;
         }
-        pos1 = metal::float2(particlesA.particles[i].pos.x, particlesA.particles[i].pos.y);
-        vel1 = metal::float2(particlesA.particles[i].vel.x, particlesA.particles[i].vel.y);
-        if (metal::distance(pos1, vPos) < params.rule1Distance) {
-            cMass = cMass + pos1;
-            cMassCount = cMassCount + 1;
+        pos1 = particlesSrc.particles[i].pos;
+        vel1 = particlesSrc.particles[i].vel;
+        if ((metal::distance(pos1, vPos) < params.rule1Distance)) {
+            cMass = (cMass + pos1);
+            cMassCount = (cMassCount + 1);
         }
-        if (metal::distance(pos1, vPos) < params.rule2Distance) {
-            colVel = colVel - pos1 - vPos;
+        if ((metal::distance(pos1, vPos) < params.rule2Distance)) {
+            colVel = (colVel - (pos1 - vPos));
         }
-        if (metal::distance(pos1, vPos) < params.rule3Distance) {
-            cVel = cVel + vel1;
-            cVelCount = cVelCount + 1;
+        if ((metal::distance(pos1, vPos) < params.rule3Distance)) {
+            cVel = (cVel + vel1);
+            cVelCount = (cVelCount + 1);
         }
     }
-    if (cMassCount == 0) {
-        cMass = cMass / static_cast<float2>(metal::int2(cMassCount, cMassCount)) + vPos;
+    if ((cMassCount > 0)) {
+        cMass = ((cMass * (1.0 / static_cast<float>(cMassCount))) - vPos);
     }
-    if (cVelCount == 0) {
-        cVel = cVel / static_cast<float2>(metal::int2(cVelCount, cVelCount));
+    if ((cVelCount > 0)) {
+        cVel = (cVel * (1.0 / static_cast<float>(cVelCount)));
     }
-    vVel = vVel + cMass * params.rule1Scale + colVel * params.rule2Scale + cVel * params.rule3Scale;
-    vVel = metal::normalize(vVel) * metal::clamp(metal::length(vVel), 0.0, 0.1);
-    vPos = vPos + vVel * params.deltaT;
-    if (vPos.x < -1.0) {
+    vVel = (((vVel + (cMass * params.rule1Scale)) + (colVel * params.rule2Scale)) + (cVel * params.rule3Scale));
+    vVel = (metal::normalize(vVel) * metal::clamp(metal::length(vVel), 0.0, 0.1));
+    vPos = (vPos + (vVel * params.deltaT));
+    if ((vPos.x < -1.0)) {
         vPos.x = 1.0;
     }
-    if (vPos.x == 1.0) {
+    if ((vPos.x > 1.0)) {
         vPos.x = -1.0;
     }
-    if (vPos.y < -1.0) {
+    if ((vPos.y < -1.0)) {
         vPos.y = 1.0;
     }
-    if (vPos.y == 1.0) {
+    if ((vPos.y > 1.0)) {
         vPos.y = -1.0;
     }
-    particlesB.particles[gl_GlobalInvocationID.x].pos = vPos;
-    particlesB.particles[gl_GlobalInvocationID.x].vel = vVel;
+    particlesDst.particles[gl_GlobalInvocationID.x].pos = vPos;
+    particlesDst.particles[gl_GlobalInvocationID.x].vel = vVel;
+    return ;
 }
 

--- a/tests/snapshots/snapshots__boids.spvasm.snap
+++ b/tests/snapshots/snapshots__boids.spvasm.snap
@@ -5,539 +5,405 @@ expression: dis
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 418
+; Bound: 298
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Vertex %3 "main" %83 %23 %15 %6
-OpEntryPoint Fragment %88 "main" %90
-OpEntryPoint GLCompute %108 "main" %112
-OpExecutionMode %88 OriginUpperLeft
-OpExecutionMode %108 LocalSize 1 1 1
-OpDecorate %6 BuiltIn Position
-OpDecorate %15 Location 2
-OpDecorate %23 Location 1
-OpDecorate %83 Location 0
-OpDecorate %90 Location 0
-OpDecorate %112 BuiltIn GlobalInvocationId
-OpDecorate %127 BufferBlock
-OpMemberDecorate %127 0 Offset 0
-OpDecorate %128 ArrayStride 16
-OpDecorate %129 Block
-OpMemberDecorate %129 0 Offset 0
-OpMemberDecorate %129 1 Offset 8
-OpDecorate %126 DescriptorSet 0
-OpDecorate %126 Binding 1
-OpDecorate %235 Block
-OpMemberDecorate %235 0 Offset 0
-OpMemberDecorate %235 1 Offset 4
-OpMemberDecorate %235 2 Offset 8
-OpMemberDecorate %235 3 Offset 12
-OpMemberDecorate %235 4 Offset 16
-OpMemberDecorate %235 5 Offset 20
-OpMemberDecorate %235 6 Offset 24
-OpDecorate %234 DescriptorSet 0
-OpDecorate %234 Binding 0
-OpDecorate %394 DescriptorSet 0
-OpDecorate %394 Binding 2
-%2 = OpTypeVoid
-%4 = OpTypeFunction %2
-%8 = OpTypeFloat 32
-%7 = OpTypeVector %8 4
-%9 = OpTypePointer Output %7
-%6 = OpVariable  %9  Output
-%11 = OpTypeVector %8 2
-%16 = OpTypePointer Input %11
-%15 = OpVariable  %16  Input
-%17 = OpTypeInt 32 1
-%18 = OpConstant  %17  0
-%19 = OpTypePointer Input %8
-%23 = OpVariable  %16  Input
-%24 = OpConstant  %17  0
-%25 = OpTypePointer Input %8
-%28 = OpConstant  %17  1
-%29 = OpTypePointer Input %8
-%35 = OpConstant  %17  1
-%36 = OpTypePointer Input %8
-%40 = OpConstant  %17  0
-%41 = OpTypePointer Input %8
-%44 = OpConstant  %17  1
-%45 = OpTypePointer Input %8
-%52 = OpConstant  %17  0
-%53 = OpTypePointer Input %8
-%57 = OpConstant  %17  0
-%58 = OpTypePointer Input %8
-%61 = OpConstant  %17  1
-%62 = OpTypePointer Input %8
-%68 = OpConstant  %17  1
-%69 = OpTypePointer Input %8
-%73 = OpConstant  %17  0
-%74 = OpTypePointer Input %8
-%77 = OpConstant  %17  1
-%78 = OpTypePointer Input %8
-%83 = OpVariable  %16  Input
-%85 = OpConstant  %8  0.0
-%86 = OpConstant  %8  1.0
-%90 = OpVariable  %9  Output
-%93 = OpTypePointer Function %11
-%99 = OpConstant  %17  0
-%100 = OpTypePointer Function %17
-%106 = OpTypeInt 32 0
-%105 = OpConstant  %106  0
-%107 = OpTypePointer Function %106
-%113 = OpTypeVector %106 3
-%114 = OpTypePointer Input %113
-%112 = OpVariable  %114  Input
-%115 = OpConstant  %17  0
-%116 = OpTypePointer Input %106
-%118 = OpConstant  %106  5
-%119 = OpTypeBool
-%129 = OpTypeStruct %11 %11
-%128 = OpTypeArray %129 %118
-%127 = OpTypeStruct %128
-%130 = OpTypePointer Uniform %127
-%126 = OpVariable  %130  Uniform
-%131 = OpConstant  %17  0
-%132 = OpTypePointer Uniform %128
-%134 = OpConstant  %17  0
-%135 = OpTypePointer Input %106
-%137 = OpTypePointer Uniform %129
-%138 = OpConstant  %17  0
-%139 = OpTypePointer Uniform %11
-%144 = OpConstant  %17  0
-%145 = OpTypePointer Uniform %128
-%147 = OpConstant  %17  0
-%148 = OpTypePointer Input %106
-%150 = OpTypePointer Uniform %129
-%151 = OpConstant  %17  1
-%152 = OpTypePointer Uniform %11
-%169 = OpConstant  %17  0
-%170 = OpTypePointer Input %106
-%179 = OpConstant  %17  0
-%180 = OpTypePointer Uniform %128
-%182 = OpTypePointer Uniform %129
-%183 = OpConstant  %17  0
-%184 = OpTypePointer Uniform %11
-%185 = OpConstant  %17  0
-%186 = OpTypePointer Uniform %8
-%192 = OpConstant  %17  0
-%193 = OpTypePointer Uniform %128
-%195 = OpTypePointer Uniform %129
-%196 = OpConstant  %17  0
-%197 = OpTypePointer Uniform %11
-%198 = OpConstant  %17  1
-%199 = OpTypePointer Uniform %8
-%206 = OpConstant  %17  0
-%207 = OpTypePointer Uniform %128
-%209 = OpTypePointer Uniform %129
-%210 = OpConstant  %17  1
-%211 = OpTypePointer Uniform %11
-%212 = OpConstant  %17  0
-%213 = OpTypePointer Uniform %8
-%219 = OpConstant  %17  0
-%220 = OpTypePointer Uniform %128
-%222 = OpTypePointer Uniform %129
-%223 = OpConstant  %17  1
-%224 = OpTypePointer Uniform %11
-%225 = OpConstant  %17  1
-%226 = OpTypePointer Uniform %8
-%235 = OpTypeStruct %8 %8 %8 %8 %8 %8 %8
-%236 = OpTypePointer Uniform %235
-%234 = OpVariable  %236  Uniform
-%237 = OpConstant  %17  1
-%238 = OpTypePointer Uniform %8
-%248 = OpConstant  %17  1
-%254 = OpConstant  %17  2
-%255 = OpTypePointer Uniform %8
-%270 = OpConstant  %17  3
-%271 = OpTypePointer Uniform %8
-%283 = OpConstant  %106  1
-%292 = OpTypeVector %17 2
-%316 = OpConstant  %17  4
-%317 = OpTypePointer Uniform %8
-%322 = OpConstant  %17  5
-%323 = OpTypePointer Uniform %8
-%328 = OpConstant  %17  6
-%329 = OpTypePointer Uniform %8
-%336 = OpConstant  %8  0.1
-%343 = OpConstant  %17  0
-%344 = OpTypePointer Uniform %8
-%348 = OpConstant  %17  0
-%349 = OpTypePointer Function %8
-%351 = OpConstant  %8  -1.0
-%356 = OpConstant  %17  0
-%357 = OpTypePointer Function %8
-%360 = OpConstant  %17  0
-%361 = OpTypePointer Function %8
-%367 = OpConstant  %17  0
-%368 = OpTypePointer Function %8
-%371 = OpConstant  %17  1
-%372 = OpTypePointer Function %8
-%378 = OpConstant  %17  1
-%379 = OpTypePointer Function %8
-%382 = OpConstant  %17  1
-%383 = OpTypePointer Function %8
-%389 = OpConstant  %17  1
-%390 = OpTypePointer Function %8
-%394 = OpVariable  %130  Uniform
-%395 = OpConstant  %17  0
-%396 = OpTypePointer Uniform %128
-%398 = OpConstant  %17  0
-%399 = OpTypePointer Input %106
-%401 = OpTypePointer Uniform %129
-%402 = OpConstant  %17  0
-%403 = OpTypePointer Uniform %11
-%408 = OpConstant  %17  0
-%409 = OpTypePointer Uniform %128
-%411 = OpConstant  %17  0
-%412 = OpTypePointer Input %106
-%414 = OpTypePointer Uniform %129
-%415 = OpConstant  %17  1
-%416 = OpTypePointer Uniform %11
-%3 = OpFunction  %2  None %4
-%5 = OpLabel
-%14 = OpAccessChain  %19  %15 %18
-%20 = OpLoad  %8  %14
-%22 = OpAccessChain  %25  %23 %24
-%26 = OpLoad  %8  %22
-%27 = OpAccessChain  %29  %23 %28
-%30 = OpLoad  %8  %27
-%31 = OpExtInst  %8  %1 Atan2 %26 %30
-%21 = OpFNegate  %8  %31
-%32 = OpExtInst  %8  %1 Cos %21
-%13 = OpFMul  %8  %20 %32
-%34 = OpAccessChain  %36  %15 %35
-%37 = OpLoad  %8  %34
-%39 = OpAccessChain  %41  %23 %40
-%42 = OpLoad  %8  %39
-%43 = OpAccessChain  %45  %23 %44
-%46 = OpLoad  %8  %43
-%47 = OpExtInst  %8  %1 Atan2 %42 %46
-%38 = OpFNegate  %8  %47
-%48 = OpExtInst  %8  %1 Sin %38
-%33 = OpFMul  %8  %37 %48
-%12 = OpFSub  %8  %13 %33
-%51 = OpAccessChain  %53  %15 %52
-%54 = OpLoad  %8  %51
-%56 = OpAccessChain  %58  %23 %57
-%59 = OpLoad  %8  %56
-%60 = OpAccessChain  %62  %23 %61
-%63 = OpLoad  %8  %60
-%64 = OpExtInst  %8  %1 Atan2 %59 %63
-%55 = OpFNegate  %8  %64
-%65 = OpExtInst  %8  %1 Sin %55
-%50 = OpFMul  %8  %54 %65
-%67 = OpAccessChain  %69  %15 %68
-%70 = OpLoad  %8  %67
-%72 = OpAccessChain  %74  %23 %73
-%75 = OpLoad  %8  %72
-%76 = OpAccessChain  %78  %23 %77
-%79 = OpLoad  %8  %76
-%80 = OpExtInst  %8  %1 Atan2 %75 %79
-%71 = OpFNegate  %8  %80
-%81 = OpExtInst  %8  %1 Cos %71
-%66 = OpFMul  %8  %70 %81
-%49 = OpFAdd  %8  %50 %66
-%82 = OpCompositeConstruct  %11  %12 %49
-%84 = OpLoad  %11  %83
-%10 = OpFAdd  %11  %82 %84
-%87 = OpCompositeConstruct  %7  %10 %85 %86
-OpStore %6 %87
+OpEntryPoint GLCompute %22 "main" %27
+OpExecutionMode %22 LocalSize 64 1 1
+OpDecorate %27 BuiltIn GlobalInvocationId
+OpDecorate %42 BufferBlock
+OpMemberDecorate %42 0 Offset 0
+OpDecorate %43 ArrayStride 16
+OpDecorate %44 Block
+OpMemberDecorate %44 0 Offset 0
+OpMemberDecorate %44 1 Offset 8
+OpDecorate %41 DescriptorSet 0
+OpDecorate %41 Binding 1
+OpDecorate %117 Block
+OpMemberDecorate %117 0 Offset 0
+OpMemberDecorate %117 1 Offset 4
+OpMemberDecorate %117 2 Offset 8
+OpMemberDecorate %117 3 Offset 12
+OpMemberDecorate %117 4 Offset 16
+OpMemberDecorate %117 5 Offset 20
+OpMemberDecorate %117 6 Offset 24
+OpDecorate %116 DescriptorSet 0
+OpDecorate %116 Binding 0
+OpDecorate %274 DescriptorSet 0
+OpDecorate %274 Binding 2
+%4 = OpTypeFloat 32
+%3 = OpTypeVector %4 2
+%5 = OpTypePointer Function %3
+%12 = OpTypeInt 32 1
+%11 = OpConstant  %12  0
+%13 = OpTypePointer Function %12
+%19 = OpTypeInt 32 0
+%18 = OpConstant  %19  0
+%20 = OpTypePointer Function %19
+%21 = OpTypeVoid
+%23 = OpTypeFunction %21
+%28 = OpTypeVector %19 3
+%29 = OpTypePointer Input %28
+%27 = OpVariable  %29  Input
+%30 = OpConstant  %12  0
+%31 = OpTypePointer Input %19
+%33 = OpConstant  %12  1500
+%34 = OpTypeBool
+%44 = OpTypeStruct %3 %3
+%43 = OpTypeRuntimeArray %44
+%42 = OpTypeStruct %43
+%45 = OpTypePointer Uniform %42
+%41 = OpVariable  %45  Uniform
+%46 = OpConstant  %12  0
+%47 = OpTypePointer Uniform %43
+%49 = OpConstant  %12  0
+%50 = OpTypePointer Input %19
+%52 = OpTypePointer Uniform %44
+%53 = OpConstant  %12  0
+%54 = OpTypePointer Uniform %3
+%59 = OpConstant  %12  0
+%60 = OpTypePointer Uniform %43
+%62 = OpConstant  %12  0
+%63 = OpTypePointer Input %19
+%65 = OpTypePointer Uniform %44
+%66 = OpConstant  %12  1
+%67 = OpTypePointer Uniform %3
+%69 = OpConstant  %4  0.0
+%85 = OpConstant  %12  0
+%86 = OpTypePointer Input %19
+%94 = OpConstant  %12  0
+%95 = OpTypePointer Uniform %43
+%97 = OpTypePointer Uniform %44
+%98 = OpConstant  %12  0
+%99 = OpTypePointer Uniform %3
+%104 = OpConstant  %12  0
+%105 = OpTypePointer Uniform %43
+%107 = OpTypePointer Uniform %44
+%108 = OpConstant  %12  1
+%109 = OpTypePointer Uniform %3
+%117 = OpTypeStruct %4 %4 %4 %4 %4 %4 %4
+%118 = OpTypePointer Uniform %117
+%116 = OpVariable  %118  Uniform
+%119 = OpConstant  %12  1
+%120 = OpTypePointer Uniform %4
+%130 = OpConstant  %12  1
+%136 = OpConstant  %12  2
+%137 = OpTypePointer Uniform %4
+%152 = OpConstant  %12  3
+%153 = OpTypePointer Uniform %4
+%165 = OpConstant  %19  1
+%175 = OpConstant  %4  1.0
+%196 = OpConstant  %12  4
+%197 = OpTypePointer Uniform %4
+%202 = OpConstant  %12  5
+%203 = OpTypePointer Uniform %4
+%208 = OpConstant  %12  6
+%209 = OpTypePointer Uniform %4
+%216 = OpConstant  %4  0.1
+%223 = OpConstant  %12  0
+%224 = OpTypePointer Uniform %4
+%228 = OpConstant  %12  0
+%229 = OpTypePointer Function %4
+%231 = OpConstant  %4  -1.0
+%236 = OpConstant  %12  0
+%237 = OpTypePointer Function %4
+%240 = OpConstant  %12  0
+%241 = OpTypePointer Function %4
+%247 = OpConstant  %12  0
+%248 = OpTypePointer Function %4
+%251 = OpConstant  %12  1
+%252 = OpTypePointer Function %4
+%258 = OpConstant  %12  1
+%259 = OpTypePointer Function %4
+%262 = OpConstant  %12  1
+%263 = OpTypePointer Function %4
+%269 = OpConstant  %12  1
+%270 = OpTypePointer Function %4
+%274 = OpVariable  %45  Uniform
+%275 = OpConstant  %12  0
+%276 = OpTypePointer Uniform %43
+%278 = OpConstant  %12  0
+%279 = OpTypePointer Input %19
+%281 = OpTypePointer Uniform %44
+%282 = OpConstant  %12  0
+%283 = OpTypePointer Uniform %3
+%288 = OpConstant  %12  0
+%289 = OpTypePointer Uniform %43
+%291 = OpConstant  %12  0
+%292 = OpTypePointer Input %19
+%294 = OpTypePointer Uniform %44
+%295 = OpConstant  %12  1
+%296 = OpTypePointer Uniform %3
+%22 = OpFunction  %21  None %23
+%24 = OpLabel
+%17 = OpVariable  %20  Function %18
+%14 = OpVariable  %13  Function %11
+%8 = OpVariable  %5  Function
+%2 = OpVariable  %5  Function
+%15 = OpVariable  %5  Function
+%9 = OpVariable  %5  Function
+%6 = OpVariable  %5  Function
+%16 = OpVariable  %5  Function
+%10 = OpVariable  %13  Function %11
+%7 = OpVariable  %5  Function
+%26 = OpAccessChain  %31  %27 %30
+%32 = OpLoad  %19  %26
+%25 = OpUGreaterThanEqual  %34  %32 %33
+OpSelectionMerge %35 None
+OpBranchConditional %25 %36 %37
+%36 = OpLabel
 OpReturn
-OpFunctionEnd
-%88 = OpFunction  %2  None %4
+%37 = OpLabel
+OpBranch %35
+%35 = OpLabel
+%40 = OpAccessChain  %47  %41 %46
+%48 = OpAccessChain  %50  %27 %49
+%51 = OpLoad  %19  %48
+%39 = OpAccessChain  %52  %40 %51
+%38 = OpAccessChain  %54  %39 %53
+%55 = OpLoad  %3  %38
+OpStore %2 %55
+%58 = OpAccessChain  %60  %41 %59
+%61 = OpAccessChain  %63  %27 %62
+%64 = OpLoad  %19  %61
+%57 = OpAccessChain  %65  %58 %64
+%56 = OpAccessChain  %67  %57 %66
+%68 = OpLoad  %3  %56
+OpStore %6 %68
+%70 = OpCompositeConstruct  %3  %69 %69
+OpStore %7 %70
+%71 = OpCompositeConstruct  %3  %69 %69
+OpStore %8 %71
+%72 = OpCompositeConstruct  %3  %69 %69
+OpStore %9 %72
+OpBranch %73
+%73 = OpLabel
+OpLoopMerge %74 %76 None
+OpBranch %75
+%75 = OpLabel
+%78 = OpLoad  %19  %17
+%77 = OpUGreaterThanEqual  %34  %78 %33
+OpSelectionMerge %79 None
+OpBranchConditional %77 %80 %81
+%80 = OpLabel
+OpBranch %74
+%81 = OpLabel
+OpBranch %79
+%79 = OpLabel
+%83 = OpLoad  %19  %17
+%84 = OpAccessChain  %86  %27 %85
+%87 = OpLoad  %19  %84
+%82 = OpIEqual  %34  %83 %87
+OpSelectionMerge %88 None
+OpBranchConditional %82 %89 %90
 %89 = OpLabel
-%91 = OpCompositeConstruct  %7  %86 %86 %86 %86
-OpStore %90 %91
-OpReturn
-OpFunctionEnd
-%108 = OpFunction  %2  None %4
-%109 = OpLabel
-%104 = OpVariable  %107  Function %105
-%101 = OpVariable  %100  Function %99
-%96 = OpVariable  %93  Function
-%92 = OpVariable  %93  Function
-%102 = OpVariable  %93  Function
-%97 = OpVariable  %93  Function
-%94 = OpVariable  %93  Function
-%103 = OpVariable  %93  Function
-%98 = OpVariable  %100  Function %99
-%95 = OpVariable  %93  Function
-%111 = OpAccessChain  %116  %112 %115
-%117 = OpLoad  %106  %111
-%110 = OpUGreaterThanEqual  %119  %117 %118
-OpSelectionMerge %120 None
-OpBranchConditional %110 %121 %122
-%121 = OpLabel
-OpReturn
+OpBranch %76
+%90 = OpLabel
+OpBranch %88
+%88 = OpLabel
+%93 = OpAccessChain  %95  %41 %94
+%96 = OpLoad  %19  %17
+%92 = OpAccessChain  %97  %93 %96
+%91 = OpAccessChain  %99  %92 %98
+%100 = OpLoad  %3  %91
+OpStore %15 %100
+%103 = OpAccessChain  %105  %41 %104
+%106 = OpLoad  %19  %17
+%102 = OpAccessChain  %107  %103 %106
+%101 = OpAccessChain  %109  %102 %108
+%110 = OpLoad  %3  %101
+OpStore %16 %110
+%112 = OpLoad  %3  %15
+%113 = OpLoad  %3  %2
+%114 = OpExtInst  %4  %1 Distance %112 %113
+%115 = OpAccessChain  %120  %116 %119
+%121 = OpLoad  %4  %115
+%111 = OpFOrdLessThan  %34  %114 %121
+OpSelectionMerge %122 None
+OpBranchConditional %111 %123 %124
+%123 = OpLabel
+%126 = OpLoad  %3  %7
+%127 = OpLoad  %3  %15
+%125 = OpFAdd  %3  %126 %127
+OpStore %7 %125
+%129 = OpLoad  %12  %10
+%128 = OpIAdd  %12  %129 %130
+OpStore %10 %128
+OpBranch %122
+%124 = OpLabel
+OpBranch %122
 %122 = OpLabel
-OpBranch %120
-%120 = OpLabel
-%125 = OpAccessChain  %132  %126 %131
-%133 = OpAccessChain  %135  %112 %134
-%136 = OpLoad  %106  %133
-%124 = OpAccessChain  %137  %125 %136
-%123 = OpAccessChain  %139  %124 %138
-%140 = OpLoad  %11  %123
-OpStore %92 %140
-%143 = OpAccessChain  %145  %126 %144
-%146 = OpAccessChain  %148  %112 %147
-%149 = OpLoad  %106  %146
-%142 = OpAccessChain  %150  %143 %149
-%141 = OpAccessChain  %152  %142 %151
-%153 = OpLoad  %11  %141
-OpStore %94 %153
-%154 = OpCompositeConstruct  %11  %85 %85
-OpStore %95 %154
-%155 = OpCompositeConstruct  %11  %85 %85
-OpStore %96 %155
-%156 = OpCompositeConstruct  %11  %85 %85
-OpStore %97 %156
-OpBranch %157
+%132 = OpLoad  %3  %15
+%133 = OpLoad  %3  %2
+%134 = OpExtInst  %4  %1 Distance %132 %133
+%135 = OpAccessChain  %137  %116 %136
+%138 = OpLoad  %4  %135
+%131 = OpFOrdLessThan  %34  %134 %138
+OpSelectionMerge %139 None
+OpBranchConditional %131 %140 %141
+%140 = OpLabel
+%143 = OpLoad  %3  %9
+%145 = OpLoad  %3  %15
+%146 = OpLoad  %3  %2
+%144 = OpFSub  %3  %145 %146
+%142 = OpFSub  %3  %143 %144
+OpStore %9 %142
+OpBranch %139
+%141 = OpLabel
+OpBranch %139
+%139 = OpLabel
+%148 = OpLoad  %3  %15
+%149 = OpLoad  %3  %2
+%150 = OpExtInst  %4  %1 Distance %148 %149
+%151 = OpAccessChain  %153  %116 %152
+%154 = OpLoad  %4  %151
+%147 = OpFOrdLessThan  %34  %150 %154
+OpSelectionMerge %155 None
+OpBranchConditional %147 %156 %157
+%156 = OpLabel
+%159 = OpLoad  %3  %8
+%160 = OpLoad  %3  %16
+%158 = OpFAdd  %3  %159 %160
+OpStore %8 %158
+%162 = OpLoad  %12  %14
+%161 = OpIAdd  %12  %162 %130
+OpStore %14 %161
+OpBranch %155
 %157 = OpLabel
-OpLoopMerge %158 %160 None
-OpBranch %159
-%159 = OpLabel
-%162 = OpLoad  %106  %104
-%161 = OpUGreaterThanEqual  %119  %162 %118
-OpSelectionMerge %163 None
-OpBranchConditional %161 %164 %165
-%164 = OpLabel
-OpBranch %158
-%165 = OpLabel
-OpBranch %163
-%163 = OpLabel
-%167 = OpLoad  %106  %104
-%168 = OpAccessChain  %170  %112 %169
-%171 = OpLoad  %106  %168
-%166 = OpIEqual  %119  %167 %171
-OpSelectionMerge %172 None
-OpBranchConditional %166 %173 %174
-%173 = OpLabel
-OpBranch %160
-%174 = OpLabel
-OpBranch %172
-%172 = OpLabel
-%178 = OpAccessChain  %180  %126 %179
-%181 = OpLoad  %106  %104
-%177 = OpAccessChain  %182  %178 %181
-%176 = OpAccessChain  %184  %177 %183
-%175 = OpAccessChain  %186  %176 %185
-%187 = OpLoad  %8  %175
-%191 = OpAccessChain  %193  %126 %192
-%194 = OpLoad  %106  %104
-%190 = OpAccessChain  %195  %191 %194
-%189 = OpAccessChain  %197  %190 %196
-%188 = OpAccessChain  %199  %189 %198
-%200 = OpLoad  %8  %188
-%201 = OpCompositeConstruct  %11  %187 %200
-OpStore %102 %201
-%205 = OpAccessChain  %207  %126 %206
-%208 = OpLoad  %106  %104
-%204 = OpAccessChain  %209  %205 %208
-%203 = OpAccessChain  %211  %204 %210
-%202 = OpAccessChain  %213  %203 %212
-%214 = OpLoad  %8  %202
-%218 = OpAccessChain  %220  %126 %219
-%221 = OpLoad  %106  %104
-%217 = OpAccessChain  %222  %218 %221
-%216 = OpAccessChain  %224  %217 %223
-%215 = OpAccessChain  %226  %216 %225
-%227 = OpLoad  %8  %215
-%228 = OpCompositeConstruct  %11  %214 %227
-OpStore %103 %228
-%230 = OpLoad  %11  %102
-%231 = OpLoad  %11  %92
-%232 = OpExtInst  %8  %1 Distance %230 %231
-%233 = OpAccessChain  %238  %234 %237
-%239 = OpLoad  %8  %233
-%229 = OpFOrdLessThan  %119  %232 %239
-OpSelectionMerge %240 None
-OpBranchConditional %229 %241 %242
-%241 = OpLabel
-%244 = OpLoad  %11  %95
-%245 = OpLoad  %11  %102
-%243 = OpFAdd  %11  %244 %245
-OpStore %95 %243
-%247 = OpLoad  %17  %98
-%246 = OpIAdd  %17  %247 %248
-OpStore %98 %246
-OpBranch %240
-%242 = OpLabel
-OpBranch %240
-%240 = OpLabel
-%250 = OpLoad  %11  %102
-%251 = OpLoad  %11  %92
-%252 = OpExtInst  %8  %1 Distance %250 %251
-%253 = OpAccessChain  %255  %234 %254
-%256 = OpLoad  %8  %253
-%249 = OpFOrdLessThan  %119  %252 %256
-OpSelectionMerge %257 None
-OpBranchConditional %249 %258 %259
-%258 = OpLabel
-%261 = OpLoad  %11  %97
-%263 = OpLoad  %11  %102
-%264 = OpLoad  %11  %92
-%262 = OpFSub  %11  %263 %264
-%260 = OpFSub  %11  %261 %262
-OpStore %97 %260
-OpBranch %257
-%259 = OpLabel
-OpBranch %257
-%257 = OpLabel
-%266 = OpLoad  %11  %102
-%267 = OpLoad  %11  %92
-%268 = OpExtInst  %8  %1 Distance %266 %267
-%269 = OpAccessChain  %271  %234 %270
-%272 = OpLoad  %8  %269
-%265 = OpFOrdLessThan  %119  %268 %272
-OpSelectionMerge %273 None
-OpBranchConditional %265 %274 %275
-%274 = OpLabel
-%277 = OpLoad  %11  %96
-%278 = OpLoad  %11  %103
-%276 = OpFAdd  %11  %277 %278
-OpStore %96 %276
-%280 = OpLoad  %17  %101
-%279 = OpIAdd  %17  %280 %248
-OpStore %101 %279
-OpBranch %273
-%275 = OpLabel
-OpBranch %273
-%273 = OpLabel
-OpBranch %160
-%160 = OpLabel
-%282 = OpLoad  %106  %104
-%281 = OpIAdd  %106  %282 %283
-OpStore %104 %281
-OpBranch %157
-%158 = OpLabel
-%285 = OpLoad  %17  %98
-%284 = OpSGreaterThan  %119  %285 %99
-OpSelectionMerge %286 None
-OpBranchConditional %284 %287 %288
-%287 = OpLabel
-%291 = OpLoad  %11  %95
-%293 = OpLoad  %17  %98
-%294 = OpLoad  %17  %98
-%295 = OpCompositeConstruct  %292  %293 %294
-%296 = OpConvertSToF  %11  %295
-%290 = OpFDiv  %11  %291 %296
-%297 = OpLoad  %11  %92
-%289 = OpFAdd  %11  %290 %297
-OpStore %95 %289
-OpBranch %286
-%288 = OpLabel
-OpBranch %286
-%286 = OpLabel
-%299 = OpLoad  %17  %101
-%298 = OpSGreaterThan  %119  %299 %99
-OpSelectionMerge %300 None
-OpBranchConditional %298 %301 %302
-%301 = OpLabel
-%304 = OpLoad  %11  %96
-%305 = OpLoad  %17  %101
-%306 = OpLoad  %17  %101
-%307 = OpCompositeConstruct  %292  %305 %306
-%308 = OpConvertSToF  %11  %307
-%303 = OpFDiv  %11  %304 %308
-OpStore %96 %303
-OpBranch %300
-%302 = OpLabel
-OpBranch %300
-%300 = OpLabel
-%312 = OpLoad  %11  %94
-%314 = OpLoad  %11  %95
-%315 = OpAccessChain  %317  %234 %316
-%318 = OpLoad  %8  %315
-%313 = OpVectorTimesScalar  %11  %314 %318
-%311 = OpFAdd  %11  %312 %313
-%320 = OpLoad  %11  %97
-%321 = OpAccessChain  %323  %234 %322
-%324 = OpLoad  %8  %321
-%319 = OpVectorTimesScalar  %11  %320 %324
-%310 = OpFAdd  %11  %311 %319
-%326 = OpLoad  %11  %96
-%327 = OpAccessChain  %329  %234 %328
-%330 = OpLoad  %8  %327
-%325 = OpVectorTimesScalar  %11  %326 %330
-%309 = OpFAdd  %11  %310 %325
-OpStore %94 %309
-%332 = OpLoad  %11  %94
-%333 = OpExtInst  %11  %1 Normalize %332
-%334 = OpLoad  %11  %94
-%335 = OpExtInst  %8  %1 Length %334
-%337 = OpExtInst  %8  %1 FClamp %335 %85 %336
-%331 = OpVectorTimesScalar  %11  %333 %337
-OpStore %94 %331
-%339 = OpLoad  %11  %92
-%341 = OpLoad  %11  %94
-%342 = OpAccessChain  %344  %234 %343
-%345 = OpLoad  %8  %342
-%340 = OpVectorTimesScalar  %11  %341 %345
-%338 = OpFAdd  %11  %339 %340
-OpStore %92 %338
-%347 = OpAccessChain  %349  %92 %348
-%350 = OpLoad  %8  %347
-%346 = OpFOrdLessThan  %119  %350 %351
-OpSelectionMerge %352 None
-OpBranchConditional %346 %353 %354
-%353 = OpLabel
-%355 = OpAccessChain  %357  %92 %356
-OpStore %355 %86
-OpBranch %352
-%354 = OpLabel
-OpBranch %352
-%352 = OpLabel
-%359 = OpAccessChain  %361  %92 %360
-%362 = OpLoad  %8  %359
-%358 = OpFOrdGreaterThan  %119  %362 %86
-OpSelectionMerge %363 None
-OpBranchConditional %358 %364 %365
-%364 = OpLabel
-%366 = OpAccessChain  %368  %92 %367
-OpStore %366 %351
-OpBranch %363
-%365 = OpLabel
-OpBranch %363
-%363 = OpLabel
-%370 = OpAccessChain  %372  %92 %371
-%373 = OpLoad  %8  %370
-%369 = OpFOrdLessThan  %119  %373 %351
-OpSelectionMerge %374 None
-OpBranchConditional %369 %375 %376
-%375 = OpLabel
-%377 = OpAccessChain  %379  %92 %378
-OpStore %377 %86
-OpBranch %374
-%376 = OpLabel
-OpBranch %374
-%374 = OpLabel
-%381 = OpAccessChain  %383  %92 %382
-%384 = OpLoad  %8  %381
-%380 = OpFOrdGreaterThan  %119  %384 %86
-OpSelectionMerge %385 None
-OpBranchConditional %380 %386 %387
-%386 = OpLabel
-%388 = OpAccessChain  %390  %92 %389
-OpStore %388 %351
-OpBranch %385
-%387 = OpLabel
-OpBranch %385
-%385 = OpLabel
-%393 = OpAccessChain  %396  %394 %395
-%397 = OpAccessChain  %399  %112 %398
-%400 = OpLoad  %106  %397
-%392 = OpAccessChain  %401  %393 %400
-%391 = OpAccessChain  %403  %392 %402
-%404 = OpLoad  %11  %92
-OpStore %391 %404
-%407 = OpAccessChain  %409  %394 %408
-%410 = OpAccessChain  %412  %112 %411
-%413 = OpLoad  %106  %410
-%406 = OpAccessChain  %414  %407 %413
-%405 = OpAccessChain  %416  %406 %415
-%417 = OpLoad  %11  %94
-OpStore %405 %417
+OpBranch %155
+%155 = OpLabel
+OpBranch %76
+%76 = OpLabel
+%164 = OpLoad  %19  %17
+%163 = OpIAdd  %19  %164 %165
+OpStore %17 %163
+OpBranch %73
+%74 = OpLabel
+%167 = OpLoad  %12  %10
+%166 = OpSGreaterThan  %34  %167 %11
+OpSelectionMerge %168 None
+OpBranchConditional %166 %169 %170
+%169 = OpLabel
+%173 = OpLoad  %3  %7
+%176 = OpLoad  %12  %10
+%177 = OpConvertSToF  %4  %176
+%174 = OpFDiv  %4  %175 %177
+%172 = OpVectorTimesScalar  %3  %173 %174
+%178 = OpLoad  %3  %2
+%171 = OpFSub  %3  %172 %178
+OpStore %7 %171
+OpBranch %168
+%170 = OpLabel
+OpBranch %168
+%168 = OpLabel
+%180 = OpLoad  %12  %14
+%179 = OpSGreaterThan  %34  %180 %11
+OpSelectionMerge %181 None
+OpBranchConditional %179 %182 %183
+%182 = OpLabel
+%185 = OpLoad  %3  %8
+%187 = OpLoad  %12  %14
+%188 = OpConvertSToF  %4  %187
+%186 = OpFDiv  %4  %175 %188
+%184 = OpVectorTimesScalar  %3  %185 %186
+OpStore %8 %184
+OpBranch %181
+%183 = OpLabel
+OpBranch %181
+%181 = OpLabel
+%192 = OpLoad  %3  %6
+%194 = OpLoad  %3  %7
+%195 = OpAccessChain  %197  %116 %196
+%198 = OpLoad  %4  %195
+%193 = OpVectorTimesScalar  %3  %194 %198
+%191 = OpFAdd  %3  %192 %193
+%200 = OpLoad  %3  %9
+%201 = OpAccessChain  %203  %116 %202
+%204 = OpLoad  %4  %201
+%199 = OpVectorTimesScalar  %3  %200 %204
+%190 = OpFAdd  %3  %191 %199
+%206 = OpLoad  %3  %8
+%207 = OpAccessChain  %209  %116 %208
+%210 = OpLoad  %4  %207
+%205 = OpVectorTimesScalar  %3  %206 %210
+%189 = OpFAdd  %3  %190 %205
+OpStore %6 %189
+%212 = OpLoad  %3  %6
+%213 = OpExtInst  %3  %1 Normalize %212
+%214 = OpLoad  %3  %6
+%215 = OpExtInst  %4  %1 Length %214
+%217 = OpExtInst  %4  %1 FClamp %215 %69 %216
+%211 = OpVectorTimesScalar  %3  %213 %217
+OpStore %6 %211
+%219 = OpLoad  %3  %2
+%221 = OpLoad  %3  %6
+%222 = OpAccessChain  %224  %116 %223
+%225 = OpLoad  %4  %222
+%220 = OpVectorTimesScalar  %3  %221 %225
+%218 = OpFAdd  %3  %219 %220
+OpStore %2 %218
+%227 = OpAccessChain  %229  %2 %228
+%230 = OpLoad  %4  %227
+%226 = OpFOrdLessThan  %34  %230 %231
+OpSelectionMerge %232 None
+OpBranchConditional %226 %233 %234
+%233 = OpLabel
+%235 = OpAccessChain  %237  %2 %236
+OpStore %235 %175
+OpBranch %232
+%234 = OpLabel
+OpBranch %232
+%232 = OpLabel
+%239 = OpAccessChain  %241  %2 %240
+%242 = OpLoad  %4  %239
+%238 = OpFOrdGreaterThan  %34  %242 %175
+OpSelectionMerge %243 None
+OpBranchConditional %238 %244 %245
+%244 = OpLabel
+%246 = OpAccessChain  %248  %2 %247
+OpStore %246 %231
+OpBranch %243
+%245 = OpLabel
+OpBranch %243
+%243 = OpLabel
+%250 = OpAccessChain  %252  %2 %251
+%253 = OpLoad  %4  %250
+%249 = OpFOrdLessThan  %34  %253 %231
+OpSelectionMerge %254 None
+OpBranchConditional %249 %255 %256
+%255 = OpLabel
+%257 = OpAccessChain  %259  %2 %258
+OpStore %257 %175
+OpBranch %254
+%256 = OpLabel
+OpBranch %254
+%254 = OpLabel
+%261 = OpAccessChain  %263  %2 %262
+%264 = OpLoad  %4  %261
+%260 = OpFOrdGreaterThan  %34  %264 %175
+OpSelectionMerge %265 None
+OpBranchConditional %260 %266 %267
+%266 = OpLabel
+%268 = OpAccessChain  %270  %2 %269
+OpStore %268 %231
+OpBranch %265
+%267 = OpLabel
+OpBranch %265
+%265 = OpLabel
+%273 = OpAccessChain  %276  %274 %275
+%277 = OpAccessChain  %279  %27 %278
+%280 = OpLoad  %19  %277
+%272 = OpAccessChain  %281  %273 %280
+%271 = OpAccessChain  %283  %272 %282
+%284 = OpLoad  %3  %2
+OpStore %271 %284
+%287 = OpAccessChain  %289  %274 %288
+%290 = OpAccessChain  %292  %27 %291
+%293 = OpLoad  %19  %290
+%286 = OpAccessChain  %294  %287 %293
+%285 = OpAccessChain  %296  %286 %295
+%297 = OpLoad  %3  %6
+OpStore %285 %297
 OpReturn
 OpFunctionEnd

--- a/tests/snapshots/snapshots__collatz.msl.snap
+++ b/tests/snapshots/snapshots__collatz.msl.snap
@@ -22,15 +22,15 @@ type1 collatz_iterations(
     type1 i = 0;
     n = n_base;
     while(true) {
-        if (n <= 1) {
+        if ((n <= 1)) {
             break;
         }
-        if (n % 2 == 0) {
-            n = n / 2;
+        if (((n % 2) == 0)) {
+            n = (n / 2);
         } else {
-            n = 3 * n + 1;
+            n = ((3 * n) + 1);
         }
-        i = i + 1;
+        i = (i + 1);
     }
     return i;
 }
@@ -40,5 +40,6 @@ kernel void main1(
     device PrimeIndices& v_indices [[buffer(0)]]
 ) {
     v_indices.data[global_id.x] = collatz_iterations(v_indices.data[global_id.x]);
+    return ;
 }
 

--- a/tests/snapshots/snapshots__collatz.msl.snap
+++ b/tests/snapshots/snapshots__collatz.msl.snap
@@ -19,18 +19,18 @@ type1 collatz_iterations(
     type1 n_base
 ) {
     type1 n;
-    type1 i = 0;
+    type1 i = 0u;
     n = n_base;
     while(true) {
-        if ((n <= 1)) {
+        if ((n <= 1u)) {
             break;
         }
-        if (((n % 2) == 0)) {
-            n = (n / 2);
+        if (((n % 2u) == 0u)) {
+            n = (n / 2u);
         } else {
-            n = ((3 * n) + 1);
+            n = ((3u * n) + 1u);
         }
-        i = (i + 1);
+        i = (i + 1u);
     }
     return i;
 }

--- a/tests/snapshots/snapshots__empty.msl.snap
+++ b/tests/snapshots/snapshots__empty.msl.snap
@@ -7,5 +7,6 @@ expression: msl
 
 kernel void main1(
 ) {
+    return ;
 }
 

--- a/tests/snapshots/snapshots__quad.msl.snap
+++ b/tests/snapshots/snapshots__quad.msl.snap
@@ -32,7 +32,7 @@ vertex main1Output main1(
 ) {
     main1Output output;
     output.v_uv = input.a_uv;
-    output.o_position = metal::float4(1.2 * input.a_pos, 0.0, 1.0);
+    output.o_position = metal::float4((1.2 * input.a_pos), 0.0, 1.0);
     return output;
 }
 

--- a/tests/snapshots/snapshots__shadow.msl.snap
+++ b/tests/snapshots/snapshots__shadow.msl.snap
@@ -1,0 +1,87 @@
+---
+source: tests/snapshots.rs
+expression: msl
+---
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+typedef metal::uint4 type;
+
+struct Globals {
+    type num_lights;
+};
+
+typedef metal::float4x4 type1;
+
+typedef metal::float4 type2;
+
+struct Light {
+    type1 proj;
+    type2 pos;
+    type2 color;
+};
+
+typedef Light type3[1];
+
+struct Lights {
+    type3 data;
+};
+
+typedef metal::depth2d_array<float, metal::access::sample> type4;
+
+typedef metal::sampler type5;
+
+typedef uint type6;
+
+typedef float type7;
+
+typedef metal::float2 type8;
+
+typedef metal::int2 type9;
+
+typedef int type10;
+
+typedef metal::float3 type11;
+
+type7 fetch_shadow(
+    type6 light_id,
+    type2 homogeneous_coords
+) {
+    if ((homogeneous_coords.w <= 0.0)) {
+        return 1.0;
+    }
+    return t_shadow.sample_compare(sampler_shadow, (((metal::float2(homogeneous_coords.x, homogeneous_coords.y) * metal::float2(0.5, -0.5)) * (1.0 / homogeneous_coords.w)) + metal::float2(0.5, 0.5)), static_cast<int>(light_id), (homogeneous_coords.z * (1.0 / homogeneous_coords.w)));
+}
+
+struct fs_mainInput {
+    type11 in_normal_fs [[user(loc0)]];
+    type2 in_position_fs [[user(loc1)]];
+};
+
+struct fs_mainOutput {
+    type2 out_color_fs [[color(0)]];
+};
+
+fragment fs_mainOutput fs_main(
+    fs_mainInput input [[stage_in]],
+    constant Globals& u_globals [[buffer(0)]],
+    constant Lights& s_lights [[buffer(1)]]
+) {
+    fs_mainOutput output;
+    type11 color1 = type11(0.05, 0.05, 0.05);
+    type6 i = 0u;
+    bool loop_init = true;
+    while(true) {
+        if (!loop_init) {
+            i = (i + 1u);
+        }
+        loop_init = false;
+        if ((i >= metal::min(u_globals.num_lights.x, 10u))) {
+            break;
+        }
+        color1 = (color1 + ((fetch_shadow(i, (s_lights.data[i].proj * input.in_position_fs)) * metal::max(0.0, metal::dot(metal::normalize(input.in_normal_fs), metal::normalize((metal::float3(s_lights.data[i].pos.x, s_lights.data[i].pos.y, s_lights.data[i].pos.z) - metal::float3(input.in_position_fs.x, input.in_position_fs.y, input.in_position_fs.z)))))) * metal::float3(s_lights.data[i].color.x, s_lights.data[i].color.y, s_lights.data[i].color.z)));
+    }
+    output.out_color_fs = metal::float4(color1, 1.0);
+    return output;
+}
+

--- a/tests/snapshots/snapshots__shadow.spvasm.snap
+++ b/tests/snapshots/snapshots__shadow.spvasm.snap
@@ -1,0 +1,273 @@
+---
+source: tests/snapshots.rs
+expression: dis
+---
+; SPIR-V
+; Version: 1.0
+; Generator: rspirv
+; Bound: 220
+OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %60 "fs_main" %112 %109 %216
+OpExecutionMode %60 OriginUpperLeft
+OpDecorate %18 DescriptorSet 0
+OpDecorate %18 Binding 2
+OpDecorate %23 DescriptorSet 0
+OpDecorate %23 Binding 3
+OpDecorate %72 Block
+OpMemberDecorate %72 0 Offset 0
+OpDecorate %71 DescriptorSet 0
+OpDecorate %71 Binding 0
+OpDecorate %97 BufferBlock
+OpMemberDecorate %97 0 Offset 0
+OpDecorate %98 ArrayStride 96
+OpDecorate %99 Block
+OpMemberDecorate %99 0 Offset 0
+OpMemberDecorate %99 0 MatrixStride 16
+OpDecorate %100 ColMajor
+OpMemberDecorate %99 1 Offset 64
+OpMemberDecorate %99 2 Offset 80
+OpDecorate %96 DescriptorSet 0
+OpDecorate %96 Binding 1
+OpDecorate %109 Location 1
+OpDecorate %112 Location 0
+OpDecorate %216 Location 0
+%2 = OpTypeFloat 32
+%4 = OpTypeInt 32 0
+%6 = OpTypeVector %2 4
+%8 = OpTypeFunction %2 %4 %6
+%12 = OpConstant  %2  0.0
+%13 = OpTypeBool
+%17 = OpConstant  %2  1.0
+%19 = OpTypeImage %2 2D 1 1 0 1 Unknown
+%20 = OpTypePointer UniformConstant %19
+%18 = OpVariable  %20  UniformConstant
+%22 = OpTypeSampledImage %19
+%24 = OpTypeSampler
+%25 = OpTypePointer UniformConstant %24
+%23 = OpVariable  %25  UniformConstant
+%30 = OpTypeVector %2 2
+%34 = OpConstant  %2  0.5
+%35 = OpConstant  %2  -0.5
+%43 = OpTypeVector %2 3
+%51 = OpConstant  %2  0.0
+%54 = OpConstant  %2  0.05
+%53 = OpConstantComposite  %43  %54 %54 %54
+%55 = OpTypePointer Function %43
+%57 = OpConstant  %4  0
+%58 = OpTypePointer Function %4
+%59 = OpTypeVoid
+%61 = OpTypeFunction %59
+%73 = OpTypeVector %4 4
+%72 = OpTypeStruct %73
+%74 = OpTypePointer Uniform %72
+%71 = OpVariable  %74  Uniform
+%75 = OpTypeInt 32 1
+%76 = OpConstant  %75  0
+%77 = OpTypePointer Uniform %73
+%78 = OpConstant  %75  0
+%79 = OpTypePointer Uniform %4
+%81 = OpConstant  %4  10
+%100 = OpTypeMatrix %6 4
+%99 = OpTypeStruct %100 %6 %6
+%98 = OpTypeRuntimeArray %99
+%97 = OpTypeStruct %98
+%101 = OpTypePointer Uniform %97
+%96 = OpVariable  %101  Uniform
+%102 = OpConstant  %75  0
+%103 = OpTypePointer Uniform %98
+%105 = OpTypePointer Uniform %99
+%106 = OpConstant  %75  0
+%107 = OpTypePointer Uniform %100
+%110 = OpTypePointer Input %6
+%109 = OpVariable  %110  Input
+%113 = OpTypePointer Input %43
+%112 = OpVariable  %113  Input
+%121 = OpConstant  %75  0
+%122 = OpTypePointer Uniform %98
+%124 = OpTypePointer Uniform %99
+%125 = OpConstant  %75  1
+%126 = OpTypePointer Uniform %6
+%127 = OpConstant  %75  0
+%128 = OpTypePointer Uniform %2
+%134 = OpConstant  %75  0
+%135 = OpTypePointer Uniform %98
+%137 = OpTypePointer Uniform %99
+%138 = OpConstant  %75  1
+%139 = OpTypePointer Uniform %6
+%140 = OpConstant  %75  1
+%141 = OpTypePointer Uniform %2
+%147 = OpConstant  %75  0
+%148 = OpTypePointer Uniform %98
+%150 = OpTypePointer Uniform %99
+%151 = OpConstant  %75  1
+%152 = OpTypePointer Uniform %6
+%153 = OpConstant  %75  2
+%154 = OpTypePointer Uniform %2
+%158 = OpConstant  %75  0
+%159 = OpTypePointer Input %2
+%162 = OpConstant  %75  1
+%163 = OpTypePointer Input %2
+%166 = OpConstant  %75  2
+%167 = OpTypePointer Input %2
+%177 = OpConstant  %75  0
+%178 = OpTypePointer Uniform %98
+%180 = OpTypePointer Uniform %99
+%181 = OpConstant  %75  2
+%182 = OpTypePointer Uniform %6
+%183 = OpConstant  %75  0
+%184 = OpTypePointer Uniform %2
+%190 = OpConstant  %75  0
+%191 = OpTypePointer Uniform %98
+%193 = OpTypePointer Uniform %99
+%194 = OpConstant  %75  2
+%195 = OpTypePointer Uniform %6
+%196 = OpConstant  %75  1
+%197 = OpTypePointer Uniform %2
+%203 = OpConstant  %75  0
+%204 = OpTypePointer Uniform %98
+%206 = OpTypePointer Uniform %99
+%207 = OpConstant  %75  2
+%208 = OpTypePointer Uniform %6
+%209 = OpConstant  %75  2
+%210 = OpTypePointer Uniform %2
+%215 = OpConstant  %4  1
+%217 = OpTypePointer Output %6
+%216 = OpVariable  %217  Output
+%7 = OpFunction  %2  None %8
+%3 = OpFunctionParameter  %4
+%5 = OpFunctionParameter  %6
+%9 = OpLabel
+%11 = OpCompositeExtract  %2  %5 3
+%10 = OpFOrdLessThanEqual  %13  %11 %12
+OpSelectionMerge %14 None
+OpBranchConditional %10 %15 %16
+%15 = OpLabel
+OpReturnValue %17
+%16 = OpLabel
+OpBranch %14
+%14 = OpLabel
+%21 = OpLoad  %19  %18
+%26 = OpLoad  %24  %23
+%31 = OpCompositeExtract  %2  %5 0
+%32 = OpCompositeExtract  %2  %5 1
+%33 = OpCompositeConstruct  %30  %31 %32
+%36 = OpCompositeConstruct  %30  %34 %35
+%29 = OpFMul  %30  %33 %36
+%38 = OpCompositeExtract  %2  %5 3
+%37 = OpFDiv  %2  %17 %38
+%28 = OpVectorTimesScalar  %30  %29 %37
+%39 = OpCompositeConstruct  %30  %34 %34
+%27 = OpFAdd  %30  %28 %39
+%40 = OpCompositeExtract  %2  %27 0
+%41 = OpCompositeExtract  %2  %27 1
+%42 = OpConvertUToF  %2  %3
+%44 = OpCompositeConstruct  %43  %40 %41 %42
+%45 = OpSampledImage  %22  %21 %26
+%48 = OpCompositeExtract  %2  %5 2
+%50 = OpCompositeExtract  %2  %5 3
+%49 = OpFDiv  %2  %17 %50
+%47 = OpFMul  %2  %48 %49
+%46 = OpImageSampleDrefExplicitLod  %2  %45 %44 %47 Lod %51
+OpReturnValue %46
+OpFunctionEnd
+%60 = OpFunction  %59  None %61
+%62 = OpLabel
+%52 = OpVariable  %55  Function %53
+%56 = OpVariable  %58  Function %57
+OpBranch %63
+%63 = OpLabel
+OpLoopMerge %64 %66 None
+OpBranch %65
+%65 = OpLabel
+%68 = OpLoad  %4  %56
+%70 = OpAccessChain  %77  %71 %76
+%69 = OpAccessChain  %79  %70 %78
+%80 = OpLoad  %4  %69
+%82 = OpExtInst  %4  %1 UMin %80 %81
+%67 = OpUGreaterThanEqual  %13  %68 %82
+OpSelectionMerge %83 None
+OpBranchConditional %67 %84 %85
+%84 = OpLabel
+OpBranch %64
+%85 = OpLabel
+OpBranch %83
+%83 = OpLabel
+%87 = OpLoad  %43  %52
+%91 = OpLoad  %4  %56
+%95 = OpAccessChain  %103  %96 %102
+%104 = OpLoad  %4  %56
+%94 = OpAccessChain  %105  %95 %104
+%93 = OpAccessChain  %107  %94 %106
+%108 = OpLoad  %100  %93
+%111 = OpLoad  %6  %109
+%92 = OpMatrixTimesVector  %6  %108 %111
+%90 = OpFunctionCall  %2  %7 %91 %92
+%114 = OpLoad  %43  %112
+%115 = OpExtInst  %43  %1 Normalize %114
+%120 = OpAccessChain  %122  %96 %121
+%123 = OpLoad  %4  %56
+%119 = OpAccessChain  %124  %120 %123
+%118 = OpAccessChain  %126  %119 %125
+%117 = OpAccessChain  %128  %118 %127
+%129 = OpLoad  %2  %117
+%133 = OpAccessChain  %135  %96 %134
+%136 = OpLoad  %4  %56
+%132 = OpAccessChain  %137  %133 %136
+%131 = OpAccessChain  %139  %132 %138
+%130 = OpAccessChain  %141  %131 %140
+%142 = OpLoad  %2  %130
+%146 = OpAccessChain  %148  %96 %147
+%149 = OpLoad  %4  %56
+%145 = OpAccessChain  %150  %146 %149
+%144 = OpAccessChain  %152  %145 %151
+%143 = OpAccessChain  %154  %144 %153
+%155 = OpLoad  %2  %143
+%156 = OpCompositeConstruct  %43  %129 %142 %155
+%157 = OpAccessChain  %159  %109 %158
+%160 = OpLoad  %2  %157
+%161 = OpAccessChain  %163  %109 %162
+%164 = OpLoad  %2  %161
+%165 = OpAccessChain  %167  %109 %166
+%168 = OpLoad  %2  %165
+%169 = OpCompositeConstruct  %43  %160 %164 %168
+%116 = OpFSub  %43  %156 %169
+%170 = OpExtInst  %43  %1 Normalize %116
+%171 = OpDot  %2  %115 %170
+%172 = OpExtInst  %2  %1 FMax %12 %171
+%89 = OpFMul  %2  %90 %172
+%176 = OpAccessChain  %178  %96 %177
+%179 = OpLoad  %4  %56
+%175 = OpAccessChain  %180  %176 %179
+%174 = OpAccessChain  %182  %175 %181
+%173 = OpAccessChain  %184  %174 %183
+%185 = OpLoad  %2  %173
+%189 = OpAccessChain  %191  %96 %190
+%192 = OpLoad  %4  %56
+%188 = OpAccessChain  %193  %189 %192
+%187 = OpAccessChain  %195  %188 %194
+%186 = OpAccessChain  %197  %187 %196
+%198 = OpLoad  %2  %186
+%202 = OpAccessChain  %204  %96 %203
+%205 = OpLoad  %4  %56
+%201 = OpAccessChain  %206  %202 %205
+%200 = OpAccessChain  %208  %201 %207
+%199 = OpAccessChain  %210  %200 %209
+%211 = OpLoad  %2  %199
+%212 = OpCompositeConstruct  %43  %185 %198 %211
+%88 = OpVectorTimesScalar  %43  %212 %89
+%86 = OpFAdd  %43  %87 %88
+OpStore %52 %86
+OpBranch %66
+%66 = OpLabel
+%214 = OpLoad  %4  %56
+%213 = OpIAdd  %4  %214 %215
+OpStore %56 %213
+OpBranch %63
+%64 = OpLabel
+%218 = OpLoad  %43  %52
+%219 = OpCompositeConstruct  %6  %218 %17
+OpStore %216 %219
+OpReturn
+OpFunctionEnd

--- a/tests/snapshots/snapshots__skybox.msl.snap
+++ b/tests/snapshots/snapshots__skybox.msl.snap
@@ -47,11 +47,11 @@ vertex vs_mainOutput vs_main(
     type4 tmp1_;
     type4 tmp2_;
     type unprojected;
-    tmp1_ = static_cast<int>(in_vertex_index) / 2;
-    tmp2_ = static_cast<int>(in_vertex_index) & 1;
-    unprojected = r_data.proj_inv * metal::float4(static_cast<float>(tmp1_) * 4.0 - 1.0, static_cast<float>(tmp2_) * 4.0 - 1.0, 0.0, 1.0);
-    output.out_uv = metal::transpose(metal::float3x3(metal::float3(r_data.view[0].x, r_data.view[0].y, r_data.view[0].z), metal::float3(r_data.view[1].x, r_data.view[1].y, r_data.view[1].z), metal::float3(r_data.view[2].x, r_data.view[2].y, r_data.view[2].z))) * metal::float3(unprojected.x, unprojected.y, unprojected.z);
-    output.out_position = metal::float4(static_cast<float>(tmp1_) * 4.0 - 1.0, static_cast<float>(tmp2_) * 4.0 - 1.0, 0.0, 1.0);
+    tmp1_ = (static_cast<int>(in_vertex_index) / 2);
+    tmp2_ = (static_cast<int>(in_vertex_index) & 1);
+    unprojected = (r_data.proj_inv * metal::float4(((static_cast<float>(tmp1_) * 4.0) - 1.0), ((static_cast<float>(tmp2_) * 4.0) - 1.0), 0.0, 1.0));
+    output.out_uv = (metal::transpose(metal::float3x3(metal::float3(r_data.view[0].x, r_data.view[0].y, r_data.view[0].z), metal::float3(r_data.view[1].x, r_data.view[1].y, r_data.view[1].z), metal::float3(r_data.view[2].x, r_data.view[2].y, r_data.view[2].z))) * metal::float3(unprojected.x, unprojected.y, unprojected.z));
+    output.out_position = metal::float4(((static_cast<float>(tmp1_) * 4.0) - 1.0), ((static_cast<float>(tmp2_) * 4.0) - 1.0), 0.0, 1.0);
     return output;
 }
 


### PR DESCRIPTION
MSL:
  - actually implements `continuing` loop statement. Refactors the Namer API to aid that, and reuses the allocation within the writer.
  - fixes scoping of binary expressions
  - fixes unsigned constants
  - fixes ">" operation
  - fixes `sample_compare` calls to avoid `level(0)` option
  - fixes `return` without a value in the middle of functions

In the end, it allows wgpu-rs to run the `boids` example with pure Naga translation, not involving SPIR-V on Metal 🎉 
Unfortunately, the `shadow` example got blocked on #390. It seems good otherwise.

For testing, the `boids.wgsl` is updated, now only contains the compute part. The `shadow.wgsl` is added, it demonstrates quite a few difficulties:
  - depth sampling
  - using a resource only within a helper function (not supported by our `Interface` processor yet!)
  - "fat" constant, which we really need to process differently. Currently the value is repeated all over the place.