### PR TITLE
Vector splats

### DIFF
--- a/src/back/dot/mod.rs
+++ b/src/back/dot/mod.rs
@@ -183,6 +183,10 @@ fn write_fun(
                 (Cow::Owned(format!("AccessIndex[{}]", index)), 1)
             }
             E::Constant(_) => (Cow::Borrowed("Constant"), 2),
+            E::Splat { size, value } => {
+                edges.insert("value", value);
+                (Cow::Owned(format!("Splat{:?}", size)), 3)
+            }
             E::Compose { ref components, .. } => {
                 payload = Some(Payload::Arguments(components));
                 (Cow::Borrowed("Compose"), 3)

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1477,6 +1477,10 @@ impl<'a, W: Write> Writer<'a, W> {
             Expression::Constant(constant) => {
                 self.write_constant(&self.module.constants[constant])?
             }
+            // `Splat` is just writing `value`
+            Expression::Splat { size: _, value } => {
+                self.write_expr(value, ctx)?;
+            }
             // `Compose` is pretty simple we just write `type(components)` where `components` is a
             // comma separated list of expressions
             Expression::Compose { ty, ref components } => {

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1477,9 +1477,13 @@ impl<'a, W: Write> Writer<'a, W> {
             Expression::Constant(constant) => {
                 self.write_constant(&self.module.constants[constant])?
             }
-            // `Splat` is just writing `value`
+            // `Splat` needs to actually write down a vector, it's not always inferred in GLSL.
             Expression::Splat { size: _, value } => {
+                let resolved = ctx.info[expr].ty.inner_with(&self.module.types);
+                self.write_value_type(resolved)?;
+                write!(self.out, "(")?;
                 self.write_expr(value, ctx)?;
+                write!(self.out, ")")?
             }
             // `Compose` is pretty simple we just write `type(components)` where `components` is a
             // comma separated list of expressions

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -608,6 +608,9 @@ impl<W: Write> Writer<W> {
                 };
                 write!(self.out, "{}", coco)?;
             }
+            crate::Expression::Splat { size: _, value } => {
+                self.put_expression(value, context, is_scoped)?;
+            }
             crate::Expression::Compose { ty, ref components } => {
                 let inner = &context.module.types[ty].inner;
                 match *inner {

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1133,6 +1133,13 @@ impl Parser {
                         let last_component_inner = ctx.resolve_type(last_component)?;
                         match (&inner, last_component_inner) {
                             (
+                                &crate::TypeInner::Vector { size, .. },
+                                &crate::TypeInner::Scalar { .. },
+                            ) => crate::Expression::Splat {
+                                size,
+                                value: last_component,
+                            },
+                            (
                                 &crate::TypeInner::Scalar { .. },
                                 &crate::TypeInner::Scalar { .. },
                             )
@@ -1215,6 +1222,7 @@ impl Parser {
                         crate::TypeInner::Vector { size, kind, width } => {
                             match Composition::make(handle, size, name, name_span, ctx.expressions)?
                             {
+                                //TODO: Swizzling in IR
                                 Composition::Multi(size, components) => {
                                     let inner = crate::TypeInner::Vector { size, kind, width };
                                     crate::Expression::Compose {
@@ -1238,6 +1246,7 @@ impl Parser {
                             name_span,
                             ctx.expressions,
                         )? {
+                            //TODO: is this really supported?
                             Composition::Multi(columns, components) => {
                                 let inner = crate::TypeInner::Matrix {
                                     columns,

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -328,12 +328,50 @@ impl<'a> ExpressionContext<'a, '_, '_> {
         let mut left = parser(lexer, self.reborrow())?;
         while let Some(op) = classifier(lexer.peek().0) {
             let _ = lexer.next();
-            let expression = crate::Expression::Binary {
-                op,
-                left,
-                right: parser(lexer, self.reborrow())?,
-            };
-            left = self.expressions.append(expression);
+            let right = parser(lexer, self.reborrow())?;
+            left = self
+                .expressions
+                .append(crate::Expression::Binary { op, left, right });
+        }
+        Ok(left)
+    }
+
+    fn parse_binary_splat_op(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        classifier: impl Fn(Token<'a>) -> Option<crate::BinaryOperator>,
+        mut parser: impl FnMut(
+            &mut Lexer<'a>,
+            ExpressionContext<'a, '_, '_>,
+        ) -> Result<Handle<crate::Expression>, Error<'a>>,
+    ) -> Result<Handle<crate::Expression>, Error<'a>> {
+        let mut left = parser(lexer, self.reborrow())?;
+        while let Some(op) = classifier(lexer.peek().0) {
+            let _ = lexer.next();
+            let mut right = parser(lexer, self.reborrow())?;
+            // insert splats, if needed by the non-'*' operations
+            if op != crate::BinaryOperator::Multiply {
+                let left_size = match *self.resolve_type(left)? {
+                    crate::TypeInner::Vector { size, .. } => Some(size),
+                    _ => None,
+                };
+                match (left_size, self.resolve_type(right)?) {
+                    (Some(size), &crate::TypeInner::Scalar { .. }) => {
+                        right = self
+                            .expressions
+                            .append(crate::Expression::Splat { size, value: right });
+                    }
+                    (None, &crate::TypeInner::Vector { size, .. }) => {
+                        left = self
+                            .expressions
+                            .append(crate::Expression::Splat { size, value: left });
+                    }
+                    _ => {}
+                }
+            }
+            left = self
+                .expressions
+                .append(crate::Expression::Binary { op, left, right });
         }
         Ok(left)
     }
@@ -1354,7 +1392,7 @@ impl Parser {
                             },
                             // additive_expression
                             |lexer, mut context| {
-                                context.parse_binary_op(
+                                context.parse_binary_splat_op(
                                     lexer,
                                     |token| match token {
                                         Token::Operation('+') => Some(crate::BinaryOperator::Add),
@@ -1365,7 +1403,7 @@ impl Parser {
                                     },
                                     // multiplicative_expression
                                     |lexer, mut context| {
-                                        context.parse_binary_op(
+                                        context.parse_binary_splat_op(
                                             lexer,
                                             |token| match token {
                                                 Token::Operation('*') => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -683,6 +683,11 @@ pub enum Expression {
     },
     /// Constant value.
     Constant(Handle<Constant>),
+    /// Splat scalar into a vector.
+    Splat {
+        size: VectorSize,
+        value: Handle<Expression>,
+    },
     /// Composite expression.
     Compose {
         ty: Handle<Type>,

--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -318,6 +318,10 @@ impl FunctionInfo {
             },
             // always uniform
             E::Constant(_) => Uniformity::new(),
+            E::Splat { size: _, value } => Uniformity {
+                non_uniform_result: self.add_ref(value),
+                requirements: UniformityRequirements::empty(),
+            },
             E::Compose { ref components, .. } => {
                 let non_uniform_result = components
                     .iter()

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -20,7 +20,7 @@ fn check(input: &str, snapshot: &str) {
 fn function_without_identifier() {
     check(
         "fn () {}",
-r###"error: expected identifier, found '('
+        r###"error: expected identifier, found '('
   ┌─ wgsl:1:4
   │
 1 │ fn () {}
@@ -35,7 +35,7 @@ r###"error: expected identifier, found '('
 fn invalid_integer() {
     check(
         "fn foo([location(1.)] x: i32) {}",
-r###"error: expected identifier, found '['
+        r###"error: expected identifier, found '['
   ┌─ wgsl:1:8
   │
 1 │ fn foo([location(1.)] x: i32) {}
@@ -50,7 +50,7 @@ r###"error: expected identifier, found '['
 fn invalid_float() {
     check(
         "let scale: f32 = 1.1.;",
-r###"error: expected floating-point literal, found `1.1.`
+        r###"error: expected floating-point literal, found `1.1.`
   ┌─ wgsl:1:18
   │
 1 │ let scale: f32 = 1.1.;
@@ -65,7 +65,7 @@ r###"error: expected floating-point literal, found `1.1.`
 fn invalid_scalar_width() {
     check(
         "let scale: f32 = 1.1f1000;",
-r###"error: invalid width of `1000` for literal
+        r###"error: invalid width of `1000` for literal
   ┌─ wgsl:1:18
   │
 1 │ let scale: f32 = 1.1f1000;
@@ -88,7 +88,7 @@ fn vs_main() {
     var i: f32 = color.a;
 }
 "###,
-r###"error: invalid field accessor `a`
+        r###"error: invalid field accessor `a`
   ┌─ wgsl:5:24
   │
 5 │     var i: f32 = color.a;

--- a/tests/in/boids.wgsl
+++ b/tests/in/boids.wgsl
@@ -73,10 +73,10 @@ fn main([[builtin(global_invocation_id)]] global_invocation_id : vec3<u32>) {
     }
   }
   if (cMassCount > 0) {
-    cMass = cMass * (1.0 / f32(cMassCount)) - vPos;
+    cMass = cMass / f32(cMassCount) - vPos;
   }
   if (cVelCount > 0) {
-    cVel = cVel * (1.0 / f32(cVelCount));
+    cVel = cVel / f32(cVelCount);
   }
 
   vVel = vVel + (cMass * params.rule1Scale) +

--- a/tests/in/operators.param.ron
+++ b/tests/in/operators.param.ron
@@ -1,0 +1,7 @@
+(
+	spv_version: (1, 0),
+	spv_capabilities: [ Shader ],
+	spv_debug: false,
+	spv_adjust_coordinate_space: false,
+	msl_custom: false,
+)

--- a/tests/in/operators.wgsl
+++ b/tests/in/operators.wgsl
@@ -1,0 +1,6 @@
+[[stage(vertex)]]
+fn splat() -> [[builtin(position)]] vec4<f32> {
+	let a = (1.0 + vec2<f32>(2.0) - 3.0) / 4.0;
+	let b = vec4<i32>(5) % 2;
+	return a.xyxy + vec4<f32>(b);
+}

--- a/tests/in/shadow.wgsl
+++ b/tests/in/shadow.wgsl
@@ -29,9 +29,8 @@ fn fetch_shadow(light_id: u32, homogeneous_coords: vec4<f32>) -> f32 {
         return 1.0;
     }
     let flip_correction = vec2<f32>(0.5, -0.5);
-    let proj_correction = 1.0 / homogeneous_coords.w;
-    let light_local = homogeneous_coords.xy * flip_correction * proj_correction + vec2<f32>(0.5, 0.5);
-    return textureSampleCompare(t_shadow, sampler_shadow, light_local, i32(light_id), homogeneous_coords.z * proj_correction);
+    let light_local = homogeneous_coords.xy * flip_correction / homogeneous_coords.w + vec2<f32>(0.5, 0.5);
+    return textureSampleCompare(t_shadow, sampler_shadow, light_local, i32(light_id), homogeneous_coords.z / homogeneous_coords.w);
 }
 
 let c_ambient: vec3<f32> = vec3<f32>(0.05, 0.05, 0.05);

--- a/tests/out/boids.msl
+++ b/tests/out/boids.msl
@@ -73,10 +73,10 @@ kernel void main1(
         }
     }
     if (cMassCount > 0) {
-        cMass = (cMass * (1.0 / static_cast<float>(cMassCount))) - vPos;
+        cMass = (cMass / static_cast<float>(cMassCount)) - vPos;
     }
     if (cVelCount > 0) {
-        cVel = cVel * (1.0 / static_cast<float>(cVelCount));
+        cVel = cVel / static_cast<float>(cVelCount);
     }
     vVel = ((vVel + (cMass * params.rule1Scale)) + (colVel * params.rule2Scale)) + (cVel * params.rule3Scale);
     vVel = metal::normalize(vVel) * metal::clamp(metal::length(vVel), 0.0, 0.1);

--- a/tests/out/boids.spvasm
+++ b/tests/out/boids.spvasm
@@ -70,9 +70,9 @@ OpDecorate %40 BuiltIn GlobalInvocationId
 %9 = OpConstant  %4  0
 %10 = OpConstant  %8  1
 %11 = OpConstant  %4  1
-%12 = OpConstant  %6  1.0
-%13 = OpConstant  %6  0.1
-%14 = OpConstant  %6  -1.0
+%12 = OpConstant  %6  0.1
+%13 = OpConstant  %6  -1.0
+%14 = OpConstant  %6  1.0
 %15 = OpTypeVector %6 2
 %16 = OpTypeStruct %15 %15
 %17 = OpTypeStruct %6 %6 %6 %6 %6 %6 %6
@@ -230,8 +230,8 @@ OpBranchConditional %124 %126 %125
 %127 = OpLoad  %15  %29
 %128 = OpLoad  %8  %32
 %129 = OpConvertSToF  %6  %128
-%130 = OpFDiv  %6  %12 %129
-%131 = OpVectorTimesScalar  %15  %127 %130
+%130 = OpCompositeConstruct  %15  %129 %129
+%131 = OpFDiv  %15  %127 %130
 %132 = OpLoad  %15  %26
 %133 = OpFSub  %15  %131 %132
 OpStore %29 %133
@@ -245,8 +245,8 @@ OpBranchConditional %135 %137 %136
 %138 = OpLoad  %15  %30
 %139 = OpLoad  %8  %34
 %140 = OpConvertSToF  %6  %139
-%141 = OpFDiv  %6  %12 %140
-%142 = OpVectorTimesScalar  %15  %138 %141
+%141 = OpCompositeConstruct  %15  %140 %140
+%142 = OpFDiv  %15  %138 %141
 OpStore %30 %142
 OpBranch %136
 %136 = OpLabel
@@ -271,7 +271,7 @@ OpStore %28 %161
 %163 = OpExtInst  %15  %1 Normalize %162
 %164 = OpLoad  %15  %28
 %165 = OpExtInst  %6  %1 Length %164
-%166 = OpExtInst  %6  %1 FClamp %165 %5 %13
+%166 = OpExtInst  %6  %1 FClamp %165 %5 %12
 %167 = OpVectorTimesScalar  %15  %163 %166
 OpStore %28 %167
 %168 = OpLoad  %15  %26
@@ -283,42 +283,42 @@ OpStore %28 %167
 OpStore %26 %173
 %174 = OpLoad  %15  %26
 %175 = OpCompositeExtract  %6  %174 0
-%176 = OpFOrdLessThan  %47  %175 %14
+%176 = OpFOrdLessThan  %47  %175 %13
 OpSelectionMerge %177 None
 OpBranchConditional %176 %178 %177
 %178 = OpLabel
 %180 = OpAccessChain  %179  %26 %7
-OpStore %180 %12
+OpStore %180 %14
 OpBranch %177
 %177 = OpLabel
 %181 = OpLoad  %15  %26
 %182 = OpCompositeExtract  %6  %181 0
-%183 = OpFOrdGreaterThan  %47  %182 %12
+%183 = OpFOrdGreaterThan  %47  %182 %14
 OpSelectionMerge %184 None
 OpBranchConditional %183 %185 %184
 %185 = OpLabel
 %186 = OpAccessChain  %179  %26 %7
-OpStore %186 %14
+OpStore %186 %13
 OpBranch %184
 %184 = OpLabel
 %187 = OpLoad  %15  %26
 %188 = OpCompositeExtract  %6  %187 1
-%189 = OpFOrdLessThan  %47  %188 %14
+%189 = OpFOrdLessThan  %47  %188 %13
 OpSelectionMerge %190 None
 OpBranchConditional %189 %191 %190
 %191 = OpLabel
 %192 = OpAccessChain  %179  %26 %10
-OpStore %192 %12
+OpStore %192 %14
 OpBranch %190
 %190 = OpLabel
 %193 = OpLoad  %15  %26
 %194 = OpCompositeExtract  %6  %193 1
-%195 = OpFOrdGreaterThan  %47  %194 %12
+%195 = OpFOrdGreaterThan  %47  %194 %14
 OpSelectionMerge %196 None
 OpBranchConditional %195 %197 %196
 %197 = OpLabel
 %198 = OpAccessChain  %179  %26 %10
-OpStore %198 %14
+OpStore %198 %13
 OpBranch %196
 %196 = OpLabel
 %199 = OpLoad  %15  %26

--- a/tests/out/operators.Vertex.glsl
+++ b/tests/out/operators.Vertex.glsl
@@ -1,0 +1,11 @@
+#version 310 es
+
+precision highp float;
+
+
+void main() {
+    vec2 _expr10 = (((vec2(1.0) + vec2(2.0)) - vec2(3.0)) / vec2(4.0));
+    gl_Position = (vec4(_expr10[0], _expr10[1], _expr10[0], _expr10[1]) + vec4((ivec4(5) % ivec4(2))));
+    return;
+}
+

--- a/tests/out/operators.msl
+++ b/tests/out/operators.msl
@@ -1,0 +1,12 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+
+struct splatOutput {
+    metal::float4 member [[position]];
+};
+vertex splatOutput splat(
+) {
+    metal::float2 _e10 = ((1.0 + 2.0) - 3.0) / 4.0;
+    return splatOutput { metal::float4(_e10.x, _e10.y, _e10.x, _e10.y) + static_cast<float4>(5 % 2) };
+}

--- a/tests/out/operators.spvasm
+++ b/tests/out/operators.spvasm
@@ -1,0 +1,48 @@
+; SPIR-V
+; Version: 1.0
+; Generator: rspirv
+; Bound: 37
+OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %15 "splat" %13
+OpDecorate %13 BuiltIn Position
+%2 = OpTypeVoid
+%4 = OpTypeFloat 32
+%3 = OpConstant  %4  1.0
+%5 = OpConstant  %4  2.0
+%6 = OpConstant  %4  3.0
+%7 = OpConstant  %4  4.0
+%9 = OpTypeInt 32 1
+%8 = OpConstant  %9  5
+%10 = OpConstant  %9  2
+%11 = OpTypeVector %4 4
+%14 = OpTypePointer Output %11
+%13 = OpVariable  %14  Output
+%16 = OpTypeFunction %2
+%18 = OpTypeVector %4 2
+%26 = OpTypeVector %9 4
+%15 = OpFunction  %2  None %16
+%12 = OpLabel
+OpBranch %17
+%17 = OpLabel
+%19 = OpCompositeConstruct  %18  %5 %5
+%20 = OpCompositeConstruct  %18  %3 %3
+%21 = OpFAdd  %18  %20 %19
+%22 = OpCompositeConstruct  %18  %6 %6
+%23 = OpFSub  %18  %21 %22
+%24 = OpCompositeConstruct  %18  %7 %7
+%25 = OpFDiv  %18  %23 %24
+%27 = OpCompositeConstruct  %26  %8 %8 %8 %8
+%28 = OpCompositeConstruct  %26  %10 %10 %10 %10
+%29 = OpSMod  %26  %27 %28
+%30 = OpCompositeExtract  %4  %25 0
+%31 = OpCompositeExtract  %4  %25 1
+%32 = OpCompositeExtract  %4  %25 0
+%33 = OpCompositeExtract  %4  %25 1
+%34 = OpCompositeConstruct  %11  %30 %31 %32 %33
+%35 = OpConvertSToF  %11  %29
+%36 = OpFAdd  %11  %34 %35
+OpStore %13 %36
+OpReturn
+OpFunctionEnd

--- a/tests/out/shadow.Fragment.glsl
+++ b/tests/out/shadow.Fragment.glsl
@@ -26,7 +26,7 @@ float fetch_shadow(uint light_id, vec4 homogeneous_coords) {
     if((homogeneous_coords[3] <= 0.0)) {
         return 1.0;
     }
-    float _expr28 = textureGrad(_group_0_binding_2, vec4((((vec2(homogeneous_coords[0], homogeneous_coords[1]) * vec2(0.5, -0.5)) / homogeneous_coords[3]) + vec2(0.5, 0.5)), int(light_id), (homogeneous_coords[2] / homogeneous_coords[3])), vec2(0, 0), vec2(0,0));
+    float _expr28 = textureGrad(_group_0_binding_2, vec4((((vec2(homogeneous_coords[0], homogeneous_coords[1]) * vec2(0.5, -0.5)) / vec2(homogeneous_coords[3])) + vec2(0.5, 0.5)), int(light_id), (homogeneous_coords[2] / homogeneous_coords[3])), vec2(0, 0), vec2(0,0));
     return _expr28;
 }
 

--- a/tests/out/shadow.Fragment.glsl
+++ b/tests/out/shadow.Fragment.glsl
@@ -26,8 +26,7 @@ float fetch_shadow(uint light_id, vec4 homogeneous_coords) {
     if((homogeneous_coords[3] <= 0.0)) {
         return 1.0;
     }
-    float _expr15 = (1.0 / homogeneous_coords[3]);
-    float _expr28 = textureGrad(_group_0_binding_2, vec4((((vec2(homogeneous_coords[0], homogeneous_coords[1]) * vec2(0.5, -0.5)) * _expr15) + vec2(0.5, 0.5)), int(light_id), (homogeneous_coords[2] * _expr15)), vec2(0, 0), vec2(0,0));
+    float _expr28 = textureGrad(_group_0_binding_2, vec4((((vec2(homogeneous_coords[0], homogeneous_coords[1]) * vec2(0.5, -0.5)) / homogeneous_coords[3]) + vec2(0.5, 0.5)), int(light_id), (homogeneous_coords[2] / homogeneous_coords[3])), vec2(0, 0), vec2(0,0));
     return _expr28;
 }
 

--- a/tests/out/shadow.info.ron
+++ b/tests/out/shadow.info.ron
@@ -213,7 +213,7 @@
                             bits: 0,
                         ),
                     ),
-                    ref_count: 3,
+                    ref_count: 2,
                     assignable_global: None,
                     ty: Value(Scalar(
                         kind: Float,
@@ -838,7 +838,11 @@
                     ),
                     ref_count: 1,
                     assignable_global: None,
-                    ty: Handle(9),
+                    ty: Value(Vector(
+                        size: Bi,
+                        kind: Float,
+                        width: 4,
+                    )),
                 ),
                 (
                     uniformity: (

--- a/tests/out/shadow.msl
+++ b/tests/out/shadow.msl
@@ -25,8 +25,7 @@ float fetch_shadow(
     if (homogeneous_coords.w <= 0.0) {
         return 1.0;
     }
-    float _e15 = 1.0 / homogeneous_coords.w;
-    float _e28 = t_shadow.sample_compare(sampler_shadow, ((metal::float2(homogeneous_coords.x, homogeneous_coords.y) * metal::float2(0.5, -0.5)) * _e15) + metal::float2(0.5, 0.5), static_cast<int>(light_id), homogeneous_coords.z * _e15);
+    float _e28 = t_shadow.sample_compare(sampler_shadow, ((metal::float2(homogeneous_coords.x, homogeneous_coords.y) * metal::float2(0.5, -0.5)) / homogeneous_coords.w) + metal::float2(0.5, 0.5), static_cast<int>(light_id), homogeneous_coords.z / homogeneous_coords.w);
     return _e28;
 }
 

--- a/tests/out/shadow.ron
+++ b/tests/out/shadow.ron
@@ -969,12 +969,9 @@
                     left: 55,
                     right: 57,
                 ),
-                Compose(
-                    ty: 9,
-                    components: [
-                        13,
-                        13,
-                    ],
+                Splat(
+                    size: Bi,
+                    value: 13,
                 ),
                 Binary(
                     op: Add,

--- a/tests/out/shadow.spvasm
+++ b/tests/out/shadow.spvasm
@@ -1,13 +1,13 @@
 ; SPIR-V
 ; Version: 1.2
 ; Generator: rspirv
-; Bound: 136
+; Bound: 137
 OpCapability Shader
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %81 "fs_main" %73 %76 %79
-OpExecutionMode %81 OriginUpperLeft
+OpEntryPoint Fragment %82 "fs_main" %74 %77 %80
+OpExecutionMode %82 OriginUpperLeft
 OpSource GLSL 450
 OpName %9 "c_max_lights"
 OpName %14 "Globals"
@@ -24,12 +24,12 @@ OpName %27 "s_lights"
 OpName %29 "t_shadow"
 OpName %31 "sampler_shadow"
 OpName %36 "fetch_shadow"
-OpName %68 "color"
-OpName %70 "i"
-OpName %73 "raw_normal"
-OpName %76 "position"
-OpName %81 "fs_main"
-OpName %81 "fs_main"
+OpName %69 "color"
+OpName %71 "i"
+OpName %74 "raw_normal"
+OpName %77 "position"
+OpName %82 "fs_main"
+OpName %82 "fs_main"
 OpDecorate %14 Block
 OpMemberDecorate %14 0 Offset 0
 OpMemberDecorate %17 0 Offset 0
@@ -49,9 +49,9 @@ OpDecorate %29 DescriptorSet 0
 OpDecorate %29 Binding 2
 OpDecorate %31 DescriptorSet 0
 OpDecorate %31 Binding 3
-OpDecorate %73 Location 0
-OpDecorate %76 Location 1
-OpDecorate %79 Location 0
+OpDecorate %74 Location 0
+OpDecorate %77 Location 1
+OpDecorate %80 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpConstant  %4  0.0
@@ -86,21 +86,21 @@ OpDecorate %79 Location 0
 %37 = OpTypeFunction %4 %10 %16
 %42 = OpTypeBool
 %56 = OpTypeInt 32 1
-%60 = OpTypeSampledImage %20
-%67 = OpConstant  %4  0.0
-%69 = OpTypePointer Function %23
-%71 = OpTypePointer Function %10
-%74 = OpTypePointer Input %23
-%73 = OpVariable  %74  Input
-%77 = OpTypePointer Input %16
-%76 = OpVariable  %77  Input
-%80 = OpTypePointer Output %16
-%79 = OpVariable  %80  Output
-%82 = OpTypeFunction %2
-%92 = OpTypePointer Uniform %13
-%93 = OpConstant  %56  0
-%101 = OpTypePointer StorageBuffer %18
-%103 = OpTypePointer StorageBuffer %17
+%61 = OpTypeSampledImage %20
+%68 = OpConstant  %4  0.0
+%70 = OpTypePointer Function %23
+%72 = OpTypePointer Function %10
+%75 = OpTypePointer Input %23
+%74 = OpVariable  %75  Input
+%78 = OpTypePointer Input %16
+%77 = OpVariable  %78  Input
+%81 = OpTypePointer Output %16
+%80 = OpVariable  %81  Output
+%83 = OpTypeFunction %2
+%93 = OpTypePointer Uniform %13
+%94 = OpConstant  %56  0
+%102 = OpTypePointer StorageBuffer %18
+%104 = OpTypePointer StorageBuffer %17
 %36 = OpFunction  %4  None %37
 %34 = OpFunctionParameter  %10
 %35 = OpFunctionParameter  %16
@@ -117,92 +117,93 @@ OpBranchConditional %43 %45 %44
 OpReturnValue %5
 %44 = OpLabel
 %46 = OpCompositeConstruct  %22  %6 %7
-%47 = OpCompositeExtract  %4  %35 3
-%48 = OpFDiv  %4  %5 %47
-%49 = OpCompositeExtract  %4  %35 0
-%50 = OpCompositeExtract  %4  %35 1
-%51 = OpCompositeConstruct  %22  %49 %50
-%52 = OpFMul  %22  %51 %46
-%53 = OpVectorTimesScalar  %22  %52 %48
+%47 = OpCompositeExtract  %4  %35 0
+%48 = OpCompositeExtract  %4  %35 1
+%49 = OpCompositeConstruct  %22  %47 %48
+%50 = OpFMul  %22  %49 %46
+%51 = OpCompositeExtract  %4  %35 3
+%52 = OpCompositeConstruct  %22  %51 %51
+%53 = OpFDiv  %22  %50 %52
 %54 = OpCompositeConstruct  %22  %6 %6
 %55 = OpFAdd  %22  %53 %54
 %57 = OpBitcast  %56  %34
 %58 = OpCompositeExtract  %4  %35 2
-%59 = OpFMul  %4  %58 %48
-%61 = OpCompositeExtract  %4  %55 0
-%62 = OpCompositeExtract  %4  %55 1
-%63 = OpConvertUToF  %4  %57
-%64 = OpCompositeConstruct  %23  %61 %62 %63
-%65 = OpSampledImage  %60  %38 %39
-%66 = OpImageSampleDrefExplicitLod  %4  %65 %64 %59 Lod %67
-OpReturnValue %66
+%59 = OpCompositeExtract  %4  %35 3
+%60 = OpFDiv  %4  %58 %59
+%62 = OpCompositeExtract  %4  %55 0
+%63 = OpCompositeExtract  %4  %55 1
+%64 = OpConvertUToF  %4  %57
+%65 = OpCompositeConstruct  %23  %62 %63 %64
+%66 = OpSampledImage  %61  %38 %39
+%67 = OpImageSampleDrefExplicitLod  %4  %66 %65 %60 Lod %68
+OpReturnValue %67
 OpFunctionEnd
-%81 = OpFunction  %2  None %82
-%72 = OpLabel
-%68 = OpVariable  %69  Function %24
-%70 = OpVariable  %71  Function %11
-%75 = OpLoad  %23  %73
-%78 = OpLoad  %16  %76
-%83 = OpLoad  %20  %29
-%84 = OpLoad  %21  %31
-OpBranch %85
-%85 = OpLabel
-%86 = OpExtInst  %23  %1 Normalize %75
-OpBranch %87
-%87 = OpLabel
-OpLoopMerge %88 %90 None
-OpBranch %89
-%89 = OpLabel
-%91 = OpLoad  %10  %70
-%94 = OpAccessChain  %92  %25 %93
-%95 = OpLoad  %13  %94
-%96 = OpCompositeExtract  %10  %95 0
-%97 = OpExtInst  %10  %1 UMin %96 %9
-%98 = OpUGreaterThanEqual  %42  %91 %97
-OpSelectionMerge %99 None
-OpBranchConditional %98 %100 %99
-%100 = OpLabel
+%82 = OpFunction  %2  None %83
+%73 = OpLabel
+%69 = OpVariable  %70  Function %24
+%71 = OpVariable  %72  Function %11
+%76 = OpLoad  %23  %74
+%79 = OpLoad  %16  %77
+%84 = OpLoad  %20  %29
+%85 = OpLoad  %21  %31
+OpBranch %86
+%86 = OpLabel
+%87 = OpExtInst  %23  %1 Normalize %76
 OpBranch %88
-%99 = OpLabel
-%102 = OpLoad  %10  %70
-%104 = OpAccessChain  %103  %27 %93 %102
-%105 = OpLoad  %17  %104
-%106 = OpLoad  %10  %70
-%107 = OpCompositeExtract  %15  %105 0
-%108 = OpMatrixTimesVector  %16  %107 %78
-%109 = OpFunctionCall  %4  %36 %106 %108
-%110 = OpCompositeExtract  %16  %105 1
-%111 = OpCompositeExtract  %4  %110 0
-%112 = OpCompositeExtract  %4  %110 1
-%113 = OpCompositeExtract  %4  %110 2
-%114 = OpCompositeConstruct  %23  %111 %112 %113
-%115 = OpCompositeExtract  %4  %78 0
-%116 = OpCompositeExtract  %4  %78 1
-%117 = OpCompositeExtract  %4  %78 2
-%118 = OpCompositeConstruct  %23  %115 %116 %117
-%119 = OpFSub  %23  %114 %118
-%120 = OpExtInst  %23  %1 Normalize %119
-%121 = OpDot  %4  %86 %120
-%122 = OpExtInst  %4  %1 FMax %3 %121
-%123 = OpLoad  %23  %68
-%124 = OpFMul  %4  %109 %122
-%125 = OpCompositeExtract  %16  %105 2
-%126 = OpCompositeExtract  %4  %125 0
-%127 = OpCompositeExtract  %4  %125 1
-%128 = OpCompositeExtract  %4  %125 2
-%129 = OpCompositeConstruct  %23  %126 %127 %128
-%130 = OpVectorTimesScalar  %23  %129 %124
-%131 = OpFAdd  %23  %123 %130
-OpStore %68 %131
+%88 = OpLabel
+OpLoopMerge %89 %91 None
 OpBranch %90
 %90 = OpLabel
-%132 = OpLoad  %10  %70
-%133 = OpIAdd  %10  %132 %12
-OpStore %70 %133
-OpBranch %87
-%88 = OpLabel
-%134 = OpLoad  %23  %68
-%135 = OpCompositeConstruct  %16  %134 %5
-OpStore %79 %135
+%92 = OpLoad  %10  %71
+%95 = OpAccessChain  %93  %25 %94
+%96 = OpLoad  %13  %95
+%97 = OpCompositeExtract  %10  %96 0
+%98 = OpExtInst  %10  %1 UMin %97 %9
+%99 = OpUGreaterThanEqual  %42  %92 %98
+OpSelectionMerge %100 None
+OpBranchConditional %99 %101 %100
+%101 = OpLabel
+OpBranch %89
+%100 = OpLabel
+%103 = OpLoad  %10  %71
+%105 = OpAccessChain  %104  %27 %94 %103
+%106 = OpLoad  %17  %105
+%107 = OpLoad  %10  %71
+%108 = OpCompositeExtract  %15  %106 0
+%109 = OpMatrixTimesVector  %16  %108 %79
+%110 = OpFunctionCall  %4  %36 %107 %109
+%111 = OpCompositeExtract  %16  %106 1
+%112 = OpCompositeExtract  %4  %111 0
+%113 = OpCompositeExtract  %4  %111 1
+%114 = OpCompositeExtract  %4  %111 2
+%115 = OpCompositeConstruct  %23  %112 %113 %114
+%116 = OpCompositeExtract  %4  %79 0
+%117 = OpCompositeExtract  %4  %79 1
+%118 = OpCompositeExtract  %4  %79 2
+%119 = OpCompositeConstruct  %23  %116 %117 %118
+%120 = OpFSub  %23  %115 %119
+%121 = OpExtInst  %23  %1 Normalize %120
+%122 = OpDot  %4  %87 %121
+%123 = OpExtInst  %4  %1 FMax %3 %122
+%124 = OpLoad  %23  %69
+%125 = OpFMul  %4  %110 %123
+%126 = OpCompositeExtract  %16  %106 2
+%127 = OpCompositeExtract  %4  %126 0
+%128 = OpCompositeExtract  %4  %126 1
+%129 = OpCompositeExtract  %4  %126 2
+%130 = OpCompositeConstruct  %23  %127 %128 %129
+%131 = OpVectorTimesScalar  %23  %130 %125
+%132 = OpFAdd  %23  %124 %131
+OpStore %69 %132
+OpBranch %91
+%91 = OpLabel
+%133 = OpLoad  %10  %71
+%134 = OpIAdd  %10  %133 %12
+OpStore %71 %134
+OpBranch %88
+%89 = OpLabel
+%135 = OpLoad  %23  %69
+%136 = OpCompositeConstruct  %16  %135 %5
+OpStore %80 %136
 OpReturn
 OpFunctionEnd


### PR DESCRIPTION
See https://github.com/gpuweb/gpuweb/pull/1611

This PR adds the `Expression::Splat` variant to the IR. This is useful, versus relying on `Expression::Compose`, since the splat is much more limited, and these expressions do not require heap allocated component lists.

This is fairly trivial to support in the backends.
As for the frontends, WGSL has a bit of (necessary) complexity to auto-detect splats and build the proper IR. SPV-in also has a small piece to detect when a splat is used.