### PR TITLE
[wgsl-in] Decorations are now called attributes.

### DIFF
--- a/src/front/wgsl/conv.rs
+++ b/src/front/wgsl/conv.rs
@@ -47,7 +47,7 @@ pub fn map_interpolation(word: &str) -> Result<crate::Interpolation, Error<'_>> 
         "centroid" => Ok(crate::Interpolation::Centroid),
         "sample" => Ok(crate::Interpolation::Sample),
         "perspective" => Ok(crate::Interpolation::Perspective),
-        _ => Err(Error::UnknownDecoration(word)),
+        _ => Err(Error::UnknownAttribute(word)),
     }
 }
 


### PR DESCRIPTION
Renames:

Error::UnknownDecoration => Error::UnknownAttribute
TypeDecoration => TypeAttributes
Scope::Decoration => Scope::Attribute

various argument names, string literals, comments