### PR TITLE
[spv-in] Copy less bytes in `parse_function`

### DIFF
--- a/src/front/spv/function.rs
+++ b/src/front/spv/function.rs
@@ -317,10 +317,9 @@ impl<I: Iterator<Item = u32>> super::Parser<I> {
                 *component = function.expressions.append(load_expr);
             }
 
-            match members.len() {
-                0 => {}
-                1 => {
-                    let member = members.remove(0);
+            match &members[..] {
+                [] => {}
+                [member] => {
                     function.body.push(crate::Statement::Emit(
                         function.expressions.range_from(old_len),
                     ));
@@ -329,7 +328,7 @@ impl<I: Iterator<Item = u32>> super::Parser<I> {
                     });
                     function.result = Some(crate::FunctionResult {
                         ty: member.ty,
-                        binding: member.binding,
+                        binding: member.binding.clone(),
                     });
                 }
                 _ => {


### PR DESCRIPTION
The initial intention was to make the code a little more elegant and match on
the Vec itself instead of its length, however there's also a - probably
minuscule - performance advantage:

`Vec::remove` internally copies the removed element onto the stack. In this case
that's a `StructMember` weighting 48 bytes. The `Binding` we are actually
interested in is only 8 bytes tough.

Cloning just the `Binding` saves us from copying 40 bytes for nothing.