### PR TITLE
[Metal] Handle `length(float)` and `distance(float, float)`

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -887,7 +887,7 @@ impl<W: Write> Writer<W> {
             } => {
                 use crate::MathFunction as Mf;
 
-                let scalar_argument = match context.resolve_type(arg) {
+                let scalar_argument = match *context.resolve_type(arg) {
                     crate::TypeInner::Scalar { .. } => true,
                     _ => false,
                 };

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -887,12 +887,9 @@ impl<W: Write> Writer<W> {
             } => {
                 use crate::MathFunction as Mf;
 
-                let scalar_argument = match &context.info[arg].ty {
-                    TypeResolution::Handle(handle) => {
-                        let ty = &context.module.types[*handle];
-                        matches!(ty.inner, crate::TypeInner::Scalar { .. })
-                    }
-                    TypeResolution::Value(ty) => matches!(ty, crate::TypeInner::Scalar { .. }),
+                let scalar_argument = match context.resolve_type(arg) {
+                    crate::TypeInner::Scalar { .. } => true,
+                    _ => false,
                 };
 
                 let fun_name = match fun {
@@ -955,9 +952,9 @@ impl<W: Write> Writer<W> {
 
                 if fun == Mf::Distance && scalar_argument {
                     write!(self.out, "{}::abs(", NAMESPACE)?;
-                    self.put_expression(arg, context, true)?;
+                    self.put_expression(arg, context, false)?;
                     write!(self.out, " - ")?;
-                    self.put_expression(arg1.unwrap(), context, true)?;
+                    self.put_expression(arg1.unwrap(), context, false)?;
                     write!(self.out, ")")?;
                 } else {
                     write!(self.out, "{}::{}", NAMESPACE, fun_name)?;

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -2134,8 +2134,8 @@ fn test_stack_size() {
         }
         let stack_size = addresses.end - addresses.start;
         // check the size (in debug only)
-        // last observed macOS value: 18768
-        if stack_size < 18000 || stack_size > 20000 {
+        // last observed macOS value: 20336
+        if stack_size < 19000 || stack_size > 21000 {
             panic!("`put_expression` stack size {} has changed!", stack_size);
         }
     }


### PR DESCRIPTION
Closes https://github.com/gfx-rs/naga/issues/695. It could probably be a little tidier though, I'm open to suggestions.
```glsl
#version 450

layout(location = 0) in float a;
layout(location = 1) in float b;
layout(location = 2) in float c;

layout(location = 0) out vec4 colour;

void main() {
    float l = length(a);
    float d = distance(b, c);
    float ds = dot(b, c);
    colour = vec4(l, d, ds, 1.0);
}
```
->
```metal
void main1(
    thread float const& a,
    thread float const& b,
    thread float const& c,
    thread metal::float4& colour
) {
    float l;
    float d;
    float ds;
    l = metal::abs(a);
    d = metal::abs(b - c);
    ds = b * c;
    colour = metal::float4(l, d, ds, 1.0);
    return;
}
```