### PR TITLE
[spv-out] support Switch statements

### DIFF
--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -707,6 +707,26 @@ pub(super) fn instruction_branch_conditional(
     instruction
 }
 
+pub struct Case {
+    pub value: Word,
+    pub label_id: Word,
+}
+
+pub(super) fn instruction_switch(
+    selector_id: Word,
+    default_id: Word,
+    cases: &[Case],
+) -> Instruction {
+    let mut instruction = Instruction::new(Op::Switch);
+    instruction.add_operand(selector_id);
+    instruction.add_operand(default_id);
+    for case in cases {
+        instruction.add_operand(case.value);
+        instruction.add_operand(case.label_id);
+    }
+    instruction
+}
+
 pub(super) fn instruction_kill() -> Instruction {
     Instruction::new(Op::Kill)
 }


### PR DESCRIPTION
Tested locally on the following example:
```rust
[[stage(vertex)]]
fn main() {
	var x: i32 = 4;
	const y: f32 = 6.0;
	var z: f32;
	switch(x) {
		case 4: { z = 4.0; fallthrough;}
		case 5: { z = 5.0; }
		default: { z = 1.0; }
	}
}
```
Worked at first try!