### PR TITLE
Derive `Eq` for `msl::Options`

### DIFF
--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -126,7 +126,7 @@ enum LocationMode {
     Uniform,
 }
 
-#[derive(Clone, Debug, Hash, PartialEq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct Options {


### PR DESCRIPTION
Oops! We must have missed this one during refactoring. Needed for https://github.com/gfx-rs/gfx/pull/3719.