### PR TITLE
[spv-in] function calls and variable types as pointers

### DIFF
--- a/src/front/spv/convert.rs
+++ b/src/front/spv/convert.rs
@@ -144,3 +144,20 @@ pub fn map_builtin(word: spirv::Word, is_output: bool) -> Result<crate::BuiltIn,
         _ => return Err(Error::UnsupportedBuiltIn(word)),
     })
 }
+
+pub fn map_storage_class(word: spirv::Word) -> Result<crate::StorageClass, Error> {
+    use spirv::StorageClass as Sc;
+    Ok(match Sc::from_u32(word) {
+        Some(Sc::Function) => crate::StorageClass::Function,
+        Some(Sc::Input) => crate::StorageClass::Input,
+        Some(Sc::Output) => crate::StorageClass::Output,
+        Some(Sc::Private) => crate::StorageClass::Private,
+        Some(Sc::UniformConstant) => crate::StorageClass::Handle,
+        Some(Sc::StorageBuffer) => crate::StorageClass::Storage,
+        // we expect the `Storage` case to be filtered out before calling this function.
+        Some(Sc::Uniform) => crate::StorageClass::Uniform,
+        Some(Sc::Workgroup) => crate::StorageClass::WorkGroup,
+        Some(Sc::PushConstant) => crate::StorageClass::PushConstant,
+        _ => return Err(Error::UnsupportedStorageClass(word)),
+    })
+}

--- a/src/front/spv/error.rs
+++ b/src/front/spv/error.rs
@@ -34,7 +34,6 @@ pub enum Error {
     InvalidSign(spirv::Word),
     InvalidInnerType(spirv::Word),
     InvalidVectorSize(spirv::Word),
-    InvalidVariableClass(spirv::StorageClass),
     InvalidAccessType(spirv::Word),
     InvalidAccess(crate::Expression),
     InvalidAccessIndex(spirv::Word),

--- a/src/front/spv/function.rs
+++ b/src/front/spv/function.rs
@@ -157,9 +157,6 @@ impl<I: Iterator<Item = u32>> super::Parser<I> {
 
         fun.body = flow_graph.to_naga()?;
 
-        // done
-        self.patch_function_calls(&mut fun)?;
-
         match self.lookup_entry_point.remove(&fun_id) {
             Some(ep) => {
                 module.entry_points.push(crate::EntryPoint {

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -1754,6 +1754,16 @@ impl<I: Iterator<Item = u32>> Parser<I> {
             }?;
         }
 
+        log::info!("Patching...");
+        // patch all the function calls
+        for (_, fun) in module.functions.iter_mut() {
+            self.patch_function_calls(fun)?;
+        }
+        for ep in module.entry_points.iter_mut() {
+            self.patch_function_calls(&mut ep.function)?;
+        }
+        self.lookup_function.clear();
+
         // Check all the images and samplers to have consistent comparison property.
         for (handle, flags) in self.handle_sampling.drain() {
             if !image::patch_comparison_type(

--- a/tests/out/shadow.ron.snap
+++ b/tests/out/shadow.ron.snap
@@ -83,6 +83,20 @@ expression: output
         ),
         (
             name: None,
+            inner: Pointer(
+                base: 2,
+                class: Function,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 3,
+                class: Function,
+            ),
+        ),
+        (
+            name: None,
             inner: Vector(
                 size: Quad,
                 kind: Uint,
@@ -97,9 +111,30 @@ expression: output
                     (
                         name: Some("num_lights"),
                         span: None,
-                        ty: 11,
+                        ty: 13,
                     ),
                 ],
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 14,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 13,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 3,
+                class: Uniform,
             ),
         ),
         (
@@ -118,7 +153,7 @@ expression: output
                     (
                         name: Some("proj"),
                         span: None,
-                        ty: 13,
+                        ty: 18,
                     ),
                     (
                         name: Some("pos"),
@@ -136,7 +171,7 @@ expression: output
         (
             name: None,
             inner: Array(
-                base: 14,
+                base: 19,
                 size: Dynamic,
                 stride: Some(96),
             ),
@@ -149,9 +184,247 @@ expression: output
                     (
                         name: Some("data"),
                         span: None,
-                        ty: 15,
+                        ty: 20,
                     ),
                 ],
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 21,
+                class: Storage,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 20,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 19,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 18,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 4,
+                class: Input,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 2,
+                class: Input,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 20,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 19,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 4,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 1,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 20,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 19,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 4,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 1,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 20,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 19,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 4,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 1,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 1,
+                class: Input,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 1,
+                class: Input,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 1,
+                class: Input,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 20,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 19,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 4,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 1,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 20,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 19,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 4,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 1,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 20,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 19,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 4,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 1,
+                class: Uniform,
+            ),
+        ),
+        (
+            name: None,
+            inner: Pointer(
+                base: 4,
+                class: Output,
             ),
         ),
         (
@@ -495,7 +768,7 @@ expression: output
                 group: 0,
                 binding: 2,
             )),
-            ty: 17,
+            ty: 56,
             init: None,
             interpolation: None,
             storage_access: (
@@ -509,7 +782,7 @@ expression: output
                 group: 0,
                 binding: 3,
             )),
-            ty: 18,
+            ty: 57,
             init: None,
             interpolation: None,
             storage_access: (
@@ -523,7 +796,7 @@ expression: output
                 group: 0,
                 binding: 0,
             )),
-            ty: 12,
+            ty: 14,
             init: None,
             interpolation: None,
             storage_access: (
@@ -537,7 +810,7 @@ expression: output
                 group: 0,
                 binding: 1,
             )),
-            ty: 16,
+            ty: 21,
             init: None,
             interpolation: None,
             storage_access: (


### PR DESCRIPTION
The function call patching was wrong because it didn't work with forward declarations.

The variables as pointers thing is a required follow up to #546: the SPIR-V frontend was still considering everything to be non-pointer, unconditionally. This prevented use cases where a function argument is a pointer, and this is what `glslang` always generates (including wgpu-rs water example shaders). So this PR makes pointers really first-class in the frontend, at the cost of slightly increased complexity in the type logic.