### PR TITLE
Use source attribute of errors

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -216,10 +216,10 @@ type BackendResult = Result<(), Error>;
 #[derive(Debug, Error)]
 pub enum Error {
     /// A error occurred while writing to the output
-    #[error("Io error: {0}")]
+    #[error("I/O error")]
     IoError(#[from] IoError),
     /// The [`Module`](crate::Module) failed type resolution
-    #[error("Type error: {0}")]
+    #[error("Type error")]
     Type(#[from] TypifyError),
     /// The specified [`Version`](Version) doesn't have all required [`Features`](super)
     ///

--- a/src/front/glsl/error.rs
+++ b/src/front/glsl/error.rs
@@ -2,6 +2,7 @@ use super::parser::Token;
 use super::token::TokenMetadata;
 use std::{borrow::Cow, fmt, io};
 
+//TODO: use `thiserror`
 #[derive(Debug)]
 pub enum ErrorKind {
     EndOfFile,

--- a/src/front/spv/error.rs
+++ b/src/front/spv/error.rs
@@ -1,6 +1,7 @@
 use super::ModuleState;
 use crate::arena::Handle;
 
+//TODO: use `thiserror`
 #[derive(Debug)]
 pub enum Error {
     InvalidHeader,

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -63,7 +63,7 @@ pub enum ResolveError {
 }
 
 #[derive(Clone, Debug, Error, PartialEq)]
-#[error("Type resolution of {0:?} failed: {1}")]
+#[error("Type resolution of {0:?} failed")]
 pub struct TypifyError(Handle<crate::Expression>, #[source] ResolveError);
 
 pub struct ResolveContext<'a> {


### PR DESCRIPTION
This is how it looks now:
```
Global variable Handle(2) 'particlesSrc' is invalid:
	Storage access LOAD exceeds the allowed (empty)
```
This is how it used to look:
```
thread 'main' panicked at 'Global variable Handle(2) 'particlesSrc' is invalid: InvalidStorageAccess { allowed: (empty), seen: LOAD }', examples/convert.rs:56:31
```