### PR TITLE
Error tweaks

### DIFF
--- a/examples/convert.rs
+++ b/examples/convert.rs
@@ -158,15 +158,15 @@ fn main() {
         }
     };
 
-    // validate the IR
-    let analysis = naga::proc::Validator::new()
-        .validate(&module)
-        .unwrap_pretty();
-
     if args.len() <= 2 {
         println!("{:#?}", module);
         return;
     }
+
+    // validate the IR
+    let analysis = naga::proc::Validator::new()
+        .validate(&module)
+        .unwrap_pretty();
 
     match Path::new(&args[2])
         .extension()

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -44,7 +44,7 @@
 pub use features::Features;
 
 use crate::{
-    proc::{analyzer::Analysis, NameKey, Namer, ResolveContext, ResolveError, Typifier},
+    proc::{analyzer::Analysis, NameKey, Namer, ResolveContext, TypifyError, Typifier},
     Arena, ArraySize, BinaryOperator, Binding, BuiltIn, Bytes, ConservativeDepth, Constant,
     ConstantInner, DerivativeAxis, Expression, FastHashMap, Function, GlobalVariable, Handle,
     ImageClass, Interpolation, LocalVariable, Module, RelationalFunction, ScalarKind, ScalarValue,
@@ -220,7 +220,7 @@ pub enum Error {
     IoError(#[from] IoError),
     /// The [`Module`](crate::Module) failed type resolution
     #[error("Type error: {0}")]
-    Type(#[from] ResolveError),
+    Type(#[from] TypifyError),
     /// The specified [`Version`](Version) doesn't have all required [`Features`](super)
     ///
     /// Contains the missing [`Features`](Features)

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -44,7 +44,7 @@
 pub use features::Features;
 
 use crate::{
-    proc::{analyzer::Analysis, NameKey, Namer, ResolveContext, TypifyError, Typifier},
+    proc::{analyzer::Analysis, NameKey, Namer, ResolveContext, Typifier, TypifyError},
     Arena, ArraySize, BinaryOperator, Binding, BuiltIn, Bytes, ConservativeDepth, Constant,
     ConstantInner, DerivativeAxis, Expression, FastHashMap, Function, GlobalVariable, Handle,
     ImageClass, Interpolation, LocalVariable, Module, RelationalFunction, ScalarKind, ScalarValue,

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -16,7 +16,7 @@ we move them up to the root output structure that we define ourselves.
 
 use crate::{
     arena::Handle,
-    proc::{analyzer::Analysis, ResolveError},
+    proc::{analyzer::Analysis, TypifyError},
     FastHashMap,
 };
 use std::{
@@ -60,7 +60,7 @@ enum ResolvedBinding {
 pub enum Error {
     IO(IoError),
     Utf8(FromUtf8Error),
-    Type(ResolveError),
+    Type(TypifyError),
     MissingBindTarget(BindSource),
     InvalidImageAccess(crate::StorageAccess),
     BadName(String),
@@ -87,8 +87,8 @@ impl From<FromUtf8Error> for Error {
     }
 }
 
-impl From<ResolveError> for Error {
-    fn from(e: ResolveError) -> Self {
+impl From<TypifyError> for Error {
+    fn from(e: TypifyError) -> Self {
         Error::Type(e)
     }
 }
@@ -155,10 +155,8 @@ impl Options {
                     group,
                     binding,
                 };
-                self.binding_map
-                    .get(&source)
-                    .cloned()
-                    .map(ResolvedBinding::Resource)
+                ResolvedBinding::Resource(
+                    self.binding_map.get(&source).cloned().
                     .ok_or(Error::MissingBindTarget(source))
             }
             None => {

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -4,7 +4,7 @@ use crate::{
     arena::{Arena, Handle},
     proc::{
         analyzer::{Analysis, FunctionInfo},
-        Layouter, ResolveContext, ResolveError, Typifier,
+        Layouter, ResolveContext, TypifyError, Typifier,
     },
 };
 use spirv::Word;
@@ -22,7 +22,7 @@ pub enum Error {
     #[error("unimplemented {0:}")]
     FeatureNotImplemented(&'static str),
     #[error(transparent)]
-    Resolve(#[from] ResolveError),
+    Resolve(#[from] TypifyError),
 }
 
 struct Block {

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -4,7 +4,7 @@ use crate::{
     arena::{Arena, Handle},
     proc::{
         analyzer::{Analysis, FunctionInfo},
-        Layouter, ResolveContext, TypifyError, Typifier,
+        Layouter, ResolveContext, Typifier, TypifyError,
     },
 };
 use spirv::Word;

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -12,7 +12,7 @@ pub use interface::{Interface, Visitor};
 pub use layouter::{Alignment, Layouter};
 pub use namer::{EntryPointIndex, NameKey, Namer};
 pub use terminator::ensure_block_returns;
-pub use typifier::{ResolveContext, ResolveError, Typifier};
+pub use typifier::{ResolveContext, ResolveError, Typifier, TypifyError};
 pub use validator::{ValidationError, Validator};
 
 impl From<super::StorageFormat> for super::ScalarKind {

--- a/src/proc/validator.rs
+++ b/src/proc/validator.rs
@@ -1,6 +1,6 @@
 use super::{
     analyzer::{Analysis, AnalysisError, FunctionInfo, GlobalUse},
-    typifier::{ResolveContext, ResolveError, Typifier},
+    typifier::{TypifyError, ResolveContext, Typifier},
 };
 use crate::arena::{Arena, Handle};
 use bit_set::BitSet;
@@ -78,7 +78,7 @@ pub enum LocalVariableError {
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum FunctionError {
     #[error(transparent)]
-    Resolve(#[from] ResolveError),
+    Resolve(#[from] TypifyError),
     #[error("There are instructions after `return`/`break`/`continue`")]
     InvalidControlFlowExitTail,
     #[error("Local variable {handle:?} '{name}' is invalid: {error:?}")]

--- a/src/proc/validator.rs
+++ b/src/proc/validator.rs
@@ -1,6 +1,6 @@
 use super::{
     analyzer::{Analysis, AnalysisError, FunctionInfo, GlobalUse},
-    typifier::{TypifyError, ResolveContext, Typifier},
+    typifier::{ResolveContext, Typifier, TypifyError},
 };
 use crate::arena::{Arena, Handle};
 use bit_set::BitSet;


### PR DESCRIPTION
- don't validate in `convert` if we are only printing to console
- use `thiserror` in MSL
- have typifier report the expression handle