### PR TITLE
[Metal] Impl `Expression::Splat`

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -608,8 +608,17 @@ impl<W: Write> Writer<W> {
                 };
                 write!(self.out, "{}", coco)?;
             }
-            crate::Expression::Splat { size: _, value } => {
+            crate::Expression::Splat { size, value } => {
+                let scalar_kind = match *context.resolve_type(value) {
+                    crate::TypeInner::Scalar { kind, .. } => kind,
+                    _ => unreachable!()
+                };
+                let scalar = scalar_kind_string(scalar_kind);
+                let size = vector_size_string(size);
+
+                write!(self.out, "{}{}(", scalar, size)?;
                 self.put_expression(value, context, is_scoped)?;
+                write!(self.out, ")")?;
             }
             crate::Expression::Compose { ty, ref components } => {
                 let inner = &context.module.types[ty].inner;

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -611,13 +611,13 @@ impl<W: Write> Writer<W> {
             crate::Expression::Splat { size, value } => {
                 let scalar_kind = match *context.resolve_type(value) {
                     crate::TypeInner::Scalar { kind, .. } => kind,
-                    _ => unreachable!()
+                    _ => return Err(Error::Validation)
                 };
                 let scalar = scalar_kind_string(scalar_kind);
                 let size = vector_size_string(size);
 
                 write!(self.out, "{}{}(", scalar, size)?;
-                self.put_expression(value, context, is_scoped)?;
+                self.put_expression(value, context, true)?;
                 write!(self.out, ")")?;
             }
             crate::Expression::Compose { ty, ref components } => {

--- a/tests/out/access.msl
+++ b/tests/out/access.msl
@@ -11,5 +11,5 @@ struct fooOutput {
 vertex fooOutput foo(
   metal::uint vi [[vertex_id]]
 ) {
-    return fooOutput { static_cast<float4>(type3 {1, 2, 3, 4, 5}[vi]) };
+    return fooOutput { static_cast<float4>(int4(type3 {1, 2, 3, 4, 5}[vi])) };
 }

--- a/tests/out/boids.msl
+++ b/tests/out/boids.msl
@@ -73,10 +73,10 @@ kernel void main1(
         }
     }
     if (cMassCount > 0) {
-        cMass = (cMass / static_cast<float>(cMassCount)) - vPos;
+        cMass = (cMass / float2(static_cast<float>(cMassCount))) - vPos;
     }
     if (cVelCount > 0) {
-        cVel = cVel / static_cast<float>(cVelCount);
+        cVel = cVel / float2(static_cast<float>(cVelCount));
     }
     vVel = ((vVel + (cMass * params.rule1Scale)) + (colVel * params.rule2Scale)) + (cVel * params.rule3Scale);
     vVel = metal::normalize(vVel) * metal::clamp(metal::length(vVel), 0.0, 0.1);

--- a/tests/out/operators.msl
+++ b/tests/out/operators.msl
@@ -7,6 +7,6 @@ struct splatOutput {
 };
 vertex splatOutput splat(
 ) {
-    metal::float2 _e10 = ((1.0 + 2.0) - 3.0) / 4.0;
-    return splatOutput { metal::float4(_e10.x, _e10.y, _e10.x, _e10.y) + static_cast<float4>(5 % 2) };
+    metal::float2 _e10 = ((float2(1.0) + float2(2.0)) - float2(3.0)) / float2(4.0);
+    return splatOutput { metal::float4(_e10.x, _e10.y, _e10.x, _e10.y) + static_cast<float4>(int4(5) % int4(2)) };
 }

--- a/tests/out/shadow.msl
+++ b/tests/out/shadow.msl
@@ -25,7 +25,7 @@ float fetch_shadow(
     if (homogeneous_coords.w <= 0.0) {
         return 1.0;
     }
-    float _e28 = t_shadow.sample_compare(sampler_shadow, ((metal::float2(homogeneous_coords.x, homogeneous_coords.y) * metal::float2(0.5, -0.5)) / homogeneous_coords.w) + metal::float2(0.5, 0.5), static_cast<int>(light_id), homogeneous_coords.z / homogeneous_coords.w);
+    float _e28 = t_shadow.sample_compare(sampler_shadow, ((metal::float2(homogeneous_coords.x, homogeneous_coords.y) * metal::float2(0.5, -0.5)) / float2(homogeneous_coords.w)) + metal::float2(0.5, 0.5), static_cast<int>(light_id), homogeneous_coords.z / homogeneous_coords.w);
     return _e28;
 }
 


### PR DESCRIPTION
As an example of how this is used, this now means that the following can compile:
```glsl
#version 450

layout(location = 0) flat in uvec4 xyz;

layout(location = 0) out uvec4 colour;

void main() {
    colour = xyz >> 2;
}
```
->
```metal
#include <metal_stdlib>
#include <simd/simd.h>


void main1(
    thread metal::uint4& colour,
    thread metal::uint4 const& xyz
) {
    colour = xyz >> as_type<uint4>(int4(2));
    return;
}

struct main2Input {
    metal::uint4 xyz1 [[user(loc0), flat]];
};
struct main2Output {
    metal::uint4 member [[color(0)]];
};
fragment main2Output main2(
  main2Input varyings [[stage_in]]
) {
    metal::uint4 colour = {};
    metal::uint4 xyz = {};
    const auto xyz1 = varyings.xyz1;
    xyz = xyz1;
    main1(colour, xyz);
    return main2Output { colour };
}
```
(The `int4` is `glslc` being bad)