### PR TITLE
MSL packed vectors and shorter expressions

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1084,6 +1084,16 @@ impl<W: Write> Writer<W> {
                     vector_size_string(size)
                 )?;
             }
+            TypeResolution::Value(crate::TypeInner::Matrix { columns, rows, .. }) => {
+                write!(
+                    self.out,
+                    "{}::{}{}x{}",
+                    NAMESPACE,
+                    scalar_kind_string(crate::ScalarKind::Float),
+                    vector_size_string(columns),
+                    vector_size_string(rows),
+                )?;
+            }
             TypeResolution::Value(ref other) => {
                 log::error!("Type {:?} isn't a known local", other);
                 return Err(Error::FeatureNotImplemented("weird local type".to_string()));

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -16,7 +16,7 @@ use std::{
 
 const NAMESPACE: &str = "metal";
 const INDENT: &str = "    ";
-const BAKE_PREFIX: &str = "_expr";
+const BAKE_PREFIX: &str = "_e";
 
 #[derive(Clone)]
 struct Level(usize);

--- a/tests/out/collatz.msl.snap
+++ b/tests/out/collatz.msl.snap
@@ -36,8 +36,8 @@ kernel void main1(
   metal::uint3 global_id [[thread_position_in_grid]]
 , device PrimeIndices& v_indices [[user(fake0)]]
 ) {
-    metal::uint _expr9 = collatz_iterations(v_indices.data[global_id.x]);
-    v_indices.data[global_id.x] = _expr9;
+    metal::uint _e9 = collatz_iterations(v_indices.data[global_id.x]);
+    v_indices.data[global_id.x] = _e9;
     return;
 }
 

--- a/tests/out/image-copy.msl.snap
+++ b/tests/out/image-copy.msl.snap
@@ -13,9 +13,9 @@ kernel void main1(
 , metal::texture2d<uint, metal::access::read> image_src [[user(fake0)]]
 , metal::texture1d<uint, metal::access::write> image_dst [[user(fake0)]]
 ) {
-    metal::int2 _expr12 = (int2(image_src.get_width(), image_src.get_height()) * static_cast<int2>(metal::uint2(local_id.x, local_id.y))) % metal::int2(10, 20);
-    metal::uint4 _expr13 = image_src.read(metal::uint2(_expr12));
-    image_dst.write(_expr13, metal::uint(_expr12.x));
+    metal::int2 _e12 = (int2(image_src.get_width(), image_src.get_height()) * static_cast<int2>(metal::uint2(local_id.x, local_id.y))) % metal::int2(10, 20);
+    metal::uint4 _e13 = image_src.read(metal::uint2(_e12));
+    image_dst.write(_e13, metal::uint(_e12.x));
     return;
 }
 

--- a/tests/out/quad-vert.msl.snap
+++ b/tests/out/quad-vert.msl.snap
@@ -26,8 +26,8 @@ void main1(
     thread metal::float2 const& a_pos
 ) {
     v_uv = a_uv;
-    metal::float2 _expr13 = a_pos;
-    _.gl_Position = metal::float4(_expr13.x, _expr13.y, 0.0, 1.0);
+    metal::float2 _e13 = a_pos;
+    _.gl_Position = metal::float4(_e13.x, _e13.y, 0.0, 1.0);
     return;
 }
 

--- a/tests/out/quad.msl.snap
+++ b/tests/out/quad.msl.snap
@@ -44,10 +44,10 @@ fragment main2Output main2(
 , metal::sampler u_sampler [[user(fake0)]]
 ) {
     const auto uv2 = varyings1.uv2;
-    metal::float4 _expr4 = u_texture.sample(u_sampler, uv2);
-    if (_expr4.w == 0.0) {
+    metal::float4 _e4 = u_texture.sample(u_sampler, uv2);
+    if (_e4.w == 0.0) {
         metal::discard_fragment();
     }
-    return main2Output { _expr4.w * _expr4 };
+    return main2Output { _e4.w * _e4 };
 }
 

--- a/tests/out/shadow.msl.snap
+++ b/tests/out/shadow.msl.snap
@@ -29,9 +29,9 @@ float fetch_shadow(
     if (homogeneous_coords.w <= 0.0) {
         return 1.0;
     }
-    float _expr15 = 1.0 / homogeneous_coords.w;
-    float _expr28 = t_shadow.sample_compare(sampler_shadow, ((metal::float2(homogeneous_coords.x, homogeneous_coords.y) * metal::float2(0.5, -0.5)) * _expr15) + metal::float2(0.5, 0.5), static_cast<int>(light_id), homogeneous_coords.z * _expr15);
-    return _expr28;
+    float _e15 = 1.0 / homogeneous_coords.w;
+    float _e28 = t_shadow.sample_compare(sampler_shadow, ((metal::float2(homogeneous_coords.x, homogeneous_coords.y) * metal::float2(0.5, -0.5)) * _e15) + metal::float2(0.5, 0.5), static_cast<int>(light_id), homogeneous_coords.z * _e15);
+    return _e28;
 }
 
 struct fs_mainInput {
@@ -61,9 +61,9 @@ fragment fs_mainOutput fs_main(
         if (i >= metal::min(u_globals.num_lights.x, c_max_lights)) {
             break;
         }
-        Light _expr21 = s_lights.data[i];
-        float _expr25 = fetch_shadow(i, _expr21.proj * position, t_shadow, sampler_shadow);
-        color1 = color1 + ((_expr25 * metal::max(0.0, metal::dot(metal::normalize(raw_normal), metal::normalize(metal::float3(_expr21.pos.x, _expr21.pos.y, _expr21.pos.z) - metal::float3(position.x, position.y, position.z))))) * metal::float3(_expr21.color.x, _expr21.color.y, _expr21.color.z));
+        Light _e21 = s_lights.data[i];
+        float _e25 = fetch_shadow(i, _e21.proj * position, t_shadow, sampler_shadow);
+        color1 = color1 + ((_e25 * metal::max(0.0, metal::dot(metal::normalize(raw_normal), metal::normalize(metal::float3(_e21.pos.x, _e21.pos.y, _e21.pos.z) - metal::float3(position.x, position.y, position.z))))) * metal::float3(_e21.color.x, _e21.color.y, _e21.color.z));
     }
     return fs_mainOutput { metal::float4(color1, 1.0) };
 }

--- a/tests/out/skybox.msl.snap
+++ b/tests/out/skybox.msl.snap
@@ -29,10 +29,10 @@ vertex vs_mainOutput vs_main(
     VertexOutput out;
     tmp1_ = static_cast<int>(vertex_index) / 2;
     tmp2_ = static_cast<int>(vertex_index) & 1;
-    metal::float4 _expr24 = metal::float4((static_cast<float>(tmp1_) * 4.0) - 1.0, (static_cast<float>(tmp2_) * 4.0) - 1.0, 0.0, 1.0);
-    metal::float4 _expr50 = r_data.proj_inv * _expr24;
-    out.uv = metal::transpose(metal::float3x3(metal::float3(r_data.view[0].x, r_data.view[0].y, r_data.view[0].z), metal::float3(r_data.view[1].x, r_data.view[1].y, r_data.view[1].z), metal::float3(r_data.view[2].x, r_data.view[2].y, r_data.view[2].z))) * metal::float3(_expr50.x, _expr50.y, _expr50.z);
-    out.position = _expr24;
+    metal::float4 _e24 = metal::float4((static_cast<float>(tmp1_) * 4.0) - 1.0, (static_cast<float>(tmp2_) * 4.0) - 1.0, 0.0, 1.0);
+    metal::float4 _e50 = r_data.proj_inv * _e24;
+    out.uv = metal::transpose(metal::float3x3(metal::float3(r_data.view[0].x, r_data.view[0].y, r_data.view[0].z), metal::float3(r_data.view[1].x, r_data.view[1].y, r_data.view[1].z), metal::float3(r_data.view[2].x, r_data.view[2].y, r_data.view[2].z))) * metal::float3(_e50.x, _e50.y, _e50.z);
+    out.position = _e24;
     const auto _tmp = out;
     return vs_mainOutput { _tmp.position, _tmp.uv };
 }
@@ -58,7 +58,7 @@ fragment fs_mainOutput fs_main(
         metal::coord::normalized
     );
     const VertexOutput in = { position, varyings1.uv };
-    metal::float4 _expr5 = r_texture.sample(r_sampler, in.uv);
-    return fs_mainOutput { _expr5 };
+    metal::float4 _e5 = r_texture.sample(r_sampler, in.uv);
+    return fs_mainOutput { _e5 };
 }
 


### PR DESCRIPTION
Apparently, there are SPIR-V in the wild that require packed vec3...
This code introduces a crude but tiny and localized workaround.