### PR TITLE
Panic to prevent arena Handle overflow

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -188,6 +188,10 @@ impl<T> Arena<T> {
 
     /// Adds a new value to the arena, returning a typed handle.
     pub fn append(&mut self, value: T) -> Handle<T> {
+        debug_assert!(self.data.len() <= u32::MAX as usize);
+        if self.data.len() as u32 == u32::MAX {
+            panic!("Failed to append to Arena. Handle overflows");
+        }
         let position = self.data.len() + 1;
         let index = unsafe { Index::new_unchecked(position as u32) };
         self.data.push(value);

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -188,12 +188,9 @@ impl<T> Arena<T> {
 
     /// Adds a new value to the arena, returning a typed handle.
     pub fn append(&mut self, value: T) -> Handle<T> {
-        debug_assert!(self.data.len() <= u32::MAX as usize);
-        if self.data.len() as u32 == u32::MAX {
-            panic!("Failed to append to Arena. Handle overflows");
-        }
         let position = self.data.len() + 1;
-        let index = unsafe { Index::new_unchecked(position as u32) };
+        let index =
+            Index::new(position as u32).expect("Failed to append to Arena. Handle overflows");
         self.data.push(value);
         Handle::new(index)
     }


### PR DESCRIPTION
It seems impossible practically, but possible intentionally.
When arena size becomes `u32::MAX+1` on append the new handle returned contains 0 in NonZeroU32 which is UB.
