### PR TITLE
Diagnostics for stack allocation in MSL

### DIFF
--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -255,5 +255,5 @@ pub fn write_string(
 #[test]
 fn test_error_size() {
     use std::mem::size_of;
-    assert_eq!(size_of::<Error>(), 96);
+    assert_eq!(size_of::<Error>(), 48);
 }

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     FastHashMap,
 };
 use std::{
-    io::{Error as IoError, Write},
+    fmt::{Error as FmtError, Write},
     string::FromUtf8Error,
 };
 
@@ -68,7 +68,7 @@ enum ResolvedBinding {
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]
-    IO(#[from] IoError),
+    Format(#[from] FmtError),
     #[error(transparent)]
     Utf8(#[from] FromUtf8Error),
     #[error(transparent)]
@@ -247,8 +247,13 @@ pub fn write_string(
     analysis: &Analysis,
     options: &Options,
 ) -> Result<(String, TranslationInfo), Error> {
-    let mut w = writer::Writer::new(Vec::new());
+    let mut w = writer::Writer::new(String::new());
     let info = w.write(module, analysis, options)?;
-    let string = String::from_utf8(w.finish())?;
-    Ok((string, info))
+    Ok((w.finish(), info))
+}
+
+#[test]
+fn test_error_size() {
+    use std::mem::size_of;
+    assert_eq!(size_of::<Error>(), 96);
 }

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -692,3 +692,10 @@ impl Typifier {
         Ok(())
     }
 }
+
+#[test]
+fn test_error_size() {
+    use std::mem::size_of;
+    assert_eq!(size_of::<ResolveError>(), 80);
+    assert_eq!(size_of::<TypifyError>(), 88);
+}


### PR DESCRIPTION
Fixes #595.
It also changes `io::Error` into `fmt::Error`, which reduces the footprint from 45K to 40K.
Edit: also refactors typifier errors to get it down to 26K