### PR TITLE
Makefile: Be more flexible in removing YAML headers from snapshots.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,34 +26,38 @@ clean:
 %.png: %.dot
 	dot -Tpng $< -o $@
 
+# A command to remove the '---' YAML document start markers from the snapshots
+# before passing their contents to a validator.
+TRIM=sed -e '1d' -e '2,/---/d'
+
 validate-spv: $(SNAPSHOTS_OUT)/*.spvasm.snap
 	@set -e && for file in $^ ; do \
 		echo "Validating" $${file#"$(SNAPSHOTS_OUT)/snapshots__"};	\
-		tail -n +5 $${file} | spirv-as --target-env vulkan1.0 -o - | spirv-val; \
+		$(TRIM) $${file} | spirv-as --target-env vulkan1.0 -o - | spirv-val; \
 	done
 
 validate-msl: $(SNAPSHOTS_OUT)/*.msl.snap
 	@set -e && for file in $^ ; do \
 		echo "Validating" $${file#"$(SNAPSHOTS_OUT)/snapshots__"};	\
-		tail -n +5 $${file} | xcrun -sdk macosx metal -mmacosx-version-min=10.11 -x metal - -o /dev/null; \
+		$(TRIM) $${file} | xcrun -sdk macosx metal -mmacosx-version-min=10.11 -x metal - -o /dev/null; \
 	done
 
 validate-glsl: $(SNAPSHOTS_OUT)/*.glsl.snap
 	@set -e && for file in $(SNAPSHOTS_OUT)/*-Vertex.glsl.snap ; do \
 		echo "Validating" $${file#"$(SNAPSHOTS_OUT)/snapshots__"};\
-		tail -n +5 $${file} | glslangValidator --stdin -S vert; \
+		$(TRIM) $${file} | glslangValidator --stdin -S vert; \
 	done
 	@set -e && for file in $(SNAPSHOTS_OUT)/*-Fragment.glsl.snap ; do \
 		echo "Validating" $${file#"$(SNAPSHOTS_OUT)/snapshots__"};\
-		tail -n +5 $${file} | glslangValidator --stdin -S frag; \
+		$(TRIM) $${file} | glslangValidator --stdin -S frag; \
 	done
 	@set -e && for file in $(SNAPSHOTS_OUT)/*-Compute.glsl.snap ; do \
 		echo "Validating" $${file#"$(SNAPSHOTS_OUT)/snapshots__"};\
-		tail -n +5 $${file} | glslangValidator --stdin -S comp; \
+		$(TRIM) $${file} | glslangValidator --stdin -S comp; \
 	done
 
 validate-dot: $(SNAPSHOTS_OUT)/*.dot.snap
 	@set -e && for file in $^ ; do \
 		echo "Validating" $${file#"$(SNAPSHOTS_OUT)/snapshots__"};	\
-		tail -n +5 $${file} | dot -o /dev/null; \
+		$(TRIM) $${file} | dot -o /dev/null; \
 	done


### PR DESCRIPTION
The snapshot files in tests/out start with headers like this:

    ---
    source: tests/snapshots.rs
    expression: dis
    ---
    ; SPIR-V
    ; Version: 1.0
    ; Generator: rspirv
    ...

The Makefile's `validate-foo` targets trim off those lines with `tail -n +5`
before submitting their test to the validators.

However, some versions of the `insta` crate seem to generate headers with an
extra blank line, like this:

    ---
    source: tests/snapshots.rs
    expression: dis

    ---

This makes the `validate-foo` targets unhappy.

This commit changes the `validate-foo` targets to use `sed` to cope with both
kinds of headers.