### PR TITLE
Use fmt::Writer instead of io::Writer for glsl and hlsl backend

### DIFF
--- a/bin/convert.rs
+++ b/bin/convert.rs
@@ -237,23 +237,12 @@ fn main() {
                 _ => unreachable!(),
             };
 
-            let file = fs::OpenOptions::new()
-                .write(true)
-                .truncate(true)
-                .create(true)
-                .open(output_path)
-                .unwrap();
-
-            let mut writer = glsl::Writer::new(file, &module, info.as_ref().unwrap(), &params.glsl)
-                .unwrap_pretty();
-
-            writer
-                .write()
-                .map_err(|e| {
-                    fs::remove_file(output_path).unwrap();
-                    e
-                })
-                .unwrap();
+            let mut buffer = String::new();
+            let mut writer =
+                glsl::Writer::new(&mut buffer, &module, info.as_ref().unwrap(), &params.glsl)
+                    .unwrap_pretty();
+            writer.write().unwrap();
+            fs::write(output_path, buffer).unwrap();
         }
         #[cfg(feature = "dot-out")]
         "dot" => {

--- a/src/back/glsl/features.rs
+++ b/src/back/glsl/features.rs
@@ -3,7 +3,7 @@ use crate::{
     Binding, Bytes, Handle, ImageClass, ImageDimension, Interpolation, Sampling, ScalarKind,
     ShaderStage, StorageClass, StorageFormat, Type, TypeInner,
 };
-use std::io::Write;
+use std::fmt::Write;
 
 bitflags::bitflags! {
     /// Structure used to encode a set of additions to glsl that aren't supported by all versions

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -57,7 +57,7 @@ use features::FeaturesManager;
 use std::{
     cmp::Ordering,
     fmt,
-    io::{Error as IoError, Write},
+    fmt::{Error as FmtError, Write},
 };
 use thiserror::Error;
 
@@ -271,8 +271,8 @@ type BackendResult = Result<(), Error>;
 #[derive(Debug, Error)]
 pub enum Error {
     /// A error occurred while writing to the output
-    #[error("I/O error")]
-    IoError(#[from] IoError),
+    #[error("Format error")]
+    FmtError(#[from] FmtError),
     /// The specified [`Version`](Version) doesn't have all required [`Features`](super)
     ///
     /// Contains the missing [`Features`](Features)

--- a/src/back/hlsl/mod.rs
+++ b/src/back/hlsl/mod.rs
@@ -1,8 +1,7 @@
 mod keywords;
 mod writer;
 
-use std::io::Error as IoError;
-use std::string::FromUtf8Error;
+use std::fmt::Error as FmtError;
 use thiserror::Error;
 
 pub use writer::Writer;
@@ -10,14 +9,12 @@ pub use writer::Writer;
 #[derive(Error, Debug)]
 pub enum Error {
     #[error(transparent)]
-    IoError(#[from] IoError),
-    #[error(transparent)]
-    Utf8(#[from] FromUtf8Error),
+    IoError(#[from] FmtError),
 }
 
 pub fn write_string(module: &crate::Module) -> Result<String, Error> {
-    let mut w = Writer::new(Vec::new());
+    let mut w = Writer::new(String::new());
     w.write(module)?;
-    let output = String::from_utf8(w.finish())?;
+    let output = w.finish();
     Ok(output)
 }

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -2,7 +2,7 @@ use super::Error;
 use crate::back::hlsl::keywords::RESERVED;
 use crate::proc::{NameKey, Namer};
 use crate::FastHashMap;
-use std::io::Write;
+use std::fmt::Write;
 
 const INDENT: &str = "    ";
 

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -189,14 +189,12 @@ fn check_output_glsl(
         entry_point: ep_name.to_string(),
     };
 
-    let mut buffer = Vec::new();
+    let mut buffer = String::new();
     let mut writer = glsl::Writer::new(&mut buffer, module, info, &options).unwrap();
     writer.write().unwrap();
 
-    let string = String::from_utf8(buffer).unwrap();
-
     let ext = format!("{:?}.glsl", stage);
-    fs::write(destination.with_extension(&ext), string).unwrap();
+    fs::write(destination.with_extension(&ext), buffer).unwrap();
 }
 
 #[cfg(feature = "hlsl-out")]


### PR DESCRIPTION
As discussed in https://github.com/gfx-rs/naga/pull/727.

`wgsl-out` will be fixed in another PR.