### PR TITLE
More error information for uniformity analysis

### DIFF
--- a/bin/convert.rs
+++ b/bin/convert.rs
@@ -49,6 +49,7 @@ fn main() {
 
     let mut args = env::args();
     let _ = args.next().unwrap();
+    #[allow(clippy::while_let_on_iterator)]
     while let Some(arg) = args.next() {
         //TODO: use `strip_prefix` when MSRV reaches 1.45.0
         if arg.starts_with("--") {

--- a/tests/out/collatz.info.ron.snap
+++ b/tests/out/collatz.info.ron.snap
@@ -5,9 +5,11 @@ expression: output
 (
     functions: [
         (
-            control_flags: (
-                bits: 5,
+            uniformity: (
+                non_uniform_result: Some(4),
+                require_uniform: None,
             ),
+            may_kill: false,
             sampling_set: [],
             global_uses: [
                 (
@@ -19,183 +21,209 @@ expression: output
             ],
             expressions: [
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(1),
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: Some(1),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: Some(2),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(3),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(4),
+                        require_uniform: None,
                     ),
                     ref_count: 7,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(6),
+                        require_uniform: None,
                     ),
                     ref_count: 3,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(4),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(4),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(4),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(4),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(4),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(4),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(4),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(4),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(4),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(4),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(6),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(6),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(6),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
@@ -205,9 +233,11 @@ expression: output
     ],
     entry_points: [
         (
-            control_flags: (
-                bits: 5,
+            uniformity: (
+                non_uniform_result: Some(4),
+                require_uniform: None,
             ),
+            may_kill: false,
             sampling_set: [],
             global_uses: [
                 (
@@ -219,87 +249,99 @@ expression: output
             ],
             expressions: [
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(1),
+                        require_uniform: None,
                     ),
                     ref_count: 2,
                     assignable_global: Some(1),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        require_uniform: None,
                     ),
                     ref_count: 2,
                     assignable_global: Some(2),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(2),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(1),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(1),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(2),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(2),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(1),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(1),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(2),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 5,
+                    uniformity: (
+                        non_uniform_result: Some(4),
+                        require_uniform: None,
                     ),
-                    ref_count: 2,
+                    ref_count: 1,
                     assignable_global: None,
                 ),
             ],

--- a/tests/out/shadow.info.ron.snap
+++ b/tests/out/shadow.info.ron.snap
@@ -5,9 +5,11 @@ expression: output
 (
     functions: [
         (
-            control_flags: (
-                bits: 5,
+            uniformity: (
+                non_uniform_result: Some(44),
+                require_uniform: None,
             ),
+            may_kill: false,
             sampling_set: [
                 (
                     image: 1,
@@ -39,498 +41,569 @@ expression: output
             ],
             expressions: [
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: Some(3),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: Some(6),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(3),
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: Some(5),
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(1),
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(2),
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(7),
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: Some(7),
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 3,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 3,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(43),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 6,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 2,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(43),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(43),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 3,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
@@ -540,9 +613,11 @@ expression: output
     ],
     entry_points: [
         (
-            control_flags: (
-                bits: 5,
+            uniformity: (
+                non_uniform_result: Some(44),
+                require_uniform: None,
             ),
+            may_kill: false,
             sampling_set: [
                 (
                     image: 1,
@@ -574,827 +649,945 @@ expression: output
             ],
             expressions: [
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(3),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(6),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(3),
+                        require_uniform: None,
                     ),
                     ref_count: 4,
                     assignable_global: Some(5),
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: Some(1),
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: Some(2),
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 7,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(7),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(7),
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 0,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(43),
+                        require_uniform: None,
                     ),
                     ref_count: 3,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 11,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(3),
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(3),
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(43),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(3),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 5,
-                    ),
-                    ref_count: 2,
-                    assignable_global: None,
-                ),
-                (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(4),
-                ),
-                (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(4),
-                ),
-                (
-                    control_flags: (
-                        bits: 1,
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(4),
-                ),
-                (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(4),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(4),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(4),
-                ),
-                (
-                    control_flags: (
-                        bits: 1,
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(4),
-                ),
-                (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(4),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(4),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(4),
-                ),
-                (
-                    control_flags: (
-                        bits: 1,
-                    ),
-                    ref_count: 1,
-                    assignable_global: Some(4),
-                ),
-                (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(4),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(4),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
+                    ),
+                    ref_count: 1,
+                    assignable_global: Some(4),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
+                    ),
+                    ref_count: 1,
+                    assignable_global: None,
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: Some(3),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(5),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(3),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(3),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(5),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(3),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(3),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(5),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(3),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(3),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(2),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 5,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 0,
+                    uniformity: (
+                        non_uniform_result: None,
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: Some(4),
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 5,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 5,
+                    uniformity: (
+                        non_uniform_result: Some(43),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(44),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(43),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,
                 ),
                 (
-                    control_flags: (
-                        bits: 1,
+                    uniformity: (
+                        non_uniform_result: Some(43),
+                        require_uniform: None,
                     ),
                     ref_count: 1,
                     assignable_global: None,


### PR DESCRIPTION
This is a big update to #445. Error reporting was really harsh, since it wasn't telling the user what part of the code requires uniformity, and what part doesn't let it happen. This PR adds this information to the errors. It also fixes the logic somewhere, since the water example no longer triggers an uniformity error.