### PR TITLE
Changelog for v0.4, more flexible conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,41 @@
 # Change Log
 
-## v0.3.1 (2021-01-31)
+## v0.4 (TBD)
+  - development release for wgpu-0.8
+  - API:
+    - expressions are explicitly emitted with `Statement::Emit`
+    - entry points have inputs in arguments and outputs in the result type
+    - `input`/`output` storage classes are gone, but `push_constant` is added
+    - `Interpolation` is moved into `Binding::Location` variant
+    - real pointer semantics with required `Expression::Load`
+    - `TypeInner::ValuePointer` is added
+    - image query expressions are added
+    - new `Statement::ImageStore`
+    - all function calls are `Statement::Call`
+    - `GlobalUse` is moved out into processing
+    - field layout is controlled by `size` and `alignment` overrides, based on a default layout
+    - `Header` is removed
+    - entry points are an array instead of a map
+  - Infrastructure:
+    - control flow uniformity analysis
+    - texture-sampler combination gathering
+    - `CallGraph` processor is moved out into `glsl` backend
+    - `Interface` is removed
+    - statement tree and constants are validated
+    - code linting is more strict for matches
+  - new GraphViz `dot` backend for pretty visualization of the IR
+  - `convert` is default a binary target, published with the crate
+
+### v0.3.2 (2021-02-15)
+  - fix logical expression types
+  - fix _FragDepth_ semantics
+  - spv-in:
+    - derive block status of structures
+  - spv-out:
+    - add lots of missing math functions
+    - implement discard
+
+### v0.3.1 (2021-01-31)
   - wgsl:
     - support constant array sizes
   - spv-out:


### PR DESCRIPTION
Fixes #580
The converter changes are meant to allow dumping the IR in case of a failed analysis. This is useful to analyze why the analysis fails in the first place :)