### PR TITLE
Makefile commands for native shader validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
-.PHONY: all clean
+.PHONY: all clean validate-spv validate-msl
 .SECONDARY: boids.metal quad.metal
+SNAPSHOTS=tests/snapshots
 
 all:
 
 clean:
-	rm *.metal *.air *.metallib *.vert *.frag *.comp
+	rm *.metal *.air *.metallib *.vert *.frag *.comp *.spv
 
-%.metal: tests/snapshots/in/%.wgsl $(wildcard src/*.rs src/**/*.rs examples/*.rs)
+%.metal: $(SNAPSHOTS)/in/%.wgsl $(wildcard src/*.rs src/**/*.rs examples/*.rs)
 	cargo run --example convert --features wgsl-in,msl-out -- $< $@
 
 %.air: %.metal
@@ -22,3 +23,29 @@ clean:
 %.vert %.frag %.comp: test-data/%.wgsl $(wildcard src/*.rs src/**/*.rs examples/*.rs)
 	cargo run --example convert --features wgsl-in,glsl-out -- $< $@
 	glslangValidator $@
+
+validate-spv: $(SNAPSHOTS)/*.spvasm.snap
+	@for file in $^ ; do \
+		echo "Validating" $${file#"$(SNAPSHOTS)/snapshots__"};	\
+		tail -n +5 $${file} | spirv-as --target-env vulkan1.0 -o - | spirv-val; \
+	done
+
+validate-msl: $(SNAPSHOTS)/*.msl.snap
+	@for file in $^ ; do \
+		echo "Validating" $${file#"$(SNAPSHOTS)/snapshots__"};	\
+		tail -n +5 $${file} | xcrun -sdk macosx metal -mmacosx-version-min=10.11 -x metal - -o /dev/null; \
+	done
+
+validate-glsl: $(SNAPSHOTS)/*.glsl.snap
+	@for file in $(SNAPSHOTS)/*-Vertex.glsl.snap ; do \
+		echo "Validating" $${file#"$(SNAPSHOTS)/snapshots__"};\
+		tail -n +5 $${file} | glslangValidator --stdin -S vert; \
+	done
+	@for file in $(SNAPSHOTS)/*-Fragment.glsl.snap ; do \
+		echo "Validating" $${file#"$(SNAPSHOTS)/snapshots__"};\
+		tail -n +5 $${file} | glslangValidator --stdin -S frag; \
+	done
+	@for file in $(SNAPSHOTS)/*-Compute.glsl.snap ; do \
+		echo "Validating" $${file#"$(SNAPSHOTS)/snapshots__"};\
+		tail -n +5 $${file} | glslangValidator --stdin -S comp; \
+	done

--- a/README.md
+++ b/README.md
@@ -30,3 +30,25 @@ DXIL/DXIR       |                    |       |
 DXBC            |                    |       |
 
 :white_check_mark: = Primary support — :ok: = Secondary support — :construction: = Unsupported, but support in progress
+
+## Development workflow
+
+The main instrument aiding the development is the good old `cargo test --all-features`,
+which will run the snapshot tests as well as the unit tests.
+Any changes in the snapshots would then have to be reviewed with `cargo insta review`
+before being accepted into the code.
+
+If working on a particular front-end or back-end, it may be convenient to
+enable the relevant features in `Cargo.toml`, e.g.
+```toml
+default = ["spv-out"] #TEMP!
+```
+This allows IDE basic checks to report errors there, unless your IDE is sufficiently configurable already.
+
+Finally, when changes to the snapshots are made, we should verify that the produced shaders
+are indeed valid for the target platforms they are compiled for. We automate this with `Makefile`:
+```bash
+make validate-spv # for Vulkan shaders, requires SPIRV-Tools installed
+make validate-msl # for Metal shaders, requires XCode command-line tools installed
+make validate-glsl # for OpenGL shaders, requires GLSLang installed
+```

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -455,11 +455,7 @@ impl<'a, W: Write> Writer<'a, W> {
 
                     // Finally write the name and end the global with a `;`
                     // The leading space is important
-                    writeln!(
-                        self.out,
-                        " {};",
-                        self.names[&NameKey::GlobalVariable(handle)]
-                    )?;
+                    writeln!(self.out, " {};", self.get_global_name(handle, global))?;
 
                     writeln!(self.out)?;
                 }

--- a/tests/snapshots/snapshots__quad-Fragment.glsl.snap
+++ b/tests/snapshots/snapshots__quad-Fragment.glsl.snap
@@ -8,7 +8,7 @@ precision highp float;
 
 in vec2 _location_0_vs;
 
-uniform sampler2D u_texture;
+uniform sampler2D _group_0_binding_0;
 
 out vec4 _location_0;
 

--- a/tests/snapshots/snapshots__skybox-Fragment.glsl.snap
+++ b/tests/snapshots/snapshots__skybox-Fragment.glsl.snap
@@ -11,7 +11,7 @@ struct Data {
     mat4x4 view;
 };
 
-uniform samplerCube r_texture;
+uniform samplerCube _group_0_binding_1;
 
 in vec3 _location_0_vs;
 


### PR DESCRIPTION
This is something I wanted to do for a long time, and I think snapshots make it fairly easy to roll in.

The problem we had is that we generate the snapshot shaders, but it's tedious to double-check with the actual native SDK if those updated snapshots are valid at all. I.e. we could have a snapshot in-tree that is simply invalid, which compromises the whole idea of keeping it around. In fact, that's the case today for a few shaders.

So technically we have the native shaders produced, and we have the tools, but remembering all the tool syntax and editing the snapshot shaders to strip the header, makes it very hard to force this into a habit. Just takes too much effort!
Lo and behold - the automation:
```bash
make validate-spv # for Vulkan shaders, requires SPIRV-Tools installed
make validate-msl # for Metal shaders, requires XCode command-line tools installed
make validate-glsl # for OpenGL shaders, requires GLSLang installed
```

It's very straightforward to just call these. They are separate because they require different SDK/platforms. The developer is expected to call the ones applicable to their platforms.

I think the follow-up here should be the relevant Github Action tasks that react on the changes in those files, that install the SDKs and run these makefile commands on CI, automatically.

Interestingly, I instantly discovered 2 issues with our snapshotted shaders:
  1. the GLSL output for global images was broken. I fixed this in the PR.
  2. the SPIR-V output for calling nested functions was not gathering the I/O properly. It's #390, and I haven't fixed this yet. I don't think it should be blocking the PR.