### PR TITLE
[glsl-in] support inverse function

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1624,6 +1624,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     Mf::SmoothStep => "smoothstep",
                     Mf::Sqrt => "sqrt",
                     Mf::InverseSqrt => "inversesqrt",
+                    Mf::Inverse => "inverse",
                     Mf::Transpose => "transpose",
                     Mf::Determinant => "determinant",
                     // bits

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -646,6 +646,7 @@ impl<W: Write> Writer<W> {
                     Mf::SmoothStep => "smoothstep",
                     Mf::Sqrt => "sqrt",
                     Mf::InverseSqrt => "rsqrt",
+                    Mf::Inverse => return Err(Error::UnsupportedCall(format!("{:?}", fun))),
                     Mf::Transpose => "transpose",
                     Mf::Determinant => "determinant",
                     // bits

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1505,6 +1505,7 @@ impl Writer {
                     Mf::SmoothStep => MathOp::Ext(spirv::GLOp::SmoothStep),
                     Mf::Sqrt => MathOp::Ext(spirv::GLOp::Sqrt),
                     Mf::InverseSqrt => MathOp::Ext(spirv::GLOp::InverseSqrt),
+                    Mf::Inverse => MathOp::Ext(spirv::GLOp::MatrixInverse),
                     Mf::Transpose => MathOp::Custom(Instruction::unary(
                         spirv::Op::Transpose,
                         result_type_id,

--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -125,7 +125,9 @@ impl Program {
             &resolve_ctx,
         ) {
             //TODO: better error report
-            Err(_) => Err(ErrorKind::SemanticError("Can't resolve type".into())),
+            Err(error) => Err(ErrorKind::SemanticError(
+                format!("Can't resolve type: {:?}", error).into(),
+            )),
             Ok(()) => Ok(self.context.typifier.get(handle, &self.module.types)),
         }
     }

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -83,7 +83,8 @@ impl Program {
                         }
                     }
                     "ceil" | "round" | "floor" | "fract" | "trunc" | "sin" | "abs" | "sqrt"
-                    | "exp" | "sign" => {
+                    | "inversesqrt" | "exp" | "exp2" | "sign" | "transpose" | "inverse"
+                    | "normalize" => {
                         if fc.args.len() != 1 {
                             return Err(ErrorKind::WrongNumberArgs(name, 1, fc.args.len()));
                         }
@@ -98,8 +99,13 @@ impl Program {
                                     "sin" => MathFunction::Sin,
                                     "abs" => MathFunction::Abs,
                                     "sqrt" => MathFunction::Sqrt,
+                                    "inversesqrt" => MathFunction::InverseSqrt,
                                     "exp" => MathFunction::Exp,
+                                    "exp2" => MathFunction::Exp2,
                                     "sign" => MathFunction::Sign,
+                                    "transpose" => MathFunction::Transpose,
+                                    "inverse" => MathFunction::Inverse,
+                                    "normalize" => MathFunction::Normalize,
                                     _ => unreachable!(),
                                 },
                                 arg: fc.args[0].expression,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,6 +605,7 @@ pub enum MathFunction {
     SmoothStep,
     Sqrt,
     InverseSqrt,
+    Inverse,
     Transpose,
     Determinant,
     // bits

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -133,6 +133,7 @@ impl super::MathFunction {
             Self::SmoothStep => 3,
             Self::Sqrt => 1,
             Self::InverseSqrt => 1,
+            Self::Inverse => 1,
             Self::Transpose => 1,
             Self::Determinant => 1,
             // bits

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -427,6 +427,23 @@ impl Typifier {
                             })
                         }
                     },
+                    Mf::Inverse => match *self.get(arg, types) {
+                        crate::TypeInner::Matrix {
+                            columns,
+                            rows,
+                            width,
+                        } if columns == rows => Resolution::Value(crate::TypeInner::Matrix {
+                            columns,
+                            rows,
+                            width,
+                        }),
+                        ref other => {
+                            return Err(ResolveError::IncompatibleOperand {
+                                op: "inverse".to_string(),
+                                operand: format!("{:?}", other),
+                            })
+                        }
+                    },
                     Mf::Determinant => match *self.get(arg, types) {
                         crate::TypeInner::Matrix {
                             width,


### PR DESCRIPTION
Add support for the `inverse` GLSL function.

I also added some other math functions to the GLSL frontend that were already available but were missing from the parsing step.

Resolves #357 

~~To make the code in #357 work, I had to add support for `TypeInner::Matrix` in the `Expression::As` branch in the typifier - I'm not sure if that's correct, feedback is welcome.~~