### PR TITLE
Rewrite the type validation

### DIFF
--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -13,7 +13,7 @@ pub use layouter::{Alignment, Layouter};
 pub use namer::{EntryPointIndex, NameKey, Namer};
 pub use terminator::ensure_block_returns;
 pub use typifier::{ResolveContext, ResolveError, Typifier, TypifyError};
-pub use validator::{ValidationError, Validator};
+pub use validator::{TypeFlags, ValidationError, Validator};
 
 impl From<super::StorageFormat> for super::ScalarKind {
     fn from(format: super::StorageFormat) -> Self {


### PR DESCRIPTION
Instead of traversing the types from top to bottom, enforcing the `HOST_SHARED` flag as we go, we are now collecting the type capabilities bottom to top (naturally), and comparing against the needs for global variables and such.
The PR also adds extends the checked properties into `SIZED`, and has a general `DATA` bit for the non-handle types.

This helps to validate cases like https://github.com/gfx-rs/wgpu/issues/1223