### PR TITLE
[spv] put NonWritable on buffer variable itself

### DIFF
--- a/tests/snapshots/snapshots__boids.spvasm.snap
+++ b/tests/snapshots/snapshots__boids.spvasm.snap
@@ -17,6 +17,7 @@ OpMemberDecorate %45 1 Offset 8
 OpDecorate %47 ArrayStride 16
 OpDecorate %49 BufferBlock
 OpMemberDecorate %49 0 Offset 0
+OpDecorate %50 NonWritable
 OpDecorate %50 DescriptorSet 0
 OpDecorate %50 Binding 1
 OpDecorate %121 Block

--- a/tests/snapshots/snapshots__shadow.spvasm.snap
+++ b/tests/snapshots/snapshots__shadow.spvasm.snap
@@ -27,7 +27,7 @@ OpMemberDecorate %97 2 Offset 80
 OpDecorate %99 ArrayStride 96
 OpDecorate %101 BufferBlock
 OpMemberDecorate %101 0 Offset 0
-OpMemberDecorate %101 0 NonWritable
+OpDecorate %102 NonWritable
 OpDecorate %102 DescriptorSet 0
 OpDecorate %102 Binding 1
 OpDecorate %111 Location 1


### PR DESCRIPTION
This reduces our headache for re-using the same structure types between read-write and read-only storage buffers.
See also - https://github.com/KhronosGroup/glslang/issues/1317#issuecomment-771226026