### PR TITLE
Validate image expressions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,6 @@ pub enum ShaderStage {
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
-#[allow(missing_docs)] // The names are self evident
 pub enum StorageClass {
     /// Function locals.
     Function,

--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -6,7 +6,7 @@ Figures out the following properties:
   - expression reference counts
 !*/
 
-use super::{CallError, ExpressionError, FunctionError, ModuleInfo, ValidationFlags};
+use super::{CallError, ExpressionError, FunctionError, ModuleInfo, ShaderStages, ValidationFlags};
 use crate::{
     arena::{Arena, Handle},
     proc::{ResolveContext, TypeResolution},
@@ -164,6 +164,8 @@ impl ExpressionInfo {
 pub struct FunctionInfo {
     /// Validation flags.
     flags: ValidationFlags,
+    /// Set of shader stages where calling this function is valid.
+    pub available_stages: ShaderStages,
     /// Uniformity characteristics.
     pub uniformity: Uniformity,
     /// Function may kill the invocation.
@@ -676,6 +678,7 @@ impl ModuleInfo {
     ) -> Result<FunctionInfo, FunctionError> {
         let mut info = FunctionInfo {
             flags,
+            available_stages: ShaderStages::all(),
             uniformity: Uniformity::new(),
             may_kill: false,
             sampling_set: crate::FastHashSet::default(),
@@ -779,6 +782,7 @@ fn uniform_control_flow() {
 
     let mut info = FunctionInfo {
         flags: ValidationFlags::all(),
+        available_stages: ShaderStages::all(),
         uniformity: Uniformity::new(),
         may_kill: false,
         sampling_set: crate::FastHashSet::default(),

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -75,7 +75,7 @@ pub enum ExpressionError {
     InvalidImageArrayIndexType(Handle<crate::Expression>),
     #[error("Image other index type of {0:?} is not an integer scalar")]
     InvalidImageOtherIndexType(Handle<crate::Expression>),
-    #[error("Image coordinate index type of {1:?} does not match dimension {0:?}")]
+    #[error("Image coordinate type of {1:?} does not match dimension {0:?}")]
     InvalidImageCoordinateType(crate::ImageDimension, Handle<crate::Expression>),
     #[error("Comparison sampling mismatch: image has class {image:?}, but the sampler is comparison={sampler}, and the reference was provided={has_ref}")]
     ComparisonSamplingMismatch {
@@ -543,34 +543,14 @@ impl super::Validator {
                         arrayed,
                         dim,
                     } => {
-                        match (dim, resolver.resolve(coordinate)?) {
-                            (
-                                crate::ImageDimension::D1,
-                                &Ti::Scalar {
-                                    kind: crate::ScalarKind::Sint,
-                                    ..
-                                },
-                            )
-                            | (
-                                crate::ImageDimension::D2,
-                                &Ti::Vector {
-                                    kind: crate::ScalarKind::Sint,
-                                    ..
-                                },
-                            )
-                            | (
-                                crate::ImageDimension::D3,
-                                &Ti::Vector {
-                                    kind: crate::ScalarKind::Sint,
-                                    ..
-                                },
-                            ) => {}
+                        match resolver.resolve(coordinate)?.image_storage_coordinates() {
+                            Some(coord_dim) if coord_dim == dim => {}
                             _ => {
                                 return Err(ExpressionError::InvalidImageCoordinateType(
                                     dim, coordinate,
                                 ))
                             }
-                        }
+                        };
                         let needs_index = match class {
                             crate::ImageClass::Storage { .. } => false,
                             _ => true,

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -32,6 +32,17 @@ bitflags::bitflags! {
     }
 }
 
+bitflags::bitflags! {
+    /// Validation flags.
+    #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+    #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+    pub struct ShaderStages: u8 {
+        const VERTEX = 0x1;
+        const FRAGMENT = 0x2;
+        const COMPUTE = 0x4;
+    }
+}
+
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct ModuleInfo {

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -136,6 +136,26 @@ impl crate::TypeInner {
             Self::Array { .. } | Self::Image { .. } | Self::Sampler { .. } => false,
         }
     }
+
+    fn image_storage_coordinates(&self) -> Option<crate::ImageDimension> {
+        match *self {
+            Self::Scalar {
+                kind: crate::ScalarKind::Sint,
+                ..
+            } => Some(crate::ImageDimension::D1),
+            Self::Vector {
+                size: crate::VectorSize::Bi,
+                kind: crate::ScalarKind::Sint,
+                ..
+            } => Some(crate::ImageDimension::D2),
+            Self::Vector {
+                size: crate::VectorSize::Tri,
+                kind: crate::ScalarKind::Sint,
+                ..
+            } => Some(crate::ImageDimension::D3),
+            _ => None,
+        }
+    }
 }
 
 impl Validator {

--- a/tests/out/collatz.info.ron.snap
+++ b/tests/out/collatz.info.ron.snap
@@ -8,6 +8,9 @@ expression: output
             flags: (
                 bits: 7,
             ),
+            available_stages: (
+                bits: 7,
+            ),
             uniformity: (
                 non_uniform_result: Some(5),
                 requirements: (
@@ -348,6 +351,9 @@ expression: output
     entry_points: [
         (
             flags: (
+                bits: 7,
+            ),
+            available_stages: (
                 bits: 7,
             ),
             uniformity: (

--- a/tests/out/shadow.info.ron.snap
+++ b/tests/out/shadow.info.ron.snap
@@ -8,6 +8,9 @@ expression: output
             flags: (
                 bits: 7,
             ),
+            available_stages: (
+                bits: 7,
+            ),
             uniformity: (
                 non_uniform_result: Some(44),
                 requirements: (
@@ -1004,6 +1007,9 @@ expression: output
         ),
         (
             flags: (
+                bits: 7,
+            ),
+            available_stages: (
                 bits: 7,
             ),
             uniformity: (
@@ -2632,6 +2638,9 @@ expression: output
     entry_points: [
         (
             flags: (
+                bits: 7,
+            ),
+            available_stages: (
                 bits: 7,
             ),
             uniformity: (


### PR DESCRIPTION
Even more steps towards #59 
The only expression type left is `Math`. It's a big one, and also, interestingly, the one that motivated me to dive into the validation in the first place (more precisely, the "Frexp" operation is tricky and would benefit from type checks).