### PR TITLE
SPIRV frontend fixes for image operands and shifts

### DIFF
--- a/src/front/spv/image.rs
+++ b/src/front/spv/image.rs
@@ -88,7 +88,7 @@ fn extract_image_coordinates(
         };
         let array_index_f32 = expressions.append(extra_expr);
         let array_index = expressions.append(crate::Expression::As {
-            kind: crate::ScalarKind::Uint,
+            kind: crate::ScalarKind::Sint,
             expr: array_index_f32,
             convert: true,
         });

--- a/tests/out/shadow.info.ron.snap
+++ b/tests/out/shadow.info.ron.snap
@@ -985,7 +985,7 @@ expression: output
                     ref_count: 1,
                     assignable_global: None,
                     ty: Value(Scalar(
-                        kind: Uint,
+                        kind: Sint,
                         width: 4,
                     )),
                 ),

--- a/tests/out/shadow.ron.snap
+++ b/tests/out/shadow.ron.snap
@@ -1046,7 +1046,7 @@ expression: output
                 ),
                 As(
                     expr: 69,
-                    kind: Uint,
+                    kind: Sint,
                     convert: true,
                 ),
                 ImageSample(


### PR DESCRIPTION
The image operands were incorrect. We are expected to read 1 mask followed by the parameters, and instead we used to read each bit separately.