### PR TITLE
Miscellaneous fixes for parsing Dota shaders

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -70,6 +70,7 @@ pub struct Writer<W> {
     out: W,
     names: FastHashMap<NameKey, String>,
     named_expressions: BitSet,
+    visit_mask: BitSet,
     typifier: Typifier,
     namer: Namer,
     temp_bake_handles: Vec<Handle<crate::Expression>>,
@@ -177,6 +178,7 @@ impl<W: Write> Writer<W> {
             out,
             names: FastHashMap::default(),
             named_expressions: BitSet::new(),
+            visit_mask: BitSet::new(),
             typifier: Typifier::new(),
             namer: Namer::default(),
             temp_bake_handles: Vec::new(),
@@ -709,6 +711,7 @@ impl<W: Write> Writer<W> {
         exclude_root: bool,
     ) -> Result<(), Error> {
         // set up the search
+        self.visit_mask.clear();
         let mut interface = Interface {
             expressions: &context.expression.function.expressions,
             local_variables: &context.expression.function.local_variables,
@@ -722,6 +725,7 @@ impl<W: Write> Writer<W> {
                     None
                 },
             },
+            mask: &mut self.visit_mask,
         };
         // populate the bake handles
         interface.traverse_expr(root_handle);

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1333,7 +1333,6 @@ impl<W: Write> Writer<W> {
                     }
                     _ => LocationMode::Uniform,
                 };
-                let resolved = options.resolve_binding(stage, var, loc_mode)?;
                 let tyvar = TypedGlobalVariable {
                     module,
                     names: &self.names,
@@ -1343,7 +1342,10 @@ impl<W: Write> Writer<W> {
                 let separator = separate(last_used_global == Some(handle));
                 write!(self.out, "{}", INDENT)?;
                 tyvar.try_fmt(&mut self.out)?;
-                resolved.try_fmt_decorated(&mut self.out, separator)?;
+                if var.binding.is_some() {
+                    let resolved = options.resolve_binding(stage, var, loc_mode)?;
+                    resolved.try_fmt_decorated(&mut self.out, separator)?;
+                }
                 if let Some(value) = var.init {
                     let value_str = &self.names[&NameKey::Constant(value)];
                     write!(self.out, " = {}", value_str)?;

--- a/src/front/global_usage.rs
+++ b/src/front/global_usage.rs
@@ -2,6 +2,7 @@ use crate::{
     arena::{Arena, Handle},
     proc::{Interface, Visitor},
 };
+use bit_set::BitSet;
 
 struct GlobalUseVisitor<'a> {
     usage: &'a mut [crate::GlobalUse],
@@ -30,6 +31,7 @@ impl Visitor for GlobalUseVisitor<'_> {
 
 impl crate::Function {
     pub fn fill_global_use(&mut self, globals_num: usize, functions: &Arena<crate::Function>) {
+        let mut mask = BitSet::with_capacity(self.expressions.len());
         self.global_usage.clear();
         self.global_usage
             .resize(globals_num, crate::GlobalUse::empty());
@@ -41,6 +43,7 @@ impl crate::Function {
                 usage: &mut self.global_usage,
                 functions,
             },
+            mask: &mut mask,
         };
         io.traverse(&self.body);
     }


### PR DESCRIPTION
More steps towards #409 
The `Interface` optimization is particularly interesting. When traversing the expressions, we only want to visit each expression once, and only when looking at the block that introduces it. If we had the ownership established in the IR like #452 suggests, we'd not need to keep the bitmask here.