### PR TITLE
Specify line endings in ron snapshot tests

### DIFF
--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -226,7 +226,7 @@ fn convert_spv(name: &str) {
 
     #[cfg(feature = "serialize")]
     {
-        let config = ron::ser::PrettyConfig::default();
+        let config = ron::ser::PrettyConfig::default().with_new_line("\n".to_string());
         let output = ron::ser::to_string_pretty(&module, config).unwrap();
         with_snapshot_settings(|| {
             insta::assert_snapshot!(format!("{}.ron", name), output);


### PR DESCRIPTION
On Windows, `ron::ser::PrettyConfig::default()` defaults to `\r\n` line endings, which caused the snapshot tests to fail (and print the whole file in the error log) because the existing snapshot is saved with `\n` line endings.

Explicitly specify `\n` to be the line endings to fix this.