### PR TITLE
SPV-in workaround for row-major matrices

### DIFF
--- a/src/front/spv/error.rs
+++ b/src/front/spv/error.rs
@@ -54,6 +54,5 @@ pub enum Error {
     InvalidEdgeClassification,
     FunctionCallCycle(spirv::Word),
     // incomplete implementation error
-    UnsupportedRowMajorMatrix,
     UnsupportedMatrixStride(spirv::Word),
 }

--- a/src/front/spv/function.rs
+++ b/src/front/spv/function.rs
@@ -63,6 +63,9 @@ impl<I: Iterator<Item = u32>> super::Parser<I> {
     }
 
     pub(super) fn parse_function(&mut self, module: &mut crate::Module) -> Result<(), Error> {
+        self.lookup_expression.clear();
+        self.lookup_load_override.clear();
+
         let result_type_id = self.next()?;
         let fun_id = self.next()?;
         let _fun_control = self.next()?;


### PR DESCRIPTION
Fixes #675 
I admit, this is a real PITA, and this code reflects it.

The workaround I wanted to implement was to issue an `Load` into the matrix if we see it being row-major, followed by `Transpose`, then pretending that it was column-major all this time.
The problem is that there are many ways to cross that "ima matrix" barrier:
  - `OpAccessChain` doesn't have intermediate IDs, so we can't do it iteratively
  - it may start high up and end on a matrix, or on an element of it
  - it turns out, an array of matrices, when being a struct field, can also have this row-major decoration

If anybody can have a better idea, I'd love to consider it!