### PR TITLE
Prevent matching on a reference once and for all

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -85,7 +85,7 @@ pub enum Version {
 impl Version {
     /// Returns true if self is `Version::Embedded` (i.e. is a es version)
     fn is_es(&self) -> bool {
-        match self {
+        match *self {
             Version::Desktop(_) => false,
             Version::Embedded(_) => true,
         }
@@ -98,9 +98,9 @@ impl Version {
     /// As an invalid version number will never be added to the supported version list
     /// so this also checks for version validity
     fn is_supported(&self) -> bool {
-        match self {
-            Version::Desktop(v) => SUPPORTED_CORE_VERSIONS.contains(v),
-            Version::Embedded(v) => SUPPORTED_ES_VERSIONS.contains(v),
+        match *self {
+            Version::Desktop(v) => SUPPORTED_CORE_VERSIONS.contains(&v),
+            Version::Embedded(v) => SUPPORTED_ES_VERSIONS.contains(&v),
         }
     }
 }
@@ -117,7 +117,7 @@ impl PartialOrd for Version {
 
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
+        match *self {
             Version::Desktop(v) => write!(f, "{} core", v),
             Version::Embedded(v) => write!(f, "{} es", v),
         }
@@ -1615,7 +1615,7 @@ impl<'a, W: Write> Writer<'a, W> {
             Expression::Binary { op, left, right } => {
                 // Holds `Some(function_name)` if the binary operation is
                 // implemented as a function call
-                let function = if let (TypeInner::Vector { .. }, TypeInner::Vector { .. }) = (
+                let function = if let (&TypeInner::Vector { .. }, &TypeInner::Vector { .. }) = (
                     ctx.typifier.get(left, &self.module.types),
                     ctx.typifier.get(right, &self.module.types),
                 ) {

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -993,7 +993,7 @@ impl<W: Write> Writer<W> {
                             let (_, global) = module
                                 .global_variables
                                 .iter()
-                                .find(|(_, var)| var.ty == handle)
+                                .find(|&(_, ref var)| var.ty == handle)
                                 .expect("Unable to find a global variable using the image type");
                             let access = if global
                                 .storage_access

--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -71,12 +71,12 @@ impl<'a> Program<'a> {
         left: &ExpressionRule,
         right: &ExpressionRule,
     ) -> Result<ExpressionRule, ErrorKind> {
-        let left_is_vector = match self.resolve_type(left.expression)? {
+        let left_is_vector = match *self.resolve_type(left.expression)? {
             crate::TypeInner::Vector { .. } => true,
             _ => false,
         };
 
-        let right_is_vector = match self.resolve_type(right.expression)? {
+        let right_is_vector = match *self.resolve_type(right.expression)? {
             crate::TypeInner::Vector { .. } => true,
             _ => false,
         };

--- a/src/front/glsl/error.rs
+++ b/src/front/glsl/error.rs
@@ -26,32 +26,34 @@ pub enum ErrorKind {
 
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
+        match *self {
             ErrorKind::EndOfFile => write!(f, "Unexpected end of file"),
             ErrorKind::InvalidInput => write!(f, "InvalidInput"),
-            ErrorKind::InvalidProfile(meta, val) => {
+            ErrorKind::InvalidProfile(ref meta, ref val) => {
                 write!(f, "Invalid profile {} at {:?}", val, meta)
             }
-            ErrorKind::InvalidToken(token) => write!(f, "Invalid Token {:?}", token),
-            ErrorKind::InvalidVersion(meta, val) => {
+            ErrorKind::InvalidToken(ref token) => write!(f, "Invalid Token {:?}", token),
+            ErrorKind::InvalidVersion(ref meta, ref val) => {
                 write!(f, "Invalid version {} at {:?}", val, meta)
             }
-            ErrorKind::IoError(error) => write!(f, "IO Error {}", error),
+            ErrorKind::IoError(ref error) => write!(f, "IO Error {}", error),
             ErrorKind::ParserFail => write!(f, "Parser failed"),
             ErrorKind::ParserStackOverflow => write!(f, "Parser stack overflow"),
-            ErrorKind::NotImplemented(msg) => write!(f, "Not implemented: {}", msg),
-            ErrorKind::UnknownVariable(meta, val) => {
+            ErrorKind::NotImplemented(ref msg) => write!(f, "Not implemented: {}", msg),
+            ErrorKind::UnknownVariable(ref meta, ref val) => {
                 write!(f, "Unknown variable {} at {:?}", val, meta)
             }
-            ErrorKind::UnknownField(meta, val) => write!(f, "Unknown field {} at {:?}", val, meta),
+            ErrorKind::UnknownField(ref meta, ref val) => {
+                write!(f, "Unknown field {} at {:?}", val, meta)
+            }
             #[cfg(feature = "glsl-validate")]
-            ErrorKind::VariableAlreadyDeclared(val) => {
+            ErrorKind::VariableAlreadyDeclared(ref val) => {
                 write!(f, "Variable {} already declared in current scope", val)
             }
             ErrorKind::ExpectedConstant => write!(f, "Expected constant"),
-            ErrorKind::SemanticError(msg) => write!(f, "Semantic error: {}", msg),
-            ErrorKind::PreprocessorError(val) => write!(f, "Preprocessor error: {}", val),
-            ErrorKind::WrongNumberArgs(fun, expected, actual) => {
+            ErrorKind::SemanticError(ref msg) => write!(f, "Semantic error: {}", msg),
+            ErrorKind::PreprocessorError(ref val) => write!(f, "Preprocessor error: {}", val),
+            ErrorKind::WrongNumberArgs(ref fun, expected, actual) => {
                 write!(f, "{} requires {} args, got {}", fun, expected, actual)
             }
         }

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -328,7 +328,7 @@ pomelo! {
         extra.unary_expr(UnaryOperator::Negate, &tgt)
     }
     unary_expression ::= Bang unary_expression(tgt) {
-        if let TypeInner::Scalar { kind: ScalarKind::Bool, .. } = extra.resolve_type(tgt.expression)? {
+        if let TypeInner::Scalar { kind: ScalarKind::Bool, .. } = *extra.resolve_type(tgt.expression)? {
             extra.unary_expr(UnaryOperator::Not, &tgt)
         } else {
             return Err(ErrorKind::SemanticError("Cannot apply '!' to non bool type".into()))
@@ -1070,18 +1070,18 @@ pomelo! {
         if let Some(d) = d {
             // TODO: handle multiple storage qualifiers
             let storage = d.type_qualifiers.iter().find_map(|tq| {
-                if let TypeQualifier::StorageQualifier(sc) = tq { Some(*sc) } else { None }
+                if let TypeQualifier::StorageQualifier(sc) = *tq { Some(sc) } else { None }
             }).unwrap_or(StorageQualifier::StorageClass(StorageClass::Private));
 
             match storage {
                 StorageQualifier::StorageClass(storage_class) => {
                     // TODO: Check that the storage qualifiers allow for the bindings
                     let binding = d.type_qualifiers.iter().find_map(|tq| {
-                        if let TypeQualifier::Binding(b) = tq { Some(b.clone()) } else { None }
+                        if let TypeQualifier::Binding(ref b) = *tq { Some(b.clone()) } else { None }
                     });
 
                     let interpolation = d.type_qualifiers.iter().find_map(|tq| {
-                        if let TypeQualifier::Interpolation(i) = tq { Some(*i) } else { None }
+                        if let TypeQualifier::Interpolation(interp) = *tq { Some(interp) } else { None }
                     });
 
                     for (id, initializer) in d.ids_initializers {

--- a/src/front/spv/flow.rs
+++ b/src/front/spv/flow.rs
@@ -126,7 +126,7 @@ impl FlowGraph {
                         ControlFlowEdgeType::Forward,
                     );
 
-                    for (_, target_block_id) in targets.iter() {
+                    for &(_, target_block_id) in targets.iter() {
                         let target_node_index = block_to_node[&target_block_id];
 
                         self.flow.add_edge(
@@ -201,7 +201,7 @@ impl FlowGraph {
             let phis = std::mem::replace(&mut self.flow[node_index].phis, Vec::new());
             for phi in phis.iter() {
                 let phi_var = &lookup_expression[&phi.id];
-                for (variable_id, parent_id) in phi.variables.iter() {
+                for &(variable_id, parent_id) in phi.variables.iter() {
                     let variable = &lookup_expression[&variable_id];
                     let parent_node = &mut self.flow[self.block_to_node[&parent_id]];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,12 +20,6 @@ emitted in order to take effect. This happens in one of the following ways:
 
 !*/
 
-#![warn(
-    trivial_casts,
-    trivial_numeric_casts,
-    unused_extern_crates,
-    unused_qualifications
-)]
 #![allow(
     clippy::new_without_default,
     clippy::unneeded_field_pattern,
@@ -33,6 +27,13 @@ emitted in order to take effect. This happens in one of the following ways:
 )]
 // TODO: use `strip_prefix` instead when Rust 1.45 <= MSRV
 #![allow(clippy::manual_strip, clippy::unknown_clippy_lints)]
+#![warn(
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_qualifications,
+    clippy::pattern_type_mismatch
+)]
 #![deny(clippy::panic)]
 
 mod arena;
@@ -418,7 +419,7 @@ pub struct Constant {
 }
 
 /// A literal scalar value, used in constants.
-#[derive(Debug, PartialEq, Clone, PartialOrd)]
+#[derive(Debug, PartialEq, Clone, Copy, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub enum ScalarValue {
@@ -429,7 +430,7 @@ pub enum ScalarValue {
 }
 
 /// Additional information, dependent on the kind of constant.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub enum ConstantInner {


### PR DESCRIPTION
This enables `clippy::pattern_type_mismatch` warning for the whole project. We've already tried to follow it, unofficially, via my annoying review pings (sorry!). Now it's a part of the workflow, checked by CI. I'm really happy that we can do this :)
See also - https://github.com/rust-lang/rust-clippy/issues/6885