### PR TITLE
[spv-out] fix initial ID 0 and 1 assignments

### DIFF
--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -206,22 +206,24 @@ impl Writer {
         flags: WriterFlags,
         capabilities: crate::FastHashSet<spirv::Capability>,
     ) -> Self {
+        let gl450_ext_inst_id = 1;
+        let void_type = 2;
         Writer {
             physical_layout: PhysicalLayout::new(header),
             logical_layout: LogicalLayout::default(),
-            id_count: 2, // 0 is void type, 1 is the GLSL ext inst
+            id_count: 2, // see `gl450_ext_inst_id` and `void_type`
             capabilities,
             debugs: vec![],
             annotations: vec![],
             flags,
-            void_type: 0,
+            void_type,
             lookup_type: crate::FastHashMap::default(),
             lookup_function: crate::FastHashMap::default(),
             lookup_function_type: crate::FastHashMap::default(),
             lookup_constant: crate::FastHashMap::default(),
             lookup_global_variable: crate::FastHashMap::default(),
             struct_type_handles: crate::FastHashMap::default(),
-            gl450_ext_inst_id: 1,
+            gl450_ext_inst_id,
             layouter: Layouter::default(),
             typifier: Typifier::new(),
         }

--- a/tests/out/boids.spvasm.snap
+++ b/tests/out/boids.spvasm.snap
@@ -32,7 +32,7 @@ OpDecorate %122 DescriptorSet 0
 OpDecorate %122 Binding 0
 OpDecorate %274 DescriptorSet 0
 OpDecorate %274 Binding 2
-%0 = OpTypeVoid
+%2 = OpTypeVoid
 %4 = OpTypeInt 32 1
 %3 = OpConstant  %4  1500
 %6 = OpTypeFloat 32
@@ -49,7 +49,7 @@ OpDecorate %274 Binding 2
 %17 = OpTypePointer Function %16
 %23 = OpTypePointer Function %4
 %28 = OpTypePointer Function %9
-%30 = OpTypeFunction %0
+%30 = OpTypeFunction %2
 %32 = OpTypeBool
 %35 = OpTypeVector %9 3
 %37 = OpTypePointer Input %35
@@ -135,7 +135,7 @@ OpDecorate %274 Binding 2
 %294 = OpTypePointer Uniform %45
 %295 = OpTypePointer Uniform %16
 %296 = OpConstant  %4  1
-%29 = OpFunction  %0  None %30
+%29 = OpFunction  %2  None %30
 %31 = OpLabel
 %27 = OpVariable  %28  Function %8
 %24 = OpVariable  %23  Function %7

--- a/tests/out/collatz.spvasm.snap
+++ b/tests/out/collatz.spvasm.snap
@@ -17,7 +17,7 @@ OpMemberDecorate %45 0 Offset 0
 OpDecorate %46 DescriptorSet 0
 OpDecorate %46 Binding 0
 OpDecorate %53 BuiltIn GlobalInvocationId
-%0 = OpTypeVoid
+%2 = OpTypeVoid
 %4 = OpTypeInt 32 0
 %3 = OpConstant  %4  0
 %5 = OpConstant  %4  1
@@ -26,7 +26,7 @@ OpDecorate %53 BuiltIn GlobalInvocationId
 %9 = OpTypePointer Function %4
 %13 = OpTypeFunction %4 %4
 %19 = OpTypeBool
-%40 = OpTypeFunction %0
+%40 = OpTypeFunction %2
 %43 = OpTypeRuntimeArray %4
 %45 = OpTypeStruct %43
 %47 = OpTypePointer Uniform %45
@@ -92,7 +92,7 @@ OpBranch %15
 %38 = OpLoad  %4  %10
 OpReturnValue %38
 OpFunctionEnd
-%39 = OpFunction  %0  None %40
+%39 = OpFunction  %2  None %40
 %41 = OpLabel
 %44 = OpAccessChain  %48  %46 %50
 %51 = OpAccessChain  %55  %53 %56

--- a/tests/out/empty.spvasm.snap
+++ b/tests/out/empty.spvasm.snap
@@ -11,9 +11,9 @@ OpCapability Shader
 OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %3 "main"
 OpExecutionMode %3 LocalSize 1 1 1
-%0 = OpTypeVoid
-%4 = OpTypeFunction %0
-%3 = OpFunction  %0  None %4
+%2 = OpTypeVoid
+%4 = OpTypeFunction %2
+%3 = OpFunction  %2  None %4
 %5 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/tests/out/quad.spvasm.snap
+++ b/tests/out/quad.spvasm.snap
@@ -22,12 +22,12 @@ OpDecorate %27 Binding 0
 OpDecorate %32 DescriptorSet 0
 OpDecorate %32 Binding 1
 OpDecorate %35 Location 0
-%0 = OpTypeVoid
+%2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpConstant  %4  1.2
 %5 = OpConstant  %4  0.0
 %6 = OpConstant  %4  1.0
-%8 = OpTypeFunction %0
+%8 = OpTypeFunction %2
 %10 = OpTypeVector %4 2
 %12 = OpTypePointer Output %10
 %11 = OpVariable  %12  Output
@@ -46,7 +46,7 @@ OpDecorate %35 Location 0
 %33 = OpTypePointer UniformConstant %31
 %32 = OpVariable  %33  UniformConstant
 %35 = OpVariable  %14  Input
-%7 = OpFunction  %0  None %8
+%7 = OpFunction  %2  None %8
 %9 = OpLabel
 %15 = OpLoad  %10  %13
 OpStore %11 %15
@@ -56,7 +56,7 @@ OpStore %11 %15
 OpStore %17 %22
 OpReturn
 OpFunctionEnd
-%23 = OpFunction  %0  None %8
+%23 = OpFunction  %2  None %8
 %24 = OpLabel
 %29 = OpLoad  %26  %27
 %34 = OpLoad  %31  %32

--- a/tests/out/shadow.spvasm.snap
+++ b/tests/out/shadow.spvasm.snap
@@ -33,7 +33,7 @@ OpDecorate %102 Binding 1
 OpDecorate %111 Location 1
 OpDecorate %114 Location 0
 OpDecorate %217 Location 0
-%0 = OpTypeVoid
+%2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpConstant  %4  0.0
 %5 = OpConstant  %4  1.0
@@ -61,7 +61,7 @@ OpDecorate %217 Location 0
 %59 = OpConstant  %4  0.0
 %61 = OpTypePointer Function %10
 %63 = OpTypePointer Function %12
-%65 = OpTypeFunction %0
+%65 = OpTypeFunction %2
 %74 = OpTypeVector %12 4
 %76 = OpTypeStruct %74
 %78 = OpTypePointer Uniform %76
@@ -173,7 +173,7 @@ OpBranch %24
 %54 = OpImageSampleDrefExplicitLod  %4  %53 %52 %55 Lod %59
 OpReturnValue %54
 OpFunctionEnd
-%64 = OpFunction  %0  None %65
+%64 = OpFunction  %2  None %65
 %66 = OpLabel
 %60 = OpVariable  %61  Function %9
 %62 = OpVariable  %63  Function %13

--- a/tests/out/skybox.spvasm.snap
+++ b/tests/out/skybox.spvasm.snap
@@ -30,7 +30,7 @@ OpDecorate %174 Binding 1
 OpDecorate %179 DescriptorSet 0
 OpDecorate %179 Binding 2
 OpDecorate %182 Location 0
-%0 = OpTypeVoid
+%2 = OpTypeVoid
 %4 = OpTypeInt 32 1
 %3 = OpConstant  %4  2
 %5 = OpConstant  %4  1
@@ -41,7 +41,7 @@ OpDecorate %182 Location 0
 %11 = OpTypePointer Function %4
 %14 = OpTypeVector %7 4
 %15 = OpTypePointer Function %14
-%17 = OpTypeFunction %0
+%17 = OpTypeFunction %2
 %20 = OpTypeInt 32 0
 %22 = OpTypePointer Input %20
 %21 = OpVariable  %22  Input
@@ -127,7 +127,7 @@ OpDecorate %182 Location 0
 %179 = OpVariable  %180  UniformConstant
 %183 = OpTypePointer Input %46
 %182 = OpVariable  %183  Input
-%16 = OpFunction  %0  None %17
+%16 = OpFunction  %2  None %17
 %18 = OpLabel
 %10 = OpVariable  %11  Function
 %12 = OpVariable  %11  Function
@@ -215,7 +215,7 @@ OpStore %47 %49
 OpStore %159 %169
 OpReturn
 OpFunctionEnd
-%170 = OpFunction  %0  None %17
+%170 = OpFunction  %2  None %17
 %171 = OpLabel
 %176 = OpLoad  %173  %174
 %181 = OpLoad  %178  %179

--- a/tests/out/texture-array.spvasm.snap
+++ b/tests/out/texture-array.spvasm.snap
@@ -21,10 +21,10 @@ OpDecorate %31 Binding 2
 OpDecorate %35 Location 0
 OpDecorate %40 DescriptorSet 0
 OpDecorate %40 Binding 1
-%0 = OpTypeVoid
+%2 = OpTypeVoid
 %4 = OpTypeInt 32 1
 %3 = OpConstant  %4  0
-%6 = OpTypeFunction %0
+%6 = OpTypeFunction %2
 %8 = OpTypeBool
 %10 = OpTypeInt 32 0
 %12 = OpTypeStruct %10
@@ -47,7 +47,7 @@ OpDecorate %40 Binding 1
 %36 = OpTypePointer Input %34
 %35 = OpVariable  %36  Input
 %40 = OpVariable  %27  UniformConstant
-%5 = OpFunction  %0  None %6
+%5 = OpFunction  %2  None %6
 %7 = OpLabel
 %11 = OpAccessChain  %15  %13 %16
 %17 = OpLoad  %10  %11


### PR DESCRIPTION
Apparently ID 0 can't be used freely, but spirv-val only complains in a specific phase of the moon.