### PR TITLE
[wgsl] Add parser error snapshot

### DIFF
--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,0 +1,15 @@
+#[cfg(feature = "wgsl-in")]
+macro_rules! err {
+    ($value:expr, @$snapshot:literal) => {
+        ::insta::assert_snapshot!(naga::front::wgsl::parse_str($value).expect_err("expected parser error").to_string(), @$snapshot);
+    };
+}
+
+#[cfg(feature = "wgsl-in")]
+#[test]
+fn function_without_identifier() {
+    err!(
+        "fn () {}",
+        @"error while parsing WGSL in scopes [FunctionDecl] at line 1 pos 4: unexpected token Paren('('), expected ident"
+    );
+}


### PR DESCRIPTION
This starts to track parser errors for the WGSL frontend. The snapshots are inline (instead of separate files like shader snapshots) because the parser errors should generally remain small.

The benefits of error snapshots are basically the same as shader snapshots – it lets us verify that the error is returned correctly and that we avoid regressions as parts move around internally.