### PR TITLE
[spv-in] support string instruction

### DIFF
--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -1643,6 +1643,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                 Op::MemoryModel => self.parse_memory_model(inst),
                 Op::EntryPoint => self.parse_entry_point(inst),
                 Op::ExecutionMode => self.parse_execution_mode(inst),
+                Op::String => self.parse_string(inst),
                 Op::Source => self.parse_source(inst),
                 Op::SourceExtension => self.parse_source_extension(inst),
                 Op::Name => self.parse_name(inst),
@@ -1826,6 +1827,13 @@ impl<I: Iterator<Item = u32>> Parser<I> {
             }
         }
 
+        Ok(())
+    }
+
+    fn parse_string(&mut self, inst: Instruction) -> Result<(), Error> {
+        self.switch(ModuleState::Source, inst.op)?;
+        inst.expect_at_least(3)?;
+        let (_name, _) = self.next_string(inst.wc - 1)?;
         Ok(())
     }
 


### PR DESCRIPTION
Add support for the `OpString` instruction.

`shaderc` adds a `OpString` instruction with the source filename to generated SPIR-V, which causes otherwise well-validating shaders to not parse. (Ref. #265) 

This is a dummy implementation that basically ignores the result of the instruction. This is valid here, because [the spec](https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#OpString) explicitly allows ignoring it, and other instructions where the result may be used (`OpLine` and `OpSource`) either don't parse yet (`OpLine`) or are ignored as well (`OpSource`).