### PR TITLE
spv-in: fix if branches in CFG

### DIFF
--- a/src/front/spv/flow.rs
+++ b/src/front/spv/flow.rs
@@ -251,12 +251,21 @@ impl FlowGraph {
                             reject: self.naga_traverse(false_node_index, Some(merge_node_index))?,
                         });
                     } else {
+                        let true_merges_to_false = has_path_connecting(
+                            &self.flow,
+                            true_node_index,
+                            false_node_index,
+                            None,
+                        );
+                        let stop_node_index = if true_merges_to_false {
+                            Some(merge_node_index)
+                        } else {
+                            stop_node_index
+                        };
+
                         result.push(crate::Statement::If {
                             condition,
-                            accept: self.naga_traverse(
-                                self.block_to_node[&true_id],
-                                Some(merge_node_index),
-                            )?,
+                            accept: self.naga_traverse(true_node_index, stop_node_index)?,
                             reject: vec![],
                         });
                     }


### PR DESCRIPTION
Fixes #520

In case false and merge node are the same in a Header block there can be 2 cases
- path along true edge ends up in the merge/false node
- path along true edge ends up somewhere else

In both cases a separate stop index needs to be used
- first case it is the false/false node
- second case it is just stop index passed on from above