### PR TITLE
[wgsl] ignore offset decorations on struct fields

### DIFF
--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1197,6 +1197,12 @@ impl Parser {
                             lexer.expect(Token::Paren(')'))?;
                             ready = false;
                         }
+                        Token::Word("offset") if ready => {
+                            lexer.expect(Token::Paren('('))?;
+                            let _offset = lexer.next_uint_literal()?;
+                            lexer.expect(Token::Paren(')'))?;
+                            ready = false;
+                        }
                         other => return Err(Error::Unexpected(other, "decoration separator")),
                     }
                 }


### PR DESCRIPTION
naga does not require offset decorations on struct fields in WGSL
source, and automatically adds them to spv output. The `tint` compiler
does not automatically add them, and requires that they be present in
the WGSL source.

A potential confusion is that an spv binary missing required
`OpMemberDecorate` instructions that set the field's offset will fail
validation when run through `spirv-val`. But since naga automatically
produces these offsets, the same spv binary passed through naga will
be successfully validated.

This change is to ignore these decorations in naga's WGSL front end so
that the same WGSL source can be used with naga and tint to produce
valid spv.

Fixes #455