### PR TITLE
spv-in: path forward

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ pomelo = { version = "0.1.4", optional = true }
 thiserror = "1.0.21"
 serde = { version = "1.0", features = ["derive"], optional = true }
 petgraph = { version ="0.5", optional = true }
+rose_tree = { version ="0.2", optional = true }
 pp-rs = { version = "0.1", optional = true }
 #env_logger = "0.8" # uncomment temporarily for developing with the binary target
 
@@ -36,7 +37,7 @@ glsl-out = ["petgraph"]
 msl-out = []
 serialize = ["serde"]
 deserialize = ["serde"]
-spv-in = ["petgraph", "spirv"]
+spv-in = ["petgraph", "spirv", "rose_tree"]
 spv-out = ["spirv"]
 wgsl-in = ["codespan-reporting"]
 wgsl-out = []

--- a/src/front/spv/error.rs
+++ b/src/front/spv/error.rs
@@ -97,6 +97,8 @@ pub enum Error {
     InvalidTerminator,
     #[error("invalid edge classification")]
     InvalidEdgeClassification,
+    #[error("cycle detected in the CFG during traversal at {0}")]
+    ControlFlowGraphCycle(crate::front::spv::BlockId),
     #[error("recursive function call %{0}")]
     FunctionCallCycle(spirv::Word),
     #[error("invalid array size {0:?}")]

--- a/src/front/spv/function.rs
+++ b/src/front/spv/function.rs
@@ -181,7 +181,7 @@ impl<I: Iterator<Item = u32>> super::Parser<I> {
             }
         }
 
-        fun.body = flow_graph.to_naga()?;
+        fun.body = flow_graph.convert_to_naga()?;
 
         // done
         let fun_handle = module.functions.append(fun);

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -2148,6 +2148,9 @@ impl<I: Iterator<Item = u32>> Parser<I> {
             block,
             terminator,
             merge,
+            construct: petgraph::graph::node_index(0),
+            position: 0,
+            visited: false,
         })
     }
 


### PR DESCRIPTION
Fixes #613, #691, #578, #683
Makes obsolete: #690 

A lot of stuff is borrowed/inspired by Tint.

Changes
- Added postorder traversal
- Added constructs based on postorder traversal
- Add HashSet of all points traversal should be stopped
- Reworked when/where to stop for if selection
- Slightly improved CFG Visualization for better debugging
- Adds loop detection
- Replaces of cloning blocks with move
