### PR TITLE
Fix validation for `textureDimensions(t)` call

### DIFF
--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -592,10 +592,10 @@ impl super::Validator {
                         };
                         let good = match query {
                             crate::ImageQuery::NumLayers => arrayed,
+                            crate::ImageQuery::Size { level: None } => true,
                             crate::ImageQuery::Size { level: Some(_) }
                             | crate::ImageQuery::NumLevels => can_level,
-                            crate::ImageQuery::Size { level: None }
-                            | crate::ImageQuery::NumSamples => !can_level,
+                            crate::ImageQuery::NumSamples => !can_level,
                         };
                         if !good {
                             return Err(ExpressionError::InvalidImageClass(class));


### PR DESCRIPTION
Fixes #696

Based on the [spec for textureDimensions()](https://gpuweb.github.io/gpuweb/wgsl/#texturedimensions) - it should be valid for all image classes without mip level param.