### PR TITLE
Fix matrix multiplication types

### DIFF
--- a/tests/out/collatz.info.ron.snap
+++ b/tests/out/collatz.info.ron.snap
@@ -265,10 +265,7 @@ expression: output
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
-                        kind: Uint,
-                        width: 4,
-                    )),
+                    ty: Handle(1),
                 ),
                 (
                     uniformity: (
@@ -293,10 +290,7 @@ expression: output
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Value(Scalar(
-                        kind: Uint,
-                        width: 4,
-                    )),
+                    ty: Handle(1),
                 ),
                 (
                     uniformity: (

--- a/tests/out/shadow.info.ron.snap
+++ b/tests/out/shadow.info.ron.snap
@@ -2416,7 +2416,10 @@ expression: output
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Handle(1),
+                    ty: Value(Scalar(
+                        kind: Float,
+                        width: 4,
+                    )),
                 ),
                 (
                     uniformity: (


### PR DESCRIPTION
Our typification code didn't support Matrix * Matrix if they are different types. Now it does.