### PR TITLE
Make layout validation optional, disable the struct size check

### DIFF
--- a/src/valid/interface.rs
+++ b/src/valid/interface.rs
@@ -1,6 +1,6 @@
 use super::{
     analyzer::{FunctionInfo, GlobalUse},
-    Disalignment, FunctionError, ModuleInfo, ShaderStages, TypeFlags,
+    Disalignment, FunctionError, ModuleInfo, ShaderStages, TypeFlags, ValidationFlags,
 };
 use crate::arena::{Arena, Handle};
 
@@ -275,10 +275,12 @@ impl super::Validator {
                 match types[var.ty].inner {
                     crate::TypeInner::Struct { block: true, .. } => {
                         if let Err((ty_handle, ref disalignment)) = type_info.storage_layout {
-                            return Err(GlobalVariableError::Alignment(
-                                ty_handle,
-                                disalignment.clone(),
-                            ));
+                            if self.flags.contains(ValidationFlags::STRUCT_LAYOUTS) {
+                                return Err(GlobalVariableError::Alignment(
+                                    ty_handle,
+                                    disalignment.clone(),
+                                ));
+                            }
                         }
                     }
                     _ => return Err(GlobalVariableError::InvalidType),
@@ -293,10 +295,12 @@ impl super::Validator {
                 match types[var.ty].inner {
                     crate::TypeInner::Struct { block: true, .. } => {
                         if let Err((ty_handle, ref disalignment)) = type_info.uniform_layout {
-                            return Err(GlobalVariableError::Alignment(
-                                ty_handle,
-                                disalignment.clone(),
-                            ));
+                            if self.flags.contains(ValidationFlags::STRUCT_LAYOUTS) {
+                                return Err(GlobalVariableError::Alignment(
+                                    ty_handle,
+                                    disalignment.clone(),
+                                ));
+                            }
                         }
                     }
                     _ => return Err(GlobalVariableError::InvalidType),

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -26,9 +26,14 @@ bitflags::bitflags! {
     #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
     #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
     pub struct ValidationFlags: u8 {
+        /// Expressions.
         const EXPRESSIONS = 0x1;
+        /// Statements and blocks of them.
         const BLOCKS = 0x2;
+        /// Uniformity of control flow for operations that require it.
         const CONTROL_FLOW_UNIFORMITY = 0x4;
+        /// Host-shareable structure layouts.
+        const STRUCT_LAYOUTS = 0x8;
     }
 }
 

--- a/src/valid/type.rs
+++ b/src/valid/type.rs
@@ -209,19 +209,19 @@ impl super::Validator {
                             }
                         }
 
-                        let effective_alignment = match stride {
+                        let effective_stride = match stride {
                             Some(stride) => stride.get(),
                             None => base_layout.size,
                         };
                         let uniform_layout =
-                            if effective_alignment & UNIFORM_LAYOUT_ALIGNMENT_MASK == 0 {
+                            if effective_stride & UNIFORM_LAYOUT_ALIGNMENT_MASK == 0 {
                                 base_info.uniform_layout.clone()
                             } else {
                                 Err((
                                     handle,
                                     Disalignment::ArrayStride {
-                                        stride: effective_alignment,
-                                        alignment: effective_alignment,
+                                        stride: effective_stride,
+                                        alignment: UNIFORM_LAYOUT_ALIGNMENT_MASK + 1,
                                     },
                                 ))
                             };
@@ -295,12 +295,17 @@ impl super::Validator {
                     storage_layout = storage_layout.or_else(|_| base_info.storage_layout.clone());
                 }
 
-                if uniform_layout.is_ok() && offset % UNIFORM_LAYOUT_ALIGNMENT_MASK == 0 {
+                // disabled temporarily, see https://github.com/gpuweb/gpuweb/issues/1558
+                const CHECK_STRUCT_SIZE: bool = false;
+                if CHECK_STRUCT_SIZE
+                    && uniform_layout.is_ok()
+                    && offset & UNIFORM_LAYOUT_ALIGNMENT_MASK != 0
+                {
                     uniform_layout = Err((
                         handle,
                         Disalignment::StructSize {
                             size: offset,
-                            alignment: UNIFORM_LAYOUT_ALIGNMENT_MASK,
+                            alignment: UNIFORM_LAYOUT_ALIGNMENT_MASK + 1,
                         },
                     ));
                 }

--- a/tests/out/collatz.info.ron.snap
+++ b/tests/out/collatz.info.ron.snap
@@ -6,7 +6,7 @@ expression: output
     functions: [
         (
             flags: (
-                bits: 7,
+                bits: 15,
             ),
             available_stages: (
                 bits: 7,
@@ -351,7 +351,7 @@ expression: output
     entry_points: [
         (
             flags: (
-                bits: 7,
+                bits: 15,
             ),
             available_stages: (
                 bits: 7,

--- a/tests/out/shadow.info.ron.snap
+++ b/tests/out/shadow.info.ron.snap
@@ -6,7 +6,7 @@ expression: output
     functions: [
         (
             flags: (
-                bits: 7,
+                bits: 15,
             ),
             available_stages: (
                 bits: 7,
@@ -1007,7 +1007,7 @@ expression: output
         ),
         (
             flags: (
-                bits: 7,
+                bits: 15,
             ),
             available_stages: (
                 bits: 7,
@@ -2638,7 +2638,7 @@ expression: output
     entry_points: [
         (
             flags: (
-                bits: 7,
+                bits: 15,
             ),
             available_stages: (
                 bits: 7,


### PR DESCRIPTION
The struct size check was just plain broken, and if I fix it, we'd start failing on the boids example...
Disabling now until https://github.com/gpuweb/gpuweb/issues/1558 is cleared.