### PR TITLE
Add a note about references and pointers to `Expression::Load`

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -676,8 +676,9 @@ impl<W: Write> Writer<W> {
                 write!(self.out, "{}", name)?;
             }
             crate::Expression::Load { pointer } => {
-                // We don't do any dereferencing with `*` here as pointer arguments are done
-                // by `&` references and not `*` pointers, which do not need to be dereferenced.
+                // We don't do any dereferencing with `*` here as pointer arguments to functions
+                // are done by `&` references and not `*` pointers, which do not need to be
+                // dereferenced.
                 self.put_expression(pointer, context, is_scoped)?;
             }
             crate::Expression::ImageSample {

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -676,7 +676,8 @@ impl<W: Write> Writer<W> {
                 write!(self.out, "{}", name)?;
             }
             crate::Expression::Load { pointer } => {
-                //write!(self.out, "*")?;
+                // We don't do any dereferencing with `*` here as pointer arguments are done
+                // by `&` references and not `*` pointers, which do not need to be dereferenced.
                 self.put_expression(pointer, context, is_scoped)?;
             }
             crate::Expression::ImageSample {

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -677,7 +677,7 @@ impl<W: Write> Writer<W> {
             }
             crate::Expression::Load { pointer } => {
                 // We don't do any dereferencing with `*` here as pointer arguments to functions
-                // are done by `&` references and not `*` pointers, which do not need to be
+                // are done by `&` references and not `*` pointers which do not need to be
                 // dereferenced.
                 self.put_expression(pointer, context, is_scoped)?;
             }

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -677,7 +677,7 @@ impl<W: Write> Writer<W> {
             }
             crate::Expression::Load { pointer } => {
                 // We don't do any dereferencing with `*` here as pointer arguments to functions
-                // are done by `&` references and not `*` pointers which do not need to be
+                // are done by `&` references and not `*` pointers. These do not need to be
                 // dereferenced.
                 self.put_expression(pointer, context, is_scoped)?;
             }


### PR DESCRIPTION
This seemed important to clarify.