### PR TITLE
[wgsl] support nested type parameters

### DIFF
--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1359,15 +1359,15 @@ impl Parser {
                 }
             }
             "ptr" => {
-                lexer.expect(Token::Paren('<'))?;
+                lexer.expect_generic_paren('<')?;
                 let class = conv::map_storage_class(lexer.next_ident()?)?;
                 lexer.expect(Token::Separator(','))?;
                 let (base, _access) = self.parse_type_decl(lexer, None, type_arena, const_arena)?;
-                lexer.expect(Token::Paren('>'))?;
+                lexer.expect_generic_paren('>')?;
                 crate::TypeInner::Pointer { base, class }
             }
             "array" => {
-                lexer.expect(Token::Paren('<'))?;
+                lexer.expect_generic_paren('<')?;
                 let (base, _access) = self.parse_type_decl(lexer, None, type_arena, const_arena)?;
                 let size = if lexer.skip(Token::Separator(',')) {
                     let const_handle =
@@ -1376,7 +1376,7 @@ impl Parser {
                 } else {
                     crate::ArraySize::Dynamic
                 };
-                lexer.expect(Token::Paren('>'))?;
+                lexer.expect_generic_paren('>')?;
 
                 crate::TypeInner::Array {
                     base,


### PR DESCRIPTION
Adds a ~~context to the lexer to keep track of the type parameter nesting level~~ `next_generic` method to the lexer that skips parsing shift operations.

This could be kept fairly simple ~~and limited to the lexer~~ because WGSL doesn't allow operations inside type parameters.

Tested on this shader sample:

```wgsl
  var x: array<vec2<f32>>;
  var y: array<array<vec2<f32>>>;

  var a: i32 = 12 << 1;
  
  if (a < 10 >> 3) {
    a = 10;
  }

  var b: i32 = 10 < 12 >> 1;
```

Resolves #415