### PR TITLE
[glsl-out] fix cached expressions

### DIFF
--- a/src/back/mod.rs
+++ b/src/back/mod.rs
@@ -12,13 +12,18 @@ pub mod spv;
 impl crate::Expression {
     /// Returns the ref count, upon reaching which this expression
     /// should be considered for baking.
+    ///
+    /// Note: we have to cache any expressions that depend on the control flow,
+    /// or otherwise they may be moved into a non-uniform contol flow, accidentally.
     #[allow(dead_code)]
     fn bake_ref_count(&self) -> usize {
         match *self {
             // accesses are never cached, only loads are
             crate::Expression::Access { .. } | crate::Expression::AccessIndex { .. } => !0,
-            // image operations look better when isolated
+            // sampling may use the control flow, and image ops look better by themselves
             crate::Expression::ImageSample { .. } | crate::Expression::ImageLoad { .. } => 1,
+            // derivatives use the control flow
+            crate::Expression::Derivative { .. } => 1,
             // cache expressions that are referenced multiple times
             _ => 2,
         }

--- a/tests/out/quad-Fragment.glsl.snap
+++ b/tests/out/quad-Fragment.glsl.snap
@@ -13,10 +13,11 @@ uniform highp sampler2D _group_0_binding_0;
 out vec4 _location_0;
 
 void main() {
-    if((texture(_group_0_binding_0, vec2(_location_0_vs))[3] == 0.0)) {
+    vec4 _expr9 = texture(_group_0_binding_0, vec2(_location_0_vs));
+    if((_expr9[3] == 0.0)) {
         discard;
     }
-    _location_0 = (texture(_group_0_binding_0, vec2(_location_0_vs))[3] * texture(_group_0_binding_0, vec2(_location_0_vs)));
+    _location_0 = (_expr9[3] * _expr9);
     return;
 }
 

--- a/tests/out/shadow-Fragment.glsl.snap
+++ b/tests/out/shadow-Fragment.glsl.snap
@@ -32,7 +32,9 @@ float fetch_shadow(uint light_id, vec4 homogeneous_coords) {
     if((homogeneous_coords[3] <= 0.0)) {
         return 1.0;
     }
-    return textureGrad(_group_0_binding_2, vec4((((vec2(homogeneous_coords[0], homogeneous_coords[1]) * vec2(0.5, -0.5)) * (1.0 / homogeneous_coords[3])) + vec2(0.5, 0.5)), int(light_id), (homogeneous_coords[2] * (1.0 / homogeneous_coords[3]))), vec2(0, 0), vec2(0,0));
+    float _expr15 = (1.0 / homogeneous_coords[3]);
+    float _expr28 = textureGrad(_group_0_binding_2, vec4((((vec2(homogeneous_coords[0], homogeneous_coords[1]) * vec2(0.5, -0.5)) * _expr15) + vec2(0.5, 0.5)), int(light_id), (homogeneous_coords[2] * _expr15)), vec2(0, 0), vec2(0,0));
+    return _expr28;
 }
 
 void main() {
@@ -51,3 +53,5 @@ void main() {
     _location_0 = vec4(color1, 1.0);
     return;
 }
+
+

--- a/tests/out/skybox-Fragment.glsl.snap
+++ b/tests/out/skybox-Fragment.glsl.snap
@@ -13,6 +13,9 @@ in vec3 _location_0_vs;
 out vec4 _location_0;
 
 void main() {
-    _location_0 = texture(_group_0_binding_1, vec3(_location_0_vs));
+    vec4 _expr9 = texture(_group_0_binding_1, vec3(_location_0_vs));
+    _location_0 = _expr9;
     return;
 }
+
+


### PR DESCRIPTION
Fixes #565

The problem with emitting here was that it only worked on expressions that have registered types. A lot of expressions don't.

Related, this PR also includes a small change in all the frontends to force the caching of `Derivative` expression, so that it gets tied to the region and doesn't slip deeper where the control flow may be less uniform.

Finally, `cached_expressions` needed to be reset between the functions, so that we don't hit it accidentally.