### PR TITLE
Move Layouter into ModuleInfo

### DIFF
--- a/src/proc/layouter.rs
+++ b/src/proc/layouter.rs
@@ -5,6 +5,8 @@ pub type Alignment = NonZeroU32;
 
 /// Alignment information for a type.
 #[derive(Clone, Copy, Debug, Hash, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct TypeLayout {
     pub size: u32,
     pub alignment: Alignment,
@@ -14,6 +16,8 @@ pub struct TypeLayout {
 /// It uses the default layout algorithm/table, described in
 /// https://github.com/gpuweb/gpuweb/issues/1393
 #[derive(Debug, Default)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct Layouter {
     layouts: Vec<TypeLayout>,
 }

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -5,7 +5,7 @@ mod namer;
 mod terminator;
 mod typifier;
 
-pub use layouter::{Alignment, Layouter};
+pub use layouter::{Alignment, Layouter, TypeLayout};
 pub use namer::{EntryPointIndex, NameKey, Namer};
 pub use terminator::ensure_block_returns;
 pub use typifier::{ResolveContext, ResolveError, TypeResolution};

--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -715,13 +715,6 @@ impl ModuleInfo {
     }
 }
 
-impl ops::Index<Handle<crate::Function>> for ModuleInfo {
-    type Output = FunctionInfo;
-    fn index(&self, handle: Handle<crate::Function>) -> &FunctionInfo {
-        &self.functions[handle.index()]
-    }
-}
-
 #[test]
 fn uniform_control_flow() {
     use crate::{Expression as E, Statement as S};

--- a/tests/out/boids.spvasm.snap
+++ b/tests/out/boids.spvasm.snap
@@ -13,55 +13,55 @@ OpEntryPoint GLCompute %43 "main" %40
 OpExecutionMode %43 LocalSize 64 1 1
 OpSource GLSL 450
 OpName %3 "NUM_PARTICLES"
-OpName %16 "SimParams"
-OpMemberName %16 0 "deltaT"
-OpMemberName %16 1 "rule1Distance"
-OpMemberName %16 2 "rule2Distance"
-OpMemberName %16 3 "rule3Distance"
-OpMemberName %16 4 "rule1Scale"
-OpMemberName %16 5 "rule2Scale"
-OpMemberName %16 6 "rule3Scale"
-OpName %15 "params"
+OpName %16 "Particle"
+OpMemberName %16 0 "pos"
+OpMemberName %16 1 "vel"
+OpName %17 "SimParams"
+OpMemberName %17 0 "deltaT"
+OpMemberName %17 1 "rule1Distance"
+OpMemberName %17 2 "rule2Distance"
+OpMemberName %17 3 "rule3Distance"
+OpMemberName %17 4 "rule1Scale"
+OpMemberName %17 5 "rule2Scale"
+OpMemberName %17 6 "rule3Scale"
 OpName %19 "Particles"
 OpMemberName %19 0 "particles"
-OpName %21 "Particle"
-OpMemberName %21 0 "pos"
-OpMemberName %21 1 "vel"
-OpName %18 "particlesSrc"
-OpName %24 "particlesDst"
-OpName %25 "vPos"
-OpName %27 "vVel"
-OpName %28 "cMass"
-OpName %29 "cVel"
-OpName %30 "colVel"
-OpName %31 "cMassCount"
-OpName %33 "cVelCount"
-OpName %34 "pos"
-OpName %35 "vel"
-OpName %36 "i"
+OpName %21 "params"
+OpName %23 "particlesSrc"
+OpName %25 "particlesDst"
+OpName %26 "vPos"
+OpName %28 "vVel"
+OpName %29 "cMass"
+OpName %30 "cVel"
+OpName %31 "colVel"
+OpName %32 "cMassCount"
+OpName %34 "cVelCount"
+OpName %35 "pos"
+OpName %36 "vel"
+OpName %37 "i"
 OpName %40 "global_invocation_id"
 OpName %43 "main"
 OpName %43 "main"
-OpDecorate %16 Block
 OpMemberDecorate %16 0 Offset 0
-OpMemberDecorate %16 1 Offset 4
-OpMemberDecorate %16 2 Offset 8
-OpMemberDecorate %16 3 Offset 12
-OpMemberDecorate %16 4 Offset 16
-OpMemberDecorate %16 5 Offset 20
-OpMemberDecorate %16 6 Offset 24
-OpDecorate %15 DescriptorSet 0
-OpDecorate %15 Binding 0
+OpMemberDecorate %16 1 Offset 8
+OpDecorate %17 Block
+OpMemberDecorate %17 0 Offset 0
+OpMemberDecorate %17 1 Offset 4
+OpMemberDecorate %17 2 Offset 8
+OpMemberDecorate %17 3 Offset 12
+OpMemberDecorate %17 4 Offset 16
+OpMemberDecorate %17 5 Offset 20
+OpMemberDecorate %17 6 Offset 24
+OpDecorate %18 ArrayStride 16
 OpDecorate %19 BufferBlock
 OpMemberDecorate %19 0 Offset 0
-OpDecorate %20 ArrayStride 16
-OpMemberDecorate %21 0 Offset 0
-OpMemberDecorate %21 1 Offset 8
-OpDecorate %18 NonWritable
-OpDecorate %18 DescriptorSet 0
-OpDecorate %18 Binding 1
-OpDecorate %24 DescriptorSet 0
-OpDecorate %24 Binding 2
+OpDecorate %21 DescriptorSet 0
+OpDecorate %21 Binding 0
+OpDecorate %23 NonWritable
+OpDecorate %23 DescriptorSet 0
+OpDecorate %23 Binding 1
+OpDecorate %25 DescriptorSet 0
+OpDecorate %25 Binding 2
 OpDecorate %40 BuiltIn GlobalInvocationId
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 0
@@ -76,27 +76,27 @@ OpDecorate %40 BuiltIn GlobalInvocationId
 %12 = OpConstant  %6  1.0
 %13 = OpConstant  %6  0.1
 %14 = OpConstant  %6  -1.0
-%16 = OpTypeStruct %6 %6 %6 %6 %6 %6 %6
-%17 = OpTypePointer Uniform %16
-%15 = OpVariable  %17  Uniform
-%22 = OpTypeVector %6 2
-%21 = OpTypeStruct %22 %22
-%20 = OpTypeRuntimeArray %21
-%19 = OpTypeStruct %20
-%23 = OpTypePointer Uniform %19
-%18 = OpVariable  %23  Uniform
-%24 = OpVariable  %23  Uniform
-%26 = OpTypePointer Function %22
-%32 = OpTypePointer Function %8
-%37 = OpTypePointer Function %4
-%39 = OpTypeVector %4 3
-%41 = OpTypePointer Input %39
+%15 = OpTypeVector %6 2
+%16 = OpTypeStruct %15 %15
+%17 = OpTypeStruct %6 %6 %6 %6 %6 %6 %6
+%18 = OpTypeRuntimeArray %16
+%19 = OpTypeStruct %18
+%20 = OpTypeVector %4 3
+%22 = OpTypePointer Uniform %17
+%21 = OpVariable  %22  Uniform
+%24 = OpTypePointer Uniform %19
+%23 = OpVariable  %24  Uniform
+%25 = OpVariable  %24  Uniform
+%27 = OpTypePointer Function %15
+%33 = OpTypePointer Function %8
+%38 = OpTypePointer Function %4
+%41 = OpTypePointer Input %20
 %40 = OpVariable  %41  Input
 %44 = OpTypeFunction %2
 %47 = OpTypeBool
-%51 = OpTypePointer Uniform %20
-%52 = OpTypePointer Uniform %21
-%53 = OpTypePointer Uniform %22
+%51 = OpTypePointer Uniform %18
+%52 = OpTypePointer Uniform %16
+%53 = OpTypePointer Uniform %15
 %54 = OpConstant  %8  0
 %55 = OpConstant  %8  0
 %58 = OpConstant  %8  1
@@ -123,18 +123,18 @@ OpDecorate %40 BuiltIn GlobalInvocationId
 %218 = OpConstant  %8  1
 %219 = OpConstant  %8  0
 %43 = OpFunction  %2  None %44
-%38 = OpLabel
-%36 = OpVariable  %37  Function %9
-%33 = OpVariable  %32  Function %7
-%29 = OpVariable  %26  Function
-%25 = OpVariable  %26  Function
-%34 = OpVariable  %26  Function
-%30 = OpVariable  %26  Function
-%27 = OpVariable  %26  Function
-%35 = OpVariable  %26  Function
-%31 = OpVariable  %32  Function %7
-%28 = OpVariable  %26  Function
-%42 = OpLoad  %39  %40
+%39 = OpLabel
+%37 = OpVariable  %38  Function %9
+%34 = OpVariable  %33  Function %7
+%30 = OpVariable  %27  Function
+%26 = OpVariable  %27  Function
+%35 = OpVariable  %27  Function
+%31 = OpVariable  %27  Function
+%28 = OpVariable  %27  Function
+%36 = OpVariable  %27  Function
+%32 = OpVariable  %33  Function %7
+%29 = OpVariable  %27  Function
+%42 = OpLoad  %20  %40
 OpBranch %45
 %45 = OpLabel
 %46 = OpCompositeExtract  %4  %42 0
@@ -144,209 +144,209 @@ OpBranchConditional %48 %50 %49
 %50 = OpLabel
 OpReturn
 %49 = OpLabel
-%56 = OpAccessChain  %53  %18 %55 %46 %54
-%57 = OpLoad  %22  %56
-OpStore %25 %57
-%60 = OpAccessChain  %53  %18 %59 %46 %58
-%61 = OpLoad  %22  %60
-OpStore %27 %61
-%62 = OpCompositeConstruct  %22  %5 %5
-OpStore %28 %62
-%63 = OpCompositeConstruct  %22  %5 %5
-OpStore %29 %63
-%64 = OpCompositeConstruct  %22  %5 %5
-OpStore %30 %64
+%56 = OpAccessChain  %53  %23 %55 %46 %54
+%57 = OpLoad  %15  %56
+OpStore %26 %57
+%60 = OpAccessChain  %53  %23 %59 %46 %58
+%61 = OpLoad  %15  %60
+OpStore %28 %61
+%62 = OpCompositeConstruct  %15  %5 %5
+OpStore %29 %62
+%63 = OpCompositeConstruct  %15  %5 %5
+OpStore %30 %63
+%64 = OpCompositeConstruct  %15  %5 %5
+OpStore %31 %64
 OpBranch %65
 %65 = OpLabel
 OpLoopMerge %66 %68 None
 OpBranch %67
 %67 = OpLabel
-%69 = OpLoad  %4  %36
+%69 = OpLoad  %4  %37
 %70 = OpUGreaterThanEqual  %47  %69 %3
 OpSelectionMerge %71 None
 OpBranchConditional %70 %72 %71
 %72 = OpLabel
 OpBranch %66
 %71 = OpLabel
-%73 = OpLoad  %4  %36
+%73 = OpLoad  %4  %37
 %74 = OpIEqual  %47  %73 %46
 OpSelectionMerge %75 None
 OpBranchConditional %74 %76 %75
 %76 = OpLabel
 OpBranch %68
 %75 = OpLabel
-%77 = OpLoad  %4  %36
-%80 = OpAccessChain  %53  %18 %79 %77 %78
-%81 = OpLoad  %22  %80
-OpStore %34 %81
-%82 = OpLoad  %4  %36
-%85 = OpAccessChain  %53  %18 %84 %82 %83
-%86 = OpLoad  %22  %85
-OpStore %35 %86
-%87 = OpLoad  %22  %34
-%88 = OpLoad  %22  %25
+%77 = OpLoad  %4  %37
+%80 = OpAccessChain  %53  %23 %79 %77 %78
+%81 = OpLoad  %15  %80
+OpStore %35 %81
+%82 = OpLoad  %4  %37
+%85 = OpAccessChain  %53  %23 %84 %82 %83
+%86 = OpLoad  %15  %85
+OpStore %36 %86
+%87 = OpLoad  %15  %35
+%88 = OpLoad  %15  %26
 %89 = OpExtInst  %6  %1 Distance %87 %88
-%92 = OpAccessChain  %90  %15 %91
+%92 = OpAccessChain  %90  %21 %91
 %93 = OpLoad  %6  %92
 %94 = OpFOrdLessThan  %47  %89 %93
 OpSelectionMerge %95 None
 OpBranchConditional %94 %96 %95
 %96 = OpLabel
-%97 = OpLoad  %22  %28
-%98 = OpLoad  %22  %34
-%99 = OpFAdd  %22  %97 %98
-OpStore %28 %99
-%100 = OpLoad  %8  %31
+%97 = OpLoad  %15  %29
+%98 = OpLoad  %15  %35
+%99 = OpFAdd  %15  %97 %98
+OpStore %29 %99
+%100 = OpLoad  %8  %32
 %101 = OpIAdd  %8  %100 %10
-OpStore %31 %101
+OpStore %32 %101
 OpBranch %95
 %95 = OpLabel
-%102 = OpLoad  %22  %34
-%103 = OpLoad  %22  %25
+%102 = OpLoad  %15  %35
+%103 = OpLoad  %15  %26
 %104 = OpExtInst  %6  %1 Distance %102 %103
-%106 = OpAccessChain  %90  %15 %105
+%106 = OpAccessChain  %90  %21 %105
 %107 = OpLoad  %6  %106
 %108 = OpFOrdLessThan  %47  %104 %107
 OpSelectionMerge %109 None
 OpBranchConditional %108 %110 %109
 %110 = OpLabel
-%111 = OpLoad  %22  %30
-%112 = OpLoad  %22  %34
-%113 = OpLoad  %22  %25
-%114 = OpFSub  %22  %112 %113
-%115 = OpFSub  %22  %111 %114
-OpStore %30 %115
+%111 = OpLoad  %15  %31
+%112 = OpLoad  %15  %35
+%113 = OpLoad  %15  %26
+%114 = OpFSub  %15  %112 %113
+%115 = OpFSub  %15  %111 %114
+OpStore %31 %115
 OpBranch %109
 %109 = OpLabel
-%116 = OpLoad  %22  %34
-%117 = OpLoad  %22  %25
+%116 = OpLoad  %15  %35
+%117 = OpLoad  %15  %26
 %118 = OpExtInst  %6  %1 Distance %116 %117
-%120 = OpAccessChain  %90  %15 %119
+%120 = OpAccessChain  %90  %21 %119
 %121 = OpLoad  %6  %120
 %122 = OpFOrdLessThan  %47  %118 %121
 OpSelectionMerge %123 None
 OpBranchConditional %122 %124 %123
 %124 = OpLabel
-%125 = OpLoad  %22  %29
-%126 = OpLoad  %22  %35
-%127 = OpFAdd  %22  %125 %126
-OpStore %29 %127
-%128 = OpLoad  %8  %33
+%125 = OpLoad  %15  %30
+%126 = OpLoad  %15  %36
+%127 = OpFAdd  %15  %125 %126
+OpStore %30 %127
+%128 = OpLoad  %8  %34
 %129 = OpIAdd  %8  %128 %10
-OpStore %33 %129
+OpStore %34 %129
 OpBranch %123
 %123 = OpLabel
 OpBranch %68
 %68 = OpLabel
-%130 = OpLoad  %4  %36
+%130 = OpLoad  %4  %37
 %131 = OpIAdd  %4  %130 %11
-OpStore %36 %131
+OpStore %37 %131
 OpBranch %65
 %66 = OpLabel
-%132 = OpLoad  %8  %31
+%132 = OpLoad  %8  %32
 %133 = OpSGreaterThan  %47  %132 %7
 OpSelectionMerge %134 None
 OpBranchConditional %133 %135 %134
 %135 = OpLabel
-%136 = OpLoad  %22  %28
-%137 = OpLoad  %8  %31
+%136 = OpLoad  %15  %29
+%137 = OpLoad  %8  %32
 %138 = OpConvertSToF  %6  %137
 %139 = OpFDiv  %6  %12 %138
-%140 = OpVectorTimesScalar  %22  %136 %139
-%141 = OpLoad  %22  %25
-%142 = OpFSub  %22  %140 %141
-OpStore %28 %142
+%140 = OpVectorTimesScalar  %15  %136 %139
+%141 = OpLoad  %15  %26
+%142 = OpFSub  %15  %140 %141
+OpStore %29 %142
 OpBranch %134
 %134 = OpLabel
-%143 = OpLoad  %8  %33
+%143 = OpLoad  %8  %34
 %144 = OpSGreaterThan  %47  %143 %7
 OpSelectionMerge %145 None
 OpBranchConditional %144 %146 %145
 %146 = OpLabel
-%147 = OpLoad  %22  %29
-%148 = OpLoad  %8  %33
+%147 = OpLoad  %15  %30
+%148 = OpLoad  %8  %34
 %149 = OpConvertSToF  %6  %148
 %150 = OpFDiv  %6  %12 %149
-%151 = OpVectorTimesScalar  %22  %147 %150
-OpStore %29 %151
+%151 = OpVectorTimesScalar  %15  %147 %150
+OpStore %30 %151
 OpBranch %145
 %145 = OpLabel
-%152 = OpLoad  %22  %27
-%153 = OpLoad  %22  %28
-%155 = OpAccessChain  %90  %15 %154
+%152 = OpLoad  %15  %28
+%153 = OpLoad  %15  %29
+%155 = OpAccessChain  %90  %21 %154
 %156 = OpLoad  %6  %155
-%157 = OpVectorTimesScalar  %22  %153 %156
-%158 = OpFAdd  %22  %152 %157
-%159 = OpLoad  %22  %30
-%161 = OpAccessChain  %90  %15 %160
+%157 = OpVectorTimesScalar  %15  %153 %156
+%158 = OpFAdd  %15  %152 %157
+%159 = OpLoad  %15  %31
+%161 = OpAccessChain  %90  %21 %160
 %162 = OpLoad  %6  %161
-%163 = OpVectorTimesScalar  %22  %159 %162
-%164 = OpFAdd  %22  %158 %163
-%165 = OpLoad  %22  %29
-%167 = OpAccessChain  %90  %15 %166
+%163 = OpVectorTimesScalar  %15  %159 %162
+%164 = OpFAdd  %15  %158 %163
+%165 = OpLoad  %15  %30
+%167 = OpAccessChain  %90  %21 %166
 %168 = OpLoad  %6  %167
-%169 = OpVectorTimesScalar  %22  %165 %168
-%170 = OpFAdd  %22  %164 %169
-OpStore %27 %170
-%171 = OpLoad  %22  %27
-%172 = OpExtInst  %22  %1 Normalize %171
-%173 = OpLoad  %22  %27
+%169 = OpVectorTimesScalar  %15  %165 %168
+%170 = OpFAdd  %15  %164 %169
+OpStore %28 %170
+%171 = OpLoad  %15  %28
+%172 = OpExtInst  %15  %1 Normalize %171
+%173 = OpLoad  %15  %28
 %174 = OpExtInst  %6  %1 Length %173
 %175 = OpExtInst  %6  %1 FClamp %174 %5 %13
-%176 = OpVectorTimesScalar  %22  %172 %175
-OpStore %27 %176
-%177 = OpLoad  %22  %25
-%178 = OpLoad  %22  %27
-%180 = OpAccessChain  %90  %15 %179
+%176 = OpVectorTimesScalar  %15  %172 %175
+OpStore %28 %176
+%177 = OpLoad  %15  %26
+%178 = OpLoad  %15  %28
+%180 = OpAccessChain  %90  %21 %179
 %181 = OpLoad  %6  %180
-%182 = OpVectorTimesScalar  %22  %178 %181
-%183 = OpFAdd  %22  %177 %182
-OpStore %25 %183
-%184 = OpLoad  %22  %25
+%182 = OpVectorTimesScalar  %15  %178 %181
+%183 = OpFAdd  %15  %177 %182
+OpStore %26 %183
+%184 = OpLoad  %15  %26
 %185 = OpCompositeExtract  %6  %184 0
 %186 = OpFOrdLessThan  %47  %185 %14
 OpSelectionMerge %187 None
 OpBranchConditional %186 %188 %187
 %188 = OpLabel
-%191 = OpAccessChain  %189  %25 %190
+%191 = OpAccessChain  %189  %26 %190
 OpStore %191 %12
 OpBranch %187
 %187 = OpLabel
-%192 = OpLoad  %22  %25
+%192 = OpLoad  %15  %26
 %193 = OpCompositeExtract  %6  %192 0
 %194 = OpFOrdGreaterThan  %47  %193 %12
 OpSelectionMerge %195 None
 OpBranchConditional %194 %196 %195
 %196 = OpLabel
-%198 = OpAccessChain  %189  %25 %197
+%198 = OpAccessChain  %189  %26 %197
 OpStore %198 %14
 OpBranch %195
 %195 = OpLabel
-%199 = OpLoad  %22  %25
+%199 = OpLoad  %15  %26
 %200 = OpCompositeExtract  %6  %199 1
 %201 = OpFOrdLessThan  %47  %200 %14
 OpSelectionMerge %202 None
 OpBranchConditional %201 %203 %202
 %203 = OpLabel
-%205 = OpAccessChain  %189  %25 %204
+%205 = OpAccessChain  %189  %26 %204
 OpStore %205 %12
 OpBranch %202
 %202 = OpLabel
-%206 = OpLoad  %22  %25
+%206 = OpLoad  %15  %26
 %207 = OpCompositeExtract  %6  %206 1
 %208 = OpFOrdGreaterThan  %47  %207 %12
 OpSelectionMerge %209 None
 OpBranchConditional %208 %210 %209
 %210 = OpLabel
-%212 = OpAccessChain  %189  %25 %211
+%212 = OpAccessChain  %189  %26 %211
 OpStore %212 %14
 OpBranch %209
 %209 = OpLabel
-%213 = OpLoad  %22  %25
-%216 = OpAccessChain  %53  %24 %215 %46 %214
+%213 = OpLoad  %15  %26
+%216 = OpAccessChain  %53  %25 %215 %46 %214
 OpStore %216 %213
-%217 = OpLoad  %22  %27
-%220 = OpAccessChain  %53  %24 %219 %46 %218
+%217 = OpLoad  %15  %28
+%220 = OpAccessChain  %53  %25 %219 %46 %218
 OpStore %220 %217
 OpReturn
 OpFunctionEnd

--- a/tests/out/collatz.info.ron.snap
+++ b/tests/out/collatz.info.ron.snap
@@ -498,4 +498,24 @@ expression: output
             ],
         ),
     ],
+    layouter: (
+        layouts: [
+            (
+                size: 4,
+                alignment: 4,
+            ),
+            (
+                size: 4,
+                alignment: 4,
+            ),
+            (
+                size: 4,
+                alignment: 4,
+            ),
+            (
+                size: 12,
+                alignment: 16,
+            ),
+        ],
+    ),
 )

--- a/tests/out/collatz.spvasm.snap
+++ b/tests/out/collatz.spvasm.snap
@@ -14,18 +14,18 @@ OpExecutionMode %48 LocalSize 1 1 1
 OpSource GLSL 450
 OpName %9 "PrimeIndices"
 OpMemberName %9 0 "data"
-OpName %8 "v_indices"
-OpName %12 "n"
-OpName %14 "i"
-OpName %17 "collatz_iterations"
+OpName %11 "v_indices"
+OpName %13 "n"
+OpName %15 "i"
+OpName %18 "collatz_iterations"
 OpName %45 "global_id"
 OpName %48 "main"
 OpName %48 "main"
+OpDecorate %8 ArrayStride 4
 OpDecorate %9 BufferBlock
 OpMemberDecorate %9 0 Offset 0
-OpDecorate %10 ArrayStride 4
-OpDecorate %8 DescriptorSet 0
-OpDecorate %8 Binding 0
+OpDecorate %11 DescriptorSet 0
+OpDecorate %11 Binding 0
 OpDecorate %45 BuiltIn GlobalInvocationId
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 0
@@ -33,80 +33,80 @@ OpDecorate %45 BuiltIn GlobalInvocationId
 %5 = OpConstant  %4  1
 %6 = OpConstant  %4  2
 %7 = OpConstant  %4  3
-%10 = OpTypeRuntimeArray %4
-%9 = OpTypeStruct %10
-%11 = OpTypePointer Uniform %9
-%8 = OpVariable  %11  Uniform
-%13 = OpTypePointer Function %4
-%18 = OpTypeFunction %4 %4
-%25 = OpTypeBool
-%44 = OpTypeVector %4 3
-%46 = OpTypePointer Input %44
+%8 = OpTypeRuntimeArray %4
+%9 = OpTypeStruct %8
+%10 = OpTypeVector %4 3
+%12 = OpTypePointer Uniform %9
+%11 = OpVariable  %12  Uniform
+%14 = OpTypePointer Function %4
+%19 = OpTypeFunction %4 %4
+%26 = OpTypeBool
+%46 = OpTypePointer Input %10
 %45 = OpVariable  %46  Input
 %49 = OpTypeFunction %2
-%51 = OpTypePointer Uniform %10
+%51 = OpTypePointer Uniform %8
 %53 = OpTypePointer Uniform %4
 %55 = OpTypeInt 32 1
 %56 = OpConstant  %55  0
 %60 = OpConstant  %55  0
-%17 = OpFunction  %4  None %18
-%16 = OpFunctionParameter  %4
-%15 = OpLabel
-%12 = OpVariable  %13  Function
-%14 = OpVariable  %13  Function %3
-OpBranch %19
-%19 = OpLabel
-OpStore %12 %16
+%18 = OpFunction  %4  None %19
+%17 = OpFunctionParameter  %4
+%16 = OpLabel
+%13 = OpVariable  %14  Function
+%15 = OpVariable  %14  Function %3
 OpBranch %20
 %20 = OpLabel
-OpLoopMerge %21 %23 None
-OpBranch %22
-%22 = OpLabel
-%24 = OpLoad  %4  %12
-%26 = OpULessThanEqual  %25  %24 %5
-OpSelectionMerge %27 None
-OpBranchConditional %26 %28 %27
-%28 = OpLabel
+OpStore %13 %17
 OpBranch %21
-%27 = OpLabel
-%29 = OpLoad  %4  %12
-%30 = OpUMod  %4  %29 %6
-%31 = OpIEqual  %25  %30 %3
-OpSelectionMerge %32 None
-OpBranchConditional %31 %33 %34
-%33 = OpLabel
-%35 = OpLoad  %4  %12
-%36 = OpUDiv  %4  %35 %6
-OpStore %12 %36
-OpBranch %32
-%34 = OpLabel
-%37 = OpLoad  %4  %12
-%38 = OpIMul  %4  %7 %37
-%39 = OpIAdd  %4  %38 %5
-OpStore %12 %39
-OpBranch %32
-%32 = OpLabel
-%40 = OpLoad  %4  %14
-%41 = OpIAdd  %4  %40 %5
-OpStore %14 %41
+%21 = OpLabel
+OpLoopMerge %22 %24 None
 OpBranch %23
 %23 = OpLabel
-OpBranch %20
-%21 = OpLabel
-%42 = OpLoad  %4  %14
-OpReturnValue %42
+%25 = OpLoad  %4  %13
+%27 = OpULessThanEqual  %26  %25 %5
+OpSelectionMerge %28 None
+OpBranchConditional %27 %29 %28
+%29 = OpLabel
+OpBranch %22
+%28 = OpLabel
+%30 = OpLoad  %4  %13
+%31 = OpUMod  %4  %30 %6
+%32 = OpIEqual  %26  %31 %3
+OpSelectionMerge %33 None
+OpBranchConditional %32 %34 %35
+%34 = OpLabel
+%36 = OpLoad  %4  %13
+%37 = OpUDiv  %4  %36 %6
+OpStore %13 %37
+OpBranch %33
+%35 = OpLabel
+%38 = OpLoad  %4  %13
+%39 = OpIMul  %4  %7 %38
+%40 = OpIAdd  %4  %39 %5
+OpStore %13 %40
+OpBranch %33
+%33 = OpLabel
+%41 = OpLoad  %4  %15
+%42 = OpIAdd  %4  %41 %5
+OpStore %15 %42
+OpBranch %24
+%24 = OpLabel
+OpBranch %21
+%22 = OpLabel
+%43 = OpLoad  %4  %15
+OpReturnValue %43
 OpFunctionEnd
 %48 = OpFunction  %2  None %49
-%43 = OpLabel
-%47 = OpLoad  %44  %45
+%44 = OpLabel
+%47 = OpLoad  %10  %45
 OpBranch %50
 %50 = OpLabel
 %52 = OpCompositeExtract  %4  %47 0
 %54 = OpCompositeExtract  %4  %47 0
-%57 = OpAccessChain  %53  %8 %56 %54
+%57 = OpAccessChain  %53  %11 %56 %54
 %58 = OpLoad  %4  %57
-%59 = OpFunctionCall  %4  %17 %58
-%61 = OpAccessChain  %53  %8 %60 %52
+%59 = OpFunctionCall  %4  %18 %58
+%61 = OpAccessChain  %53  %11 %60 %52
 OpStore %61 %59
 OpReturn
 OpFunctionEnd

--- a/tests/out/quad.spvasm.snap
+++ b/tests/out/quad.spvasm.snap
@@ -14,10 +14,10 @@ OpEntryPoint Fragment %47 "main" %44 %46
 OpExecutionMode %47 OriginUpperLeft
 OpSource GLSL 450
 OpName %3 "c_scale"
-OpName %7 "u_texture"
-OpName %10 "u_sampler"
-OpName %13 "out"
-OpName %14 "VertexOutput"
+OpName %9 "VertexOutput"
+OpName %12 "u_texture"
+OpName %14 "u_sampler"
+OpName %16 "out"
 OpName %19 "pos"
 OpName %22 "uv"
 OpName %24 "uv"
@@ -27,10 +27,10 @@ OpName %28 "main"
 OpName %44 "uv"
 OpName %47 "main"
 OpName %47 "main"
-OpDecorate %7 DescriptorSet 0
-OpDecorate %7 Binding 0
-OpDecorate %10 DescriptorSet 0
-OpDecorate %10 Binding 1
+OpDecorate %12 DescriptorSet 0
+OpDecorate %12 Binding 0
+OpDecorate %14 DescriptorSet 0
+OpDecorate %14 Binding 1
 OpDecorate %19 Location 0
 OpDecorate %22 Location 1
 OpDecorate %24 Location 0
@@ -42,62 +42,62 @@ OpDecorate %46 Location 0
 %3 = OpConstant  %4  1.2
 %5 = OpConstant  %4  0.0
 %6 = OpConstant  %4  1.0
-%8 = OpTypeImage %4 2D 0 0 0 1 Unknown
-%9 = OpTypePointer UniformConstant %8
-%7 = OpVariable  %9  UniformConstant
+%7 = OpTypeVector %4 2
+%8 = OpTypeVector %4 4
+%9 = OpTypeStruct %7 %8
+%10 = OpTypeImage %4 2D 0 0 0 1 Unknown
 %11 = OpTypeSampler
-%12 = OpTypePointer UniformConstant %11
-%10 = OpVariable  %12  UniformConstant
-%15 = OpTypeVector %4 2
-%16 = OpTypeVector %4 4
-%14 = OpTypeStruct %15 %16
-%17 = OpTypePointer Function %14
-%20 = OpTypePointer Input %15
+%13 = OpTypePointer UniformConstant %10
+%12 = OpVariable  %13  UniformConstant
+%15 = OpTypePointer UniformConstant %11
+%14 = OpVariable  %15  UniformConstant
+%17 = OpTypePointer Function %9
+%20 = OpTypePointer Input %7
 %19 = OpVariable  %20  Input
 %22 = OpVariable  %20  Input
-%25 = OpTypePointer Output %15
+%25 = OpTypePointer Output %7
 %24 = OpVariable  %25  Output
-%27 = OpTypePointer Output %16
+%27 = OpTypePointer Output %8
 %26 = OpVariable  %27  Output
 %29 = OpTypeFunction %2
-%31 = OpTypePointer Function %15
+%31 = OpTypePointer Function %7
 %32 = OpTypeInt 32 1
 %33 = OpConstant  %32  0
-%35 = OpTypePointer Function %16
+%35 = OpTypePointer Function %8
 %38 = OpConstant  %32  1
 %44 = OpVariable  %20  Input
 %46 = OpVariable  %27  Output
-%51 = OpTypeSampledImage %8
+%51 = OpTypeSampledImage %10
 %55 = OpTypeBool
 %28 = OpFunction  %2  None %29
 %18 = OpLabel
-%13 = OpVariable  %17  Function
-%21 = OpLoad  %15  %19
-%23 = OpLoad  %15  %22
+%16 = OpVariable  %17  Function
+%21 = OpLoad  %7  %19
+%23 = OpLoad  %7  %22
 OpBranch %30
 %30 = OpLabel
-%34 = OpAccessChain  %31  %13 %33
+%34 = OpAccessChain  %31  %16 %33
 OpStore %34 %23
-%36 = OpVectorTimesScalar  %15  %21 %3
-%37 = OpCompositeConstruct  %16  %36 %5 %6
-%39 = OpAccessChain  %35  %13 %38
+%36 = OpVectorTimesScalar  %7  %21 %3
+%37 = OpCompositeConstruct  %8  %36 %5 %6
+%39 = OpAccessChain  %35  %16 %38
 OpStore %39 %37
-%40 = OpLoad  %14  %13
-%41 = OpCompositeExtract  %15  %40 0
+%40 = OpLoad  %9  %16
+%41 = OpCompositeExtract  %7  %40 0
 OpStore %24 %41
-%42 = OpCompositeExtract  %16  %40 1
+%42 = OpCompositeExtract  %8  %40 1
 OpStore %26 %42
 OpReturn
 OpFunctionEnd
 %47 = OpFunction  %2  None %29
 %43 = OpLabel
-%45 = OpLoad  %15  %44
-%48 = OpLoad  %8  %7
-%49 = OpLoad  %11  %10
+%45 = OpLoad  %7  %44
+%48 = OpLoad  %10  %12
+%49 = OpLoad  %11  %14
 OpBranch %50
 %50 = OpLabel
 %52 = OpSampledImage  %51  %48 %49
-%53 = OpImageSampleImplicitLod  %16  %52 %45
+%53 = OpImageSampleImplicitLod  %8  %52 %45
 %54 = OpCompositeExtract  %4  %53 3
 %56 = OpFOrdEqual  %55  %54 %5
 OpSelectionMerge %57 None
@@ -106,7 +106,7 @@ OpBranchConditional %56 %58 %57
 OpKill
 %57 = OpLabel
 %59 = OpCompositeExtract  %4  %53 3
-%60 = OpVectorTimesScalar  %16  %53 %59
+%60 = OpVectorTimesScalar  %8  %53 %59
 OpStore %46 %60
 OpReturn
 OpFunctionEnd

--- a/tests/out/shadow.info.ron.snap
+++ b/tests/out/shadow.info.ron.snap
@@ -2749,4 +2749,236 @@ expression: output
             ],
         ),
     ],
+    layouter: (
+        layouts: [
+            (
+                size: 4,
+                alignment: 4,
+            ),
+            (
+                size: 12,
+                alignment: 16,
+            ),
+            (
+                size: 4,
+                alignment: 4,
+            ),
+            (
+                size: 16,
+                alignment: 16,
+            ),
+            (
+                size: 1,
+                alignment: 1,
+            ),
+            (
+                size: 8,
+                alignment: 8,
+            ),
+            (
+                size: 0,
+                alignment: 1,
+            ),
+            (
+                size: 0,
+                alignment: 1,
+            ),
+            (
+                size: 8,
+                alignment: 8,
+            ),
+            (
+                size: 4,
+                alignment: 4,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 16,
+                alignment: 16,
+            ),
+            (
+                size: 16,
+                alignment: 16,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 64,
+                alignment: 16,
+            ),
+            (
+                size: 96,
+                alignment: 16,
+            ),
+            (
+                size: 96,
+                alignment: 96,
+            ),
+            (
+                size: 96,
+                alignment: 96,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 4,
+                alignment: 1,
+            ),
+            (
+                size: 0,
+                alignment: 1,
+            ),
+            (
+                size: 0,
+                alignment: 1,
+            ),
+        ],
+    ),
 )

--- a/tests/out/shadow.spvasm.snap
+++ b/tests/out/shadow.spvasm.snap
@@ -12,46 +12,46 @@ OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %81 "fs_main" %73 %76 %79
 OpExecutionMode %81 OriginUpperLeft
 OpSource GLSL 450
-OpName %9 "c_ambient"
-OpName %11 "c_max_lights"
-OpName %16 "Globals"
-OpMemberName %16 0 "num_lights"
-OpName %15 "u_globals"
-OpName %20 "Lights"
-OpMemberName %20 0 "data"
-OpName %22 "Light"
-OpMemberName %22 0 "proj"
-OpMemberName %22 1 "pos"
-OpMemberName %22 2 "color"
-OpName %19 "s_lights"
-OpName %26 "t_shadow"
-OpName %29 "sampler_shadow"
-OpName %35 "fetch_shadow"
+OpName %9 "c_max_lights"
+OpName %14 "Globals"
+OpMemberName %14 0 "num_lights"
+OpName %17 "Light"
+OpMemberName %17 0 "proj"
+OpMemberName %17 1 "pos"
+OpMemberName %17 2 "color"
+OpName %19 "Lights"
+OpMemberName %19 0 "data"
+OpName %24 "c_ambient"
+OpName %25 "u_globals"
+OpName %27 "s_lights"
+OpName %29 "t_shadow"
+OpName %31 "sampler_shadow"
+OpName %36 "fetch_shadow"
 OpName %68 "color"
 OpName %70 "i"
 OpName %73 "raw_normal"
 OpName %76 "position"
 OpName %81 "fs_main"
 OpName %81 "fs_main"
-OpDecorate %16 Block
-OpMemberDecorate %16 0 Offset 0
-OpDecorate %15 DescriptorSet 0
-OpDecorate %15 Binding 0
-OpDecorate %20 BufferBlock
-OpMemberDecorate %20 0 Offset 0
-OpDecorate %21 ArrayStride 96
-OpMemberDecorate %22 0 Offset 0
-OpMemberDecorate %22 0 ColMajor
-OpMemberDecorate %22 0 MatrixStride 16
-OpMemberDecorate %22 1 Offset 64
-OpMemberDecorate %22 2 Offset 80
-OpDecorate %19 NonWritable
-OpDecorate %19 DescriptorSet 0
-OpDecorate %19 Binding 1
-OpDecorate %26 DescriptorSet 0
-OpDecorate %26 Binding 2
+OpDecorate %14 Block
+OpMemberDecorate %14 0 Offset 0
+OpMemberDecorate %17 0 Offset 0
+OpMemberDecorate %17 0 ColMajor
+OpMemberDecorate %17 0 MatrixStride 16
+OpMemberDecorate %17 1 Offset 64
+OpMemberDecorate %17 2 Offset 80
+OpDecorate %18 ArrayStride 96
+OpDecorate %19 BufferBlock
+OpMemberDecorate %19 0 Offset 0
+OpDecorate %25 DescriptorSet 0
+OpDecorate %25 Binding 0
+OpDecorate %27 NonWritable
+OpDecorate %27 DescriptorSet 0
+OpDecorate %27 Binding 1
 OpDecorate %29 DescriptorSet 0
-OpDecorate %29 Binding 3
+OpDecorate %29 Binding 2
+OpDecorate %31 DescriptorSet 0
+OpDecorate %31 Binding 3
 OpDecorate %73 Location 0
 OpDecorate %76 Location 1
 OpDecorate %79 Location 0
@@ -62,151 +62,151 @@ OpDecorate %79 Location 0
 %6 = OpConstant  %4  0.5
 %7 = OpConstant  %4  -0.5
 %8 = OpConstant  %4  0.05
-%10 = OpTypeVector %4 3
-%9 = OpConstantComposite  %10  %8 %8 %8
-%12 = OpTypeInt 32 0
-%11 = OpConstant  %12  10
-%13 = OpConstant  %12  0
-%14 = OpConstant  %12  1
-%17 = OpTypeVector %12 4
-%16 = OpTypeStruct %17
-%18 = OpTypePointer Uniform %16
-%15 = OpVariable  %18  Uniform
-%24 = OpTypeVector %4 4
-%23 = OpTypeMatrix %24 4
-%22 = OpTypeStruct %23 %24 %24
-%21 = OpTypeRuntimeArray %22
-%20 = OpTypeStruct %21
-%25 = OpTypePointer Uniform %20
-%19 = OpVariable  %25  Uniform
-%27 = OpTypeImage %4 2D 1 1 0 1 Unknown
-%28 = OpTypePointer UniformConstant %27
-%26 = OpVariable  %28  UniformConstant
-%30 = OpTypeSampler
-%31 = OpTypePointer UniformConstant %30
-%29 = OpVariable  %31  UniformConstant
-%36 = OpTypeFunction %4 %12 %24
-%41 = OpTypeBool
-%45 = OpTypeVector %4 2
+%10 = OpTypeInt 32 0
+%9 = OpConstant  %10  10
+%11 = OpConstant  %10  0
+%12 = OpConstant  %10  1
+%13 = OpTypeVector %10 4
+%14 = OpTypeStruct %13
+%16 = OpTypeVector %4 4
+%15 = OpTypeMatrix %16 4
+%17 = OpTypeStruct %15 %16 %16
+%18 = OpTypeRuntimeArray %17
+%19 = OpTypeStruct %18
+%20 = OpTypeImage %4 2D 1 1 0 1 Unknown
+%21 = OpTypeSampler
+%22 = OpTypeVector %4 2
+%23 = OpTypeVector %4 3
+%24 = OpConstantComposite  %23  %8 %8 %8
+%26 = OpTypePointer Uniform %14
+%25 = OpVariable  %26  Uniform
+%28 = OpTypePointer Uniform %19
+%27 = OpVariable  %28  Uniform
+%30 = OpTypePointer UniformConstant %20
+%29 = OpVariable  %30  UniformConstant
+%32 = OpTypePointer UniformConstant %21
+%31 = OpVariable  %32  UniformConstant
+%37 = OpTypeFunction %4 %10 %16
+%42 = OpTypeBool
 %56 = OpTypeInt 32 1
-%60 = OpTypeSampledImage %27
+%60 = OpTypeSampledImage %20
 %67 = OpConstant  %4  0.0
-%69 = OpTypePointer Function %10
-%71 = OpTypePointer Function %12
-%74 = OpTypePointer Input %10
+%69 = OpTypePointer Function %23
+%71 = OpTypePointer Function %10
+%74 = OpTypePointer Input %23
 %73 = OpVariable  %74  Input
-%77 = OpTypePointer Input %24
+%77 = OpTypePointer Input %16
 %76 = OpVariable  %77  Input
-%80 = OpTypePointer Output %24
+%80 = OpTypePointer Output %16
 %79 = OpVariable  %80  Output
 %82 = OpTypeFunction %2
-%92 = OpTypePointer Uniform %17
+%92 = OpTypePointer Uniform %13
 %93 = OpConstant  %56  0
-%101 = OpTypePointer Uniform %21
-%103 = OpTypePointer Uniform %22
+%101 = OpTypePointer Uniform %18
+%103 = OpTypePointer Uniform %17
 %104 = OpConstant  %56  0
-%35 = OpFunction  %4  None %36
-%33 = OpFunctionParameter  %12
-%34 = OpFunctionParameter  %24
-%32 = OpLabel
-%37 = OpLoad  %27  %26
-%38 = OpLoad  %30  %29
-OpBranch %39
-%39 = OpLabel
-%40 = OpCompositeExtract  %4  %34 3
-%42 = OpFOrdLessThanEqual  %41  %40 %3
-OpSelectionMerge %43 None
-OpBranchConditional %42 %44 %43
-%44 = OpLabel
+%36 = OpFunction  %4  None %37
+%34 = OpFunctionParameter  %10
+%35 = OpFunctionParameter  %16
+%33 = OpLabel
+%38 = OpLoad  %20  %29
+%39 = OpLoad  %21  %31
+OpBranch %40
+%40 = OpLabel
+%41 = OpCompositeExtract  %4  %35 3
+%43 = OpFOrdLessThanEqual  %42  %41 %3
+OpSelectionMerge %44 None
+OpBranchConditional %43 %45 %44
+%45 = OpLabel
 OpReturnValue %5
-%43 = OpLabel
-%46 = OpCompositeConstruct  %45  %6 %7
-%47 = OpCompositeExtract  %4  %34 3
+%44 = OpLabel
+%46 = OpCompositeConstruct  %22  %6 %7
+%47 = OpCompositeExtract  %4  %35 3
 %48 = OpFDiv  %4  %5 %47
-%49 = OpCompositeExtract  %4  %34 0
-%50 = OpCompositeExtract  %4  %34 1
-%51 = OpCompositeConstruct  %45  %49 %50
-%52 = OpFMul  %45  %51 %46
-%53 = OpVectorTimesScalar  %45  %52 %48
-%54 = OpCompositeConstruct  %45  %6 %6
-%55 = OpFAdd  %45  %53 %54
-%57 = OpBitcast  %56  %33
-%58 = OpCompositeExtract  %4  %34 2
+%49 = OpCompositeExtract  %4  %35 0
+%50 = OpCompositeExtract  %4  %35 1
+%51 = OpCompositeConstruct  %22  %49 %50
+%52 = OpFMul  %22  %51 %46
+%53 = OpVectorTimesScalar  %22  %52 %48
+%54 = OpCompositeConstruct  %22  %6 %6
+%55 = OpFAdd  %22  %53 %54
+%57 = OpBitcast  %56  %34
+%58 = OpCompositeExtract  %4  %35 2
 %59 = OpFMul  %4  %58 %48
 %61 = OpCompositeExtract  %4  %55 0
 %62 = OpCompositeExtract  %4  %55 1
 %63 = OpConvertUToF  %4  %57
-%64 = OpCompositeConstruct  %10  %61 %62 %63
-%65 = OpSampledImage  %60  %37 %38
+%64 = OpCompositeConstruct  %23  %61 %62 %63
+%65 = OpSampledImage  %60  %38 %39
 %66 = OpImageSampleDrefExplicitLod  %4  %65 %64 %59 Lod %67
 OpReturnValue %66
 OpFunctionEnd
 %81 = OpFunction  %2  None %82
 %72 = OpLabel
-%68 = OpVariable  %69  Function %9
-%70 = OpVariable  %71  Function %13
-%75 = OpLoad  %10  %73
-%78 = OpLoad  %24  %76
-%83 = OpLoad  %27  %26
-%84 = OpLoad  %30  %29
+%68 = OpVariable  %69  Function %24
+%70 = OpVariable  %71  Function %11
+%75 = OpLoad  %23  %73
+%78 = OpLoad  %16  %76
+%83 = OpLoad  %20  %29
+%84 = OpLoad  %21  %31
 OpBranch %85
 %85 = OpLabel
-%86 = OpExtInst  %10  %1 Normalize %75
+%86 = OpExtInst  %23  %1 Normalize %75
 OpBranch %87
 %87 = OpLabel
 OpLoopMerge %88 %90 None
 OpBranch %89
 %89 = OpLabel
-%91 = OpLoad  %12  %70
-%94 = OpAccessChain  %92  %15 %93
-%95 = OpLoad  %17  %94
-%96 = OpCompositeExtract  %12  %95 0
-%97 = OpExtInst  %12  %1 UMin %96 %11
-%98 = OpUGreaterThanEqual  %41  %91 %97
+%91 = OpLoad  %10  %70
+%94 = OpAccessChain  %92  %25 %93
+%95 = OpLoad  %13  %94
+%96 = OpCompositeExtract  %10  %95 0
+%97 = OpExtInst  %10  %1 UMin %96 %9
+%98 = OpUGreaterThanEqual  %42  %91 %97
 OpSelectionMerge %99 None
 OpBranchConditional %98 %100 %99
 %100 = OpLabel
 OpBranch %88
 %99 = OpLabel
-%102 = OpLoad  %12  %70
-%105 = OpAccessChain  %103  %19 %104 %102
-%106 = OpLoad  %22  %105
-%107 = OpLoad  %12  %70
-%108 = OpCompositeExtract  %23  %106 0
-%109 = OpMatrixTimesVector  %24  %108 %78
-%110 = OpFunctionCall  %4  %35 %107 %109
-%111 = OpCompositeExtract  %24  %106 1
+%102 = OpLoad  %10  %70
+%105 = OpAccessChain  %103  %27 %104 %102
+%106 = OpLoad  %17  %105
+%107 = OpLoad  %10  %70
+%108 = OpCompositeExtract  %15  %106 0
+%109 = OpMatrixTimesVector  %16  %108 %78
+%110 = OpFunctionCall  %4  %36 %107 %109
+%111 = OpCompositeExtract  %16  %106 1
 %112 = OpCompositeExtract  %4  %111 0
 %113 = OpCompositeExtract  %4  %111 1
 %114 = OpCompositeExtract  %4  %111 2
-%115 = OpCompositeConstruct  %10  %112 %113 %114
+%115 = OpCompositeConstruct  %23  %112 %113 %114
 %116 = OpCompositeExtract  %4  %78 0
 %117 = OpCompositeExtract  %4  %78 1
 %118 = OpCompositeExtract  %4  %78 2
-%119 = OpCompositeConstruct  %10  %116 %117 %118
-%120 = OpFSub  %10  %115 %119
-%121 = OpExtInst  %10  %1 Normalize %120
+%119 = OpCompositeConstruct  %23  %116 %117 %118
+%120 = OpFSub  %23  %115 %119
+%121 = OpExtInst  %23  %1 Normalize %120
 %122 = OpDot  %4  %86 %121
 %123 = OpExtInst  %4  %1 FMax %3 %122
-%124 = OpLoad  %10  %68
+%124 = OpLoad  %23  %68
 %125 = OpFMul  %4  %110 %123
-%126 = OpCompositeExtract  %24  %106 2
+%126 = OpCompositeExtract  %16  %106 2
 %127 = OpCompositeExtract  %4  %126 0
 %128 = OpCompositeExtract  %4  %126 1
 %129 = OpCompositeExtract  %4  %126 2
-%130 = OpCompositeConstruct  %10  %127 %128 %129
-%131 = OpVectorTimesScalar  %10  %130 %125
-%132 = OpFAdd  %10  %124 %131
+%130 = OpCompositeConstruct  %23  %127 %128 %129
+%131 = OpVectorTimesScalar  %23  %130 %125
+%132 = OpFAdd  %23  %124 %131
 OpStore %68 %132
 OpBranch %90
 %90 = OpLabel
-%133 = OpLoad  %12  %70
-%134 = OpIAdd  %12  %133 %14
+%133 = OpLoad  %10  %70
+%134 = OpIAdd  %10  %133 %12
 OpStore %70 %134
 OpBranch %87
 %88 = OpLabel
-%135 = OpLoad  %10  %68
-%136 = OpCompositeConstruct  %24  %135 %5
+%135 = OpLoad  %23  %68
+%136 = OpCompositeConstruct  %16  %135 %5
 OpStore %79 %136
 OpReturn
 OpFunctionEnd

--- a/tests/out/skybox.spvasm.snap
+++ b/tests/out/skybox.spvasm.snap
@@ -9,45 +9,45 @@ expression: dis
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Vertex %37 "vs_main" %30 %33 %35
+OpEntryPoint Vertex %38 "vs_main" %31 %34 %36
 OpEntryPoint Fragment %108 "fs_main" %101 %104 %107
 OpExecutionMode %108 OriginUpperLeft
 OpSource GLSL 450
-OpName %11 "Data"
-OpMemberName %11 0 "proj_inv"
-OpMemberName %11 1 "view"
-OpName %10 "r_data"
-OpName %15 "r_texture"
-OpName %18 "r_sampler"
-OpName %21 "tmp1"
-OpName %23 "tmp2"
-OpName %24 "out"
-OpName %25 "VertexOutput"
-OpName %30 "vertex_index"
-OpName %33 "position"
-OpName %35 "uv"
-OpName %37 "vs_main"
-OpName %37 "vs_main"
+OpName %12 "VertexOutput"
+OpName %14 "Data"
+OpMemberName %14 0 "proj_inv"
+OpMemberName %14 1 "view"
+OpName %19 "r_data"
+OpName %21 "r_texture"
+OpName %23 "r_sampler"
+OpName %25 "tmp1"
+OpName %27 "tmp2"
+OpName %28 "out"
+OpName %31 "vertex_index"
+OpName %34 "position"
+OpName %36 "uv"
+OpName %38 "vs_main"
+OpName %38 "vs_main"
 OpName %101 "position"
 OpName %104 "uv"
 OpName %108 "fs_main"
 OpName %108 "fs_main"
-OpDecorate %11 Block
-OpMemberDecorate %11 0 Offset 0
-OpMemberDecorate %11 0 ColMajor
-OpMemberDecorate %11 0 MatrixStride 16
-OpMemberDecorate %11 1 Offset 64
-OpMemberDecorate %11 1 ColMajor
-OpMemberDecorate %11 1 MatrixStride 16
-OpDecorate %10 DescriptorSet 0
-OpDecorate %10 Binding 0
-OpDecorate %15 DescriptorSet 0
-OpDecorate %15 Binding 1
-OpDecorate %18 DescriptorSet 0
-OpDecorate %18 Binding 2
-OpDecorate %30 BuiltIn VertexIndex
-OpDecorate %33 BuiltIn Position
-OpDecorate %35 Location 0
+OpDecorate %14 Block
+OpMemberDecorate %14 0 Offset 0
+OpMemberDecorate %14 0 ColMajor
+OpMemberDecorate %14 0 MatrixStride 16
+OpMemberDecorate %14 1 Offset 64
+OpMemberDecorate %14 1 ColMajor
+OpMemberDecorate %14 1 MatrixStride 16
+OpDecorate %19 DescriptorSet 0
+OpDecorate %19 Binding 0
+OpDecorate %21 DescriptorSet 0
+OpDecorate %21 Binding 1
+OpDecorate %23 DescriptorSet 0
+OpDecorate %23 Binding 2
+OpDecorate %31 BuiltIn VertexIndex
+OpDecorate %34 BuiltIn Position
+OpDecorate %36 Location 0
 OpDecorate %101 BuiltIn FragCoord
 OpDecorate %104 Location 0
 OpDecorate %107 Location 0
@@ -59,122 +59,122 @@ OpDecorate %107 Location 0
 %6 = OpConstant  %7  4.0
 %8 = OpConstant  %7  1.0
 %9 = OpConstant  %7  0.0
-%13 = OpTypeVector %7 4
-%12 = OpTypeMatrix %13 4
-%11 = OpTypeStruct %12 %12
-%14 = OpTypePointer Uniform %11
-%10 = OpVariable  %14  Uniform
-%16 = OpTypeImage %7 Cube 0 0 0 1 Unknown
-%17 = OpTypePointer UniformConstant %16
-%15 = OpVariable  %17  UniformConstant
-%19 = OpTypeSampler
-%20 = OpTypePointer UniformConstant %19
-%18 = OpVariable  %20  UniformConstant
-%22 = OpTypePointer Function %4
-%26 = OpTypeVector %7 3
-%25 = OpTypeStruct %13 %26
-%27 = OpTypePointer Function %25
-%29 = OpTypeInt 32 0
-%31 = OpTypePointer Input %29
-%30 = OpVariable  %31  Input
-%34 = OpTypePointer Output %13
-%33 = OpVariable  %34  Output
-%36 = OpTypePointer Output %26
-%35 = OpVariable  %36  Output
-%38 = OpTypeFunction %2
-%53 = OpTypePointer Uniform %12
-%54 = OpConstant  %4  1
-%62 = OpConstant  %4  1
-%70 = OpConstant  %4  1
-%78 = OpTypeMatrix %26 3
+%10 = OpTypeVector %7 4
+%11 = OpTypeVector %7 3
+%12 = OpTypeStruct %10 %11
+%13 = OpTypeMatrix %10 4
+%14 = OpTypeStruct %13 %13
+%15 = OpTypeInt 32 0
+%16 = OpTypeMatrix %11 3
+%17 = OpTypeImage %7 Cube 0 0 0 1 Unknown
+%18 = OpTypeSampler
+%20 = OpTypePointer Uniform %14
+%19 = OpVariable  %20  Uniform
+%22 = OpTypePointer UniformConstant %17
+%21 = OpVariable  %22  UniformConstant
+%24 = OpTypePointer UniformConstant %18
+%23 = OpVariable  %24  UniformConstant
+%26 = OpTypePointer Function %4
+%29 = OpTypePointer Function %12
+%32 = OpTypePointer Input %15
+%31 = OpVariable  %32  Input
+%35 = OpTypePointer Output %10
+%34 = OpVariable  %35  Output
+%37 = OpTypePointer Output %11
+%36 = OpVariable  %37  Output
+%39 = OpTypeFunction %2
+%54 = OpTypePointer Uniform %13
+%55 = OpConstant  %4  1
+%63 = OpConstant  %4  1
+%71 = OpConstant  %4  1
 %81 = OpConstant  %4  0
-%85 = OpTypePointer Function %26
+%85 = OpTypePointer Function %11
 %91 = OpConstant  %4  1
-%93 = OpTypePointer Function %13
+%93 = OpTypePointer Function %10
 %94 = OpConstant  %4  0
-%102 = OpTypePointer Input %13
+%102 = OpTypePointer Input %10
 %101 = OpVariable  %102  Input
-%105 = OpTypePointer Input %26
+%105 = OpTypePointer Input %11
 %104 = OpVariable  %105  Input
-%107 = OpVariable  %34  Output
-%113 = OpTypeSampledImage %16
-%37 = OpFunction  %2  None %38
-%28 = OpLabel
-%21 = OpVariable  %22  Function
-%23 = OpVariable  %22  Function
-%24 = OpVariable  %27  Function
-%32 = OpLoad  %29  %30
-OpBranch %39
-%39 = OpLabel
-%40 = OpBitcast  %4  %32
-%41 = OpSDiv  %4  %40 %3
-OpStore %21 %41
-%42 = OpBitcast  %4  %32
-%43 = OpBitwiseAnd  %4  %42 %5
-OpStore %23 %43
-%44 = OpLoad  %4  %21
-%45 = OpConvertSToF  %7  %44
-%46 = OpFMul  %7  %45 %6
-%47 = OpFSub  %7  %46 %8
-%48 = OpLoad  %4  %23
-%49 = OpConvertSToF  %7  %48
-%50 = OpFMul  %7  %49 %6
-%51 = OpFSub  %7  %50 %8
-%52 = OpCompositeConstruct  %13  %47 %51 %9 %8
-%55 = OpAccessChain  %53  %10 %54
-%56 = OpLoad  %12  %55
-%57 = OpCompositeExtract  %13  %56 0
-%58 = OpCompositeExtract  %7  %57 0
-%59 = OpCompositeExtract  %7  %57 1
-%60 = OpCompositeExtract  %7  %57 2
-%61 = OpCompositeConstruct  %26  %58 %59 %60
-%63 = OpAccessChain  %53  %10 %62
-%64 = OpLoad  %12  %63
-%65 = OpCompositeExtract  %13  %64 1
-%66 = OpCompositeExtract  %7  %65 0
-%67 = OpCompositeExtract  %7  %65 1
-%68 = OpCompositeExtract  %7  %65 2
-%69 = OpCompositeConstruct  %26  %66 %67 %68
-%71 = OpAccessChain  %53  %10 %70
-%72 = OpLoad  %12  %71
-%73 = OpCompositeExtract  %13  %72 2
-%74 = OpCompositeExtract  %7  %73 0
-%75 = OpCompositeExtract  %7  %73 1
-%76 = OpCompositeExtract  %7  %73 2
-%77 = OpCompositeConstruct  %26  %74 %75 %76
-%79 = OpCompositeConstruct  %78  %61 %69 %77
-%80 = OpTranspose  %78  %79
-%82 = OpAccessChain  %53  %10 %81
-%83 = OpLoad  %12  %82
-%84 = OpMatrixTimesVector  %13  %83 %52
+%107 = OpVariable  %35  Output
+%113 = OpTypeSampledImage %17
+%38 = OpFunction  %2  None %39
+%30 = OpLabel
+%25 = OpVariable  %26  Function
+%27 = OpVariable  %26  Function
+%28 = OpVariable  %29  Function
+%33 = OpLoad  %15  %31
+OpBranch %40
+%40 = OpLabel
+%41 = OpBitcast  %4  %33
+%42 = OpSDiv  %4  %41 %3
+OpStore %25 %42
+%43 = OpBitcast  %4  %33
+%44 = OpBitwiseAnd  %4  %43 %5
+OpStore %27 %44
+%45 = OpLoad  %4  %25
+%46 = OpConvertSToF  %7  %45
+%47 = OpFMul  %7  %46 %6
+%48 = OpFSub  %7  %47 %8
+%49 = OpLoad  %4  %27
+%50 = OpConvertSToF  %7  %49
+%51 = OpFMul  %7  %50 %6
+%52 = OpFSub  %7  %51 %8
+%53 = OpCompositeConstruct  %10  %48 %52 %9 %8
+%56 = OpAccessChain  %54  %19 %55
+%57 = OpLoad  %13  %56
+%58 = OpCompositeExtract  %10  %57 0
+%59 = OpCompositeExtract  %7  %58 0
+%60 = OpCompositeExtract  %7  %58 1
+%61 = OpCompositeExtract  %7  %58 2
+%62 = OpCompositeConstruct  %11  %59 %60 %61
+%64 = OpAccessChain  %54  %19 %63
+%65 = OpLoad  %13  %64
+%66 = OpCompositeExtract  %10  %65 1
+%67 = OpCompositeExtract  %7  %66 0
+%68 = OpCompositeExtract  %7  %66 1
+%69 = OpCompositeExtract  %7  %66 2
+%70 = OpCompositeConstruct  %11  %67 %68 %69
+%72 = OpAccessChain  %54  %19 %71
+%73 = OpLoad  %13  %72
+%74 = OpCompositeExtract  %10  %73 2
+%75 = OpCompositeExtract  %7  %74 0
+%76 = OpCompositeExtract  %7  %74 1
+%77 = OpCompositeExtract  %7  %74 2
+%78 = OpCompositeConstruct  %11  %75 %76 %77
+%79 = OpCompositeConstruct  %16  %62 %70 %78
+%80 = OpTranspose  %16  %79
+%82 = OpAccessChain  %54  %19 %81
+%83 = OpLoad  %13  %82
+%84 = OpMatrixTimesVector  %10  %83 %53
 %86 = OpCompositeExtract  %7  %84 0
 %87 = OpCompositeExtract  %7  %84 1
 %88 = OpCompositeExtract  %7  %84 2
-%89 = OpCompositeConstruct  %26  %86 %87 %88
-%90 = OpMatrixTimesVector  %26  %80 %89
-%92 = OpAccessChain  %85  %24 %91
+%89 = OpCompositeConstruct  %11  %86 %87 %88
+%90 = OpMatrixTimesVector  %11  %80 %89
+%92 = OpAccessChain  %85  %28 %91
 OpStore %92 %90
-%95 = OpAccessChain  %93  %24 %94
-OpStore %95 %52
-%96 = OpLoad  %25  %24
-%97 = OpCompositeExtract  %13  %96 0
-OpStore %33 %97
-%98 = OpCompositeExtract  %26  %96 1
-OpStore %35 %98
+%95 = OpAccessChain  %93  %28 %94
+OpStore %95 %53
+%96 = OpLoad  %12  %28
+%97 = OpCompositeExtract  %10  %96 0
+OpStore %34 %97
+%98 = OpCompositeExtract  %11  %96 1
+OpStore %36 %98
 OpReturn
 OpFunctionEnd
-%108 = OpFunction  %2  None %38
+%108 = OpFunction  %2  None %39
 %99 = OpLabel
-%103 = OpLoad  %13  %101
-%106 = OpLoad  %26  %104
-%100 = OpCompositeConstruct  %25  %103 %106
-%109 = OpLoad  %16  %15
-%110 = OpLoad  %19  %18
+%103 = OpLoad  %10  %101
+%106 = OpLoad  %11  %104
+%100 = OpCompositeConstruct  %12  %103 %106
+%109 = OpLoad  %17  %21
+%110 = OpLoad  %18  %23
 OpBranch %111
 %111 = OpLabel
-%112 = OpCompositeExtract  %26  %100 1
+%112 = OpCompositeExtract  %11  %100 1
 %114 = OpSampledImage  %113  %109 %110
-%115 = OpImageSampleImplicitLod  %13  %114 %112
+%115 = OpImageSampleImplicitLod  %10  %114 %112
 OpStore %107 %115
 OpReturn
 OpFunctionEnd

--- a/tests/out/texture-array.spvasm.snap
+++ b/tests/out/texture-array.spvasm.snap
@@ -9,75 +9,75 @@ expression: dis
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %24 "main" %18 %22
+OpEntryPoint Fragment %24 "main" %19 %22
 OpExecutionMode %24 OriginUpperLeft
 OpSource GLSL 450
-OpName %5 "texture0"
-OpName %9 "texture1"
-OpName %10 "sampler"
-OpName %14 "PushConstants"
-OpMemberName %14 0 "index"
-OpName %13 "pc"
-OpName %18 "tex_coord"
+OpName %8 "PushConstants"
+OpMemberName %8 0 "index"
+OpName %11 "texture0"
+OpName %13 "texture1"
+OpName %14 "sampler"
+OpName %16 "pc"
+OpName %19 "tex_coord"
 OpName %24 "main"
 OpName %24 "main"
-OpDecorate %5 DescriptorSet 0
-OpDecorate %5 Binding 0
-OpDecorate %9 DescriptorSet 0
-OpDecorate %9 Binding 1
-OpDecorate %10 DescriptorSet 0
-OpDecorate %10 Binding 2
-OpDecorate %14 Block
-OpMemberDecorate %14 0 Offset 0
-OpDecorate %18 Location 0
+OpDecorate %8 Block
+OpMemberDecorate %8 0 Offset 0
+OpDecorate %11 DescriptorSet 0
+OpDecorate %11 Binding 0
+OpDecorate %13 DescriptorSet 0
+OpDecorate %13 Binding 1
+OpDecorate %14 DescriptorSet 0
+OpDecorate %14 Binding 2
+OpDecorate %19 Location 0
 OpDecorate %22 Location 1
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 0
 %3 = OpConstant  %4  0
-%7 = OpTypeFloat 32
-%6 = OpTypeImage %7 2D 0 0 0 1 Unknown
-%8 = OpTypePointer UniformConstant %6
-%5 = OpVariable  %8  UniformConstant
-%9 = OpVariable  %8  UniformConstant
-%11 = OpTypeSampler
-%12 = OpTypePointer UniformConstant %11
-%10 = OpVariable  %12  UniformConstant
-%14 = OpTypeStruct %4
-%15 = OpTypePointer PushConstant %14
-%13 = OpVariable  %15  PushConstant
-%17 = OpTypeVector %7 2
-%19 = OpTypePointer Input %17
-%18 = OpVariable  %19  Input
-%21 = OpTypeVector %7 4
-%23 = OpTypePointer Output %21
+%6 = OpTypeFloat 32
+%5 = OpTypeImage %6 2D 0 0 0 1 Unknown
+%7 = OpTypeSampler
+%8 = OpTypeStruct %4
+%9 = OpTypeVector %6 2
+%10 = OpTypeVector %6 4
+%12 = OpTypePointer UniformConstant %5
+%11 = OpVariable  %12  UniformConstant
+%13 = OpVariable  %12  UniformConstant
+%15 = OpTypePointer UniformConstant %7
+%14 = OpVariable  %15  UniformConstant
+%17 = OpTypePointer PushConstant %8
+%16 = OpVariable  %17  PushConstant
+%20 = OpTypePointer Input %9
+%19 = OpVariable  %20  Input
+%23 = OpTypePointer Output %10
 %22 = OpVariable  %23  Output
 %25 = OpTypeFunction %2
 %30 = OpTypePointer PushConstant %4
 %31 = OpTypeInt 32 1
 %32 = OpConstant  %31  0
 %35 = OpTypeBool
-%40 = OpTypeSampledImage %6
+%40 = OpTypeSampledImage %5
 %24 = OpFunction  %2  None %25
-%16 = OpLabel
-%20 = OpLoad  %17  %18
-%26 = OpLoad  %6  %5
-%27 = OpLoad  %6  %9
-%28 = OpLoad  %11  %10
+%18 = OpLabel
+%21 = OpLoad  %9  %19
+%26 = OpLoad  %5  %11
+%27 = OpLoad  %5  %13
+%28 = OpLoad  %7  %14
 OpBranch %29
 %29 = OpLabel
-%33 = OpAccessChain  %30  %13 %32
+%33 = OpAccessChain  %30  %16 %32
 %34 = OpLoad  %4  %33
 %36 = OpIEqual  %35  %34 %3
 OpSelectionMerge %37 None
 OpBranchConditional %36 %38 %39
 %38 = OpLabel
 %41 = OpSampledImage  %40  %26 %28
-%42 = OpImageSampleImplicitLod  %21  %41 %20
+%42 = OpImageSampleImplicitLod  %10  %41 %21
 OpStore %22 %42
 OpReturn
 %39 = OpLabel
 %43 = OpSampledImage  %40  %27 %28
-%44 = OpImageSampleImplicitLod  %21  %43 %20
+%44 = OpImageSampleImplicitLod  %10  %43 %21
 OpStore %22 %44
 OpReturn
 %37 = OpLabel


### PR DESCRIPTION
Continuation of #602 
The type layout is now a part of `ModuleInfo`.

I switched spv-out to use it instead of creating a separate layout object, and I faced a problem wrt how things are organized there. With lazy type serialization, it would take a lot of boilerplate to propagate the layouter to all the things - basically to all the `write_` methods, since most of them call `get_type_id`.

Instead, I did what I wanted to do for some time and refactored the type serialization more drastically. Now all the "handle" types are serialized at the start. There is just a trick we were missing to make it work:
  - first, all the scalar constants are serialized
  - then gather the types corresponding to structures
  - then all the types
  - then all the composite constants

I also made it so the `LookupType::Local` is populated based on `make_local`, which reduces the code complexity a bit.

Reviewer note: most of the LOCs changed stem from the reftest changes in SPIR-V, since we are serializing types in a different order now. I wonder if we could generate IDs in such a way that these kind of changes are minimized?.. (cc @MatusT )
A good addition to the LOCs volume is from the `Layouter` itself, which is now a part of IR snapshots (and it's good!).