### PR TITLE
[glsl-out] Set precision for image type and fix structure type in statement

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1008,8 +1008,16 @@ impl<'a, W: Write> Writer<'a, W> {
                         let min_ref_count = ctx.expressions[handle].bake_ref_count();
                         if min_ref_count <= ctx.info[handle].ref_count {
                             write!(self.out, "{}", INDENT.repeat(indent))?;
+                            match self.module.types[ty_handle].inner {
+                                TypeInner::Struct { .. } => {
+                                    let ty_name = &self.names[&NameKey::Type(ty_handle)];
+                                    write!(self.out, "{}", ty_name)?;
+                                }
+                                _ => {
+                                    self.write_type(ty_handle)?;
+                                }
+                            };
                             let name = format!("_expr{}", handle.index());
-                            self.write_type(ty_handle)?;
                             write!(self.out, " {} = ", name)?;
                             self.write_expr(handle, ctx)?;
                             writeln!(self.out, ";")?;

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -669,7 +669,7 @@ impl<'a, W: Write> Writer<'a, W> {
 
         write!(
             self.out,
-            "{}{}{}{}{}{}",
+            "highp {}{}{}{}{}{}",
             glsl_scalar(kind, 4)?.prefix,
             base,
             glsl_dimension(dim),

--- a/tests/out/quad-Fragment.glsl.snap
+++ b/tests/out/quad-Fragment.glsl.snap
@@ -8,7 +8,7 @@ precision highp float;
 
 in vec2 _location_0_vs;
 
-uniform sampler2D _group_0_binding_0;
+uniform highp sampler2D _group_0_binding_0;
 
 out vec4 _location_0;
 

--- a/tests/out/skybox-Fragment.glsl.snap
+++ b/tests/out/skybox-Fragment.glsl.snap
@@ -11,7 +11,7 @@ struct Data {
     mat4x4 view;
 };
 
-uniform samplerCube _group_0_binding_1;
+uniform highp samplerCube _group_0_binding_1;
 
 in vec3 _location_0_vs;
 


### PR DESCRIPTION
Before:
```glsl
Light_block_2 {
    mat4x4 proj;
    vec4 pos;
    vec4 color;
} _expr29 = _group_0_binding_1.data[i];
```

After:
```glsl
Light _expr29 = _group_0_binding_1.data[i];
```