### PR TITLE
[glsl-out]: bake frequently used expressions

### DIFF
--- a/examples/convert.rs
+++ b/examples/convert.rs
@@ -252,7 +252,7 @@ fn main() {
                 .open(&args[2])
                 .unwrap();
 
-            let mut writer = glsl::Writer::new(file, &module, &options).unwrap_pretty();
+            let mut writer = glsl::Writer::new(file, &module, &options, &analysis).unwrap_pretty();
 
             writer
                 .write()

--- a/tests/out/skybox-Vertex.glsl.snap
+++ b/tests/out/skybox-Vertex.glsl.snap
@@ -22,10 +22,13 @@ void main() {
     int tmp1_;
     int tmp2_;
     vec4 unprojected;
+    vec4 _naga_expression_26 = _group_0_binding_0.view[0];
+    vec4 _naga_expression_32 = _group_0_binding_0.view[1];
+    vec4 _naga_expression_38 = _group_0_binding_0.view[2];
     tmp1_ = (int(gl_VertexID) / 2);
     tmp2_ = (int(gl_VertexID) & 1);
     unprojected = (_group_0_binding_0.proj_inv * vec4(((float(tmp1_) * 4.0) - 1.0), ((float(tmp2_) * 4.0) - 1.0), 0.0, 1.0));
-    _location_0_vs = (transpose(mat3x3(vec3(_group_0_binding_0.view[0][0], _group_0_binding_0.view[0][1], _group_0_binding_0.view[0][2]), vec3(_group_0_binding_0.view[1][0], _group_0_binding_0.view[1][1], _group_0_binding_0.view[1][2]), vec3(_group_0_binding_0.view[2][0], _group_0_binding_0.view[2][1], _group_0_binding_0.view[2][2]))) * vec3(unprojected[0], unprojected[1], unprojected[2]));
+    _location_0_vs = (transpose(mat3x3(vec3(_naga_expression_26[0], _naga_expression_26[1], _naga_expression_26[2]), vec3(_naga_expression_32[0], _naga_expression_32[1], _naga_expression_32[2]), vec3(_naga_expression_38[0], _naga_expression_38[1], _naga_expression_38[2]))) * vec3(unprojected[0], unprojected[1], unprojected[2]));
     gl_Position = vec4(((float(tmp1_) * 4.0) - 1.0), ((float(tmp2_) * 4.0) - 1.0), 0.0, 1.0);
     return;
 }

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -117,7 +117,13 @@ fn check_output_msl(
 }
 
 #[cfg(feature = "glsl-out")]
-fn check_output_glsl(module: &naga::Module, name: &str, stage: naga::ShaderStage, ep_name: &str) {
+fn check_output_glsl(
+    module: &naga::Module,
+    analysis: &naga::proc::analyzer::Analysis,
+    name: &str,
+    stage: naga::ShaderStage,
+    ep_name: &str,
+) {
     use naga::back::glsl;
 
     let options = glsl::Options {
@@ -126,7 +132,7 @@ fn check_output_glsl(module: &naga::Module, name: &str, stage: naga::ShaderStage
     };
 
     let mut buffer = Vec::new();
-    let mut writer = glsl::Writer::new(&mut buffer, &module, &options).unwrap();
+    let mut writer = glsl::Writer::new(&mut buffer, &module, &options, analysis).unwrap();
     writer.write().unwrap();
 
     let string = String::from_utf8(buffer).unwrap();
@@ -167,7 +173,7 @@ fn convert_wgsl(name: &str, language: Language) {
     {
         if language.contains(Language::GLSL) {
             for &(stage, ref ep_name) in module.entry_points.keys() {
-                check_output_glsl(&module, name, stage, ep_name);
+                check_output_glsl(&module, &analysis, name, stage, ep_name);
             }
         }
     }


### PR DESCRIPTION
Uses the results of analysis to bake frequently used expressions and avoid exponential explosions when writing