### PR TITLE
Align the block decoration with SPIR-V, require storage buffers

### DIFF
--- a/src/back/spv/helpers.rs
+++ b/src/back/spv/helpers.rs
@@ -1,13 +1,13 @@
 use spirv::Word;
 
-pub(crate) fn bytes_to_words(bytes: &[u8]) -> Vec<Word> {
+pub(super) fn bytes_to_words(bytes: &[u8]) -> Vec<Word> {
     bytes
         .chunks(4)
         .map(|chars| chars.iter().rev().fold(0u32, |u, c| (u << 8) | *c as u32))
         .collect()
 }
 
-pub(crate) fn string_to_words(input: &str) -> Vec<Word> {
+pub(super) fn string_to_words(input: &str) -> Vec<Word> {
     let bytes = input.as_bytes();
     let mut words = bytes_to_words(bytes);
 
@@ -17,4 +17,16 @@ pub(crate) fn string_to_words(input: &str) -> Vec<Word> {
     }
 
     words
+}
+
+pub(super) fn map_storage_class(class: crate::StorageClass) -> spirv::StorageClass {
+    match class {
+        crate::StorageClass::Handle => spirv::StorageClass::UniformConstant,
+        crate::StorageClass::Function => spirv::StorageClass::Function,
+        crate::StorageClass::Private => spirv::StorageClass::Private,
+        crate::StorageClass::Storage => spirv::StorageClass::StorageBuffer,
+        crate::StorageClass::Uniform => spirv::StorageClass::Uniform,
+        crate::StorageClass::WorkGroup => spirv::StorageClass::Workgroup,
+        crate::StorageClass::PushConstant => spirv::StorageClass::PushConstant,
+    }
 }

--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -81,6 +81,12 @@ impl super::Instruction {
     //  Extension Instructions
     //
 
+    pub(super) fn extension(name: &str) -> Self {
+        let mut instruction = Self::new(Op::Extension);
+        instruction.add_operands(helpers::string_to_words(name));
+        instruction
+    }
+
     pub(super) fn ext_inst_import(id: Word, name: &str) -> Self {
         let mut instruction = Self::new(Op::ExtInstImport);
         instruction.set_result(id);

--- a/src/back/spv/layout.rs
+++ b/src/back/spv/layout.rs
@@ -23,26 +23,6 @@ impl PhysicalLayout {
         sink.extend(iter::once(self.bound));
         sink.extend(iter::once(self.instruction_schema));
     }
-
-    pub(super) fn supports_storage_buffers(&self) -> bool {
-        self.version >= 0x10300
-    }
-
-    pub(super) fn map_storage_class(&self, class: crate::StorageClass) -> spirv::StorageClass {
-        match class {
-            crate::StorageClass::Handle => spirv::StorageClass::UniformConstant,
-            crate::StorageClass::Function => spirv::StorageClass::Function,
-            crate::StorageClass::Private => spirv::StorageClass::Private,
-            crate::StorageClass::Storage if self.supports_storage_buffers() => {
-                spirv::StorageClass::StorageBuffer
-            }
-            crate::StorageClass::Storage | crate::StorageClass::Uniform => {
-                spirv::StorageClass::Uniform
-            }
-            crate::StorageClass::WorkGroup => spirv::StorageClass::Workgroup,
-            crate::StorageClass::PushConstant => spirv::StorageClass::PushConstant,
-        }
-    }
 }
 
 impl LogicalLayout {

--- a/src/back/spv/mod.rs
+++ b/src/back/spv/mod.rs
@@ -1,3 +1,6 @@
+/*! Standard Portable Intermediate Representation (SPIR-V) backend
+!*/
+
 mod helpers;
 mod instructions;
 mod layout;

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::panic, clippy::needless_lifetimes)]
+#![allow(clippy::panic, clippy::needless_lifetimes, clippy::upper_case_acronyms)]
 use pomelo::pomelo;
 pomelo! {
     //%verbose;

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -2406,7 +2406,6 @@ impl<I: Iterator<Item = u32>> Parser<I> {
 
         let mut members = Vec::with_capacity(inst.wc as usize - 2);
         let mut member_type_ids = Vec::with_capacity(members.capacity());
-        let mut host_shared = false;
         for i in 0..u32::from(inst.wc) - 2 {
             let type_id = self.next()?;
             member_type_ids.push(type_id);
@@ -2415,8 +2414,6 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                 .future_member_decor
                 .remove(&(id, i))
                 .unwrap_or_default();
-            // this is a bit of a hack
-            host_shared |= decor.offset.is_some();
             members.push(crate::StructMember {
                 name: decor.name,
                 ty,
@@ -2427,7 +2424,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
         }
 
         let inner = crate::TypeInner::Struct {
-            block: block_decor.is_some() || host_shared,
+            block: block_decor.is_some(),
             members,
         };
         let ty_handle = module.types.append(crate::Type {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,13 +20,16 @@ emitted in order to take effect. This happens in one of the following ways:
 
 !*/
 
+// TODO: use `strip_prefix` instead when Rust 1.45 <= MSRV
 #![allow(
+    renamed_and_removed_lints,
+    unknown_lints, // requires Rust 1.51
     clippy::new_without_default,
     clippy::unneeded_field_pattern,
-    clippy::match_like_matches_macro
+    clippy::match_like_matches_macro,
+    clippy::manual_strip,
+    clippy::unknown_clippy_lints,
 )]
-// TODO: use `strip_prefix` instead when Rust 1.45 <= MSRV
-#![allow(clippy::manual_strip, clippy::unknown_clippy_lints)]
 #![warn(
     trivial_casts,
     trivial_numeric_casts,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,6 +393,7 @@ pub enum TypeInner {
     },
     /// User-defined structure.
     Struct {
+        /// This is a top-level host-shareable structure.
         block: bool,
         members: Vec<StructMember>,
     },

--- a/src/valid/interface.rs
+++ b/src/valid/interface.rs
@@ -272,42 +272,32 @@ impl super::Validator {
         let (allowed_storage_access, required_type_flags, is_resource) = match var.class {
             crate::StorageClass::Function => return Err(GlobalVariableError::InvalidUsage),
             crate::StorageClass::Storage => {
-                match types[var.ty].inner {
-                    crate::TypeInner::Struct { block: true, .. } => {
-                        if let Err((ty_handle, ref disalignment)) = type_info.storage_layout {
-                            if self.flags.contains(ValidationFlags::STRUCT_LAYOUTS) {
-                                return Err(GlobalVariableError::Alignment(
-                                    ty_handle,
-                                    disalignment.clone(),
-                                ));
-                            }
-                        }
+                if let Err((ty_handle, ref disalignment)) = type_info.storage_layout {
+                    if self.flags.contains(ValidationFlags::STRUCT_LAYOUTS) {
+                        return Err(GlobalVariableError::Alignment(
+                            ty_handle,
+                            disalignment.clone(),
+                        ));
                     }
-                    _ => return Err(GlobalVariableError::InvalidType),
                 }
                 (
                     crate::StorageAccess::all(),
-                    TypeFlags::DATA | TypeFlags::HOST_SHARED,
+                    TypeFlags::DATA | TypeFlags::HOST_SHARED | TypeFlags::BLOCK,
                     true,
                 )
             }
             crate::StorageClass::Uniform => {
-                match types[var.ty].inner {
-                    crate::TypeInner::Struct { block: true, .. } => {
-                        if let Err((ty_handle, ref disalignment)) = type_info.uniform_layout {
-                            if self.flags.contains(ValidationFlags::STRUCT_LAYOUTS) {
-                                return Err(GlobalVariableError::Alignment(
-                                    ty_handle,
-                                    disalignment.clone(),
-                                ));
-                            }
-                        }
+                if let Err((ty_handle, ref disalignment)) = type_info.uniform_layout {
+                    if self.flags.contains(ValidationFlags::STRUCT_LAYOUTS) {
+                        return Err(GlobalVariableError::Alignment(
+                            ty_handle,
+                            disalignment.clone(),
+                        ));
                     }
-                    _ => return Err(GlobalVariableError::InvalidType),
                 }
                 (
                     crate::StorageAccess::empty(),
-                    TypeFlags::DATA | TypeFlags::SIZED | TypeFlags::HOST_SHARED,
+                    TypeFlags::DATA | TypeFlags::SIZED | TypeFlags::HOST_SHARED | TypeFlags::BLOCK,
                     true,
                 )
             }

--- a/tests/in/boids.wgsl
+++ b/tests/in/boids.wgsl
@@ -1,6 +1,5 @@
 const NUM_PARTICLES: u32 = 1500u;
 
-[[block]]
 struct Particle {
   pos : vec2<f32>;
   vel : vec2<f32>;

--- a/tests/in/shadow.wgsl
+++ b/tests/in/shadow.wgsl
@@ -6,7 +6,6 @@ struct Globals {
 [[group(0), binding(0)]]
 var<uniform> u_globals: Globals;
 
-[[block]]
 struct Light {
     proj: mat4x4<f32>;
     pos: vec4<f32>;

--- a/tests/out/boids.spvasm.snap
+++ b/tests/out/boids.spvasm.snap
@@ -7,6 +7,7 @@ expression: dis
 ; Generator: rspirv
 ; Bound: 221
 OpCapability Shader
+OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %43 "main" %40
@@ -53,7 +54,7 @@ OpMemberDecorate %17 4 Offset 16
 OpMemberDecorate %17 5 Offset 20
 OpMemberDecorate %17 6 Offset 24
 OpDecorate %18 ArrayStride 16
-OpDecorate %19 BufferBlock
+OpDecorate %19 Block
 OpMemberDecorate %19 0 Offset 0
 OpDecorate %21 DescriptorSet 0
 OpDecorate %21 Binding 0
@@ -84,9 +85,9 @@ OpDecorate %40 BuiltIn GlobalInvocationId
 %20 = OpTypeVector %4 3
 %22 = OpTypePointer Uniform %17
 %21 = OpVariable  %22  Uniform
-%24 = OpTypePointer Uniform %19
-%23 = OpVariable  %24  Uniform
-%25 = OpVariable  %24  Uniform
+%24 = OpTypePointer StorageBuffer %19
+%23 = OpVariable  %24  StorageBuffer
+%25 = OpVariable  %24  StorageBuffer
 %27 = OpTypePointer Function %15
 %33 = OpTypePointer Function %8
 %38 = OpTypePointer Function %4
@@ -94,9 +95,9 @@ OpDecorate %40 BuiltIn GlobalInvocationId
 %40 = OpVariable  %41  Input
 %44 = OpTypeFunction %2
 %47 = OpTypeBool
-%51 = OpTypePointer Uniform %18
-%52 = OpTypePointer Uniform %16
-%53 = OpTypePointer Uniform %15
+%51 = OpTypePointer StorageBuffer %18
+%52 = OpTypePointer StorageBuffer %16
+%53 = OpTypePointer StorageBuffer %15
 %54 = OpConstant  %8  0
 %55 = OpConstant  %8  0
 %58 = OpConstant  %8  1

--- a/tests/out/collatz.spvasm.snap
+++ b/tests/out/collatz.spvasm.snap
@@ -7,6 +7,7 @@ expression: dis
 ; Generator: rspirv
 ; Bound: 62
 OpCapability Shader
+OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %48 "main" %45
@@ -22,7 +23,7 @@ OpName %45 "global_id"
 OpName %48 "main"
 OpName %48 "main"
 OpDecorate %8 ArrayStride 4
-OpDecorate %9 BufferBlock
+OpDecorate %9 Block
 OpMemberDecorate %9 0 Offset 0
 OpDecorate %11 DescriptorSet 0
 OpDecorate %11 Binding 0
@@ -36,16 +37,16 @@ OpDecorate %45 BuiltIn GlobalInvocationId
 %8 = OpTypeRuntimeArray %4
 %9 = OpTypeStruct %8
 %10 = OpTypeVector %4 3
-%12 = OpTypePointer Uniform %9
-%11 = OpVariable  %12  Uniform
+%12 = OpTypePointer StorageBuffer %9
+%11 = OpVariable  %12  StorageBuffer
 %14 = OpTypePointer Function %4
 %19 = OpTypeFunction %4 %4
 %26 = OpTypeBool
 %46 = OpTypePointer Input %10
 %45 = OpVariable  %46  Input
 %49 = OpTypeFunction %2
-%51 = OpTypePointer Uniform %8
-%53 = OpTypePointer Uniform %4
+%51 = OpTypePointer StorageBuffer %8
+%53 = OpTypePointer StorageBuffer %4
 %55 = OpTypeInt 32 1
 %56 = OpConstant  %55  0
 %60 = OpConstant  %55  0

--- a/tests/out/quad.spvasm.snap
+++ b/tests/out/quad.spvasm.snap
@@ -15,6 +15,8 @@ OpExecutionMode %47 OriginUpperLeft
 OpSource GLSL 450
 OpName %3 "c_scale"
 OpName %9 "VertexOutput"
+OpMemberName %9 0 "uv"
+OpMemberName %9 1 "position"
 OpName %12 "u_texture"
 OpName %14 "u_sampler"
 OpName %16 "out"
@@ -27,6 +29,8 @@ OpName %28 "main"
 OpName %44 "uv"
 OpName %47 "main"
 OpName %47 "main"
+OpMemberDecorate %9 0 Offset 0
+OpMemberDecorate %9 1 Offset 8
 OpDecorate %12 DescriptorSet 0
 OpDecorate %12 Binding 0
 OpDecorate %14 DescriptorSet 0

--- a/tests/out/shadow.ron.snap
+++ b/tests/out/shadow.ron.snap
@@ -150,7 +150,7 @@ expression: output
         (
             name: Some("Light"),
             inner: Struct(
-                block: true,
+                block: false,
                 members: [
                     (
                         name: Some("proj"),

--- a/tests/out/shadow.spvasm.snap
+++ b/tests/out/shadow.spvasm.snap
@@ -7,6 +7,7 @@ expression: dis
 ; Generator: rspirv
 ; Bound: 137
 OpCapability Shader
+OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %81 "fs_main" %73 %76 %79
@@ -41,7 +42,7 @@ OpMemberDecorate %17 0 MatrixStride 16
 OpMemberDecorate %17 1 Offset 64
 OpMemberDecorate %17 2 Offset 80
 OpDecorate %18 ArrayStride 96
-OpDecorate %19 BufferBlock
+OpDecorate %19 Block
 OpMemberDecorate %19 0 Offset 0
 OpDecorate %25 DescriptorSet 0
 OpDecorate %25 Binding 0
@@ -80,8 +81,8 @@ OpDecorate %79 Location 0
 %24 = OpConstantComposite  %23  %8 %8 %8
 %26 = OpTypePointer Uniform %14
 %25 = OpVariable  %26  Uniform
-%28 = OpTypePointer Uniform %19
-%27 = OpVariable  %28  Uniform
+%28 = OpTypePointer StorageBuffer %19
+%27 = OpVariable  %28  StorageBuffer
 %30 = OpTypePointer UniformConstant %20
 %29 = OpVariable  %30  UniformConstant
 %32 = OpTypePointer UniformConstant %21
@@ -102,8 +103,8 @@ OpDecorate %79 Location 0
 %82 = OpTypeFunction %2
 %92 = OpTypePointer Uniform %13
 %93 = OpConstant  %56  0
-%101 = OpTypePointer Uniform %18
-%103 = OpTypePointer Uniform %17
+%101 = OpTypePointer StorageBuffer %18
+%103 = OpTypePointer StorageBuffer %17
 %104 = OpConstant  %56  0
 %36 = OpFunction  %4  None %37
 %34 = OpFunctionParameter  %10

--- a/tests/out/skybox.spvasm.snap
+++ b/tests/out/skybox.spvasm.snap
@@ -14,6 +14,8 @@ OpEntryPoint Fragment %108 "fs_main" %101 %104 %107
 OpExecutionMode %108 OriginUpperLeft
 OpSource GLSL 450
 OpName %12 "VertexOutput"
+OpMemberName %12 0 "position"
+OpMemberName %12 1 "uv"
 OpName %14 "Data"
 OpMemberName %14 0 "proj_inv"
 OpMemberName %14 1 "view"
@@ -32,6 +34,8 @@ OpName %101 "position"
 OpName %104 "uv"
 OpName %108 "fs_main"
 OpName %108 "fs_main"
+OpMemberDecorate %12 0 Offset 0
+OpMemberDecorate %12 1 Offset 16
 OpDecorate %14 Block
 OpMemberDecorate %14 0 Offset 0
 OpMemberDecorate %14 0 ColMajor


### PR DESCRIPTION
Closes #611
The side effect of this change is that now we require SPV-1.3 or `SPV_KHR_storage_buffer_storage_class`. Apparently, this is universally supported, and it's a good thing. You can see how the code size is reduced in the PR.