### PR TITLE
[spv-in] pre-emit constant expressions

### DIFF
--- a/tests/out/quad-vert.msl.snap
+++ b/tests/out/quad-vert.msl.snap
@@ -42,8 +42,8 @@ void main1(
     thread type1 const& a_pos
 ) {
     v_uv = a_uv;
-    type1 _expr9 = a_pos;
-    _.gl_Position = metal::float4(_expr9.x, _expr9.y, const_0f, const_1f);
+    type1 _expr13 = a_pos;
+    _.gl_Position = metal::float4(_expr13.x, _expr13.y, const_0f, const_1f);
     return;
 }
 

--- a/tests/out/shadow.info.ron.snap
+++ b/tests/out/shadow.info.ron.snap
@@ -12,7 +12,7 @@ expression: output
                 bits: 7,
             ),
             uniformity: (
-                non_uniform_result: Some(44),
+                non_uniform_result: Some(48),
                 requirements: (
                     bits: 0,
                 ),
@@ -161,6 +161,62 @@ expression: output
                             bits: 0,
                         ),
                     ),
+                    ref_count: 0,
+                    assignable_global: None,
+                    ty: Value(Scalar(
+                        kind: Sint,
+                        width: 4,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (
+                            bits: 0,
+                        ),
+                    ),
+                    ref_count: 0,
+                    assignable_global: None,
+                    ty: Value(Scalar(
+                        kind: Sint,
+                        width: 4,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (
+                            bits: 0,
+                        ),
+                    ),
+                    ref_count: 0,
+                    assignable_global: None,
+                    ty: Value(Scalar(
+                        kind: Sint,
+                        width: 4,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (
+                            bits: 0,
+                        ),
+                    ),
+                    ref_count: 0,
+                    assignable_global: None,
+                    ty: Value(Scalar(
+                        kind: Sint,
+                        width: 4,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (
+                            bits: 0,
+                        ),
+                    ),
                     ref_count: 3,
                     assignable_global: None,
                     ty: Value(Scalar(
@@ -629,7 +685,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(43),
+                        non_uniform_result: Some(47),
                         requirements: (
                             bits: 0,
                         ),
@@ -640,7 +696,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -651,7 +707,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -665,7 +721,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -679,7 +735,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -693,7 +749,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -707,7 +763,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -729,7 +785,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -740,7 +796,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -754,7 +810,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -768,7 +824,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -790,7 +846,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -801,7 +857,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -815,7 +871,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -829,7 +885,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(43),
+                        non_uniform_result: Some(47),
                         requirements: (
                             bits: 0,
                         ),
@@ -843,7 +899,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(43),
+                        non_uniform_result: Some(47),
                         requirements: (
                             bits: 0,
                         ),
@@ -857,7 +913,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -868,7 +924,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -882,7 +938,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -896,7 +952,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -910,7 +966,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -924,7 +980,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -938,7 +994,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -952,7 +1008,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -963,7 +1019,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -977,7 +1033,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -991,7 +1047,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1013,7 +1069,7 @@ expression: output
                 bits: 7,
             ),
             uniformity: (
-                non_uniform_result: Some(44),
+                non_uniform_result: Some(48),
                 requirements: (
                     bits: 0,
                 ),
@@ -1165,6 +1221,62 @@ expression: output
                     ref_count: 0,
                     assignable_global: None,
                     ty: Value(Scalar(
+                        kind: Sint,
+                        width: 4,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (
+                            bits: 0,
+                        ),
+                    ),
+                    ref_count: 0,
+                    assignable_global: None,
+                    ty: Value(Scalar(
+                        kind: Sint,
+                        width: 4,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (
+                            bits: 0,
+                        ),
+                    ),
+                    ref_count: 0,
+                    assignable_global: None,
+                    ty: Value(Scalar(
+                        kind: Sint,
+                        width: 4,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (
+                            bits: 0,
+                        ),
+                    ),
+                    ref_count: 0,
+                    assignable_global: None,
+                    ty: Value(Scalar(
+                        kind: Sint,
+                        width: 4,
+                    )),
+                ),
+                (
+                    uniformity: (
+                        non_uniform_result: None,
+                        requirements: (
+                            bits: 0,
+                        ),
+                    ),
+                    ref_count: 0,
+                    assignable_global: None,
+                    ty: Value(Scalar(
                         kind: Float,
                         width: 4,
                     )),
@@ -1630,7 +1742,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(43),
+                        non_uniform_result: Some(47),
                         requirements: (
                             bits: 0,
                         ),
@@ -1644,7 +1756,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1658,7 +1770,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1727,7 +1839,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1741,7 +1853,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(43),
+                        non_uniform_result: Some(47),
                         requirements: (
                             bits: 0,
                         ),
@@ -1752,7 +1864,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1777,7 +1889,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1788,7 +1900,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1802,7 +1914,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1816,7 +1928,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1838,7 +1950,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1853,7 +1965,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1900,7 +2012,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1911,7 +2023,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1925,7 +2037,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1939,7 +2051,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1955,7 +2067,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1983,7 +2095,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -1994,7 +2106,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2008,7 +2120,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2022,7 +2134,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2038,7 +2150,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2066,7 +2178,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2077,7 +2189,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2091,7 +2203,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2105,7 +2217,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2121,7 +2233,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2135,7 +2247,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2247,7 +2359,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2258,7 +2370,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2297,7 +2409,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2322,7 +2434,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2333,7 +2445,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2347,7 +2459,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2361,7 +2473,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2377,7 +2489,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2405,7 +2517,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2416,7 +2528,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2430,7 +2542,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2444,7 +2556,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2460,7 +2572,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2488,7 +2600,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2499,7 +2611,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2513,7 +2625,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2527,7 +2639,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2543,7 +2655,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2557,7 +2669,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2568,7 +2680,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2579,7 +2691,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(43),
+                        non_uniform_result: Some(47),
                         requirements: (
                             bits: 0,
                         ),
@@ -2590,7 +2702,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2601,7 +2713,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(44),
+                        non_uniform_result: Some(48),
                         requirements: (
                             bits: 0,
                         ),
@@ -2612,7 +2724,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(43),
+                        non_uniform_result: Some(47),
                         requirements: (
                             bits: 0,
                         ),
@@ -2623,7 +2735,7 @@ expression: output
                 ),
                 (
                     uniformity: (
-                        non_uniform_result: Some(43),
+                        non_uniform_result: Some(47),
                         requirements: (
                             bits: 0,
                         ),
@@ -2644,7 +2756,7 @@ expression: output
                 bits: 7,
             ),
             uniformity: (
-                non_uniform_result: Some(44),
+                non_uniform_result: Some(48),
                 requirements: (
                     bits: 0,
                 ),

--- a/tests/out/shadow.ron.snap
+++ b/tests/out/shadow.ron.snap
@@ -882,6 +882,10 @@ expression: output
                 GlobalVariable(2),
                 GlobalVariable(4),
                 GlobalVariable(7),
+                Constant(1),
+                Constant(2),
+                Constant(3),
+                Constant(4),
                 Constant(20),
                 Constant(7),
                 Constant(33),
@@ -920,165 +924,165 @@ expression: output
                 FunctionArgument(0),
                 FunctionArgument(1),
                 AccessIndex(
-                    base: 44,
+                    base: 48,
                     index: 3,
                 ),
                 Binary(
                     op: LessEqual,
-                    left: 45,
-                    right: 42,
+                    left: 49,
+                    right: 46,
                 ),
                 AccessIndex(
-                    base: 44,
+                    base: 48,
                     index: 0,
                 ),
                 AccessIndex(
-                    base: 44,
+                    base: 48,
                     index: 1,
                 ),
                 Compose(
                     ty: 9,
                     components: [
-                        47,
-                        48,
+                        51,
+                        52,
                     ],
                 ),
                 Compose(
                     ty: 9,
                     components: [
-                        9,
-                        18,
+                        13,
+                        22,
                     ],
                 ),
                 Binary(
                     op: Multiply,
-                    left: 49,
-                    right: 50,
+                    left: 53,
+                    right: 54,
                 ),
                 AccessIndex(
-                    base: 44,
+                    base: 48,
                     index: 3,
                 ),
                 Binary(
                     op: Divide,
-                    left: 30,
-                    right: 52,
+                    left: 34,
+                    right: 56,
                 ),
                 Binary(
                     op: Multiply,
-                    left: 51,
-                    right: 53,
+                    left: 55,
+                    right: 57,
                 ),
                 Compose(
                     ty: 9,
                     components: [
-                        9,
-                        9,
+                        13,
+                        13,
                     ],
                 ),
                 Binary(
                     op: Add,
-                    left: 54,
-                    right: 55,
+                    left: 58,
+                    right: 59,
                 ),
                 AccessIndex(
-                    base: 56,
+                    base: 60,
                     index: 0,
                 ),
                 AccessIndex(
-                    base: 56,
+                    base: 60,
                     index: 1,
                 ),
                 As(
-                    expr: 43,
+                    expr: 47,
                     kind: Sint,
                     convert: false,
                 ),
                 As(
-                    expr: 59,
+                    expr: 63,
                     kind: Float,
                     convert: true,
                 ),
                 Compose(
                     ty: 2,
                     components: [
-                        57,
-                        58,
-                        60,
+                        61,
+                        62,
+                        64,
                     ],
                 ),
                 AccessIndex(
-                    base: 44,
+                    base: 48,
                     index: 2,
                 ),
                 AccessIndex(
-                    base: 44,
+                    base: 48,
                     index: 3,
                 ),
                 Binary(
                     op: Divide,
-                    left: 30,
-                    right: 63,
+                    left: 34,
+                    right: 67,
                 ),
                 Binary(
                     op: Multiply,
-                    left: 62,
-                    right: 64,
+                    left: 66,
+                    right: 68,
                 ),
                 AccessIndex(
-                    base: 61,
+                    base: 65,
                     index: 0,
                 ),
                 AccessIndex(
-                    base: 61,
+                    base: 65,
                     index: 1,
                 ),
                 Compose(
                     ty: 6,
                     components: [
-                        66,
-                        67,
+                        70,
+                        71,
                     ],
                 ),
                 AccessIndex(
-                    base: 61,
+                    base: 65,
                     index: 2,
                 ),
                 As(
-                    expr: 69,
+                    expr: 73,
                     kind: Sint,
                     convert: true,
                 ),
                 ImageSample(
                     image: 4,
                     sampler: 5,
-                    coordinate: 68,
-                    array_index: Some(70),
+                    coordinate: 72,
+                    array_index: Some(74),
                     offset: None,
-                    level: Exact(21),
-                    depth_ref: Some(65),
+                    level: Exact(25),
+                    depth_ref: Some(69),
                 ),
             ],
             body: [
                 Emit((
-                    start: 44,
-                    end: 46,
+                    start: 48,
+                    end: 50,
                 )),
                 If(
-                    condition: 46,
+                    condition: 50,
                     accept: [
                         Return(
-                            value: Some(30),
+                            value: Some(34),
                         ),
                     ],
                     reject: [],
                 ),
                 Emit((
-                    start: 46,
-                    end: 71,
+                    start: 50,
+                    end: 75,
                 )),
                 Return(
-                    value: Some(71),
+                    value: Some(75),
                 ),
             ],
         ),
@@ -1106,6 +1110,10 @@ expression: output
                 GlobalVariable(2),
                 GlobalVariable(4),
                 GlobalVariable(7),
+                Constant(1),
+                Constant(2),
+                Constant(3),
+                Constant(4),
                 Constant(20),
                 Constant(7),
                 Constant(33),
@@ -1144,61 +1152,61 @@ expression: output
                 LocalVariable(1),
                 LocalVariable(2),
                 Load(
-                    pointer: 44,
+                    pointer: 48,
                 ),
                 AccessIndex(
                     base: 1,
                     index: 0,
                 ),
                 Access(
-                    base: 46,
-                    index: 37,
+                    base: 50,
+                    index: 41,
                 ),
                 Load(
-                    pointer: 47,
+                    pointer: 51,
                 ),
                 Math(
                     fun: Min,
-                    arg: 48,
-                    arg1: Some(28),
+                    arg: 52,
+                    arg1: Some(32),
                     arg2: None,
                 ),
                 Binary(
                     op: GreaterEqual,
-                    left: 45,
-                    right: 49,
+                    left: 49,
+                    right: 53,
                 ),
                 Load(
-                    pointer: 43,
+                    pointer: 47,
                 ),
                 Load(
-                    pointer: 44,
+                    pointer: 48,
                 ),
                 AccessIndex(
                     base: 6,
                     index: 0,
                 ),
                 Load(
-                    pointer: 44,
+                    pointer: 48,
                 ),
                 Access(
-                    base: 53,
-                    index: 54,
+                    base: 57,
+                    index: 58,
                 ),
                 AccessIndex(
-                    base: 55,
+                    base: 59,
                     index: 0,
                 ),
                 Load(
-                    pointer: 56,
+                    pointer: 60,
                 ),
                 Load(
                     pointer: 3,
                 ),
                 Binary(
                     op: Multiply,
-                    left: 57,
-                    right: 58,
+                    left: 61,
+                    right: 62,
                 ),
                 Call(1),
                 Load(
@@ -1206,7 +1214,7 @@ expression: output
                 ),
                 Math(
                     fun: Normalize,
-                    arg: 61,
+                    arg: 65,
                     arg1: None,
                     arg2: None,
                 ),
@@ -1215,232 +1223,232 @@ expression: output
                     index: 0,
                 ),
                 Load(
-                    pointer: 44,
+                    pointer: 48,
                 ),
                 Access(
-                    base: 63,
-                    index: 64,
+                    base: 67,
+                    index: 68,
                 ),
                 AccessIndex(
-                    base: 65,
-                    index: 1,
-                ),
-                Access(
-                    base: 66,
-                    index: 31,
-                ),
-                Load(
-                    pointer: 67,
-                ),
-                AccessIndex(
-                    base: 6,
-                    index: 0,
-                ),
-                Load(
-                    pointer: 44,
-                ),
-                Access(
                     base: 69,
-                    index: 70,
-                ),
-                AccessIndex(
-                    base: 71,
                     index: 1,
                 ),
                 Access(
-                    base: 72,
-                    index: 38,
+                    base: 70,
+                    index: 35,
                 ),
                 Load(
-                    pointer: 73,
+                    pointer: 71,
                 ),
                 AccessIndex(
                     base: 6,
                     index: 0,
                 ),
                 Load(
-                    pointer: 44,
+                    pointer: 48,
                 ),
                 Access(
-                    base: 75,
-                    index: 76,
+                    base: 73,
+                    index: 74,
                 ),
                 AccessIndex(
-                    base: 77,
+                    base: 75,
                     index: 1,
                 ),
                 Access(
-                    base: 78,
-                    index: 13,
+                    base: 76,
+                    index: 42,
                 ),
                 Load(
-                    pointer: 79,
+                    pointer: 77,
+                ),
+                AccessIndex(
+                    base: 6,
+                    index: 0,
+                ),
+                Load(
+                    pointer: 48,
+                ),
+                Access(
+                    base: 79,
+                    index: 80,
+                ),
+                AccessIndex(
+                    base: 81,
+                    index: 1,
+                ),
+                Access(
+                    base: 82,
+                    index: 17,
+                ),
+                Load(
+                    pointer: 83,
                 ),
                 Compose(
                     ty: 2,
                     components: [
-                        68,
-                        74,
-                        80,
+                        72,
+                        78,
+                        84,
                     ],
                 ),
                 Access(
                     base: 3,
-                    index: 36,
-                ),
-                Load(
-                    pointer: 82,
-                ),
-                Access(
-                    base: 3,
-                    index: 12,
-                ),
-                Load(
-                    pointer: 84,
-                ),
-                Access(
-                    base: 3,
-                    index: 23,
+                    index: 40,
                 ),
                 Load(
                     pointer: 86,
                 ),
+                Access(
+                    base: 3,
+                    index: 16,
+                ),
+                Load(
+                    pointer: 88,
+                ),
+                Access(
+                    base: 3,
+                    index: 27,
+                ),
+                Load(
+                    pointer: 90,
+                ),
                 Compose(
                     ty: 2,
                     components: [
-                        83,
-                        85,
                         87,
+                        89,
+                        91,
                     ],
                 ),
                 Binary(
                     op: Subtract,
-                    left: 81,
-                    right: 88,
+                    left: 85,
+                    right: 92,
                 ),
                 Math(
                     fun: Normalize,
-                    arg: 89,
+                    arg: 93,
                     arg1: None,
                     arg2: None,
                 ),
                 Math(
                     fun: Dot,
-                    arg: 62,
-                    arg1: Some(90),
+                    arg: 66,
+                    arg1: Some(94),
                     arg2: None,
                 ),
                 Math(
                     fun: Max,
-                    arg: 42,
-                    arg1: Some(91),
+                    arg: 46,
+                    arg1: Some(95),
                     arg2: None,
                 ),
                 Binary(
                     op: Multiply,
-                    left: 60,
-                    right: 92,
+                    left: 64,
+                    right: 96,
                 ),
                 AccessIndex(
                     base: 6,
                     index: 0,
                 ),
                 Load(
-                    pointer: 44,
+                    pointer: 48,
                 ),
                 Access(
-                    base: 94,
-                    index: 95,
+                    base: 98,
+                    index: 99,
                 ),
                 AccessIndex(
-                    base: 96,
-                    index: 2,
-                ),
-                Access(
-                    base: 97,
-                    index: 10,
-                ),
-                Load(
-                    pointer: 98,
-                ),
-                AccessIndex(
-                    base: 6,
-                    index: 0,
-                ),
-                Load(
-                    pointer: 44,
-                ),
-                Access(
                     base: 100,
-                    index: 101,
-                ),
-                AccessIndex(
-                    base: 102,
                     index: 2,
                 ),
                 Access(
-                    base: 103,
-                    index: 19,
+                    base: 101,
+                    index: 14,
                 ),
                 Load(
-                    pointer: 104,
+                    pointer: 102,
                 ),
                 AccessIndex(
                     base: 6,
                     index: 0,
                 ),
                 Load(
-                    pointer: 44,
+                    pointer: 48,
                 ),
                 Access(
-                    base: 106,
-                    index: 107,
+                    base: 104,
+                    index: 105,
                 ),
                 AccessIndex(
-                    base: 108,
+                    base: 106,
                     index: 2,
                 ),
                 Access(
-                    base: 109,
-                    index: 26,
+                    base: 107,
+                    index: 23,
                 ),
                 Load(
-                    pointer: 110,
+                    pointer: 108,
+                ),
+                AccessIndex(
+                    base: 6,
+                    index: 0,
+                ),
+                Load(
+                    pointer: 48,
+                ),
+                Access(
+                    base: 110,
+                    index: 111,
+                ),
+                AccessIndex(
+                    base: 112,
+                    index: 2,
+                ),
+                Access(
+                    base: 113,
+                    index: 30,
+                ),
+                Load(
+                    pointer: 114,
                 ),
                 Compose(
                     ty: 2,
                     components: [
-                        99,
-                        105,
-                        111,
+                        103,
+                        109,
+                        115,
                     ],
                 ),
                 Binary(
                     op: Multiply,
-                    left: 112,
-                    right: 93,
+                    left: 116,
+                    right: 97,
                 ),
                 Binary(
                     op: Add,
-                    left: 51,
-                    right: 113,
+                    left: 55,
+                    right: 117,
                 ),
                 Load(
-                    pointer: 44,
+                    pointer: 48,
                 ),
                 Binary(
                     op: Add,
-                    left: 115,
-                    right: 27,
+                    left: 119,
+                    right: 31,
                 ),
                 Load(
-                    pointer: 43,
+                    pointer: 47,
                 ),
                 Compose(
                     ty: 4,
                     components: [
-                        117,
-                        30,
+                        121,
+                        34,
                     ],
                 ),
             ],
@@ -1448,55 +1456,55 @@ expression: output
                 Loop(
                     body: [
                         Emit((
-                            start: 44,
-                            end: 50,
+                            start: 48,
+                            end: 54,
                         )),
                         If(
-                            condition: 50,
+                            condition: 54,
                             accept: [
                                 Break,
                             ],
                             reject: [],
                         ),
                         Emit((
-                            start: 50,
-                            end: 59,
+                            start: 54,
+                            end: 63,
                         )),
                         Call(
                             function: 1,
                             arguments: [
-                                52,
-                                59,
+                                56,
+                                63,
                             ],
-                            result: Some(60),
+                            result: Some(64),
                         ),
                         Emit((
-                            start: 60,
-                            end: 114,
+                            start: 64,
+                            end: 118,
                         )),
                         Store(
-                            pointer: 43,
-                            value: 114,
+                            pointer: 47,
+                            value: 118,
                         ),
                     ],
                     continuing: [
                         Emit((
-                            start: 114,
-                            end: 116,
+                            start: 118,
+                            end: 120,
                         )),
                         Store(
-                            pointer: 44,
-                            value: 116,
+                            pointer: 48,
+                            value: 120,
                         ),
                     ],
                 ),
                 Emit((
-                    start: 116,
-                    end: 118,
+                    start: 120,
+                    end: 122,
                 )),
                 Store(
                     pointer: 7,
-                    value: 118,
+                    value: 122,
                 ),
                 Return(
                     value: None,


### PR DESCRIPTION
If we emit them on the fly, we hit a validation error, since frontends aren't expected to emit constant expressions.