### PR TITLE
[wgsl] allow empty for statement headers, and other compliance additions

### DIFF
--- a/src/front/wgsl/tests.rs
+++ b/src/front/wgsl/tests.rs
@@ -144,6 +144,16 @@ fn parse_loop() {
     ",
     )
     .unwrap();
+    parse_str(
+        "
+        fn main() {
+            for(;;) {
+                break;
+            }
+        }
+    ",
+    )
+    .unwrap();
 }
 
 #[test]


### PR DESCRIPTION
The first commit allows for statement header components to be optional.

This parses now correctly:

```wgsl
for(;;) {
   ...
}
```

The second commit limits the allowed initializer contents to `variable_statement | assignment_statement | func_call_statement` instead of allowing any statement.