### PR TITLE
Add Serialize/Deserialize derives for `mtl::EntryPointError`

### DIFF
--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -57,6 +57,7 @@ pub struct BindTarget {
 }
 
 #[derive(Clone, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct BindSource {
     pub stage: crate::ShaderStage,
@@ -95,6 +96,8 @@ pub enum Error {
 }
 
 #[derive(Clone, Debug, PartialEq, thiserror::Error)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub enum EntryPointError {
     #[error("mapping of {0:?} is missing")]
     MissingBinding(BindSource),


### PR DESCRIPTION
This struct is used by the [`EntryPointMap`](https://github.com/gfx-rs/gfx/blob/3ee1ca9ba486b166a52765024d8d149cbb28d486/src/backend/metal/src/native.rs#L30-L36) in the gfx Metal backend. Implementing `Serialize` and `Deserialize` for this means that we can then serialize a SPIR-V -> MSL transformation cache (see also https://github.com/gfx-rs/gfx/pull/3719 and https://github.com/gfx-rs/gfx/issues/3716#issuecomment-816575736).