### PR TITLE
[spv-in] patch function calls before deriving the global use

### DIFF
--- a/src/front/spv/function.rs
+++ b/src/front/spv/function.rs
@@ -146,6 +146,7 @@ impl<I: Iterator<Item = u32>> super::Parser<I> {
         fun.body = flow_graph.to_naga()?;
 
         // done
+        self.patch_function_calls(&mut fun)?;
         fun.fill_global_use(module.global_variables.len(), &module.functions);
 
         let dump_suffix = match self.lookup_entry_point.remove(&fun_id) {

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -1689,13 +1689,6 @@ impl<I: Iterator<Item = u32>> Parser<I> {
             }
         }
 
-        for (_, func) in module.functions.iter_mut() {
-            self.patch_function_calls(func)?;
-        }
-        for (_, ep) in module.entry_points.iter_mut() {
-            self.patch_function_calls(&mut ep.function)?;
-        }
-
         if !self.future_decor.is_empty() {
             log::warn!("Unused item decorations: {:?}", self.future_decor);
             self.future_decor.clear();


### PR DESCRIPTION
We had a bug in there, since global use resolution needs proper function indices, and ours were unpatched.