### PR TITLE
[glsl-in] Fix the way equality is handled

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1456,7 +1456,9 @@ impl<'a, W: Write> Writer<'a, W> {
 
                 write!(self.out, ")")?
             }
-            // `Binary` we just write `left op right`
+            // `Binary` we just write `left op right`, except when dealing with
+            // comparison operations on vectors as they are implemented with
+            // builtin functions.
             // Once again we wrap everything in parantheses to avoid precedence issues
             Expression::Binary { op, left, right } => {
                 // Holds `Some(function_name)` if the binary operation is
@@ -1470,6 +1472,8 @@ impl<'a, W: Write> Writer<'a, W> {
                         BinaryOperator::LessEqual => Some("lessThanEqual"),
                         BinaryOperator::Greater => Some("greaterThan"),
                         BinaryOperator::GreaterEqual => Some("greaterThanEqual"),
+                        BinaryOperator::Equal => Some("equal"),
+                        BinaryOperator::NotEqual => Some("notEqual"),
                         _ => None,
                     }
                 } else {

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -146,7 +146,8 @@ impl Program {
                             statements: fc.args.into_iter().flat_map(|a| a.statements).collect(),
                         })
                     }
-                    "lessThan" | "greaterThan" => {
+                    "lessThan" | "greaterThan" | "lessThanEqual" | "greaterThanEqual" | "equal"
+                    | "notEqual" => {
                         if fc.args.len() != 2 {
                             return Err(ErrorKind::WrongNumberArgs(name, 2, fc.args.len()));
                         }
@@ -155,6 +156,10 @@ impl Program {
                                 op: match name.as_str() {
                                     "lessThan" => BinaryOperator::Less,
                                     "greaterThan" => BinaryOperator::Greater,
+                                    "lessThanEqual" => BinaryOperator::LessEqual,
+                                    "greaterThanEqual" => BinaryOperator::GreaterEqual,
+                                    "equal" => BinaryOperator::Equal,
+                                    "notEqual" => BinaryOperator::NotEqual,
                                     _ => unreachable!(),
                                 },
                                 left: fc.args[0].expression,

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -367,10 +367,10 @@ pomelo! {
     }
     equality_expression ::= relational_expression;
     equality_expression ::= equality_expression(left) EqOp relational_expression(right) {
-        extra.binary_expr(BinaryOperator::Equal, &left, &right)
+        extra.equality_expr(true, &left, &right)?
     }
     equality_expression ::= equality_expression(left) NeOp relational_expression(right) {
-        extra.binary_expr(BinaryOperator::NotEqual, &left, &right)
+        extra.equality_expr(false, &left, &right)?
     }
     and_expression ::= equality_expression;
     and_expression ::= and_expression(left) Ampersand equality_expression(right) {


### PR DESCRIPTION
Vector equality in glsl is now handled as `all(equal(vec1, vec2))` and inequality as `any(notEqual(vec1, vec2))`