### PR TITLE
[Metal] Handle `NaN` and `inf` correctly in constants

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -253,8 +253,15 @@ impl<'a> Display for ConstantContext<'a> {
                     write!(out, "{}u", value)
                 }
                 crate::ScalarValue::Float(value) => {
-                    let suffix = if value.fract() == 0.0 { ".0" } else { "" };
-                    write!(out, "{}{}", value, suffix)
+                    if value.is_infinite() {
+                        write!(out, "INFINITY")
+                    } else if value.is_nan() {
+                        write!(out, "NAN")
+                    } else {
+                        let suffix = if value.fract() == 0.0 { ".0" } else { "" };
+
+                        write!(out, "{}{}", value, suffix)
+                    }
                 }
                 crate::ScalarValue::Bool(value) => {
                     write!(out, "{}", value)

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -254,7 +254,8 @@ impl<'a> Display for ConstantContext<'a> {
                 }
                 crate::ScalarValue::Float(value) => {
                     if value.is_infinite() {
-                        write!(out, "INFINITY")
+                        let sign = if value.is_sign_negative() { "-" } else { "" };
+                        write!(out, "{}INFINITY", sign)
                     } else if value.is_nan() {
                         write!(out, "NAN")
                     } else {


### PR DESCRIPTION
See https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf table 6.5.
Before:
```glsl
#version 450

layout(location = 0) out vec4 colour;

void main() {
    colour = vec4(1.0/0.0, 0.0/0.0, 0.0, 1.0);
}
```
->
```metal
constexpr constant metal::float4 const_type1_ = {inf, NaN, 0.0, 1.0};
```
->
```
inf_nan.metal:4:50: error: use of undeclared identifier 'inf'
constexpr constant metal::float4 const_type1_ = {inf, NaN, 0.0, 1.0};
                                                 ^
inf_nan.metal:4:55: error: use of undeclared identifier 'NaN'
constexpr constant metal::float4 const_type1_ = {inf, NaN, 0.0, 1.0};
```
After:
```metal
constexpr constant metal::float4 const_type1_ = {INFINITY, NAN, 0.0, 1.0};
```