### PR TITLE
[msl-out] fix varying input structures

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -894,12 +894,12 @@ impl<W: Write> Writer<W> {
             let global_use = GlobalUse::all(); //TODO
             match ty.inner {
                 crate::TypeInner::Scalar { kind, .. } => {
-                    write!(self.out, "typedef {} {}", scalar_kind_string(kind), name)?;
+                    writeln!(self.out, "typedef {} {};", scalar_kind_string(kind), name)?;
                 }
                 crate::TypeInner::Vector { size, kind, .. } => {
-                    write!(
+                    writeln!(
                         self.out,
-                        "typedef {}::{}{} {}",
+                        "typedef {}::{}{} {};",
                         NAMESPACE,
                         scalar_kind_string(kind),
                         vector_size_string(size),
@@ -907,9 +907,9 @@ impl<W: Write> Writer<W> {
                     )?;
                 }
                 crate::TypeInner::Matrix { columns, rows, .. } => {
-                    write!(
+                    writeln!(
                         self.out,
-                        "typedef {}::{}{}x{} {}",
+                        "typedef {}::{}{}x{} {};",
                         NAMESPACE,
                         scalar_kind_string(crate::ScalarKind::Float),
                         vector_size_string(columns),
@@ -923,7 +923,7 @@ impl<W: Write> Writer<W> {
                         Some(name) => name,
                         None => continue,
                     };
-                    write!(self.out, "typedef {} {} *{}", class_name, base_name, name)?;
+                    writeln!(self.out, "typedef {} {} *{};", class_name, base_name, name)?;
                 }
                 crate::TypeInner::ValuePointer {
                     size: None,
@@ -935,9 +935,9 @@ impl<W: Write> Writer<W> {
                         Some(name) => name,
                         None => continue,
                     };
-                    write!(
+                    writeln!(
                         self.out,
-                        "typedef {} {} *{}",
+                        "typedef {} {} *{};",
                         class_name,
                         scalar_kind_string(kind),
                         name
@@ -953,9 +953,9 @@ impl<W: Write> Writer<W> {
                         Some(name) => name,
                         None => continue,
                     };
-                    write!(
+                    writeln!(
                         self.out,
-                        "typedef {} {}::{}{} {}",
+                        "typedef {} {}::{}{} {};",
                         class_name,
                         NAMESPACE,
                         scalar_kind_string(kind),
@@ -975,7 +975,7 @@ impl<W: Write> Writer<W> {
                         }
                         crate::ArraySize::Dynamic => "1",
                     };
-                    write!(self.out, "typedef {} {}[{}]", base_name, name, size_str)?;
+                    writeln!(self.out, "typedef {} {}[{}];", base_name, name, size_str)?;
                 }
                 crate::TypeInner::Struct {
                     block: _,
@@ -987,7 +987,7 @@ impl<W: Write> Writer<W> {
                         let base_name = &self.names[&NameKey::Type(member.ty)];
                         writeln!(self.out, "{}{} {};", INDENT, base_name, member_name)?;
                     }
-                    write!(self.out, "}}")?;
+                    writeln!(self.out, "}};")?;
                 }
                 crate::TypeInner::Image {
                     dim,
@@ -1030,9 +1030,9 @@ impl<W: Write> Writer<W> {
                     };
                     let base_name = scalar_kind_string(kind);
                     let array_str = if arrayed { "_array" } else { "" };
-                    write!(
+                    writeln!(
                         self.out,
-                        "typedef {}::{}{}{}{}<{}, {}::access::{}> {}",
+                        "typedef {}::{}{}{}{}<{}, {}::access::{}> {};",
                         NAMESPACE,
                         texture_str,
                         dim_str,
@@ -1045,11 +1045,9 @@ impl<W: Write> Writer<W> {
                     )?;
                 }
                 crate::TypeInner::Sampler { comparison: _ } => {
-                    write!(self.out, "typedef {}::sampler {}", NAMESPACE, name)?;
+                    writeln!(self.out, "typedef {}::sampler {};", NAMESPACE, name)?;
                 }
             }
-            writeln!(self.out, ";")?;
-            writeln!(self.out)?;
         }
         Ok(())
     }
@@ -1418,19 +1416,21 @@ impl<W: Write> Writer<W> {
                         let struct_name = &self.names[&NameKey::Type(arg.ty)];
                         write!(
                             self.out,
-                            "{}const {} {} = {{",
+                            "{}const {} {} = {{ ",
                             INDENT, struct_name, arg_name
                         )?;
-                        for member_index in 0..members.len() {
+                        for (member_index, member) in members.iter().enumerate() {
                             let name =
                                 &self.names[&NameKey::StructMember(arg.ty, member_index as u32)];
-                            let separator = if member_index != 0 { ", " } else { "" };
-                            write!(self.out, "{}{}", INDENT, separator)?;
-                            if let Some(crate::Binding::Location(..)) = arg.binding {
+                            if member_index != 0 {
+                                write!(self.out, ", ")?;
+                            }
+                            if let Some(crate::Binding::Location(..)) = member.binding {
                                 write!(self.out, "{}.", varyings_member_name)?;
                             }
                             write!(self.out, "{}", name)?;
                         }
+                        writeln!(self.out, " }};")?;
                     }
                     _ => {
                         if let Some(crate::Binding::Location(..)) = arg.binding {

--- a/tests/in/skybox.wgsl
+++ b/tests/in/skybox.wgsl
@@ -37,6 +37,6 @@ var r_texture: texture_cube<f32>;
 var r_sampler: sampler;
 
 [[stage(fragment)]]
-fn fs_main([[location(0)]] uv: vec3<f32>) -> [[location(0)]] vec4<f32> {
-    return textureSample(r_texture, r_sampler, uv);
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+    return textureSample(r_texture, r_sampler, in.uv);
 }

--- a/tests/out/boids.msl.snap
+++ b/tests/out/boids.msl.snap
@@ -6,16 +6,12 @@ expression: msl
 #include <simd/simd.h>
 
 typedef uint type;
-
 typedef metal::float2 type1;
-
 struct Particle {
     type1 pos;
     type1 vel;
 };
-
 typedef float type2;
-
 struct SimParams {
     type2 deltaT;
     type2 rule1Distance;
@@ -25,17 +21,12 @@ struct SimParams {
     type2 rule2Scale;
     type2 rule3Scale;
 };
-
 typedef Particle type3[1];
-
 struct Particles {
     type3 particles;
 };
-
 typedef metal::uint3 type4;
-
 typedef int type5;
-
 constexpr constant int NUM_PARTICLES = 1500;
 constexpr constant float const_0f = 0.0;
 constexpr constant int const_0i = 0;

--- a/tests/out/collatz.msl.snap
+++ b/tests/out/collatz.msl.snap
@@ -6,15 +6,11 @@ expression: msl
 #include <simd/simd.h>
 
 typedef uint type;
-
 typedef type type1[1];
-
 struct PrimeIndices {
     type1 data;
 };
-
 typedef metal::uint3 type2;
-
 constexpr constant unsigned const_0u = 0u;
 constexpr constant unsigned const_1u = 1u;
 constexpr constant unsigned const_2u = 2u;

--- a/tests/out/quad.msl.snap
+++ b/tests/out/quad.msl.snap
@@ -6,20 +6,14 @@ expression: msl
 #include <simd/simd.h>
 
 typedef float type;
-
 typedef metal::float2 type1;
-
 typedef metal::float4 type2;
-
 struct VertexOutput {
     type1 uv;
     type2 position;
 };
-
 typedef metal::texture2d<float, metal::access::sample> type3;
-
 typedef metal::sampler type4;
-
 constexpr constant float c_scale = 1.2;
 constexpr constant float const_0f = 0.0;
 constexpr constant float const_1f = 1.0;

--- a/tests/out/shadow.msl.snap
+++ b/tests/out/shadow.msl.snap
@@ -6,39 +6,26 @@ expression: msl
 #include <simd/simd.h>
 
 typedef metal::uint4 type;
-
 struct Globals {
     type num_lights;
 };
-
 typedef metal::float4x4 type1;
-
 typedef metal::float4 type2;
-
 struct Light {
     type1 proj;
     type2 pos;
     type2 color;
 };
-
 typedef Light type3[1];
-
 struct Lights {
     type3 data;
 };
-
 typedef metal::depth2d_array<float, metal::access::sample> type4;
-
 typedef metal::sampler type5;
-
 typedef uint type6;
-
 typedef float type7;
-
 typedef metal::float2 type8;
-
 typedef metal::float3 type9;
-
 constexpr constant float const_0f = 0.0;
 constexpr constant float const_1f = 1.0;
 constexpr constant float const_0_50f = 0.5;

--- a/tests/out/skybox-Fragment.glsl.snap
+++ b/tests/out/skybox-Fragment.glsl.snap
@@ -17,9 +17,9 @@ layout(location = 0) in vec3 _vs2fs_location0;
 layout(location = 0) out vec4 _fs2p_location0;
 
 void main() {
-    vec3 uv1 = _vs2fs_location0;
-    vec4 _expr4 = texture(_group_0_binding_1, vec3(uv1));
-    _fs2p_location0 = _expr4;
+    VertexOutput in1 = VertexOutput(gl_FragCoord, _vs2fs_location0);
+    vec4 _expr5 = texture(_group_0_binding_1, vec3(in1.uv));
+    _fs2p_location0 = _expr5;
     return;
 }
 

--- a/tests/out/skybox.msl.snap
+++ b/tests/out/skybox.msl.snap
@@ -6,31 +6,21 @@ expression: msl
 #include <simd/simd.h>
 
 typedef metal::float4 type;
-
 typedef metal::float3 type1;
-
 struct VertexOutput {
     type position;
     type1 uv;
 };
-
 typedef metal::float4x4 type2;
-
 struct Data {
     type2 proj_inv;
     type2 view;
 };
-
 typedef uint type3;
-
 typedef int type4;
-
 typedef metal::float3x3 type5;
-
 typedef metal::texturecube<float, metal::access::sample> type6;
-
 typedef metal::sampler type7;
-
 constexpr constant int const_2i = 2;
 constexpr constant int const_1i = 1;
 constexpr constant float const_4f = 4.0;
@@ -60,18 +50,19 @@ vertex vs_mainOutput vs_main(
 }
 
 struct fs_mainInput {
-    type1 uv1 [[user(loc0)]];
+    type1 uv [[user(loc0)]];
 };
 struct fs_mainOutput {
     type member1 [[color(0)]];
 };
 fragment fs_mainOutput fs_main(
   fs_mainInput varyings1 [[stage_in]]
+, type position [[position]]
 , type6 r_texture [[texture(0)]]
 , type7 r_sampler [[sampler(1)]]
 ) {
-    const auto uv1 = varyings1.uv1;
-    metal::float4 _expr4 = r_texture.sample(r_sampler, uv1);
-    return fs_mainOutput { _expr4 };
+    const VertexOutput in = { position, varyings1.uv };
+    metal::float4 _expr5 = r_texture.sample(r_sampler, in.uv);
+    return fs_mainOutput { _expr5 };
 }
 

--- a/tests/out/skybox.spvasm.snap
+++ b/tests/out/skybox.spvasm.snap
@@ -5,13 +5,13 @@ expression: dis
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 111
+; Bound: 116
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Vertex %37 "vs_main" %30 %33 %35
-OpEntryPoint Fragment %104 "fs_main" %100 %103
-OpExecutionMode %104 OriginUpperLeft
+OpEntryPoint Fragment %108 "fs_main" %101 %104 %107
+OpExecutionMode %108 OriginUpperLeft
 OpSource GLSL 450
 OpName %11 "Data"
 OpMemberName %11 0 "proj_inv"
@@ -28,9 +28,10 @@ OpName %33 "position"
 OpName %35 "uv"
 OpName %37 "vs_main"
 OpName %37 "vs_main"
-OpName %100 "uv"
-OpName %104 "fs_main"
-OpName %104 "fs_main"
+OpName %101 "position"
+OpName %104 "uv"
+OpName %108 "fs_main"
+OpName %108 "fs_main"
 OpDecorate %11 Block
 OpMemberDecorate %11 0 Offset 0
 OpMemberDecorate %11 0 ColMajor
@@ -47,8 +48,9 @@ OpDecorate %18 Binding 2
 OpDecorate %30 BuiltIn VertexIndex
 OpDecorate %33 BuiltIn Position
 OpDecorate %35 Location 0
-OpDecorate %100 Location 0
-OpDecorate %103 Location 0
+OpDecorate %101 BuiltIn FragCoord
+OpDecorate %104 Location 0
+OpDecorate %107 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 1
 %3 = OpConstant  %4  2
@@ -90,10 +92,12 @@ OpDecorate %103 Location 0
 %91 = OpConstant  %4  1
 %93 = OpTypePointer Function %13
 %94 = OpConstant  %4  0
-%101 = OpTypePointer Input %26
-%100 = OpVariable  %101  Input
-%103 = OpVariable  %34  Output
-%108 = OpTypeSampledImage %16
+%102 = OpTypePointer Input %13
+%101 = OpVariable  %102  Input
+%105 = OpTypePointer Input %26
+%104 = OpVariable  %105  Input
+%107 = OpVariable  %34  Output
+%113 = OpTypeSampledImage %16
 %37 = OpFunction  %2  None %38
 %28 = OpLabel
 %21 = OpVariable  %22  Function
@@ -159,15 +163,18 @@ OpStore %33 %97
 OpStore %35 %98
 OpReturn
 OpFunctionEnd
-%104 = OpFunction  %2  None %38
+%108 = OpFunction  %2  None %38
 %99 = OpLabel
-%102 = OpLoad  %26  %100
-%105 = OpLoad  %16  %15
-%106 = OpLoad  %19  %18
-OpBranch %107
-%107 = OpLabel
-%109 = OpSampledImage  %108  %105 %106
-%110 = OpImageSampleImplicitLod  %13  %109 %102
-OpStore %103 %110
+%103 = OpLoad  %13  %101
+%106 = OpLoad  %26  %104
+%100 = OpCompositeConstruct  %25  %103 %106
+%109 = OpLoad  %16  %15
+%110 = OpLoad  %19  %18
+OpBranch %111
+%111 = OpLabel
+%112 = OpCompositeExtract  %26  %100 1
+%114 = OpSampledImage  %113  %109 %110
+%115 = OpImageSampleImplicitLod  %13  %114 %112
+OpStore %107 %115
 OpReturn
 OpFunctionEnd


### PR DESCRIPTION
Now we have a snapshot test for `in: VaryingStructure` kind of argument of an entry point. The Metal backend wasn't processing it correctly. Now it does.