### PR TITLE
[msl] fix mutability of function parameters

### DIFF
--- a/tests/out/quad-vert.msl.snap
+++ b/tests/out/quad-vert.msl.snap
@@ -36,10 +36,10 @@ struct type10 {
     type6 gl_ClipDistance1;
 };
 void main1(
-    type1 v_uv,
-    type1 a_uv,
-    gl_PerVertex _,
-    type1 a_pos
+    thread type1& v_uv,
+    thread type1 const& a_uv,
+    thread gl_PerVertex& _,
+    thread type1 const& a_pos
 ) {
     v_uv = a_uv;
     type1 _expr9 = a_pos;


### PR DESCRIPTION
Our MSL code, translated from SPIR-V, was totally wrong. It couldn't modify the private vars that were returned from the wrapped function.
With this change, the Metal backend can not only serve the https://github.com/gfx-rs/wgpu-rs/pull/763 by generating valid code, it can also do so when generating SPIR-V and then parsing it back!