### PR TITLE
Fix expression validation check

### DIFF
--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -536,7 +536,7 @@ impl super::Validator {
             if expr.needs_pre_emit() {
                 self.valid_expression_set.insert(handle.index());
             }
-            if !self.flags.contains(ValidationFlags::EXPRESSIONS) {
+            if self.flags.contains(ValidationFlags::EXPRESSIONS) {
                 match self.validate_expression(
                     handle,
                     expr,

--- a/tests/in/shadow.wgsl
+++ b/tests/in/shadow.wgsl
@@ -23,7 +23,7 @@ var<storage> s_lights: [[access(read)]] Lights;
 [[group(0), binding(2)]]
 var t_shadow: texture_depth_2d_array;
 [[group(0), binding(3)]]
-var sampler_shadow: sampler;
+var sampler_shadow: sampler_comparison;
 
 fn fetch_shadow(light_id: u32, homogeneous_coords: vec4<f32>) -> f32 {
     if (homogeneous_coords.w <= 0.0) {


### PR DESCRIPTION
Looks like the expression validation check was flipped, unfortunately.
This should be merged after #609, which addresses the correctness of the image array index.