### PR TITLE
Validate structure layouts

### DIFF
--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -487,7 +487,10 @@ impl super::Validator {
         }
 
         for (index, argument) in fun.arguments.iter().enumerate() {
-            if !self.type_flags[argument.ty.index()].contains(TypeFlags::DATA) {
+            if !self.types[argument.ty.index()]
+                .flags
+                .contains(TypeFlags::DATA)
+            {
                 return Err(FunctionError::InvalidArgumentType {
                     index,
                     name: argument.name.clone().unwrap_or_default(),

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -2,6 +2,7 @@ mod analyzer;
 mod expression;
 mod function;
 mod interface;
+mod r#type;
 
 use crate::{
     arena::{Arena, Handle},
@@ -9,7 +10,6 @@ use crate::{
     FastHashSet,
 };
 use bit_set::BitSet;
-use thiserror::Error;
 
 //TODO: analyze the model at the same time as we validate it,
 // merge the corresponding matches over expressions and statements.
@@ -20,6 +20,7 @@ pub use analyzer::{
 pub use expression::ExpressionError;
 pub use function::{CallError, FunctionError, LocalVariableError};
 pub use interface::{EntryPointError, GlobalVariableError, VaryingError};
+pub use r#type::{Disalignment, TypeError, TypeFlags};
 
 bitflags::bitflags! {
     /// Validation flags.
@@ -32,74 +33,13 @@ bitflags::bitflags! {
     }
 }
 
-bitflags::bitflags! {
-    #[repr(transparent)]
-    pub struct TypeFlags: u8 {
-        /// Can be used for data variables.
-        const DATA = 0x1;
-        /// The data type has known size.
-        const SIZED = 0x2;
-        /// Can be be used for interfacing between pipeline stages.
-        const INTERFACE = 0x4;
-        /// Can be used for host-shareable structures.
-        const HOST_SHARED = 0x8;
-    }
-}
-
-#[derive(Clone, Debug, Error)]
-pub enum Disalignment {
-    #[error("The array stride {stride} is not a multiple of the required alignment {alignment}")]
-    ArrayStride { stride: u32, alignment: u32 },
-    #[error("The struct size {size}, is not a multiple of the required alignment {alignment}")]
-    StructSize { size: u32, alignment: u32 },
-    #[error("The struct member[{index}] offset {offset} is not a multiple of the required alignment {alignment}")]
-    Member {
-        index: u32,
-        offset: u32,
-        alignment: u32,
-    },
-    #[error("The struct member[{index}] is not statically sized")]
-    UnsizedMember { index: u32 },
-}
-
-// Only makes sense if `flags.contains(HOST_SHARED)`
-type LayoutCompatibility = Result<(), (Handle<crate::Type>, Disalignment)>;
-
-// For the uniform buffer alignment, array strides and struct sizes must be multiples of 16.
-const UNIFORM_LAYOUT_ALIGNMENT_MASK: u32 = 0xF;
-
-#[derive(Clone, Debug)]
-struct TypeInfo {
-    flags: TypeFlags,
-    uniform_layout: LayoutCompatibility,
-    storage_layout: LayoutCompatibility,
-}
-
-impl TypeInfo {
-    fn new() -> Self {
-        TypeInfo {
-            flags: TypeFlags::empty(),
-            uniform_layout: Ok(()),
-            storage_layout: Ok(()),
-        }
-    }
-
-    fn from_flags(flags: TypeFlags) -> Self {
-        TypeInfo {
-            flags,
-            uniform_layout: Ok(()),
-            storage_layout: Ok(()),
-        }
-    }
-}
-
 #[derive(Debug)]
 pub struct Validator {
     flags: ValidationFlags,
     //Note: this is a bit tricky: some of the front-ends as well as backends
     // already have to use the typifier, so the work here is redundant in a way.
     typifier: Typifier,
-    types: Vec<TypeInfo>,
+    types: Vec<r#type::TypeInfo>,
     location_mask: BitSet,
     bind_group_masks: Vec<BitSet>,
     select_cases: FastHashSet<i32>,
@@ -107,37 +47,7 @@ pub struct Validator {
     valid_expression_set: BitSet,
 }
 
-#[derive(Clone, Debug, Error)]
-pub enum TypeError {
-    #[error("The {0:?} scalar width {1} is not supported")]
-    InvalidWidth(crate::ScalarKind, crate::Bytes),
-    #[error("The base handle {0:?} can not be resolved")]
-    UnresolvedBase(Handle<crate::Type>),
-    #[error("Expected data type, found {0:?}")]
-    InvalidData(Handle<crate::Type>),
-    #[error("Structure type {0:?} can not be a block structure")]
-    InvalidBlockType(Handle<crate::Type>),
-    #[error("Base type {0:?} for the array is invalid")]
-    InvalidArrayBaseType(Handle<crate::Type>),
-    #[error("The constant {0:?} can not be used for an array size")]
-    InvalidArraySizeConstant(Handle<crate::Constant>),
-    #[error(
-        "Array stride {stride} is not a multiple of the base element alignment {base_alignment}"
-    )]
-    UnalignedArrayStride { stride: u32, base_alignment: u32 },
-    #[error("Array stride {stride} is smaller than the base element size {base_size}")]
-    InsufficientArrayStride { stride: u32, base_size: u32 },
-    #[error("Field '{0}' can't be dynamically-sized, has type {1:?}")]
-    InvalidDynamicArray(String, Handle<crate::Type>),
-    #[error("Structure member[{index}] size {size} is not a sufficient to hold {base_size}")]
-    InsufficientMemberSize {
-        index: u32,
-        size: u32,
-        base_size: u32,
-    },
-}
-
-#[derive(Clone, Debug, Error)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum ConstantError {
     #[error("The type doesn't match the constant")]
     InvalidType,
@@ -147,7 +57,7 @@ pub enum ConstantError {
     UnresolvedSize(Handle<crate::Constant>),
 }
 
-#[derive(Clone, Debug, Error)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum ValidationError {
     #[error("Type {handle:?} '{name}' is invalid")]
     Type {
@@ -223,220 +133,6 @@ impl Validator {
         }
     }
 
-    fn check_width(kind: crate::ScalarKind, width: crate::Bytes) -> bool {
-        match kind {
-            crate::ScalarKind::Bool => width == crate::BOOL_WIDTH,
-            _ => width == 4,
-        }
-    }
-
-    fn validate_type(
-        &self,
-        ty: &crate::Type,
-        handle: Handle<crate::Type>,
-        constants: &Arena<crate::Constant>,
-        layouter: &Layouter,
-    ) -> Result<TypeInfo, TypeError> {
-        use crate::TypeInner as Ti;
-        Ok(match ty.inner {
-            Ti::Scalar { kind, width } | Ti::Vector { kind, width, .. } => {
-                if !Self::check_width(kind, width) {
-                    return Err(TypeError::InvalidWidth(kind, width));
-                }
-                TypeInfo::from_flags(
-                    TypeFlags::DATA
-                        | TypeFlags::SIZED
-                        | TypeFlags::INTERFACE
-                        | TypeFlags::HOST_SHARED,
-                )
-            }
-            Ti::Matrix { width, .. } => {
-                if !Self::check_width(crate::ScalarKind::Float, width) {
-                    return Err(TypeError::InvalidWidth(crate::ScalarKind::Float, width));
-                }
-                TypeInfo::from_flags(
-                    TypeFlags::DATA
-                        | TypeFlags::SIZED
-                        | TypeFlags::INTERFACE
-                        | TypeFlags::HOST_SHARED,
-                )
-            }
-            Ti::Pointer { base, class: _ } => {
-                if base >= handle {
-                    return Err(TypeError::UnresolvedBase(base));
-                }
-                TypeInfo::from_flags(TypeFlags::DATA | TypeFlags::SIZED)
-            }
-            Ti::ValuePointer {
-                size: _,
-                kind,
-                width,
-                class: _,
-            } => {
-                if !Self::check_width(kind, width) {
-                    return Err(TypeError::InvalidWidth(kind, width));
-                }
-                TypeInfo::from_flags(TypeFlags::SIZED)
-            }
-            Ti::Array { base, size, stride } => {
-                if base >= handle {
-                    return Err(TypeError::UnresolvedBase(base));
-                }
-                let base_info = &self.types[base.index()];
-                if !base_info.flags.contains(TypeFlags::DATA | TypeFlags::SIZED) {
-                    return Err(TypeError::InvalidArrayBaseType(base));
-                }
-
-                let base_layout = &layouter[base];
-                if let Some(stride) = stride {
-                    if stride.get() % base_layout.alignment.get() != 0 {
-                        return Err(TypeError::UnalignedArrayStride {
-                            stride: stride.get(),
-                            base_alignment: base_layout.alignment.get(),
-                        });
-                    }
-                    if stride.get() < base_layout.size {
-                        return Err(TypeError::InsufficientArrayStride {
-                            stride: stride.get(),
-                            base_size: base_layout.size,
-                        });
-                    }
-                }
-
-                let (sized_flag, uniform_layout) = match size {
-                    crate::ArraySize::Constant(const_handle) => {
-                        match constants.try_get(const_handle) {
-                            Some(&crate::Constant {
-                                inner:
-                                    crate::ConstantInner::Scalar {
-                                        width: _,
-                                        value: crate::ScalarValue::Uint(_),
-                                    },
-                                ..
-                            }) => {}
-                            // Accept a signed integer size to avoid
-                            // requiring an explicit uint
-                            // literal. Type inference should make
-                            // this unnecessary.
-                            Some(&crate::Constant {
-                                inner:
-                                    crate::ConstantInner::Scalar {
-                                        width: _,
-                                        value: crate::ScalarValue::Sint(_),
-                                    },
-                                ..
-                            }) => {}
-                            other => {
-                                log::warn!("Array size {:?}", other);
-                                return Err(TypeError::InvalidArraySizeConstant(const_handle));
-                            }
-                        }
-
-                        let effective_alignment = match stride {
-                            Some(stride) => stride.get(),
-                            None => base_layout.size,
-                        };
-                        let uniform_layout =
-                            if effective_alignment & UNIFORM_LAYOUT_ALIGNMENT_MASK == 0 {
-                                base_info.uniform_layout.clone()
-                            } else {
-                                Err((
-                                    handle,
-                                    Disalignment::ArrayStride {
-                                        stride: effective_alignment,
-                                        alignment: effective_alignment,
-                                    },
-                                ))
-                            };
-                        (TypeFlags::SIZED, uniform_layout)
-                    }
-                    //Note: this will be detected at the struct level
-                    crate::ArraySize::Dynamic => (TypeFlags::empty(), Ok(())),
-                };
-
-                let base_mask = TypeFlags::HOST_SHARED | TypeFlags::INTERFACE;
-                TypeInfo {
-                    flags: TypeFlags::DATA | (base_info.flags & base_mask) | sized_flag,
-                    uniform_layout,
-                    storage_layout: base_info.storage_layout.clone(),
-                }
-            }
-            Ti::Struct { block, ref members } => {
-                let mut flags = TypeFlags::all();
-                let mut uniform_layout = Ok(());
-                let mut storage_layout = Ok(());
-                let mut offset = 0;
-                for (i, member) in members.iter().enumerate() {
-                    if member.ty >= handle {
-                        return Err(TypeError::UnresolvedBase(member.ty));
-                    }
-                    let base_info = &self.types[member.ty.index()];
-                    flags &= base_info.flags;
-                    if !base_info.flags.contains(TypeFlags::DATA) {
-                        return Err(TypeError::InvalidData(member.ty));
-                    }
-                    if block && !base_info.flags.contains(TypeFlags::INTERFACE) {
-                        return Err(TypeError::InvalidBlockType(member.ty));
-                    }
-
-                    let base_layout = &layouter[member.ty];
-                    let (range, _alignment) = layouter.member_placement(offset, member);
-                    if range.end - range.start < base_layout.size {
-                        return Err(TypeError::InsufficientMemberSize {
-                            index: i as u32,
-                            size: range.end - range.start,
-                            base_size: base_layout.size,
-                        });
-                    }
-                    if range.start % base_layout.alignment.get() != 0 {
-                        let result = Err((
-                            handle,
-                            Disalignment::Member {
-                                index: i as u32,
-                                offset: range.start,
-                                alignment: base_layout.alignment.get(),
-                            },
-                        ));
-                        uniform_layout = uniform_layout.or_else(|_| result.clone());
-                        storage_layout = storage_layout.or(result);
-                    }
-                    offset = range.end;
-
-                    // only the last field can be unsized
-                    if !base_info.flags.contains(TypeFlags::SIZED) {
-                        if i + 1 != members.len() {
-                            let name = member.name.clone().unwrap_or_default();
-                            return Err(TypeError::InvalidDynamicArray(name, member.ty));
-                        }
-                        if uniform_layout.is_ok() {
-                            uniform_layout =
-                                Err((handle, Disalignment::UnsizedMember { index: i as u32 }));
-                        }
-                    }
-
-                    uniform_layout = uniform_layout.or_else(|_| base_info.uniform_layout.clone());
-                    storage_layout = storage_layout.or_else(|_| base_info.storage_layout.clone());
-                }
-
-                if uniform_layout.is_ok() && offset % UNIFORM_LAYOUT_ALIGNMENT_MASK == 0 {
-                    uniform_layout = Err((
-                        handle,
-                        Disalignment::StructSize {
-                            size: offset,
-                            alignment: UNIFORM_LAYOUT_ALIGNMENT_MASK,
-                        },
-                    ));
-                }
-                TypeInfo {
-                    flags,
-                    uniform_layout,
-                    storage_layout,
-                }
-            }
-            Ti::Image { .. } | Ti::Sampler { .. } => TypeInfo::from_flags(TypeFlags::empty()),
-        })
-    }
-
     fn validate_constant(
         &self,
         handle: Handle<crate::Constant>,
@@ -478,9 +174,7 @@ impl Validator {
 
     /// Check the given module to be valid.
     pub fn validate(&mut self, module: &crate::Module) -> Result<ModuleInfo, ValidationError> {
-        self.typifier.clear();
-        self.types.clear();
-        self.types.resize(module.types.len(), TypeInfo::new());
+        self.reset_types(module.types.len());
 
         let mod_info = ModuleInfo::new(module, self.flags)?;
 

--- a/src/valid/type.rs
+++ b/src/valid/type.rs
@@ -1,0 +1,317 @@
+use crate::{
+    arena::{Arena, Handle},
+    proc::Layouter,
+};
+
+bitflags::bitflags! {
+    #[repr(transparent)]
+    pub struct TypeFlags: u8 {
+        /// Can be used for data variables.
+        const DATA = 0x1;
+        /// The data type has known size.
+        const SIZED = 0x2;
+        /// Can be be used for interfacing between pipeline stages.
+        const INTERFACE = 0x4;
+        /// Can be used for host-shareable structures.
+        const HOST_SHARED = 0x8;
+    }
+}
+
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum Disalignment {
+    #[error("The array stride {stride} is not a multiple of the required alignment {alignment}")]
+    ArrayStride { stride: u32, alignment: u32 },
+    #[error("The struct size {size}, is not a multiple of the required alignment {alignment}")]
+    StructSize { size: u32, alignment: u32 },
+    #[error("The struct member[{index}] offset {offset} is not a multiple of the required alignment {alignment}")]
+    Member {
+        index: u32,
+        offset: u32,
+        alignment: u32,
+    },
+    #[error("The struct member[{index}] is not statically sized")]
+    UnsizedMember { index: u32 },
+}
+
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum TypeError {
+    #[error("The {0:?} scalar width {1} is not supported")]
+    InvalidWidth(crate::ScalarKind, crate::Bytes),
+    #[error("The base handle {0:?} can not be resolved")]
+    UnresolvedBase(Handle<crate::Type>),
+    #[error("Expected data type, found {0:?}")]
+    InvalidData(Handle<crate::Type>),
+    #[error("Structure type {0:?} can not be a block structure")]
+    InvalidBlockType(Handle<crate::Type>),
+    #[error("Base type {0:?} for the array is invalid")]
+    InvalidArrayBaseType(Handle<crate::Type>),
+    #[error("The constant {0:?} can not be used for an array size")]
+    InvalidArraySizeConstant(Handle<crate::Constant>),
+    #[error(
+        "Array stride {stride} is not a multiple of the base element alignment {base_alignment}"
+    )]
+    UnalignedArrayStride { stride: u32, base_alignment: u32 },
+    #[error("Array stride {stride} is smaller than the base element size {base_size}")]
+    InsufficientArrayStride { stride: u32, base_size: u32 },
+    #[error("Field '{0}' can't be dynamically-sized, has type {1:?}")]
+    InvalidDynamicArray(String, Handle<crate::Type>),
+    #[error("Structure member[{index}] size {size} is not a sufficient to hold {base_size}")]
+    InsufficientMemberSize {
+        index: u32,
+        size: u32,
+        base_size: u32,
+    },
+}
+
+// Only makes sense if `flags.contains(HOST_SHARED)`
+type LayoutCompatibility = Result<(), (Handle<crate::Type>, Disalignment)>;
+
+// For the uniform buffer alignment, array strides and struct sizes must be multiples of 16.
+const UNIFORM_LAYOUT_ALIGNMENT_MASK: u32 = 0xF;
+
+#[derive(Clone, Debug)]
+pub(super) struct TypeInfo {
+    pub flags: TypeFlags,
+    pub uniform_layout: LayoutCompatibility,
+    pub storage_layout: LayoutCompatibility,
+}
+
+impl TypeInfo {
+    fn new() -> Self {
+        TypeInfo {
+            flags: TypeFlags::empty(),
+            uniform_layout: Ok(()),
+            storage_layout: Ok(()),
+        }
+    }
+
+    fn from_flags(flags: TypeFlags) -> Self {
+        TypeInfo {
+            flags,
+            uniform_layout: Ok(()),
+            storage_layout: Ok(()),
+        }
+    }
+}
+
+impl super::Validator {
+    pub(super) fn check_width(kind: crate::ScalarKind, width: crate::Bytes) -> bool {
+        match kind {
+            crate::ScalarKind::Bool => width == crate::BOOL_WIDTH,
+            _ => width == 4,
+        }
+    }
+
+    pub(super) fn reset_types(&mut self, size: usize) {
+        self.typifier.clear();
+        self.types.clear();
+        self.types.resize(size, TypeInfo::new());
+    }
+
+    pub(super) fn validate_type(
+        &self,
+        ty: &crate::Type,
+        handle: Handle<crate::Type>,
+        constants: &Arena<crate::Constant>,
+        layouter: &Layouter,
+    ) -> Result<TypeInfo, TypeError> {
+        use crate::TypeInner as Ti;
+        Ok(match ty.inner {
+            Ti::Scalar { kind, width } | Ti::Vector { kind, width, .. } => {
+                if !Self::check_width(kind, width) {
+                    return Err(TypeError::InvalidWidth(kind, width));
+                }
+                TypeInfo::from_flags(
+                    TypeFlags::DATA
+                        | TypeFlags::SIZED
+                        | TypeFlags::INTERFACE
+                        | TypeFlags::HOST_SHARED,
+                )
+            }
+            Ti::Matrix { width, .. } => {
+                if !Self::check_width(crate::ScalarKind::Float, width) {
+                    return Err(TypeError::InvalidWidth(crate::ScalarKind::Float, width));
+                }
+                TypeInfo::from_flags(
+                    TypeFlags::DATA
+                        | TypeFlags::SIZED
+                        | TypeFlags::INTERFACE
+                        | TypeFlags::HOST_SHARED,
+                )
+            }
+            Ti::Pointer { base, class: _ } => {
+                if base >= handle {
+                    return Err(TypeError::UnresolvedBase(base));
+                }
+                TypeInfo::from_flags(TypeFlags::DATA | TypeFlags::SIZED)
+            }
+            Ti::ValuePointer {
+                size: _,
+                kind,
+                width,
+                class: _,
+            } => {
+                if !Self::check_width(kind, width) {
+                    return Err(TypeError::InvalidWidth(kind, width));
+                }
+                TypeInfo::from_flags(TypeFlags::SIZED)
+            }
+            Ti::Array { base, size, stride } => {
+                if base >= handle {
+                    return Err(TypeError::UnresolvedBase(base));
+                }
+                let base_info = &self.types[base.index()];
+                if !base_info.flags.contains(TypeFlags::DATA | TypeFlags::SIZED) {
+                    return Err(TypeError::InvalidArrayBaseType(base));
+                }
+
+                let base_layout = &layouter[base];
+                if let Some(stride) = stride {
+                    if stride.get() % base_layout.alignment.get() != 0 {
+                        return Err(TypeError::UnalignedArrayStride {
+                            stride: stride.get(),
+                            base_alignment: base_layout.alignment.get(),
+                        });
+                    }
+                    if stride.get() < base_layout.size {
+                        return Err(TypeError::InsufficientArrayStride {
+                            stride: stride.get(),
+                            base_size: base_layout.size,
+                        });
+                    }
+                }
+
+                let (sized_flag, uniform_layout) = match size {
+                    crate::ArraySize::Constant(const_handle) => {
+                        match constants.try_get(const_handle) {
+                            Some(&crate::Constant {
+                                inner:
+                                    crate::ConstantInner::Scalar {
+                                        width: _,
+                                        value: crate::ScalarValue::Uint(_),
+                                    },
+                                ..
+                            }) => {}
+                            // Accept a signed integer size to avoid
+                            // requiring an explicit uint
+                            // literal. Type inference should make
+                            // this unnecessary.
+                            Some(&crate::Constant {
+                                inner:
+                                    crate::ConstantInner::Scalar {
+                                        width: _,
+                                        value: crate::ScalarValue::Sint(_),
+                                    },
+                                ..
+                            }) => {}
+                            other => {
+                                log::warn!("Array size {:?}", other);
+                                return Err(TypeError::InvalidArraySizeConstant(const_handle));
+                            }
+                        }
+
+                        let effective_alignment = match stride {
+                            Some(stride) => stride.get(),
+                            None => base_layout.size,
+                        };
+                        let uniform_layout =
+                            if effective_alignment & UNIFORM_LAYOUT_ALIGNMENT_MASK == 0 {
+                                base_info.uniform_layout.clone()
+                            } else {
+                                Err((
+                                    handle,
+                                    Disalignment::ArrayStride {
+                                        stride: effective_alignment,
+                                        alignment: effective_alignment,
+                                    },
+                                ))
+                            };
+                        (TypeFlags::SIZED, uniform_layout)
+                    }
+                    //Note: this will be detected at the struct level
+                    crate::ArraySize::Dynamic => (TypeFlags::empty(), Ok(())),
+                };
+
+                let base_mask = TypeFlags::HOST_SHARED | TypeFlags::INTERFACE;
+                TypeInfo {
+                    flags: TypeFlags::DATA | (base_info.flags & base_mask) | sized_flag,
+                    uniform_layout,
+                    storage_layout: base_info.storage_layout.clone(),
+                }
+            }
+            Ti::Struct { block, ref members } => {
+                let mut flags = TypeFlags::all();
+                let mut uniform_layout = Ok(());
+                let mut storage_layout = Ok(());
+                let mut offset = 0;
+                for (i, member) in members.iter().enumerate() {
+                    if member.ty >= handle {
+                        return Err(TypeError::UnresolvedBase(member.ty));
+                    }
+                    let base_info = &self.types[member.ty.index()];
+                    flags &= base_info.flags;
+                    if !base_info.flags.contains(TypeFlags::DATA) {
+                        return Err(TypeError::InvalidData(member.ty));
+                    }
+                    if block && !base_info.flags.contains(TypeFlags::INTERFACE) {
+                        return Err(TypeError::InvalidBlockType(member.ty));
+                    }
+
+                    let base_layout = &layouter[member.ty];
+                    let (range, _alignment) = layouter.member_placement(offset, member);
+                    if range.end - range.start < base_layout.size {
+                        return Err(TypeError::InsufficientMemberSize {
+                            index: i as u32,
+                            size: range.end - range.start,
+                            base_size: base_layout.size,
+                        });
+                    }
+                    if range.start % base_layout.alignment.get() != 0 {
+                        let result = Err((
+                            handle,
+                            Disalignment::Member {
+                                index: i as u32,
+                                offset: range.start,
+                                alignment: base_layout.alignment.get(),
+                            },
+                        ));
+                        uniform_layout = uniform_layout.or_else(|_| result.clone());
+                        storage_layout = storage_layout.or(result);
+                    }
+                    offset = range.end;
+
+                    // only the last field can be unsized
+                    if !base_info.flags.contains(TypeFlags::SIZED) {
+                        if i + 1 != members.len() {
+                            let name = member.name.clone().unwrap_or_default();
+                            return Err(TypeError::InvalidDynamicArray(name, member.ty));
+                        }
+                        if uniform_layout.is_ok() {
+                            uniform_layout =
+                                Err((handle, Disalignment::UnsizedMember { index: i as u32 }));
+                        }
+                    }
+
+                    uniform_layout = uniform_layout.or_else(|_| base_info.uniform_layout.clone());
+                    storage_layout = storage_layout.or_else(|_| base_info.storage_layout.clone());
+                }
+
+                if uniform_layout.is_ok() && offset % UNIFORM_LAYOUT_ALIGNMENT_MASK == 0 {
+                    uniform_layout = Err((
+                        handle,
+                        Disalignment::StructSize {
+                            size: offset,
+                            alignment: UNIFORM_LAYOUT_ALIGNMENT_MASK,
+                        },
+                    ));
+                }
+                TypeInfo {
+                    flags,
+                    uniform_layout,
+                    storage_layout,
+                }
+            }
+            Ti::Image { .. } | Ti::Sampler { .. } => TypeInfo::from_flags(TypeFlags::empty()),
+        })
+    }
+}


### PR DESCRIPTION
I was hoping that introducing these errors would prevent people from using unaligned types in WGSL. However, it looks like the spec is not saying anything about `f32` or `vec3<f32>` in https://gpuweb.github.io/gpuweb/wgsl.html#storage-class-constraints, or I'm just missing it.
In any way, this code can be extended when we have all the restrictions on the table.