### PR TITLE
Analyzer processor

### DIFF
--- a/examples/convert.rs
+++ b/examples/convert.rs
@@ -147,7 +147,8 @@ fn main() {
     };
 
     // validate the IR
-    naga::proc::Validator::new()
+    #[cfg_attr(not(feature = "msl-out"), allow(unused_variables))]
+    let analysis = naga::proc::Validator::new()
         .validate(&module)
         .unwrap_pretty();
 
@@ -190,7 +191,7 @@ fn main() {
                 spirv_cross_compatibility: false,
                 binding_map,
             };
-            let (msl, _) = msl::write_string(&module, &options).unwrap();
+            let (msl, _) = msl::write_string(&module, &analysis, &options).unwrap();
             fs::write(&args[2], msl).unwrap();
         }
         #[cfg(feature = "spv-out")]

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1908,7 +1908,7 @@ struct TextureMappingVisitor<'a> {
 }
 
 impl<'a> Visitor for TextureMappingVisitor<'a> {
-    fn visit_expr(&mut self, expr: &crate::Expression) {
+    fn visit_expr(&mut self, _: Handle<crate::Expression>, expr: &crate::Expression) {
         // We only care about `ImageSample` and `ImageLoad`
         //
         // Both `image` and `sampler` are `Expression::GlobalVariable` otherwise the module is

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -14,7 +14,11 @@ the output struct. If there is a structure in the outputs, and it contains any b
 we move them up to the root output structure that we define ourselves.
 !*/
 
-use crate::{arena::Handle, proc::ResolveError, FastHashMap};
+use crate::{
+    arena::Handle,
+    proc::{analyzer::Analysis, ResolveError},
+    FastHashMap,
+};
 use std::{
     io::{Error as IoError, Write},
     string::FromUtf8Error,
@@ -66,6 +70,7 @@ pub enum Error {
     UnexpectedSampleLevel(crate::SampleLevel),
     UnsupportedCall(String),
     UnsupportedDynamicArrayLength,
+    FeatureNotImplemented(String),
     /// The source IR is not valid.
     Validation,
 }
@@ -222,10 +227,11 @@ pub struct TranslationInfo {
 
 pub fn write_string(
     module: &crate::Module,
+    analysis: &Analysis,
     options: &Options,
 ) -> Result<(String, TranslationInfo), Error> {
     let mut w = writer::Writer::new(Vec::new());
-    let info = w.write(module, options)?;
+    let info = w.write(module, analysis, options)?;
     let string = String::from_utf8(w.finish())?;
     Ok((string, info))
 }

--- a/src/front/global_usage.rs
+++ b/src/front/global_usage.rs
@@ -9,13 +9,13 @@ struct GlobalUseVisitor<'a> {
 }
 
 impl Visitor for GlobalUseVisitor<'_> {
-    fn visit_expr(&mut self, expr: &crate::Expression) {
+    fn visit_expr(&mut self, _: Handle<crate::Expression>, expr: &crate::Expression) {
         if let crate::Expression::GlobalVariable(handle) = expr {
             self.usage[handle.index()] |= crate::GlobalUse::READ;
         }
     }
 
-    fn visit_lhs_expr(&mut self, expr: &crate::Expression) {
+    fn visit_lhs_expr(&mut self, _: Handle<crate::Expression>, expr: &crate::Expression) {
         if let crate::Expression::GlobalVariable(handle) = expr {
             self.usage[handle.index()] |= crate::GlobalUse::WRITE;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -641,6 +641,7 @@ pub enum ImageQuery {
 
 /// An expression that can be evaluated to obtain a value.
 #[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub enum Expression {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -640,6 +640,8 @@ pub enum ImageQuery {
 }
 
 /// An expression that can be evaluated to obtain a value.
+///
+/// This is a Single Static Assignment (SSA) scheme similar to SPIR-V.
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "serialize", derive(Serialize))]

--- a/src/proc/analyzer.rs
+++ b/src/proc/analyzer.rs
@@ -1,0 +1,350 @@
+/*! Module analyzer.
+
+Figures out the following properties:
+  - control flow uniformity
+  - texture/sampler pairs
+  - expression reference counts
+!*/
+
+use crate::arena::{Arena, Handle};
+
+bitflags::bitflags! {
+    #[derive(Default)]
+    pub struct ControlFlags: u8 {
+        /// The result is not dynamically uniform.
+        const NON_UNIFORM_RESULT = 0x1;
+        /// Uniform control flow is required by the code.
+        const REQUIRE_UNIFORM = 0x2;
+        /// The code may exit the control flow.
+        const MAY_EXIT = 0x4;
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct SamplingKey {
+    pub image: Handle<crate::GlobalVariable>,
+    pub sampler: Handle<crate::GlobalVariable>,
+}
+
+#[derive(Clone, Default)]
+pub struct ExpressionInfo {
+    pub control_flags: ControlFlags,
+    pub ref_count: usize,
+}
+
+pub struct FunctionInfo {
+    pub control_flags: ControlFlags,
+    pub sampling_set: crate::FastHashSet<SamplingKey>,
+    pub expressions: Box<[ExpressionInfo]>,
+}
+
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum AnalysisError {
+    #[error("Expression {0:?} is not a global variable!")]
+    ExpectedGlobalVariable(crate::Expression),
+    //TODO: add more information here!
+    #[error("Required uniformity of control flow is not fulfilled")]
+    NonUniformControlFlow,
+}
+
+impl FunctionInfo {
+    #[must_use]
+    fn add_ref(&mut self, handle: Handle<crate::Expression>) -> ControlFlags {
+        let info = &mut self.expressions[handle.index()];
+        info.ref_count += 1;
+        info.control_flags
+    }
+
+    fn process_expression(
+        &mut self,
+        handle: Handle<crate::Expression>,
+        expression_arena: &Arena<crate::Expression>,
+        global_var_arena: &Arena<crate::GlobalVariable>,
+        other_functions: &[FunctionInfo],
+    ) -> Result<(), AnalysisError> {
+        use crate::{Expression as E, SampleLevel as Sl};
+
+        let control_flags = match expression_arena[handle] {
+            E::Access { base, index } => self.add_ref(base) | self.add_ref(index),
+            E::AccessIndex { base, .. } => self.add_ref(base),
+            E::Constant(_) => ControlFlags::empty(),
+            E::Compose { ref components, .. } => {
+                let mut accum = ControlFlags::empty();
+                for &comp in components {
+                    accum |= self.add_ref(comp);
+                }
+                accum
+            }
+            E::FunctionArgument(_) => ControlFlags::NON_UNIFORM_RESULT, //TODO?
+            E::GlobalVariable(handle) => {
+                let var = &global_var_arena[handle];
+                match var.binding {
+                    Some(crate::Binding::BuiltIn(built_in)) => match built_in {
+                        crate::BuiltIn::FrontFacing
+                        | crate::BuiltIn::WorkGroupId
+                        | crate::BuiltIn::WorkGroupSize => ControlFlags::empty(),
+                        _ => ControlFlags::NON_UNIFORM_RESULT,
+                    },
+                    _ if var.class == crate::StorageClass::Input
+                        && var.interpolation == Some(crate::Interpolation::Flat) =>
+                    {
+                        ControlFlags::empty()
+                    }
+                    _ => ControlFlags::NON_UNIFORM_RESULT,
+                }
+            }
+            E::LocalVariable(_) => {
+                ControlFlags::NON_UNIFORM_RESULT //TODO?
+            }
+            E::Load { pointer } => self.add_ref(pointer),
+            E::ImageSample {
+                image,
+                sampler,
+                coordinate,
+                array_index,
+                offset: _,
+                level,
+                depth_ref,
+            } => {
+                self.sampling_set.insert(SamplingKey {
+                    image: match expression_arena[image] {
+                        crate::Expression::GlobalVariable(var) => var,
+                        ref other => {
+                            return Err(AnalysisError::ExpectedGlobalVariable(other.clone()))
+                        }
+                    },
+                    sampler: match expression_arena[sampler] {
+                        crate::Expression::GlobalVariable(var) => var,
+                        ref other => {
+                            return Err(AnalysisError::ExpectedGlobalVariable(other.clone()))
+                        }
+                    },
+                });
+                let array_flags = match array_index {
+                    Some(h) => self.add_ref(h),
+                    None => ControlFlags::empty(),
+                };
+                let level_flags = match level {
+                    Sl::Auto => ControlFlags::REQUIRE_UNIFORM,
+                    Sl::Zero => ControlFlags::empty(),
+                    Sl::Exact(h) | Sl::Bias(h) => self.add_ref(h),
+                    Sl::Gradient { x, y } => self.add_ref(x) | self.add_ref(y),
+                };
+                let dref_flags = match depth_ref {
+                    Some(h) => self.add_ref(h),
+                    None => ControlFlags::empty(),
+                };
+                self.add_ref(image)
+                    | self.add_ref(sampler)
+                    | self.add_ref(coordinate)
+                    | array_flags
+                    | level_flags
+                    | dref_flags
+            }
+            E::ImageLoad {
+                image,
+                coordinate,
+                array_index,
+                index,
+            } => {
+                let array_flags = match array_index {
+                    Some(h) => self.add_ref(h),
+                    None => ControlFlags::empty(),
+                };
+                let index_flags = match index {
+                    Some(h) => self.add_ref(h),
+                    None => ControlFlags::empty(),
+                };
+                self.add_ref(image) | self.add_ref(coordinate) | array_flags | index_flags
+            }
+            E::ImageQuery { image, query } => {
+                let query_flags = match query {
+                    crate::ImageQuery::Size { level: Some(h) } => self.add_ref(h),
+                    _ => ControlFlags::empty(),
+                };
+                self.add_ref(image) | query_flags
+            }
+            E::Unary { expr, .. } => self.add_ref(expr),
+            E::Binary { left, right, .. } => self.add_ref(left) | self.add_ref(right),
+            E::Select {
+                condition,
+                accept,
+                reject,
+            } => self.add_ref(condition) | self.add_ref(accept) | self.add_ref(reject),
+            E::Derivative { expr, .. } => ControlFlags::REQUIRE_UNIFORM | self.add_ref(expr),
+            E::Relational { argument, .. } => self.add_ref(argument),
+            E::Math {
+                arg, arg1, arg2, ..
+            } => {
+                let arg1_flags = match arg1 {
+                    Some(h) => self.add_ref(h),
+                    None => ControlFlags::empty(),
+                };
+                let arg2_flags = match arg2 {
+                    Some(h) => self.add_ref(h),
+                    None => ControlFlags::empty(),
+                };
+                self.add_ref(arg) | arg1_flags | arg2_flags
+            }
+            E::As { expr, .. } => self.add_ref(expr),
+            E::Call {
+                function,
+                ref arguments,
+            } => {
+                let other_info = &other_functions[function.index()];
+                for key in other_info.sampling_set.iter() {
+                    self.sampling_set.insert(key.clone());
+                }
+                let mut accum = other_info.control_flags;
+                for &argument in arguments {
+                    accum |= self.add_ref(argument);
+                }
+                accum
+            }
+            E::ArrayLength(expr) => self.add_ref(expr),
+        };
+
+        self.expressions[handle.index()] = ExpressionInfo {
+            control_flags,
+            ref_count: 0,
+        };
+        Ok(())
+    }
+
+    fn process_block(
+        &mut self,
+        statements: &[crate::Statement],
+        other_functions: &[FunctionInfo],
+        mut is_uniform: bool,
+    ) -> Result<ControlFlags, AnalysisError> {
+        use crate::Statement as S;
+        let mut block_flags = ControlFlags::empty();
+        for statement in statements {
+            let flags = match *statement {
+                S::Break | S::Continue => ControlFlags::empty(),
+                S::Kill => ControlFlags::MAY_EXIT,
+                S::Block(ref b) => self.process_block(b, other_functions, is_uniform)?,
+                S::If {
+                    condition,
+                    ref accept,
+                    ref reject,
+                } => {
+                    let flags = self.add_ref(condition);
+                    if flags.contains(ControlFlags::REQUIRE_UNIFORM) && !is_uniform {
+                        log::warn!("If condition {:?} needs uniformity", condition);
+                        return Err(AnalysisError::NonUniformControlFlow);
+                    }
+                    let branch_uniform =
+                        is_uniform && !flags.contains(ControlFlags::NON_UNIFORM_RESULT);
+                    flags
+                        | self.process_block(accept, other_functions, branch_uniform)?
+                        | self.process_block(reject, other_functions, branch_uniform)?
+                }
+                S::Switch {
+                    selector,
+                    ref cases,
+                    ref default,
+                } => {
+                    let mut flags = self.add_ref(selector);
+                    if flags.contains(ControlFlags::REQUIRE_UNIFORM) && !is_uniform {
+                        log::warn!("Switch selector {:?} needs uniformity", selector);
+                        return Err(AnalysisError::NonUniformControlFlow);
+                    }
+                    let branch_uniform =
+                        is_uniform && !flags.contains(ControlFlags::NON_UNIFORM_RESULT);
+                    let mut still_uniform = branch_uniform;
+                    for case in cases.iter() {
+                        let case_flags =
+                            self.process_block(&case.body, other_functions, still_uniform)?;
+                        flags |= case_flags;
+                        if case.fall_through {
+                            still_uniform &= !case_flags.contains(ControlFlags::MAY_EXIT);
+                        } else {
+                            still_uniform = branch_uniform;
+                        }
+                    }
+                    flags | self.process_block(default, other_functions, still_uniform)?
+                }
+                S::Loop {
+                    ref body,
+                    ref continuing,
+                } => {
+                    let flags = self.process_block(body, other_functions, is_uniform)?;
+                    let still_uniform = is_uniform && !flags.contains(ControlFlags::MAY_EXIT);
+                    self.process_block(continuing, other_functions, still_uniform)?
+                }
+                S::Return { value } => {
+                    let flags = match value {
+                        Some(expr) => self.add_ref(expr),
+                        None => ControlFlags::empty(),
+                    };
+                    ControlFlags::MAY_EXIT | flags
+                }
+                S::Store { pointer, value } => self.add_ref(pointer) | self.add_ref(value),
+                S::Call {
+                    function,
+                    ref arguments,
+                } => {
+                    let mut flags = other_functions[function.index()].control_flags;
+                    for &argument in arguments {
+                        flags |= self.add_ref(argument);
+                    }
+                    flags
+                }
+            };
+
+            if flags.contains(ControlFlags::REQUIRE_UNIFORM) && !is_uniform {
+                return Err(AnalysisError::NonUniformControlFlow);
+            }
+            is_uniform &= !flags.contains(ControlFlags::MAY_EXIT);
+            block_flags |= flags;
+        }
+        Ok(block_flags)
+    }
+}
+
+#[derive(Default)]
+pub struct Analysis {
+    functions: Vec<FunctionInfo>,
+    entry_points: crate::FastHashMap<(crate::ShaderStage, String), FunctionInfo>,
+}
+
+impl Analysis {
+    fn process_function(
+        &self,
+        fun: &crate::Function,
+        global_var_arena: &Arena<crate::GlobalVariable>,
+    ) -> Result<FunctionInfo, AnalysisError> {
+        let mut info = FunctionInfo {
+            control_flags: ControlFlags::empty(),
+            sampling_set: crate::FastHashSet::default(),
+            expressions: vec![ExpressionInfo::default(); fun.expressions.len()].into_boxed_slice(),
+        };
+
+        for (handle, _) in fun.expressions.iter() {
+            info.process_expression(handle, &fun.expressions, global_var_arena, &self.functions)?;
+        }
+
+        info.control_flags = info.process_block(&fun.body, &self.functions, true)?;
+
+        Ok(info)
+    }
+
+    pub fn new(module: &crate::Module) -> Result<Self, AnalysisError> {
+        let mut this = Analysis {
+            functions: Vec::with_capacity(module.functions.len()),
+            entry_points: crate::FastHashMap::default(),
+        };
+        for (_, fun) in module.functions.iter() {
+            let info = this.process_function(fun, &module.global_variables)?;
+            this.functions.push(info);
+        }
+
+        for (key, ep) in module.entry_points.iter() {
+            let info = this.process_function(&ep.function, &module.global_variables)?;
+            this.entry_points.insert(key.clone(), info);
+        }
+
+        Ok(this)
+    }
+}

--- a/src/proc/interface.rs
+++ b/src/proc/interface.rs
@@ -7,8 +7,8 @@ pub struct Interface<'a, T> {
 }
 
 pub trait Visitor {
-    fn visit_expr(&mut self, _: &crate::Expression) {}
-    fn visit_lhs_expr(&mut self, _: &crate::Expression) {}
+    fn visit_expr(&mut self, _: Handle<crate::Expression>, _: &crate::Expression) {}
+    fn visit_lhs_expr(&mut self, _: Handle<crate::Expression>, _: &crate::Expression) {}
     fn visit_fun(&mut self, _: Handle<crate::Function>) {}
 }
 
@@ -16,12 +16,12 @@ impl<'a, T> Interface<'a, T>
 where
     T: Visitor,
 {
-    fn traverse_expr(&mut self, handle: Handle<crate::Expression>) {
+    pub fn traverse_expr(&mut self, handle: Handle<crate::Expression>) {
         use crate::Expression as E;
 
         let expr = &self.expressions[handle];
 
-        self.visitor.visit_expr(expr);
+        self.visitor.visit_expr(handle, expr);
 
         match *expr {
             E::Access { base, index } => {
@@ -200,7 +200,7 @@ where
                             _ => break,
                         }
                     }
-                    self.visitor.visit_lhs_expr(&self.expressions[left]);
+                    self.visitor.visit_lhs_expr(left, &self.expressions[left]);
                     self.traverse_expr(value);
                 }
                 S::Call {

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -1,5 +1,6 @@
 //! Module processing functionality.
 
+pub mod analyzer;
 #[cfg(feature = "petgraph")]
 mod call_graph;
 mod interface;

--- a/tests/out/shadow.msl.snap
+++ b/tests/out/shadow.msl.snap
@@ -52,7 +52,8 @@ type7 fetch_shadow(
     if ((homogeneous_coords.w <= 0.0)) {
         return 1.0;
     }
-    return t_shadow.sample_compare(sampler_shadow, (((metal::float2(homogeneous_coords.x, homogeneous_coords.y) * metal::float2(0.5, -0.5)) * (1.0 / homogeneous_coords.w)) + metal::float2(0.5, 0.5)), static_cast<int>(light_id), (homogeneous_coords.z * (1.0 / homogeneous_coords.w)));
+    float expr15 = (1.0 / homogeneous_coords.w);
+    return t_shadow.sample_compare(sampler_shadow, (((metal::float2(homogeneous_coords.x, homogeneous_coords.y) * metal::float2(0.5, -0.5)) * expr15) + metal::float2(0.5, 0.5)), static_cast<int>(light_id), (homogeneous_coords.z * expr15));
 }
 
 struct fs_mainInput {
@@ -83,7 +84,9 @@ fragment fs_mainOutput fs_main(
         if ((i >= metal::min(u_globals.num_lights.x, 10u))) {
             break;
         }
-        color1 = (color1 + ((fetch_shadow(i, (s_lights.data[i].proj * input.in_position_fs), t_shadow, sampler_shadow) * metal::max(0.0, metal::dot(metal::normalize(input.in_normal_fs), metal::normalize((metal::float3(s_lights.data[i].pos.x, s_lights.data[i].pos.y, s_lights.data[i].pos.z) - metal::float3(input.in_position_fs.x, input.in_position_fs.y, input.in_position_fs.z)))))) * metal::float3(s_lights.data[i].color.x, s_lights.data[i].color.y, s_lights.data[i].color.z)));
+        Light expr18 = s_lights.data[i];
+        type7 expr21 = fetch_shadow(i, (expr18.proj * input.in_position_fs), t_shadow, sampler_shadow);
+        color1 = (color1 + ((expr21 * metal::max(0.0, metal::dot(metal::normalize(input.in_normal_fs), metal::normalize((metal::float3(expr18.pos.x, expr18.pos.y, expr18.pos.z) - metal::float3(input.in_position_fs.x, input.in_position_fs.y, input.in_position_fs.z)))))) * metal::float3(expr18.color.x, expr18.color.y, expr18.color.z)));
     }
     output.out_color_fs = metal::float4(color1, 1.0);
     return output;

--- a/tests/out/skybox.msl.snap
+++ b/tests/out/skybox.msl.snap
@@ -47,9 +47,10 @@ vertex vs_mainOutput vs_main(
     type unprojected;
     tmp1_ = (static_cast<int>(in_vertex_index) / 2);
     tmp2_ = (static_cast<int>(in_vertex_index) & 1);
-    unprojected = (r_data.proj_inv * metal::float4(((static_cast<float>(tmp1_) * 4.0) - 1.0), ((static_cast<float>(tmp2_) * 4.0) - 1.0), 0.0, 1.0));
+    type expr24 = metal::float4(((static_cast<float>(tmp1_) * 4.0) - 1.0), ((static_cast<float>(tmp2_) * 4.0) - 1.0), 0.0, 1.0);
+    unprojected = (r_data.proj_inv * expr24);
     output.out_uv = (metal::transpose(metal::float3x3(metal::float3(r_data.view[0].x, r_data.view[0].y, r_data.view[0].z), metal::float3(r_data.view[1].x, r_data.view[1].y, r_data.view[1].z), metal::float3(r_data.view[2].x, r_data.view[2].y, r_data.view[2].z))) * metal::float3(unprojected.x, unprojected.y, unprojected.z));
-    output.out_position = metal::float4(((static_cast<float>(tmp1_) * 4.0) - 1.0), ((static_cast<float>(tmp2_) * 4.0) - 1.0), 0.0, 1.0);
+    output.out_position = expr24;
     return output;
 }
 

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -16,7 +16,7 @@ fn check_glsl(name: &str) {
 
     match naga::front::glsl::parse_str(&input, "main", stage, Default::default()) {
         Ok(m) => match naga::proc::Validator::new().validate(&m) {
-            Ok(()) => (),
+            Ok(_analysis) => (),
             Err(e) => panic!("Unable to validate {}: {:?}", name, e),
         },
         Err(e) => panic!("Unable to parse {}: {:?}", name, e),


### PR DESCRIPTION
Figures out the following properties:
  - control flow uniformity. This is only needed for validation.
  - texture/sampler pairs. This is needed for `wgpu` level validation.
  - expression reference counts. This is needed for the backends to figure out when to re-use the expressions.

Roughly, the idea is that validation will produce this analysis as an artifact, and the backends will accept it.