### PR TITLE
[glsl-in] Expression ownership

### DIFF
--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -10,10 +10,17 @@ use super::token::TokenMetadata;
 impl Program<'_> {
     pub fn lookup_variable(&mut self, name: &str) -> Result<Option<Handle<Expression>>, ErrorKind> {
         if let Some(local_var) = self.context.lookup_local_var(name) {
-            return Ok(Some(local_var));
+            let load = self
+                .context
+                .expressions
+                .append(Expression::Load { pointer: local_var });
+            return Ok(Some(load));
         }
         if let Some(global_var) = self.context.lookup_global_var_exps.get(name) {
-            return Ok(Some(*global_var));
+            let load = self.context.expressions.append(Expression::Load {
+                pointer: *global_var,
+            });
+            return Ok(Some(load));
         }
         if let Some(constant) = self.context.lookup_constant_exps.get(name) {
             return Ok(Some(*constant));


### PR DESCRIPTION
Just copy pasted info for easy ref:

GLSL-in shoud roughly following wgsl-in:

1. Generate Expression::Load whenever we operate on a value of a variable (both locals and globals)
2. Track the expressions we produce (possibly using Emitter struct that's currently shared between spv-in and wgsl-in):
- flush (into Statement::Emit) before adding a statement using any of the expressions
- exclude the Expression::Constant and Expression::Call by flushing before we add them, and restarting the emitter afterwards