### PR TITLE
[Metal] Determine whether a load expression should dereference a pointer

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -668,7 +668,17 @@ impl<W: Write> Writer<W> {
                 write!(self.out, "{}", name)?;
             }
             crate::Expression::Load { pointer } => {
-                //write!(self.out, "*")?;
+                let should_dereference = match context.info[pointer].ty {
+                    TypeResolution::Handle(handle) => {
+                        let ty = &context.module.types[handle];
+                        matches!(ty.inner, crate::TypeInner::Pointer { .. })
+                    }
+                    TypeResolution::Value(_) => false,
+                };
+
+                if should_dereference {
+                    write!(self.out, "*")?;
+                }
                 self.put_expression(pointer, context, is_scoped)?;
             }
             crate::Expression::ImageSample {

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -668,12 +668,12 @@ impl<W: Write> Writer<W> {
                 write!(self.out, "{}", name)?;
             }
             crate::Expression::Load { pointer } => {
-                let should_dereference = match context.info[pointer].ty {
-                    TypeResolution::Handle(handle) => {
-                        let ty = &context.module.types[handle];
-                        matches!(ty.inner, crate::TypeInner::Pointer { .. })
-                    }
-                    TypeResolution::Value(_) => false,
+                let should_dereference = match &context.function.expressions[pointer] {
+                    crate::Expression::AccessIndex { .. } => false,
+                    crate::Expression::Access { .. } => false,
+                    crate::Expression::LocalVariable { .. } => false,
+                    crate::Expression::GlobalVariable { .. } => false,
+                    _ => true,
                 };
 
                 if should_dereference {

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -668,7 +668,7 @@ impl<W: Write> Writer<W> {
                 write!(self.out, "{}", name)?;
             }
             crate::Expression::Load { pointer } => {
-                let should_dereference = match &context.function.expressions[pointer] {
+                let should_dereference = match context.function.expressions[pointer] {
                     crate::Expression::AccessIndex { .. } => false,
                     crate::Expression::Access { .. } => false,
                     crate::Expression::LocalVariable { .. } => false,


### PR DESCRIPTION
This is one half of a fix for https://github.com/gfx-rs/naga/issues/685.

Now, instead of the incorrect
```metal
metal::float2 lerpvf2vf2vf2_(
    thread metal::float2* a,
    thread metal::float2* b,
    thread metal::float2* f
) {
    return a + ((b - a) * f);
}
```

we get

```metal
metal::float2 lerpvf2vf2vf2_(
    thread metal::float2* a,
    thread metal::float2* b,
    thread metal::float2* f
) {
    return *a + ((*b - *a) * *f);
}
```

The function is still called the wrong way though.