### PR TITLE
[wgsl] track number of bytes consumed per token

### DIFF
--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -162,6 +162,13 @@ impl<'a> Lexer<'a> {
         Lexer { input }
     }
 
+    fn peek_token_and_rest(&mut self) -> (Token<'a>, &'a str) {
+        let mut cloned = self.clone();
+        let token = cloned.next();
+        let rest = cloned.input;
+        (token, rest)
+    }
+
     #[must_use]
     pub(super) fn next(&mut self) -> Token<'a> {
         let original_len = self.input.len();
@@ -177,7 +184,8 @@ impl<'a> Lexer<'a> {
 
     #[must_use]
     pub(super) fn peek(&mut self) -> Token<'a> {
-        self.clone().next()
+        let (token, _) = self.peek_token_and_rest();
+        token
     }
 
     pub(super) fn expect(&mut self, expected: Token<'a>) -> Result<(), Error<'a>> {
@@ -207,8 +215,9 @@ impl<'a> Lexer<'a> {
     }
 
     pub(super) fn skip(&mut self, what: Token<'_>) -> bool {
-        if self.peek() == what {
-            let _ = self.next();
+        let (peeked_token, rest) = self.peek_token_and_rest();
+        if peeked_token == what {
+            self.input = rest;
             true
         } else {
             false

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -38,6 +38,7 @@ pub enum Token<'a> {
     Arrow,
     Unknown(char),
     UnterminatedString,
+    Trivia,
     End,
 }
 


### PR DESCRIPTION
This isn't a very useful change on its own, but we need to track the number of bytes consumed per token in order to support #380 or other later contextual errors that need to know the byte span of relevant tokens.

Alternatively we could derive it by measuring the change in `self.input.len()` whenever `self.input` is changed, but counting the bytes directly as they're consumed felt like the most straightforward path.

If these changes seem useful, I was thinking we could land this PR on its own to avoid diverging too much from `master` in my branch.