### PR TITLE
Validate composite constants

### DIFF
--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -850,21 +850,9 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                         let index_expr_data = &expressions[index_expr.handle];
                         let index_maybe = match *index_expr_data {
                             crate::Expression::Constant(const_handle) => {
-                                match const_arena[const_handle].inner {
-                                    crate::ConstantInner::Scalar {
-                                        width: _,
-                                        value: crate::ScalarValue::Uint(v),
-                                    } => Some(v as u32),
-                                    crate::ConstantInner::Scalar {
-                                        width: _,
-                                        value: crate::ScalarValue::Sint(v),
-                                    } => Some(v as u32),
-                                    _ => {
-                                        return Err(Error::InvalidAccess(
-                                            crate::Expression::Constant(const_handle),
-                                        ))
-                                    }
-                                }
+                                Some(const_arena[const_handle].to_array_length().ok_or(
+                                    Error::InvalidAccess(crate::Expression::Constant(const_handle)),
+                                )?)
                             }
                             _ => None,
                         };

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -62,6 +62,18 @@ impl Clone for TypeResolution {
     }
 }
 
+impl crate::ConstantInner {
+    pub fn resolve_type(&self) -> TypeResolution {
+        match *self {
+            Self::Scalar { width, ref value } => TypeResolution::Value(crate::TypeInner::Scalar {
+                kind: value.scalar_kind(),
+                width,
+            }),
+            Self::Composite { ty, components: _ } => TypeResolution::Handle(ty),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Error, PartialEq)]
 pub enum ResolveError {
     #[error("Index {index} is out of bounds for expression {expr:?}")]

--- a/src/valid/compose.rs
+++ b/src/valid/compose.rs
@@ -1,0 +1,131 @@
+use crate::{
+    arena::{Arena, Handle},
+    proc::TypeResolution,
+};
+
+#[derive(Clone, Debug, thiserror::Error)]
+#[cfg_attr(test, derive(PartialEq))]
+pub enum ComposeError {
+    #[error("Compose type {0:?} doesn't exist")]
+    TypeDoesntExist(Handle<crate::Type>),
+    #[error("Composing of type {0:?} can't be done")]
+    Type(Handle<crate::Type>),
+    #[error("Composing expects {expected} components but {given} were given")]
+    ComponentCount { given: u32, expected: u32 },
+    #[error("Composing {index}'s component type is not expected")]
+    ComponentType { index: u32 },
+}
+
+pub fn validate_compose(
+    self_ty_handle: Handle<crate::Type>,
+    constant_arena: &Arena<crate::Constant>,
+    type_arena: &Arena<crate::Type>,
+    component_resolutions: impl ExactSizeIterator<Item = TypeResolution>,
+) -> Result<(), ComposeError> {
+    use crate::TypeInner as Ti;
+
+    let self_ty = type_arena
+        .try_get(self_ty_handle)
+        .ok_or(ComposeError::TypeDoesntExist(self_ty_handle))?;
+    match self_ty.inner {
+        // vectors are composed from scalars or other vectors
+        Ti::Vector { size, kind, width } => {
+            let mut total = 0;
+            for (index, comp_res) in component_resolutions.enumerate() {
+                total += match *comp_res.inner_with(type_arena) {
+                    Ti::Scalar {
+                        kind: comp_kind,
+                        width: comp_width,
+                    } if comp_kind == kind && comp_width == width => 1,
+                    Ti::Vector {
+                        size: comp_size,
+                        kind: comp_kind,
+                        width: comp_width,
+                    } if comp_kind == kind && comp_width == width => comp_size as u32,
+                    ref other => {
+                        log::error!("Vector component[{}] type {:?}", index, other);
+                        return Err(ComposeError::ComponentType {
+                            index: index as u32,
+                        });
+                    }
+                };
+            }
+            if size as u32 != total {
+                return Err(ComposeError::ComponentCount {
+                    expected: size as u32,
+                    given: total,
+                });
+            }
+        }
+        // matrix are composed from column vectors
+        Ti::Matrix {
+            columns,
+            rows,
+            width,
+        } => {
+            let inner = Ti::Vector {
+                size: rows,
+                kind: crate::ScalarKind::Float,
+                width,
+            };
+            if columns as usize != component_resolutions.len() {
+                return Err(ComposeError::ComponentCount {
+                    expected: columns as u32,
+                    given: component_resolutions.len() as u32,
+                });
+            }
+            for (index, comp_res) in component_resolutions.enumerate() {
+                if comp_res.inner_with(type_arena) != &inner {
+                    log::error!("Matrix component[{}] type {:?}", index, comp_res);
+                    return Err(ComposeError::ComponentType {
+                        index: index as u32,
+                    });
+                }
+            }
+        }
+        Ti::Array {
+            base,
+            size: crate::ArraySize::Constant(handle),
+            stride: _,
+        } => {
+            let count = constant_arena[handle].to_array_length().unwrap();
+            if count as usize != component_resolutions.len() {
+                return Err(ComposeError::ComponentCount {
+                    expected: count,
+                    given: component_resolutions.len() as u32,
+                });
+            }
+            for (index, comp_res) in component_resolutions.enumerate() {
+                if comp_res.inner_with(type_arena) != &type_arena[base].inner {
+                    log::error!("Array component[{}] type {:?}", index, comp_res);
+                    return Err(ComposeError::ComponentType {
+                        index: index as u32,
+                    });
+                }
+            }
+        }
+        Ti::Struct { ref members, .. } => {
+            if members.len() != component_resolutions.len() {
+                return Err(ComposeError::ComponentCount {
+                    given: component_resolutions.len() as u32,
+                    expected: members.len() as u32,
+                });
+            }
+            for (index, (member, comp_res)) in members.iter().zip(component_resolutions).enumerate()
+            {
+                if comp_res.inner_with(type_arena) != &type_arena[member.ty].inner {
+                    log::error!("Struct component[{}] type {:?}", index, comp_res);
+                    return Err(ComposeError::ComponentType {
+                        index: index as u32,
+                    });
+                }
+            }
+        }
+        ref other => {
+            log::error!("Composing of {:?}", other);
+            return Err(ComposeError::Type(self_ty_handle));
+        }
+    }
+
+    Ok(())
+}

--- a/tests/out/collatz.info.ron
+++ b/tests/out/collatz.info.ron
@@ -2,7 +2,7 @@
     functions: [
         (
             flags: (
-                bits: 15,
+                bits: 31,
             ),
             available_stages: (
                 bits: 7,
@@ -341,7 +341,7 @@
     entry_points: [
         (
             flags: (
-                bits: 15,
+                bits: 31,
             ),
             available_stages: (
                 bits: 7,

--- a/tests/out/shadow.info.ron
+++ b/tests/out/shadow.info.ron
@@ -2,7 +2,7 @@
     functions: [
         (
             flags: (
-                bits: 15,
+                bits: 31,
             ),
             available_stages: (
                 bits: 7,
@@ -1063,7 +1063,7 @@
         ),
         (
             flags: (
-                bits: 15,
+                bits: 31,
             ),
             available_stages: (
                 bits: 7,
@@ -2753,7 +2753,7 @@
     entry_points: [
         (
             flags: (
-                bits: 15,
+                bits: 31,
             ),
             available_stages: (
                 bits: 7,


### PR DESCRIPTION
Fixes #726 
Here is what it says now:
> Constant [25] 'XYZ2RGB' is invalid:
	Composing expects 3 components but 9 were given
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', bin/convert.rs:219:61

Note: we'll likely need to allow this particular case in WGSL. That's not the point of this PR. Instead, it tries to cover the gap we had in the composite constant validation, and share this code with composite expressions.