### PR TITLE
[glsl-out] use existing Analysis instead of implementing Visitor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,6 @@ env_logger = "0.8"
 ron = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 spirv = { package = "spirv_headers", version = "1.5", features = ["deserialize"] }
-insta = { version = "1.3", features = ["glob"] }
+# `similar` dependency, introduced in 1.5.3, breaks MSRV
+insta = { version = "=1.5.2", features = ["glob"] }
 rspirv = "0.7"

--- a/examples/convert.rs
+++ b/examples/convert.rs
@@ -149,7 +149,6 @@ fn main() {
     };
 
     // validate the IR
-    #[cfg_attr(not(feature = "msl-out"), allow(unused_variables))]
     let analysis = naga::proc::Validator::new()
         .validate(&module)
         .unwrap_pretty();
@@ -258,7 +257,7 @@ fn main() {
                 .open(&args[2])
                 .unwrap();
 
-            let mut writer = glsl::Writer::new(file, &module, &options).unwrap_pretty();
+            let mut writer = glsl::Writer::new(file, &module, &analysis, &options).unwrap_pretty();
 
             writer
                 .write()


### PR DESCRIPTION
Based on #445 
Part of the larger move to use the intermediate processing artifacts in the backends.