### PR TITLE
[glsl-in] Fix double constant lexing and lex uint constants

### DIFF
--- a/src/front/glsl/lex.rs
+++ b/src/front/glsl/lex.rs
@@ -93,21 +93,24 @@ impl<'a> Lexer<'a> {
                 }
             }
             '0'..='9' => {
-                let (number, _, pos) =
+                let (number, remainder, pos) =
                     consume_any(input, |c| (('0'..='9').contains(&c) || c == '.'));
+                let mut remainder_chars = remainder.chars();
+                let first = remainder_chars.next().and_then(|c| c.to_lowercase().next());
+
                 if number.find('.').is_some() {
-                    if (
-                        chars.next().map(|c| c.to_lowercase().next().unwrap()),
-                        chars.next().map(|c| c.to_lowercase().next().unwrap()),
-                    ) == (Some('l'), Some('f'))
-                    {
+                    let second = remainder_chars.next().and_then(|c| c.to_lowercase().next());
+
+                    if (first, second) == (Some('l'), Some('f')) {
                         meta.chars.end = start + pos + 2;
                         Some(Token::DoubleConstant((meta, number.parse().unwrap())))
                     } else {
                         meta.chars.end = start + pos;
-
                         Some(Token::FloatConstant((meta, number.parse().unwrap())))
                     }
+                } else if first == Some('u') {
+                    meta.chars.end = start + pos + 1;
+                    Some(Token::UintConstant((meta, number.parse().unwrap())))
                 } else {
                     meta.chars.end = start + pos;
                     Some(Token::IntConstant((meta, number.parse().unwrap())))

--- a/src/front/glsl/lex_tests.rs
+++ b/src/front/glsl/lex_tests.rs
@@ -343,4 +343,92 @@ fn tokens() {
         })
     );
     assert_eq!(lex.next(), None);
+
+    // float constants
+    let mut lex = Lexer::new("120.0 130.0lf 140.0Lf 150.0LF");
+    assert_eq!(
+        lex.next().unwrap(),
+        FloatConstant((
+            TokenMetadata {
+                line: 0,
+                chars: 0..5
+            },
+            120.0,
+        ))
+    );
+    assert_eq!(
+        lex.next().unwrap(),
+        DoubleConstant((
+            TokenMetadata {
+                line: 0,
+                chars: 6..13
+            },
+            130.0,
+        ))
+    );
+    assert_eq!(
+        lex.next().unwrap(),
+        DoubleConstant((
+            TokenMetadata {
+                line: 0,
+                chars: 14..21
+            },
+            140.0,
+        ))
+    );
+    assert_eq!(
+        lex.next().unwrap(),
+        DoubleConstant((
+            TokenMetadata {
+                line: 0,
+                chars: 22..29
+            },
+            150.0,
+        ))
+    );
+    assert_eq!(lex.next(), None);
+
+    // Integer constants
+    let mut lex = Lexer::new("120 130u 140U 150");
+    assert_eq!(
+        lex.next().unwrap(),
+        IntConstant((
+            TokenMetadata {
+                line: 0,
+                chars: 0..3
+            },
+            120,
+        ))
+    );
+    assert_eq!(
+        lex.next().unwrap(),
+        UintConstant((
+            TokenMetadata {
+                line: 0,
+                chars: 4..8
+            },
+            130,
+        ))
+    );
+    assert_eq!(
+        lex.next().unwrap(),
+        UintConstant((
+            TokenMetadata {
+                line: 0,
+                chars: 9..13
+            },
+            140,
+        ))
+    );
+    assert_eq!(
+        lex.next().unwrap(),
+        IntConstant((
+            TokenMetadata {
+                line: 0,
+                chars: 14..17
+            },
+            150,
+        ))
+    );
+    assert_eq!(lex.next(), None);
 }

--- a/src/front/glsl/lex_tests.rs
+++ b/src/front/glsl/lex_tests.rs
@@ -389,7 +389,7 @@ fn tokens() {
     assert_eq!(lex.next(), None);
 
     // Integer constants
-    let mut lex = Lexer::new("120 130u 140U 150");
+    let mut lex = Lexer::new("120 130u 140U 150 0x1f 0xf2U 0xF1u");
     assert_eq!(
         lex.next().unwrap(),
         IntConstant((
@@ -428,6 +428,36 @@ fn tokens() {
                 chars: 14..17
             },
             150,
+        ))
+    );
+    assert_eq!(
+        lex.next().unwrap(),
+        IntConstant((
+            TokenMetadata {
+                line: 0,
+                chars: 18..22
+            },
+            31,
+        ))
+    );
+    assert_eq!(
+        lex.next().unwrap(),
+        UintConstant((
+            TokenMetadata {
+                line: 0,
+                chars: 23..28
+            },
+            242,
+        ))
+    );
+    assert_eq!(
+        lex.next().unwrap(),
+        UintConstant((
+            TokenMetadata {
+                line: 0,
+                chars: 29..34
+            },
+            241,
         ))
     );
     assert_eq!(lex.next(), None);

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -180,7 +180,19 @@ pomelo! {
             extra.context.expressions.append(Expression::Constant(ch))
         )
     }
-    // primary_expression ::= UintConstant;
+    primary_expression ::= UintConstant(i) {
+        let ch = extra.module.constants.fetch_or_append(Constant {
+            name: None,
+            specialization: None,
+            inner: ConstantInner::Scalar {
+                width: 4,
+                value: ScalarValue::Uint(i.1),
+            },
+        });
+        ExpressionRule::from_expression(
+            extra.context.expressions.append(Expression::Constant(ch))
+        )
+    }
     primary_expression ::= FloatConstant(f) {
         let ch = extra.module.constants.fetch_or_append(Constant {
             name: None,
@@ -207,7 +219,19 @@ pomelo! {
             extra.context.expressions.append(Expression::Constant(ch))
         )
     }
-    // primary_expression ::= DoubleConstant;
+    primary_expression ::= DoubleConstant(f) {
+        let ch = extra.module.constants.fetch_or_append(Constant {
+            name: None,
+            specialization: None,
+            inner: ConstantInner::Scalar {
+                width: 8,
+                value: ScalarValue::Float(f.1),
+            },
+        });
+        ExpressionRule::from_expression(
+            extra.context.expressions.append(Expression::Constant(ch))
+        )
+    }
     primary_expression ::= LeftParen expression(e) RightParen {
         e
     }


### PR DESCRIPTION
Fixes double constants (ending with "lf") being treated as floats and added support for uint constants (ending with "u")