### PR TITLE
Set default SPIR-V version in convert example

### DIFF
--- a/examples/convert.rs
+++ b/examples/convert.rs
@@ -74,6 +74,7 @@ fn main() {
             let mut param = Parameters::default();
             // very useful to have this by default
             param.spv_capabilities.insert(spirv::Capability::Shader);
+            param.spv_version = (1, 0);
             param
         }
     };


### PR DESCRIPTION
After #466 the convert example panicked with `target SPIRV-0.0 is not supported` in the `spv-out` path since it was set to `(0, 0)` with the default constructor.