### PR TITLE
[wgsl-in] Use codespan to report errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 bitflags = "1"
 bit-set = "0.5"
+codespan-reporting = { version = "0.11.0", optional = true }
 fxhash = "0.2"
 log = "0.4"
 num-traits = "0.2"
@@ -32,7 +33,7 @@ serialize = ["serde"]
 deserialize = ["serde"]
 spv-in = ["petgraph", "spirv"]
 spv-out = ["spirv"]
-wgsl-in = []
+wgsl-in = ["codespan-reporting"]
 
 [[bin]]
 name = "convert"

--- a/bin/convert.rs
+++ b/bin/convert.rs
@@ -100,7 +100,14 @@ fn main() {
         #[cfg(feature = "wgsl-in")]
         "wgsl" => {
             let input = fs::read_to_string(input_path).unwrap();
-            naga::front::wgsl::parse_str(&input).unwrap_pretty()
+            let result = naga::front::wgsl::parse_str(&input);
+            match result {
+                Ok(v) => v,
+                Err(ref e) => {
+                    e.emit_to_stderr();
+                    panic!("unable to parse WGSL");
+                }
+            }
         }
         #[cfg(feature = "glsl-in")]
         "vert" => {

--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -258,7 +258,7 @@ impl<'a> Lexer<'a> {
     pub(super) fn next_ident(&mut self) -> Result<&'a str, Error<'a>> {
         match self.next() {
             (Token::Word(word), _) => Ok(word),
-            other => Err(Error::Unexpected(other, "ident")),
+            other => Err(Error::Unexpected(other, "identifier")),
         }
     }
 
@@ -304,10 +304,6 @@ impl<'a> Lexer<'a> {
         let format = conv::map_storage_format(self.next_ident()?)?;
         self.expect(Token::Paren('>'))?;
         Ok(format)
-    }
-
-    pub(super) fn offset_from(&self, source: &'a str) -> usize {
-        source.len() - self.input.len()
     }
 }
 

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,7 +1,12 @@
 #[cfg(feature = "wgsl-in")]
 macro_rules! err {
     ($value:expr, @$snapshot:literal) => {
-        ::insta::assert_snapshot!(naga::front::wgsl::parse_str($value).expect_err("expected parser error").to_string(), @$snapshot);
+        ::insta::assert_snapshot!(
+            naga::front::wgsl::parse_str($value)
+                .expect_err("expected parser error")
+                .emit_to_string(),
+            @$snapshot
+        );
     };
 }
 
@@ -10,6 +15,13 @@ macro_rules! err {
 fn function_without_identifier() {
     err!(
         "fn () {}",
-        @"error while parsing WGSL in scopes [FunctionDecl] at line 1 pos 4: unexpected token Paren('('), expected ident"
+        @r###"
+    error: expected identifier, found '('
+      ┌─ wgsl:1:4
+      │
+    1 │ fn () {}
+      │    ^ expected identifier
+
+    "###
     );
 }


### PR DESCRIPTION
Fixes #380 (at least for wgsl-in)

Only `Unexpected` includes span information for now. We can expand this to include all the other variants without much trouble but we could do it in separate PRs.

`StringErrorBuffer` is currently only used in `emit_to_string`, so we could make the fields of `ParseError` public and move `StringErrorBuffer` inside the tests module if we don't want to expose `emit_to_string` outside of tests.