### PR TITLE
[wgsl-in] Add descriptions for more errors

### DIFF
--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -1,4 +1,5 @@
 use super::{conv, Error, Token, TokenSpan};
+use std::ops::Range;
 
 fn _consume_str<'a>(input: &'a str, what: &str) -> Option<&'a str> {
     if input.starts_with(what) {
@@ -255,6 +256,13 @@ impl<'a> Lexer<'a> {
         }
     }
 
+    pub(super) fn next_ident_with_span(&mut self) -> Result<(&'a str, Range<usize>), Error<'a>> {
+        match self.next() {
+            (Token::Word(word), span) => Ok((word, span)),
+            other => Err(Error::Unexpected(other, "identifier")),
+        }
+    }
+
     pub(super) fn next_ident(&mut self) -> Result<&'a str, Error<'a>> {
         match self.next() {
             (Token::Word(word), _) => Ok(word),
@@ -264,28 +272,26 @@ impl<'a> Lexer<'a> {
 
     fn _next_float_literal(&mut self) -> Result<f32, Error<'a>> {
         match self.next() {
-            (Token::Number { value, .. }, _) => {
-                value.parse().map_err(|err| Error::BadFloat(value, err))
-            }
-            other => Err(Error::Unexpected(other, "float literal")),
+            (Token::Number { value, .. }, span) => value.parse().map_err(|_| Error::BadFloat(span)),
+            other => Err(Error::Unexpected(other, "floating-point literal")),
         }
     }
 
     pub(super) fn next_uint_literal(&mut self) -> Result<u32, Error<'a>> {
         match self.next() {
-            (Token::Number { value, .. }, _) => {
-                value.parse().map_err(|err| Error::BadInteger(value, err))
+            (Token::Number { value, .. }, span) => {
+                value.parse().map_err(|_| Error::BadInteger(span))
             }
-            other => Err(Error::Unexpected(other, "uint literal")),
+            other => Err(Error::Unexpected(other, "unsigned integer literal")),
         }
     }
 
     pub(super) fn next_sint_literal(&mut self) -> Result<i32, Error<'a>> {
         match self.next() {
-            (Token::Number { value, .. }, _) => {
-                value.parse().map_err(|err| Error::BadInteger(value, err))
+            (Token::Number { value, .. }, span) => {
+                value.parse().map_err(|_| Error::BadInteger(span))
             }
-            other => Err(Error::Unexpected(other, "sint literal")),
+            other => Err(Error::Unexpected(other, "signed integer literal")),
         }
     }
 

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -25,3 +25,75 @@ fn function_without_identifier() {
     "###
     );
 }
+
+#[cfg(feature = "wgsl-in")]
+#[test]
+fn invalid_integer() {
+    err!(
+        "[[location(1.)]] var<in> pos : vec2<f32>;",
+        @r###"
+    error: expected integer literal, found `1.`
+      ┌─ wgsl:1:12
+      │
+    1 │ [[location(1.)]] var<in> pos : vec2<f32>;
+      │            ^^ expected integer
+
+    "###
+    );
+}
+
+#[cfg(feature = "wgsl-in")]
+#[test]
+fn invalid_float() {
+    err!(
+        "const scale: f32 = 1.1.;",
+        @r###"
+    error: expected floating-point literal, found `1.1.`
+      ┌─ wgsl:1:20
+      │
+    1 │ const scale: f32 = 1.1.;
+      │                    ^^^^ expected floating-point literal
+
+    "###
+    );
+}
+
+#[cfg(feature = "wgsl-in")]
+#[test]
+fn invalid_scalar_width() {
+    err!(
+        "const scale: f32 = 1.1f1000;",
+        @r###"
+    error: invalid width of `1000` for literal
+      ┌─ wgsl:1:20
+      │
+    1 │ const scale: f32 = 1.1f1000;
+      │                    ^^^^^^^^ invalid width
+      │
+      = note: valid width is 32
+
+    "###
+    );
+}
+
+#[cfg(feature = "wgsl-in")]
+#[test]
+fn invalid_accessor() {
+    err!(
+        r###"
+        [[stage(vertex)]]
+        fn vs_main() {
+            var color: vec3<f32> = vec3<f32>(1.0, 2.0, 3.0);
+            var i: f32 = color.a;
+        }
+    "###,
+        @r###"
+    error: invalid field accessor `a`
+      ┌─ wgsl:5:32
+      │
+    5 │             var i: f32 = color.a;
+      │                                ^ invalid accessor
+
+    "###
+    );
+}


### PR DESCRIPTION
Add some initial descriptions for `BadInteger`, `BadFloat`, `BadScalarWidth`, and `BadAccessor`. I removed some of the fields that weren't being used in the new descriptions – we could expand these over time as we improve the descriptions/notes.