### PR TITLE
[glsl-in] Populate ResolveContext with functions and add more math functions

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -58,12 +58,11 @@ impl Program {
         &mut self,
         handle: Handle<crate::Expression>,
     ) -> Result<&crate::TypeInner, ErrorKind> {
-        let functions = Arena::new(); //TODO
         let resolve_ctx = ResolveContext {
             constants: &self.module.constants,
             global_vars: &self.module.global_variables,
             local_vars: &self.context.local_variables,
-            functions: &functions,
+            functions: &self.module.functions,
             arguments: &self.context.arguments,
         };
         match self.context.typifier.grow(

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -81,7 +81,7 @@ impl Program {
                             Err(ErrorKind::SemanticError("Bad call to texture".into()))
                         }
                     }
-                    "ceil" | "round" | "floor" | "fract" | "trunc" => {
+                    "ceil" | "round" | "floor" | "fract" | "trunc" | "sin" | "abs" => {
                         if fc.args.len() != 1 {
                             return Err(ErrorKind::WrongNumberArgs(name, 1, fc.args.len()));
                         }
@@ -93,10 +93,30 @@ impl Program {
                                     "floor" => MathFunction::Floor,
                                     "fract" => MathFunction::Fract,
                                     "trunc" => MathFunction::Trunc,
+                                    "sin" => MathFunction::Sin,
+                                    "abs" => MathFunction::Abs,
                                     _ => unreachable!(),
                                 },
                                 arg: fc.args[0].expression,
                                 arg1: None,
+                                arg2: None,
+                            }),
+                            sampler: None,
+                            statements: fc.args.into_iter().flat_map(|a| a.statements).collect(),
+                        })
+                    }
+                    "mix" => {
+                        if fc.args.len() != 3 {
+                            return Err(ErrorKind::WrongNumberArgs(name, 3, fc.args.len()));
+                        }
+                        Ok(ExpressionRule {
+                            expression: self.context.expressions.append(Expression::Math {
+                                fun: match name.as_str() {
+                                    "mix" => MathFunction::Mix,
+                                    _ => unreachable!(),
+                                },
+                                arg: fc.args[0].expression,
+                                arg1: Some(fc.args[1].expression),
                                 arg2: None,
                             }),
                             sampler: None,


### PR DESCRIPTION
Populates the `ResolveContext` with the module functions, otherwise the `Typifier` would panic.

Adds support for `sin`, `abs` and `mix`