### PR TITLE
Flip Y axis in SPIR-V frontend and backend

### DIFF
--- a/bin/convert.rs
+++ b/bin/convert.rs
@@ -6,6 +6,8 @@ use std::{env, error::Error, path::Path};
 #[derive(Default)]
 struct Parameters {
     #[cfg(feature = "spv-in")]
+    spv_adjust_coordinate_space: bool,
+    #[cfg(feature = "spv-in")]
     spv_flow_dump_prefix: Option<String>,
     #[cfg(feature = "spv-out")]
     spv: naga::back::spv::Options,
@@ -102,6 +104,7 @@ fn main() {
         #[cfg(feature = "spv-in")]
         "spv" => {
             let options = naga::front::spv::Options {
+                adjust_coordinate_space: params.spv_adjust_coordinate_space,
                 flow_graph_dump_prefix: params.spv_flow_dump_prefix.map(std::path::PathBuf::from),
             };
             let input = fs::read(input_path).unwrap();

--- a/src/back/spv/mod.rs
+++ b/src/back/spv/mod.rs
@@ -13,7 +13,10 @@ use spirv::Word;
 
 bitflags::bitflags! {
     pub struct WriterFlags: u32 {
+        /// Include debug labels for everything.
         const DEBUG = 0x1;
+        /// Flip Y coordinate of `BuiltIn::Position` output.
+        const ADJUST_COORDINATE_SPACE = 0x2;
     }
 }
 
@@ -60,7 +63,7 @@ pub struct Options {
 
 impl Default for Options {
     fn default() -> Self {
-        let mut flags = WriterFlags::empty();
+        let mut flags = WriterFlags::ADJUST_COORDINATE_SPACE;
         if cfg!(debug_assertions) {
             flags |= WriterFlags::DEBUG;
         }

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -2041,7 +2041,9 @@ impl Writer {
 
             // Flip Y coordinate to adjust for coordinate space difference
             // between SPIR-V and our IR.
-            if res_member.built_in == Some(crate::BuiltIn::Position) {
+            if self.flags.contains(WriterFlags::ADJUST_COORDINATE_SPACE)
+                && res_member.built_in == Some(crate::BuiltIn::Position)
+            {
                 let access_id = self.id_gen.next();
                 let float_ptr_type_id = self.get_type_id(
                     type_arena,

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -312,9 +312,22 @@ enum ExtendedClass {
     Output,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct Options {
+    /// The IR coordinate space matches all the APIs except SPIR-V,
+    /// so by default we flip the Y coordinate of the `BuiltIn::Position`.
+    /// This flag can be used to avoid this.
+    pub adjust_coordinate_space: bool,
     pub flow_graph_dump_prefix: Option<PathBuf>,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Options {
+            adjust_coordinate_space: true,
+            flow_graph_dump_prefix: None,
+        }
+    }
 }
 
 pub struct Parser<I> {

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -1825,6 +1825,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
             crate::Module::default()
         };
 
+        // register indexing constants
         self.index_constants.clear();
         for i in 0..4 {
             let handle = module.constants.append(crate::Constant {

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -174,3 +174,12 @@ impl crate::Constant {
         }
     }
 }
+
+impl crate::Binding {
+    pub fn to_built_in(&self) -> Option<crate::BuiltIn> {
+        match *self {
+            Self::BuiltIn(bi) => Some(bi),
+            Self::Location(..) => None,
+        }
+    }
+}

--- a/tests/in/boids.param.ron
+++ b/tests/in/boids.param.ron
@@ -2,6 +2,8 @@
 	spv_flow_dump_prefix: "",
 	spv_version: (1, 0),
 	spv_capabilities: [ Shader ],
+	spv_debug: true,
+	spv_adjust_coordinate_space: false,
 	mtl_bindings: {
 		(stage: Compute, group: 0, binding: 0): (buffer: Some(0), mutable: false),
 		(stage: Compute, group: 0, binding: 1): (buffer: Some(1), mutable: true),

--- a/tests/in/collatz.param.ron
+++ b/tests/in/collatz.param.ron
@@ -2,6 +2,8 @@
 	spv_flow_dump_prefix: "",
 	spv_version: (1, 0),
 	spv_capabilities: [ Shader ],
+	spv_debug: true,
+	spv_adjust_coordinate_space: false,
 	mtl_bindings: {
 		(stage: Compute, group: 0, binding: 0): (buffer: Some(0), mutable: true),
 	}

--- a/tests/in/empty.param.ron
+++ b/tests/in/empty.param.ron
@@ -1,6 +1,8 @@
 (
 	spv_version: (1, 1),
 	spv_capabilities: [ Shader ],
+	spv_debug: false,
+	spv_adjust_coordinate_space: false,
 	mtl_bindings: {
 	}
 )

--- a/tests/in/image-copy.param.ron
+++ b/tests/in/image-copy.param.ron
@@ -1,6 +1,8 @@
 (
 	spv_version: (1, 1),
 	spv_capabilities: [ Shader, Image1D, Sampled1D ],
+	spv_debug: true,
+	spv_adjust_coordinate_space: false,
 	mtl_bindings: {
 		(stage: Compute, group: 0, binding: 1): (texture: Some(0), mutable: false),
 		(stage: Compute, group: 0, binding: 2): (texture: Some(1), mutable: true),

--- a/tests/in/quad-glsl.param.ron
+++ b/tests/in/quad-glsl.param.ron
@@ -1,5 +1,7 @@
 (
 	spv_version: (1, 0),
 	spv_capabilities: [ Shader ],
+	spv_debug: true,
+	spv_adjust_coordinate_space: true,
 	mtl_bindings: {}
 )

--- a/tests/in/quad.param.ron
+++ b/tests/in/quad.param.ron
@@ -1,6 +1,8 @@
 (
 	spv_version: (1, 0),
 	spv_capabilities: [ Shader ],
+	spv_debug: true,
+	spv_adjust_coordinate_space: true,
 	mtl_bindings: {
 		(stage: Fragment, group: 0, binding: 0): (texture: Some(0)),
 		(stage: Fragment, group: 0, binding: 1): (sampler: Some(0)),

--- a/tests/in/shadow.param.ron
+++ b/tests/in/shadow.param.ron
@@ -2,6 +2,8 @@
     spv_flow_dump_prefix: "",
     spv_version: (1, 2),
     spv_capabilities: [ Shader ],
+    spv_debug: true,
+    spv_adjust_coordinate_space: true,
     mtl_bindings: {
         (stage: Fragment, group: 0, binding: 0): (buffer: Some(0), mutable: false),
         (stage: Fragment, group: 0, binding: 1): (buffer: Some(1), mutable: false),

--- a/tests/in/skybox.param.ron
+++ b/tests/in/skybox.param.ron
@@ -2,6 +2,8 @@
 	spv_flow_dump_prefix: "",
 	spv_version: (1, 0),
 	spv_capabilities: [ Shader ],
+	spv_debug: false,
+	spv_adjust_coordinate_space: false,
 	mtl_bindings: {
 		(stage: Vertex, group: 0, binding: 0): (buffer: Some(0)),
 		(stage: Fragment, group: 0, binding: 1): (texture: Some(0)),

--- a/tests/in/texture-array.param.ron
+++ b/tests/in/texture-array.param.ron
@@ -2,6 +2,8 @@
 	spv_flow_dump_prefix: "",
 	spv_version: (1, 5),
 	spv_capabilities: [ Shader ],
+	spv_debug: true,
+	spv_adjust_coordinate_space: false,
 	mtl_bindings: {
 		(stage: Fragment, group: 0, binding: 0): (texture: Some(0)),
 		(stage: Fragment, group: 0, binding: 1): (texture: Some(1)),

--- a/tests/out/boids.spvasm.snap
+++ b/tests/out/boids.spvasm.snap
@@ -5,7 +5,7 @@ expression: dis
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 221
+; Bound: 203
 OpCapability Shader
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
@@ -98,31 +98,13 @@ OpDecorate %40 BuiltIn GlobalInvocationId
 %51 = OpTypePointer StorageBuffer %18
 %52 = OpTypePointer StorageBuffer %16
 %53 = OpTypePointer StorageBuffer %15
-%54 = OpConstant  %8  0
-%55 = OpConstant  %8  0
-%58 = OpConstant  %8  1
-%59 = OpConstant  %8  0
-%78 = OpConstant  %8  0
-%79 = OpConstant  %8  0
-%83 = OpConstant  %8  1
-%84 = OpConstant  %8  0
-%90 = OpTypePointer Uniform %6
-%91 = OpConstant  %8  1
-%105 = OpConstant  %8  2
-%119 = OpConstant  %8  3
-%154 = OpConstant  %8  4
-%160 = OpConstant  %8  5
-%166 = OpConstant  %8  6
-%179 = OpConstant  %8  0
-%189 = OpTypePointer Function %6
-%190 = OpConstant  %8  0
-%197 = OpConstant  %8  0
-%204 = OpConstant  %8  1
-%211 = OpConstant  %8  1
-%214 = OpConstant  %8  0
-%215 = OpConstant  %8  0
-%218 = OpConstant  %8  1
-%219 = OpConstant  %8  0
+%82 = OpTypePointer Uniform %6
+%96 = OpConstant  %8  2
+%110 = OpConstant  %8  3
+%145 = OpConstant  %8  4
+%151 = OpConstant  %8  5
+%157 = OpConstant  %8  6
+%179 = OpTypePointer Function %6
 %43 = OpFunction  %2  None %44
 %39 = OpLabel
 %37 = OpVariable  %38  Function %9
@@ -145,209 +127,209 @@ OpBranchConditional %48 %50 %49
 %50 = OpLabel
 OpReturn
 %49 = OpLabel
-%56 = OpAccessChain  %53  %23 %55 %46 %54
+%54 = OpAccessChain  %53  %23 %7 %46 %7
+%55 = OpLoad  %15  %54
+OpStore %26 %55
+%56 = OpAccessChain  %53  %23 %7 %46 %10
 %57 = OpLoad  %15  %56
-OpStore %26 %57
-%60 = OpAccessChain  %53  %23 %59 %46 %58
-%61 = OpLoad  %15  %60
-OpStore %28 %61
-%62 = OpCompositeConstruct  %15  %5 %5
-OpStore %29 %62
-%63 = OpCompositeConstruct  %15  %5 %5
-OpStore %30 %63
-%64 = OpCompositeConstruct  %15  %5 %5
-OpStore %31 %64
-OpBranch %65
-%65 = OpLabel
-OpLoopMerge %66 %68 None
-OpBranch %67
+OpStore %28 %57
+%58 = OpCompositeConstruct  %15  %5 %5
+OpStore %29 %58
+%59 = OpCompositeConstruct  %15  %5 %5
+OpStore %30 %59
+%60 = OpCompositeConstruct  %15  %5 %5
+OpStore %31 %60
+OpBranch %61
+%61 = OpLabel
+OpLoopMerge %62 %64 None
+OpBranch %63
+%63 = OpLabel
+%65 = OpLoad  %4  %37
+%66 = OpUGreaterThanEqual  %47  %65 %3
+OpSelectionMerge %67 None
+OpBranchConditional %66 %68 %67
+%68 = OpLabel
+OpBranch %62
 %67 = OpLabel
 %69 = OpLoad  %4  %37
-%70 = OpUGreaterThanEqual  %47  %69 %3
+%70 = OpIEqual  %47  %69 %46
 OpSelectionMerge %71 None
 OpBranchConditional %70 %72 %71
 %72 = OpLabel
-OpBranch %66
+OpBranch %64
 %71 = OpLabel
 %73 = OpLoad  %4  %37
-%74 = OpIEqual  %47  %73 %46
-OpSelectionMerge %75 None
-OpBranchConditional %74 %76 %75
-%76 = OpLabel
-OpBranch %68
-%75 = OpLabel
-%77 = OpLoad  %4  %37
-%80 = OpAccessChain  %53  %23 %79 %77 %78
-%81 = OpLoad  %15  %80
-OpStore %35 %81
-%82 = OpLoad  %4  %37
-%85 = OpAccessChain  %53  %23 %84 %82 %83
-%86 = OpLoad  %15  %85
-OpStore %36 %86
-%87 = OpLoad  %15  %35
-%88 = OpLoad  %15  %26
-%89 = OpExtInst  %6  %1 Distance %87 %88
-%92 = OpAccessChain  %90  %21 %91
-%93 = OpLoad  %6  %92
-%94 = OpFOrdLessThan  %47  %89 %93
-OpSelectionMerge %95 None
-OpBranchConditional %94 %96 %95
-%96 = OpLabel
-%97 = OpLoad  %15  %29
-%98 = OpLoad  %15  %35
-%99 = OpFAdd  %15  %97 %98
-OpStore %29 %99
-%100 = OpLoad  %8  %32
-%101 = OpIAdd  %8  %100 %10
-OpStore %32 %101
-OpBranch %95
-%95 = OpLabel
-%102 = OpLoad  %15  %35
-%103 = OpLoad  %15  %26
-%104 = OpExtInst  %6  %1 Distance %102 %103
-%106 = OpAccessChain  %90  %21 %105
-%107 = OpLoad  %6  %106
-%108 = OpFOrdLessThan  %47  %104 %107
-OpSelectionMerge %109 None
-OpBranchConditional %108 %110 %109
-%110 = OpLabel
-%111 = OpLoad  %15  %31
-%112 = OpLoad  %15  %35
-%113 = OpLoad  %15  %26
-%114 = OpFSub  %15  %112 %113
-%115 = OpFSub  %15  %111 %114
-OpStore %31 %115
-OpBranch %109
-%109 = OpLabel
-%116 = OpLoad  %15  %35
-%117 = OpLoad  %15  %26
-%118 = OpExtInst  %6  %1 Distance %116 %117
-%120 = OpAccessChain  %90  %21 %119
-%121 = OpLoad  %6  %120
-%122 = OpFOrdLessThan  %47  %118 %121
-OpSelectionMerge %123 None
-OpBranchConditional %122 %124 %123
-%124 = OpLabel
-%125 = OpLoad  %15  %30
-%126 = OpLoad  %15  %36
-%127 = OpFAdd  %15  %125 %126
-OpStore %30 %127
-%128 = OpLoad  %8  %34
-%129 = OpIAdd  %8  %128 %10
-OpStore %34 %129
-OpBranch %123
-%123 = OpLabel
-OpBranch %68
-%68 = OpLabel
-%130 = OpLoad  %4  %37
-%131 = OpIAdd  %4  %130 %11
-OpStore %37 %131
-OpBranch %65
-%66 = OpLabel
-%132 = OpLoad  %8  %32
-%133 = OpSGreaterThan  %47  %132 %7
-OpSelectionMerge %134 None
-OpBranchConditional %133 %135 %134
-%135 = OpLabel
-%136 = OpLoad  %15  %29
-%137 = OpLoad  %8  %32
-%138 = OpConvertSToF  %6  %137
-%139 = OpFDiv  %6  %12 %138
-%140 = OpVectorTimesScalar  %15  %136 %139
-%141 = OpLoad  %15  %26
-%142 = OpFSub  %15  %140 %141
-OpStore %29 %142
-OpBranch %134
-%134 = OpLabel
-%143 = OpLoad  %8  %34
-%144 = OpSGreaterThan  %47  %143 %7
-OpSelectionMerge %145 None
-OpBranchConditional %144 %146 %145
-%146 = OpLabel
-%147 = OpLoad  %15  %30
-%148 = OpLoad  %8  %34
-%149 = OpConvertSToF  %6  %148
-%150 = OpFDiv  %6  %12 %149
-%151 = OpVectorTimesScalar  %15  %147 %150
-OpStore %30 %151
-OpBranch %145
-%145 = OpLabel
-%152 = OpLoad  %15  %28
-%153 = OpLoad  %15  %29
-%155 = OpAccessChain  %90  %21 %154
-%156 = OpLoad  %6  %155
-%157 = OpVectorTimesScalar  %15  %153 %156
-%158 = OpFAdd  %15  %152 %157
-%159 = OpLoad  %15  %31
-%161 = OpAccessChain  %90  %21 %160
-%162 = OpLoad  %6  %161
-%163 = OpVectorTimesScalar  %15  %159 %162
-%164 = OpFAdd  %15  %158 %163
-%165 = OpLoad  %15  %30
-%167 = OpAccessChain  %90  %21 %166
-%168 = OpLoad  %6  %167
-%169 = OpVectorTimesScalar  %15  %165 %168
-%170 = OpFAdd  %15  %164 %169
-OpStore %28 %170
-%171 = OpLoad  %15  %28
-%172 = OpExtInst  %15  %1 Normalize %171
-%173 = OpLoad  %15  %28
-%174 = OpExtInst  %6  %1 Length %173
-%175 = OpExtInst  %6  %1 FClamp %174 %5 %13
-%176 = OpVectorTimesScalar  %15  %172 %175
-OpStore %28 %176
-%177 = OpLoad  %15  %26
-%178 = OpLoad  %15  %28
-%180 = OpAccessChain  %90  %21 %179
-%181 = OpLoad  %6  %180
-%182 = OpVectorTimesScalar  %15  %178 %181
-%183 = OpFAdd  %15  %177 %182
-OpStore %26 %183
-%184 = OpLoad  %15  %26
-%185 = OpCompositeExtract  %6  %184 0
-%186 = OpFOrdLessThan  %47  %185 %14
-OpSelectionMerge %187 None
-OpBranchConditional %186 %188 %187
-%188 = OpLabel
-%191 = OpAccessChain  %189  %26 %190
-OpStore %191 %12
-OpBranch %187
-%187 = OpLabel
-%192 = OpLoad  %15  %26
-%193 = OpCompositeExtract  %6  %192 0
-%194 = OpFOrdGreaterThan  %47  %193 %12
-OpSelectionMerge %195 None
-OpBranchConditional %194 %196 %195
-%196 = OpLabel
-%198 = OpAccessChain  %189  %26 %197
+%74 = OpAccessChain  %53  %23 %7 %73 %7
+%75 = OpLoad  %15  %74
+OpStore %35 %75
+%76 = OpLoad  %4  %37
+%77 = OpAccessChain  %53  %23 %7 %76 %10
+%78 = OpLoad  %15  %77
+OpStore %36 %78
+%79 = OpLoad  %15  %35
+%80 = OpLoad  %15  %26
+%81 = OpExtInst  %6  %1 Distance %79 %80
+%83 = OpAccessChain  %82  %21 %10
+%84 = OpLoad  %6  %83
+%85 = OpFOrdLessThan  %47  %81 %84
+OpSelectionMerge %86 None
+OpBranchConditional %85 %87 %86
+%87 = OpLabel
+%88 = OpLoad  %15  %29
+%89 = OpLoad  %15  %35
+%90 = OpFAdd  %15  %88 %89
+OpStore %29 %90
+%91 = OpLoad  %8  %32
+%92 = OpIAdd  %8  %91 %10
+OpStore %32 %92
+OpBranch %86
+%86 = OpLabel
+%93 = OpLoad  %15  %35
+%94 = OpLoad  %15  %26
+%95 = OpExtInst  %6  %1 Distance %93 %94
+%97 = OpAccessChain  %82  %21 %96
+%98 = OpLoad  %6  %97
+%99 = OpFOrdLessThan  %47  %95 %98
+OpSelectionMerge %100 None
+OpBranchConditional %99 %101 %100
+%101 = OpLabel
+%102 = OpLoad  %15  %31
+%103 = OpLoad  %15  %35
+%104 = OpLoad  %15  %26
+%105 = OpFSub  %15  %103 %104
+%106 = OpFSub  %15  %102 %105
+OpStore %31 %106
+OpBranch %100
+%100 = OpLabel
+%107 = OpLoad  %15  %35
+%108 = OpLoad  %15  %26
+%109 = OpExtInst  %6  %1 Distance %107 %108
+%111 = OpAccessChain  %82  %21 %110
+%112 = OpLoad  %6  %111
+%113 = OpFOrdLessThan  %47  %109 %112
+OpSelectionMerge %114 None
+OpBranchConditional %113 %115 %114
+%115 = OpLabel
+%116 = OpLoad  %15  %30
+%117 = OpLoad  %15  %36
+%118 = OpFAdd  %15  %116 %117
+OpStore %30 %118
+%119 = OpLoad  %8  %34
+%120 = OpIAdd  %8  %119 %10
+OpStore %34 %120
+OpBranch %114
+%114 = OpLabel
+OpBranch %64
+%64 = OpLabel
+%121 = OpLoad  %4  %37
+%122 = OpIAdd  %4  %121 %11
+OpStore %37 %122
+OpBranch %61
+%62 = OpLabel
+%123 = OpLoad  %8  %32
+%124 = OpSGreaterThan  %47  %123 %7
+OpSelectionMerge %125 None
+OpBranchConditional %124 %126 %125
+%126 = OpLabel
+%127 = OpLoad  %15  %29
+%128 = OpLoad  %8  %32
+%129 = OpConvertSToF  %6  %128
+%130 = OpFDiv  %6  %12 %129
+%131 = OpVectorTimesScalar  %15  %127 %130
+%132 = OpLoad  %15  %26
+%133 = OpFSub  %15  %131 %132
+OpStore %29 %133
+OpBranch %125
+%125 = OpLabel
+%134 = OpLoad  %8  %34
+%135 = OpSGreaterThan  %47  %134 %7
+OpSelectionMerge %136 None
+OpBranchConditional %135 %137 %136
+%137 = OpLabel
+%138 = OpLoad  %15  %30
+%139 = OpLoad  %8  %34
+%140 = OpConvertSToF  %6  %139
+%141 = OpFDiv  %6  %12 %140
+%142 = OpVectorTimesScalar  %15  %138 %141
+OpStore %30 %142
+OpBranch %136
+%136 = OpLabel
+%143 = OpLoad  %15  %28
+%144 = OpLoad  %15  %29
+%146 = OpAccessChain  %82  %21 %145
+%147 = OpLoad  %6  %146
+%148 = OpVectorTimesScalar  %15  %144 %147
+%149 = OpFAdd  %15  %143 %148
+%150 = OpLoad  %15  %31
+%152 = OpAccessChain  %82  %21 %151
+%153 = OpLoad  %6  %152
+%154 = OpVectorTimesScalar  %15  %150 %153
+%155 = OpFAdd  %15  %149 %154
+%156 = OpLoad  %15  %30
+%158 = OpAccessChain  %82  %21 %157
+%159 = OpLoad  %6  %158
+%160 = OpVectorTimesScalar  %15  %156 %159
+%161 = OpFAdd  %15  %155 %160
+OpStore %28 %161
+%162 = OpLoad  %15  %28
+%163 = OpExtInst  %15  %1 Normalize %162
+%164 = OpLoad  %15  %28
+%165 = OpExtInst  %6  %1 Length %164
+%166 = OpExtInst  %6  %1 FClamp %165 %5 %13
+%167 = OpVectorTimesScalar  %15  %163 %166
+OpStore %28 %167
+%168 = OpLoad  %15  %26
+%169 = OpLoad  %15  %28
+%170 = OpAccessChain  %82  %21 %7
+%171 = OpLoad  %6  %170
+%172 = OpVectorTimesScalar  %15  %169 %171
+%173 = OpFAdd  %15  %168 %172
+OpStore %26 %173
+%174 = OpLoad  %15  %26
+%175 = OpCompositeExtract  %6  %174 0
+%176 = OpFOrdLessThan  %47  %175 %14
+OpSelectionMerge %177 None
+OpBranchConditional %176 %178 %177
+%178 = OpLabel
+%180 = OpAccessChain  %179  %26 %7
+OpStore %180 %12
+OpBranch %177
+%177 = OpLabel
+%181 = OpLoad  %15  %26
+%182 = OpCompositeExtract  %6  %181 0
+%183 = OpFOrdGreaterThan  %47  %182 %12
+OpSelectionMerge %184 None
+OpBranchConditional %183 %185 %184
+%185 = OpLabel
+%186 = OpAccessChain  %179  %26 %7
+OpStore %186 %14
+OpBranch %184
+%184 = OpLabel
+%187 = OpLoad  %15  %26
+%188 = OpCompositeExtract  %6  %187 1
+%189 = OpFOrdLessThan  %47  %188 %14
+OpSelectionMerge %190 None
+OpBranchConditional %189 %191 %190
+%191 = OpLabel
+%192 = OpAccessChain  %179  %26 %10
+OpStore %192 %12
+OpBranch %190
+%190 = OpLabel
+%193 = OpLoad  %15  %26
+%194 = OpCompositeExtract  %6  %193 1
+%195 = OpFOrdGreaterThan  %47  %194 %12
+OpSelectionMerge %196 None
+OpBranchConditional %195 %197 %196
+%197 = OpLabel
+%198 = OpAccessChain  %179  %26 %10
 OpStore %198 %14
-OpBranch %195
-%195 = OpLabel
+OpBranch %196
+%196 = OpLabel
 %199 = OpLoad  %15  %26
-%200 = OpCompositeExtract  %6  %199 1
-%201 = OpFOrdLessThan  %47  %200 %14
-OpSelectionMerge %202 None
-OpBranchConditional %201 %203 %202
-%203 = OpLabel
-%205 = OpAccessChain  %189  %26 %204
-OpStore %205 %12
-OpBranch %202
-%202 = OpLabel
-%206 = OpLoad  %15  %26
-%207 = OpCompositeExtract  %6  %206 1
-%208 = OpFOrdGreaterThan  %47  %207 %12
-OpSelectionMerge %209 None
-OpBranchConditional %208 %210 %209
-%210 = OpLabel
-%212 = OpAccessChain  %189  %26 %211
-OpStore %212 %14
-OpBranch %209
-%209 = OpLabel
-%213 = OpLoad  %15  %26
-%216 = OpAccessChain  %53  %25 %215 %46 %214
-OpStore %216 %213
-%217 = OpLoad  %15  %28
-%220 = OpAccessChain  %53  %25 %219 %46 %218
-OpStore %220 %217
+%200 = OpAccessChain  %53  %25 %7 %46 %7
+OpStore %200 %199
+%201 = OpLoad  %15  %28
+%202 = OpAccessChain  %53  %25 %7 %46 %10
+OpStore %202 %201
 OpReturn
 OpFunctionEnd

--- a/tests/out/collatz.spvasm.snap
+++ b/tests/out/collatz.spvasm.snap
@@ -5,7 +5,7 @@ expression: dis
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 62
+; Bound: 61
 OpCapability Shader
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
@@ -49,7 +49,6 @@ OpDecorate %45 BuiltIn GlobalInvocationId
 %53 = OpTypePointer StorageBuffer %4
 %55 = OpTypeInt 32 1
 %56 = OpConstant  %55  0
-%60 = OpConstant  %55  0
 %18 = OpFunction  %4  None %19
 %17 = OpFunctionParameter  %4
 %16 = OpLabel
@@ -107,7 +106,7 @@ OpBranch %50
 %57 = OpAccessChain  %53  %11 %56 %54
 %58 = OpLoad  %4  %57
 %59 = OpFunctionCall  %4  %18 %58
-%61 = OpAccessChain  %53  %11 %60 %52
-OpStore %61 %59
+%60 = OpAccessChain  %53  %11 %56 %52
+OpStore %60 %59
 OpReturn
 OpFunctionEnd

--- a/tests/out/empty.spvasm.snap
+++ b/tests/out/empty.spvasm.snap
@@ -11,9 +11,6 @@ OpCapability Shader
 OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %4 "main"
 OpExecutionMode %4 LocalSize 1 1 1
-OpSource GLSL 450
-OpName %4 "main"
-OpName %4 "main"
 %2 = OpTypeVoid
 %5 = OpTypeFunction %2
 %4 = OpFunction  %2  None %5

--- a/tests/out/quad-vert.msl.snap
+++ b/tests/out/quad-vert.msl.snap
@@ -69,6 +69,7 @@ vertex main2Output main2(
     a_uv = a_uv1;
     a_pos = a_pos1;
     main1(v_uv, a_uv, _, a_pos);
+    _.gl_Position.y = -_.gl_Position.y;
     const auto _tmp = type10 {v_uv, _.gl_Position, _.gl_PointSize, {_.gl_ClipDistance[0]}};
     return main2Output { _tmp.member, _tmp.gl_Position1, _tmp.gl_PointSize1, {_tmp.gl_ClipDistance1[0]} };
 }

--- a/tests/out/quad-vert.msl.snap
+++ b/tests/out/quad-vert.msl.snap
@@ -69,7 +69,6 @@ vertex main2Output main2(
     a_uv = a_uv1;
     a_pos = a_pos1;
     main1(v_uv, a_uv, _, a_pos);
-    _.gl_Position.y = -_.gl_Position.y;
     const auto _tmp = type10 {v_uv, _.gl_Position, _.gl_PointSize, {_.gl_ClipDistance[0]}};
     return main2Output { _tmp.member, _tmp.gl_Position1, _tmp.gl_PointSize1, {_tmp.gl_ClipDistance1[0]} };
 }

--- a/tests/out/quad.spvasm.snap
+++ b/tests/out/quad.spvasm.snap
@@ -5,13 +5,13 @@ expression: dis
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 61
+; Bound: 66
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Vertex %28 "main" %19 %22 %24 %26
-OpEntryPoint Fragment %47 "main" %44 %46
-OpExecutionMode %47 OriginUpperLeft
+OpEntryPoint Fragment %52 "main" %49 %51
+OpExecutionMode %52 OriginUpperLeft
 OpSource GLSL 450
 OpName %3 "c_scale"
 OpName %9 "VertexOutput"
@@ -26,9 +26,9 @@ OpName %24 "uv"
 OpName %26 "position"
 OpName %28 "main"
 OpName %28 "main"
-OpName %44 "uv"
-OpName %47 "main"
-OpName %47 "main"
+OpName %49 "uv"
+OpName %52 "main"
+OpName %52 "main"
 OpMemberDecorate %9 0 Offset 0
 OpMemberDecorate %9 1 Offset 8
 OpDecorate %12 DescriptorSet 0
@@ -39,8 +39,8 @@ OpDecorate %19 Location 0
 OpDecorate %22 Location 1
 OpDecorate %24 Location 0
 OpDecorate %26 BuiltIn Position
-OpDecorate %44 Location 0
-OpDecorate %46 Location 0
+OpDecorate %49 Location 0
+OpDecorate %51 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpConstant  %4  1.2
@@ -69,10 +69,12 @@ OpDecorate %46 Location 0
 %33 = OpConstant  %32  0
 %35 = OpTypePointer Function %8
 %38 = OpConstant  %32  1
-%44 = OpVariable  %20  Input
-%46 = OpVariable  %27  Output
-%51 = OpTypeSampledImage %10
-%55 = OpTypeBool
+%44 = OpTypePointer Output %4
+%45 = OpConstant  %32  1
+%49 = OpVariable  %20  Input
+%51 = OpVariable  %27  Output
+%56 = OpTypeSampledImage %10
+%60 = OpTypeBool
 %28 = OpFunction  %2  None %29
 %18 = OpLabel
 %16 = OpVariable  %17  Function
@@ -91,26 +93,30 @@ OpStore %39 %37
 OpStore %24 %41
 %42 = OpCompositeExtract  %8  %40 1
 OpStore %26 %42
+%43 = OpAccessChain  %44  %26 %45
+%46 = OpLoad  %4  %43
+%47 = OpFNegate  %4  %46
+OpStore %43 %47
 OpReturn
 OpFunctionEnd
-%47 = OpFunction  %2  None %29
-%43 = OpLabel
-%45 = OpLoad  %7  %44
-%48 = OpLoad  %10  %12
-%49 = OpLoad  %11  %14
-OpBranch %50
-%50 = OpLabel
-%52 = OpSampledImage  %51  %48 %49
-%53 = OpImageSampleImplicitLod  %8  %52 %45
-%54 = OpCompositeExtract  %4  %53 3
-%56 = OpFOrdEqual  %55  %54 %5
-OpSelectionMerge %57 None
-OpBranchConditional %56 %58 %57
-%58 = OpLabel
+%52 = OpFunction  %2  None %29
+%48 = OpLabel
+%50 = OpLoad  %7  %49
+%53 = OpLoad  %10  %12
+%54 = OpLoad  %11  %14
+OpBranch %55
+%55 = OpLabel
+%57 = OpSampledImage  %56  %53 %54
+%58 = OpImageSampleImplicitLod  %8  %57 %50
+%59 = OpCompositeExtract  %4  %58 3
+%61 = OpFOrdEqual  %60  %59 %5
+OpSelectionMerge %62 None
+OpBranchConditional %61 %63 %62
+%63 = OpLabel
 OpKill
-%57 = OpLabel
-%59 = OpCompositeExtract  %4  %53 3
-%60 = OpVectorTimesScalar  %8  %53 %59
-OpStore %46 %60
+%62 = OpLabel
+%64 = OpCompositeExtract  %4  %58 3
+%65 = OpVectorTimesScalar  %8  %58 %64
+OpStore %51 %65
 OpReturn
 OpFunctionEnd

--- a/tests/out/quad.spvasm.snap
+++ b/tests/out/quad.spvasm.snap
@@ -5,13 +5,13 @@ expression: dis
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 66
+; Bound: 65
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Vertex %28 "main" %19 %22 %24 %26
-OpEntryPoint Fragment %52 "main" %49 %51
-OpExecutionMode %52 OriginUpperLeft
+OpEntryPoint Fragment %51 "main" %48 %50
+OpExecutionMode %51 OriginUpperLeft
 OpSource GLSL 450
 OpName %3 "c_scale"
 OpName %9 "VertexOutput"
@@ -26,9 +26,9 @@ OpName %24 "uv"
 OpName %26 "position"
 OpName %28 "main"
 OpName %28 "main"
-OpName %49 "uv"
-OpName %52 "main"
-OpName %52 "main"
+OpName %48 "uv"
+OpName %51 "main"
+OpName %51 "main"
 OpMemberDecorate %9 0 Offset 0
 OpMemberDecorate %9 1 Offset 8
 OpDecorate %12 DescriptorSet 0
@@ -39,8 +39,8 @@ OpDecorate %19 Location 0
 OpDecorate %22 Location 1
 OpDecorate %24 Location 0
 OpDecorate %26 BuiltIn Position
-OpDecorate %49 Location 0
-OpDecorate %51 Location 0
+OpDecorate %48 Location 0
+OpDecorate %50 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpConstant  %4  1.2
@@ -70,11 +70,10 @@ OpDecorate %51 Location 0
 %35 = OpTypePointer Function %8
 %38 = OpConstant  %32  1
 %44 = OpTypePointer Output %4
-%45 = OpConstant  %32  1
-%49 = OpVariable  %20  Input
-%51 = OpVariable  %27  Output
-%56 = OpTypeSampledImage %10
-%60 = OpTypeBool
+%48 = OpVariable  %20  Input
+%50 = OpVariable  %27  Output
+%55 = OpTypeSampledImage %10
+%59 = OpTypeBool
 %28 = OpFunction  %2  None %29
 %18 = OpLabel
 %16 = OpVariable  %17  Function
@@ -93,30 +92,30 @@ OpStore %39 %37
 OpStore %24 %41
 %42 = OpCompositeExtract  %8  %40 1
 OpStore %26 %42
-%43 = OpAccessChain  %44  %26 %45
-%46 = OpLoad  %4  %43
-%47 = OpFNegate  %4  %46
-OpStore %43 %47
+%43 = OpAccessChain  %44  %26 %38
+%45 = OpLoad  %4  %43
+%46 = OpFNegate  %4  %45
+OpStore %43 %46
 OpReturn
 OpFunctionEnd
-%52 = OpFunction  %2  None %29
-%48 = OpLabel
-%50 = OpLoad  %7  %49
-%53 = OpLoad  %10  %12
-%54 = OpLoad  %11  %14
-OpBranch %55
-%55 = OpLabel
-%57 = OpSampledImage  %56  %53 %54
-%58 = OpImageSampleImplicitLod  %8  %57 %50
-%59 = OpCompositeExtract  %4  %58 3
-%61 = OpFOrdEqual  %60  %59 %5
-OpSelectionMerge %62 None
-OpBranchConditional %61 %63 %62
-%63 = OpLabel
-OpKill
+%51 = OpFunction  %2  None %29
+%47 = OpLabel
+%49 = OpLoad  %7  %48
+%52 = OpLoad  %10  %12
+%53 = OpLoad  %11  %14
+OpBranch %54
+%54 = OpLabel
+%56 = OpSampledImage  %55  %52 %53
+%57 = OpImageSampleImplicitLod  %8  %56 %49
+%58 = OpCompositeExtract  %4  %57 3
+%60 = OpFOrdEqual  %59  %58 %5
+OpSelectionMerge %61 None
+OpBranchConditional %60 %62 %61
 %62 = OpLabel
-%64 = OpCompositeExtract  %4  %58 3
-%65 = OpVectorTimesScalar  %8  %58 %64
-OpStore %51 %65
+OpKill
+%61 = OpLabel
+%63 = OpCompositeExtract  %4  %57 3
+%64 = OpVectorTimesScalar  %8  %57 %63
+OpStore %50 %64
 OpReturn
 OpFunctionEnd

--- a/tests/out/shadow.spvasm.snap
+++ b/tests/out/shadow.spvasm.snap
@@ -5,7 +5,7 @@ expression: dis
 ; SPIR-V
 ; Version: 1.2
 ; Generator: rspirv
-; Bound: 137
+; Bound: 136
 OpCapability Shader
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
@@ -105,7 +105,6 @@ OpDecorate %79 Location 0
 %93 = OpConstant  %56  0
 %101 = OpTypePointer StorageBuffer %18
 %103 = OpTypePointer StorageBuffer %17
-%104 = OpConstant  %56  0
 %36 = OpFunction  %4  None %37
 %34 = OpFunctionParameter  %10
 %35 = OpFunctionParameter  %16
@@ -170,44 +169,44 @@ OpBranchConditional %98 %100 %99
 OpBranch %88
 %99 = OpLabel
 %102 = OpLoad  %10  %70
-%105 = OpAccessChain  %103  %27 %104 %102
-%106 = OpLoad  %17  %105
-%107 = OpLoad  %10  %70
-%108 = OpCompositeExtract  %15  %106 0
-%109 = OpMatrixTimesVector  %16  %108 %78
-%110 = OpFunctionCall  %4  %36 %107 %109
-%111 = OpCompositeExtract  %16  %106 1
-%112 = OpCompositeExtract  %4  %111 0
-%113 = OpCompositeExtract  %4  %111 1
-%114 = OpCompositeExtract  %4  %111 2
-%115 = OpCompositeConstruct  %23  %112 %113 %114
-%116 = OpCompositeExtract  %4  %78 0
-%117 = OpCompositeExtract  %4  %78 1
-%118 = OpCompositeExtract  %4  %78 2
-%119 = OpCompositeConstruct  %23  %116 %117 %118
-%120 = OpFSub  %23  %115 %119
-%121 = OpExtInst  %23  %1 Normalize %120
-%122 = OpDot  %4  %86 %121
-%123 = OpExtInst  %4  %1 FMax %3 %122
-%124 = OpLoad  %23  %68
-%125 = OpFMul  %4  %110 %123
-%126 = OpCompositeExtract  %16  %106 2
-%127 = OpCompositeExtract  %4  %126 0
-%128 = OpCompositeExtract  %4  %126 1
-%129 = OpCompositeExtract  %4  %126 2
-%130 = OpCompositeConstruct  %23  %127 %128 %129
-%131 = OpVectorTimesScalar  %23  %130 %125
-%132 = OpFAdd  %23  %124 %131
-OpStore %68 %132
+%104 = OpAccessChain  %103  %27 %93 %102
+%105 = OpLoad  %17  %104
+%106 = OpLoad  %10  %70
+%107 = OpCompositeExtract  %15  %105 0
+%108 = OpMatrixTimesVector  %16  %107 %78
+%109 = OpFunctionCall  %4  %36 %106 %108
+%110 = OpCompositeExtract  %16  %105 1
+%111 = OpCompositeExtract  %4  %110 0
+%112 = OpCompositeExtract  %4  %110 1
+%113 = OpCompositeExtract  %4  %110 2
+%114 = OpCompositeConstruct  %23  %111 %112 %113
+%115 = OpCompositeExtract  %4  %78 0
+%116 = OpCompositeExtract  %4  %78 1
+%117 = OpCompositeExtract  %4  %78 2
+%118 = OpCompositeConstruct  %23  %115 %116 %117
+%119 = OpFSub  %23  %114 %118
+%120 = OpExtInst  %23  %1 Normalize %119
+%121 = OpDot  %4  %86 %120
+%122 = OpExtInst  %4  %1 FMax %3 %121
+%123 = OpLoad  %23  %68
+%124 = OpFMul  %4  %109 %122
+%125 = OpCompositeExtract  %16  %105 2
+%126 = OpCompositeExtract  %4  %125 0
+%127 = OpCompositeExtract  %4  %125 1
+%128 = OpCompositeExtract  %4  %125 2
+%129 = OpCompositeConstruct  %23  %126 %127 %128
+%130 = OpVectorTimesScalar  %23  %129 %124
+%131 = OpFAdd  %23  %123 %130
+OpStore %68 %131
 OpBranch %90
 %90 = OpLabel
-%133 = OpLoad  %10  %70
-%134 = OpIAdd  %10  %133 %12
-OpStore %70 %134
+%132 = OpLoad  %10  %70
+%133 = OpIAdd  %10  %132 %12
+OpStore %70 %133
 OpBranch %87
 %88 = OpLabel
-%135 = OpLoad  %23  %68
-%136 = OpCompositeConstruct  %16  %135 %5
-OpStore %79 %136
+%134 = OpLoad  %23  %68
+%135 = OpCompositeConstruct  %16  %134 %5
+OpStore %79 %135
 OpReturn
 OpFunctionEnd

--- a/tests/out/skybox.spvasm.snap
+++ b/tests/out/skybox.spvasm.snap
@@ -5,35 +5,13 @@ expression: dis
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 115
+; Bound: 111
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Vertex %38 "vs_main" %31 %34 %36
-OpEntryPoint Fragment %107 "fs_main" %100 %103 %106
-OpExecutionMode %107 OriginUpperLeft
-OpSource GLSL 450
-OpName %12 "VertexOutput"
-OpMemberName %12 0 "position"
-OpMemberName %12 1 "uv"
-OpName %14 "Data"
-OpMemberName %14 0 "proj_inv"
-OpMemberName %14 1 "view"
-OpName %19 "r_data"
-OpName %21 "r_texture"
-OpName %23 "r_sampler"
-OpName %25 "tmp1"
-OpName %27 "tmp2"
-OpName %28 "out"
-OpName %31 "vertex_index"
-OpName %34 "position"
-OpName %36 "uv"
-OpName %38 "vs_main"
-OpName %38 "vs_main"
-OpName %100 "position"
-OpName %103 "uv"
-OpName %107 "fs_main"
-OpName %107 "fs_main"
+OpEntryPoint Fragment %103 "fs_main" %96 %99 %102
+OpExecutionMode %103 OriginUpperLeft
 OpMemberDecorate %12 0 Offset 0
 OpMemberDecorate %12 1 Offset 16
 OpDecorate %14 Block
@@ -52,9 +30,9 @@ OpDecorate %23 Binding 2
 OpDecorate %31 BuiltIn VertexIndex
 OpDecorate %34 BuiltIn Position
 OpDecorate %36 Location 0
-OpDecorate %100 BuiltIn FragCoord
-OpDecorate %103 Location 0
-OpDecorate %106 Location 0
+OpDecorate %96 BuiltIn FragCoord
+OpDecorate %99 Location 0
+OpDecorate %102 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 1
 %3 = OpConstant  %4  2
@@ -91,13 +69,12 @@ OpDecorate %106 Location 0
 %78 = OpConstant  %4  0
 %82 = OpTypePointer Function %11
 %89 = OpTypePointer Function %10
-%94 = OpTypePointer Output %7
-%101 = OpTypePointer Input %10
-%100 = OpVariable  %101  Input
-%104 = OpTypePointer Input %11
-%103 = OpVariable  %104  Input
-%106 = OpVariable  %35  Output
-%112 = OpTypeSampledImage %17
+%97 = OpTypePointer Input %10
+%96 = OpVariable  %97  Input
+%100 = OpTypePointer Input %11
+%99 = OpVariable  %100  Input
+%102 = OpVariable  %35  Output
+%108 = OpTypeSampledImage %17
 %38 = OpFunction  %2  None %39
 %30 = OpLabel
 %25 = OpVariable  %26  Function
@@ -159,26 +136,22 @@ OpStore %90 %53
 %91 = OpLoad  %12  %28
 %92 = OpCompositeExtract  %10  %91 0
 OpStore %34 %92
-%93 = OpAccessChain  %94  %34 %5
-%95 = OpLoad  %7  %93
-%96 = OpFNegate  %7  %95
-OpStore %93 %96
-%97 = OpCompositeExtract  %11  %91 1
-OpStore %36 %97
+%93 = OpCompositeExtract  %11  %91 1
+OpStore %36 %93
 OpReturn
 OpFunctionEnd
-%107 = OpFunction  %2  None %39
-%98 = OpLabel
-%102 = OpLoad  %10  %100
-%105 = OpLoad  %11  %103
-%99 = OpCompositeConstruct  %12  %102 %105
-%108 = OpLoad  %17  %21
-%109 = OpLoad  %18  %23
-OpBranch %110
-%110 = OpLabel
-%111 = OpCompositeExtract  %11  %99 1
-%113 = OpSampledImage  %112  %108 %109
-%114 = OpImageSampleImplicitLod  %10  %113 %111
-OpStore %106 %114
+%103 = OpFunction  %2  None %39
+%94 = OpLabel
+%98 = OpLoad  %10  %96
+%101 = OpLoad  %11  %99
+%95 = OpCompositeConstruct  %12  %98 %101
+%104 = OpLoad  %17  %21
+%105 = OpLoad  %18  %23
+OpBranch %106
+%106 = OpLabel
+%107 = OpCompositeExtract  %11  %95 1
+%109 = OpSampledImage  %108  %104 %105
+%110 = OpImageSampleImplicitLod  %10  %109 %107
+OpStore %102 %110
 OpReturn
 OpFunctionEnd

--- a/tests/out/skybox.spvasm.snap
+++ b/tests/out/skybox.spvasm.snap
@@ -5,13 +5,13 @@ expression: dis
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 121
+; Bound: 115
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Vertex %38 "vs_main" %31 %34 %36
-OpEntryPoint Fragment %113 "fs_main" %106 %109 %112
-OpExecutionMode %113 OriginUpperLeft
+OpEntryPoint Fragment %107 "fs_main" %100 %103 %106
+OpExecutionMode %107 OriginUpperLeft
 OpSource GLSL 450
 OpName %12 "VertexOutput"
 OpMemberName %12 0 "position"
@@ -30,10 +30,10 @@ OpName %34 "position"
 OpName %36 "uv"
 OpName %38 "vs_main"
 OpName %38 "vs_main"
-OpName %106 "position"
-OpName %109 "uv"
-OpName %113 "fs_main"
-OpName %113 "fs_main"
+OpName %100 "position"
+OpName %103 "uv"
+OpName %107 "fs_main"
+OpName %107 "fs_main"
 OpMemberDecorate %12 0 Offset 0
 OpMemberDecorate %12 1 Offset 16
 OpDecorate %14 Block
@@ -52,9 +52,9 @@ OpDecorate %23 Binding 2
 OpDecorate %31 BuiltIn VertexIndex
 OpDecorate %34 BuiltIn Position
 OpDecorate %36 Location 0
-OpDecorate %106 BuiltIn FragCoord
-OpDecorate %109 Location 0
-OpDecorate %112 Location 0
+OpDecorate %100 BuiltIn FragCoord
+OpDecorate %103 Location 0
+OpDecorate %106 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 1
 %3 = OpConstant  %4  2
@@ -88,22 +88,16 @@ OpDecorate %112 Location 0
 %36 = OpVariable  %37  Output
 %39 = OpTypeFunction %2
 %54 = OpTypePointer Uniform %13
-%55 = OpConstant  %4  1
-%63 = OpConstant  %4  1
-%71 = OpConstant  %4  1
-%81 = OpConstant  %4  0
-%85 = OpTypePointer Function %11
-%91 = OpConstant  %4  1
-%93 = OpTypePointer Function %10
-%94 = OpConstant  %4  0
-%99 = OpTypePointer Output %7
-%100 = OpConstant  %4  1
-%107 = OpTypePointer Input %10
-%106 = OpVariable  %107  Input
-%110 = OpTypePointer Input %11
-%109 = OpVariable  %110  Input
-%112 = OpVariable  %35  Output
-%118 = OpTypeSampledImage %17
+%78 = OpConstant  %4  0
+%82 = OpTypePointer Function %11
+%89 = OpTypePointer Function %10
+%94 = OpTypePointer Output %7
+%101 = OpTypePointer Input %10
+%100 = OpVariable  %101  Input
+%104 = OpTypePointer Input %11
+%103 = OpVariable  %104  Input
+%106 = OpVariable  %35  Output
+%112 = OpTypeSampledImage %17
 %38 = OpFunction  %2  None %39
 %30 = OpLabel
 %25 = OpVariable  %26  Function
@@ -127,64 +121,64 @@ OpStore %27 %44
 %51 = OpFMul  %7  %50 %6
 %52 = OpFSub  %7  %51 %8
 %53 = OpCompositeConstruct  %10  %48 %52 %9 %8
-%56 = OpAccessChain  %54  %19 %55
-%57 = OpLoad  %13  %56
-%58 = OpCompositeExtract  %10  %57 0
-%59 = OpCompositeExtract  %7  %58 0
-%60 = OpCompositeExtract  %7  %58 1
-%61 = OpCompositeExtract  %7  %58 2
-%62 = OpCompositeConstruct  %11  %59 %60 %61
-%64 = OpAccessChain  %54  %19 %63
-%65 = OpLoad  %13  %64
-%66 = OpCompositeExtract  %10  %65 1
-%67 = OpCompositeExtract  %7  %66 0
-%68 = OpCompositeExtract  %7  %66 1
-%69 = OpCompositeExtract  %7  %66 2
-%70 = OpCompositeConstruct  %11  %67 %68 %69
-%72 = OpAccessChain  %54  %19 %71
-%73 = OpLoad  %13  %72
-%74 = OpCompositeExtract  %10  %73 2
-%75 = OpCompositeExtract  %7  %74 0
-%76 = OpCompositeExtract  %7  %74 1
-%77 = OpCompositeExtract  %7  %74 2
-%78 = OpCompositeConstruct  %11  %75 %76 %77
-%79 = OpCompositeConstruct  %16  %62 %70 %78
-%80 = OpTranspose  %16  %79
-%82 = OpAccessChain  %54  %19 %81
-%83 = OpLoad  %13  %82
-%84 = OpMatrixTimesVector  %10  %83 %53
-%86 = OpCompositeExtract  %7  %84 0
-%87 = OpCompositeExtract  %7  %84 1
-%88 = OpCompositeExtract  %7  %84 2
-%89 = OpCompositeConstruct  %11  %86 %87 %88
-%90 = OpMatrixTimesVector  %11  %80 %89
-%92 = OpAccessChain  %85  %28 %91
-OpStore %92 %90
-%95 = OpAccessChain  %93  %28 %94
-OpStore %95 %53
-%96 = OpLoad  %12  %28
-%97 = OpCompositeExtract  %10  %96 0
-OpStore %34 %97
-%98 = OpAccessChain  %99  %34 %100
-%101 = OpLoad  %7  %98
-%102 = OpFNegate  %7  %101
-OpStore %98 %102
-%103 = OpCompositeExtract  %11  %96 1
-OpStore %36 %103
+%55 = OpAccessChain  %54  %19 %5
+%56 = OpLoad  %13  %55
+%57 = OpCompositeExtract  %10  %56 0
+%58 = OpCompositeExtract  %7  %57 0
+%59 = OpCompositeExtract  %7  %57 1
+%60 = OpCompositeExtract  %7  %57 2
+%61 = OpCompositeConstruct  %11  %58 %59 %60
+%62 = OpAccessChain  %54  %19 %5
+%63 = OpLoad  %13  %62
+%64 = OpCompositeExtract  %10  %63 1
+%65 = OpCompositeExtract  %7  %64 0
+%66 = OpCompositeExtract  %7  %64 1
+%67 = OpCompositeExtract  %7  %64 2
+%68 = OpCompositeConstruct  %11  %65 %66 %67
+%69 = OpAccessChain  %54  %19 %5
+%70 = OpLoad  %13  %69
+%71 = OpCompositeExtract  %10  %70 2
+%72 = OpCompositeExtract  %7  %71 0
+%73 = OpCompositeExtract  %7  %71 1
+%74 = OpCompositeExtract  %7  %71 2
+%75 = OpCompositeConstruct  %11  %72 %73 %74
+%76 = OpCompositeConstruct  %16  %61 %68 %75
+%77 = OpTranspose  %16  %76
+%79 = OpAccessChain  %54  %19 %78
+%80 = OpLoad  %13  %79
+%81 = OpMatrixTimesVector  %10  %80 %53
+%83 = OpCompositeExtract  %7  %81 0
+%84 = OpCompositeExtract  %7  %81 1
+%85 = OpCompositeExtract  %7  %81 2
+%86 = OpCompositeConstruct  %11  %83 %84 %85
+%87 = OpMatrixTimesVector  %11  %77 %86
+%88 = OpAccessChain  %82  %28 %5
+OpStore %88 %87
+%90 = OpAccessChain  %89  %28 %78
+OpStore %90 %53
+%91 = OpLoad  %12  %28
+%92 = OpCompositeExtract  %10  %91 0
+OpStore %34 %92
+%93 = OpAccessChain  %94  %34 %5
+%95 = OpLoad  %7  %93
+%96 = OpFNegate  %7  %95
+OpStore %93 %96
+%97 = OpCompositeExtract  %11  %91 1
+OpStore %36 %97
 OpReturn
 OpFunctionEnd
-%113 = OpFunction  %2  None %39
-%104 = OpLabel
-%108 = OpLoad  %10  %106
-%111 = OpLoad  %11  %109
-%105 = OpCompositeConstruct  %12  %108 %111
-%114 = OpLoad  %17  %21
-%115 = OpLoad  %18  %23
-OpBranch %116
-%116 = OpLabel
-%117 = OpCompositeExtract  %11  %105 1
-%119 = OpSampledImage  %118  %114 %115
-%120 = OpImageSampleImplicitLod  %10  %119 %117
-OpStore %112 %120
+%107 = OpFunction  %2  None %39
+%98 = OpLabel
+%102 = OpLoad  %10  %100
+%105 = OpLoad  %11  %103
+%99 = OpCompositeConstruct  %12  %102 %105
+%108 = OpLoad  %17  %21
+%109 = OpLoad  %18  %23
+OpBranch %110
+%110 = OpLabel
+%111 = OpCompositeExtract  %11  %99 1
+%113 = OpSampledImage  %112  %108 %109
+%114 = OpImageSampleImplicitLod  %10  %113 %111
+OpStore %106 %114
 OpReturn
 OpFunctionEnd

--- a/tests/out/skybox.spvasm.snap
+++ b/tests/out/skybox.spvasm.snap
@@ -5,13 +5,13 @@ expression: dis
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 116
+; Bound: 121
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Vertex %38 "vs_main" %31 %34 %36
-OpEntryPoint Fragment %108 "fs_main" %101 %104 %107
-OpExecutionMode %108 OriginUpperLeft
+OpEntryPoint Fragment %113 "fs_main" %106 %109 %112
+OpExecutionMode %113 OriginUpperLeft
 OpSource GLSL 450
 OpName %12 "VertexOutput"
 OpMemberName %12 0 "position"
@@ -30,10 +30,10 @@ OpName %34 "position"
 OpName %36 "uv"
 OpName %38 "vs_main"
 OpName %38 "vs_main"
-OpName %101 "position"
-OpName %104 "uv"
-OpName %108 "fs_main"
-OpName %108 "fs_main"
+OpName %106 "position"
+OpName %109 "uv"
+OpName %113 "fs_main"
+OpName %113 "fs_main"
 OpMemberDecorate %12 0 Offset 0
 OpMemberDecorate %12 1 Offset 16
 OpDecorate %14 Block
@@ -52,9 +52,9 @@ OpDecorate %23 Binding 2
 OpDecorate %31 BuiltIn VertexIndex
 OpDecorate %34 BuiltIn Position
 OpDecorate %36 Location 0
-OpDecorate %101 BuiltIn FragCoord
-OpDecorate %104 Location 0
-OpDecorate %107 Location 0
+OpDecorate %106 BuiltIn FragCoord
+OpDecorate %109 Location 0
+OpDecorate %112 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 1
 %3 = OpConstant  %4  2
@@ -96,12 +96,14 @@ OpDecorate %107 Location 0
 %91 = OpConstant  %4  1
 %93 = OpTypePointer Function %10
 %94 = OpConstant  %4  0
-%102 = OpTypePointer Input %10
-%101 = OpVariable  %102  Input
-%105 = OpTypePointer Input %11
-%104 = OpVariable  %105  Input
-%107 = OpVariable  %35  Output
-%113 = OpTypeSampledImage %17
+%99 = OpTypePointer Output %7
+%100 = OpConstant  %4  1
+%107 = OpTypePointer Input %10
+%106 = OpVariable  %107  Input
+%110 = OpTypePointer Input %11
+%109 = OpVariable  %110  Input
+%112 = OpVariable  %35  Output
+%118 = OpTypeSampledImage %17
 %38 = OpFunction  %2  None %39
 %30 = OpLabel
 %25 = OpVariable  %26  Function
@@ -163,22 +165,26 @@ OpStore %95 %53
 %96 = OpLoad  %12  %28
 %97 = OpCompositeExtract  %10  %96 0
 OpStore %34 %97
-%98 = OpCompositeExtract  %11  %96 1
-OpStore %36 %98
+%98 = OpAccessChain  %99  %34 %100
+%101 = OpLoad  %7  %98
+%102 = OpFNegate  %7  %101
+OpStore %98 %102
+%103 = OpCompositeExtract  %11  %96 1
+OpStore %36 %103
 OpReturn
 OpFunctionEnd
-%108 = OpFunction  %2  None %39
-%99 = OpLabel
-%103 = OpLoad  %10  %101
-%106 = OpLoad  %11  %104
-%100 = OpCompositeConstruct  %12  %103 %106
-%109 = OpLoad  %17  %21
-%110 = OpLoad  %18  %23
-OpBranch %111
-%111 = OpLabel
-%112 = OpCompositeExtract  %11  %100 1
-%114 = OpSampledImage  %113  %109 %110
-%115 = OpImageSampleImplicitLod  %10  %114 %112
-OpStore %107 %115
+%113 = OpFunction  %2  None %39
+%104 = OpLabel
+%108 = OpLoad  %10  %106
+%111 = OpLoad  %11  %109
+%105 = OpCompositeConstruct  %12  %108 %111
+%114 = OpLoad  %17  %21
+%115 = OpLoad  %18  %23
+OpBranch %116
+%116 = OpLabel
+%117 = OpCompositeExtract  %11  %105 1
+%119 = OpSampledImage  %118  %114 %115
+%120 = OpImageSampleImplicitLod  %10  %119 %117
+OpStore %112 %120
 OpReturn
 OpFunctionEnd

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -278,10 +278,13 @@ fn convert_wgsl_texture_array() {
 }
 
 #[cfg(feature = "spv-in")]
-fn convert_spv(name: &str, targets: Targets) {
+fn convert_spv(name: &str, adjust_coordinate_space: bool, targets: Targets) {
     let module = naga::front::spv::parse_u8_slice(
         &std::fs::read(format!("tests/in/{}{}", name, ".spv")).expect("Couldn't find spv file"),
-        &Default::default(),
+        &naga::front::spv::Options {
+            adjust_coordinate_space,
+            flow_graph_dump_prefix: None,
+        },
     )
     .unwrap();
     check_targets(&module, name, targets);
@@ -293,13 +296,13 @@ fn convert_spv(name: &str, targets: Targets) {
 #[cfg(feature = "spv-in")]
 #[test]
 fn convert_spv_quad_vert() {
-    convert_spv("quad-vert", Targets::METAL);
+    convert_spv("quad-vert", false, Targets::METAL);
 }
 
 #[cfg(feature = "spv-in")]
 #[test]
 fn convert_spv_shadow() {
-    convert_spv("shadow", Targets::IR | Targets::ANALYSIS);
+    convert_spv("shadow", true, Targets::IR | Targets::ANALYSIS);
 }
 
 #[cfg(feature = "glsl-in")]

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -45,6 +45,10 @@ struct Parameters {
     spv_version: (u8, u8),
     #[cfg_attr(not(feature = "spv-out"), allow(dead_code))]
     spv_capabilities: naga::FastHashSet<spirv::Capability>,
+    #[cfg_attr(not(feature = "spv-out"), allow(dead_code))]
+    spv_debug: bool,
+    #[cfg_attr(not(feature = "spv-out"), allow(dead_code))]
+    spv_adjust_coordinate_space: bool,
     #[cfg_attr(not(feature = "msl-out"), allow(dead_code))]
     mtl_bindings: naga::FastHashMap<BindSource, BindTarget>,
 }
@@ -126,9 +130,16 @@ fn check_output_spv(
     use naga::back::spv;
     use rspirv::binary::Disassemble;
 
+    let mut flags = spv::WriterFlags::empty();
+    if params.spv_debug {
+        flags |= spv::WriterFlags::DEBUG;
+    }
+    if params.spv_adjust_coordinate_space {
+        flags |= spv::WriterFlags::ADJUST_COORDINATE_SPACE;
+    }
     let options = spv::Options {
         lang_version: params.spv_version,
-        flags: spv::WriterFlags::DEBUG,
+        flags,
         capabilities: params.spv_capabilities.clone(),
     };
 


### PR DESCRIPTION
Fixes #651
Unblocks https://github.com/gfx-rs/gfx/issues/3707

Our IR has the coordinate system that matches everything but Vulkan. So in order to correctly translate, we need to flip the Y of vertex outputs in both SPV-in and SPV-out.

This is a draft because I'm still trying to figure out what flags are needed to be exposed to control this.