### PR TITLE
Validate signed integer array size constants

### DIFF
--- a/src/proc/layouter.rs
+++ b/src/proc/layouter.rs
@@ -73,6 +73,14 @@ impl Layouter {
                                 width: _,
                                 value: crate::ScalarValue::Uint(value),
                             } => value as u32,
+                            // Accept a signed integer size to avoid
+                            // requiring an explicit uint
+                            // literal. Type inference should make
+                            // this unnecessary.
+                            crate::ConstantInner::Scalar {
+                                width: _,
+                                value: crate::ScalarValue::Sint(value),
+                            } => value as u32,
                             ref other => unreachable!("Unexpected array size {:?}", other),
                         },
                         crate::ArraySize::Dynamic => 1,

--- a/src/proc/validator.rs
+++ b/src/proc/validator.rs
@@ -380,6 +380,18 @@ impl Validator {
                                     },
                                 ..
                             }) => {}
+                            // Accept a signed integer size to avoid
+                            // requiring an explicit uint
+                            // literal. Type inference should make
+                            // this unnecessary.
+                            Some(&crate::Constant {
+                                inner:
+                                    crate::ConstantInner::Scalar {
+                                        width: _,
+                                        value: crate::ScalarValue::Sint(_),
+                                    },
+                                ..
+                            }) => {}
                             other => {
                                 log::warn!("Array size {:?}", other);
                                 return Err(TypeError::InvalidArraySizeConstant(const_handle));


### PR DESCRIPTION
Until we have some amount of type inference, an integer literal used as a constant array size must have a `u` suffix. This is inconsistent with the surface syntax presented in the spec, and is a minor inconvenience.

For now, allow a signed integer array size to pass validation so that user code need not change when type inference deduces values of the correct type.

Fixes #516