### PR TITLE
WGSL trailing commas

### DIFF
--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -314,6 +314,24 @@ impl<'a> Lexer<'a> {
         self.expect(Token::Paren('>'))?;
         Ok(format)
     }
+
+    pub(super) fn open_arguments(&mut self) -> Result<(), Error<'a>> {
+        self.expect(Token::Paren('('))
+    }
+
+    pub(super) fn close_arguments(&mut self) -> Result<(), Error<'a>> {
+        let _ = self.skip(Token::Separator(','));
+        self.expect(Token::Paren(')'))
+    }
+
+    pub(super) fn next_argument(&mut self) -> Result<bool, Error<'a>> {
+        let paren = Token::Paren(')');
+        if self.skip(Token::Separator(',')) {
+            Ok(!self.skip(paren))
+        } else {
+            self.expect(paren).map(|()| false)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -1,5 +1,4 @@
-use super::{conv, Error, Token, TokenSpan};
-use std::ops::Range;
+use super::{conv, Error, Span, Token, TokenSpan};
 
 fn _consume_str<'a>(input: &'a str, what: &str) -> Option<&'a str> {
     if input.starts_with(what) {
@@ -168,6 +167,10 @@ impl<'a> Lexer<'a> {
         }
     }
 
+    pub(super) fn _leftover_span(&self) -> Span {
+        self.source.len() - self.input.len()..self.source.len()
+    }
+
     fn peek_token_and_rest(&mut self) -> (TokenSpan<'a>, &'a str) {
         let mut cloned = self.clone();
         let token = cloned.next();
@@ -256,7 +259,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    pub(super) fn next_ident_with_span(&mut self) -> Result<(&'a str, Range<usize>), Error<'a>> {
+    pub(super) fn next_ident_with_span(&mut self) -> Result<(&'a str, Span), Error<'a>> {
         match self.next() {
             (Token::Word(word), span) => Ok((word, span)),
             other => Err(Error::Unexpected(other, "identifier")),

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1048,6 +1048,7 @@ impl Parser {
                 )?;
 
                 lexer.open_arguments()?;
+                //Note: this expects at least one argument
                 let mut components = Vec::new();
                 while components.is_empty() || lexer.next_argument()? {
                     let component = self.parse_const_expression(lexer, type_arena, const_arena)?;
@@ -2206,8 +2207,12 @@ impl Parser {
                             // parse a list of values
                             let value = loop {
                                 let value = lexer.next_sint_literal()?;
-                                let _ = lexer.skip(Token::Separator(','));
-                                if lexer.skip(Token::Separator(':')) {
+                                if lexer.skip(Token::Separator(',')) {
+                                    if lexer.skip(Token::Separator(':')) {
+                                        break value;
+                                    }
+                                } else {
+                                    lexer.expect(Token::Separator(':'))?;
                                     break value;
                                 }
                                 cases.push(crate::SwitchCase {

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -2205,22 +2205,18 @@ impl Parser {
                     // cases + default
                     match lexer.next() {
                         (Token::Word("case"), _) => {
+                            // parse a list of values
                             let value = loop {
-                                // values
                                 let value = lexer.next_sint_literal()?;
-                                match lexer.next() {
-                                    (Token::Separator(','), _) => {
-                                        cases.push(crate::SwitchCase {
-                                            value,
-                                            body: Vec::new(),
-                                            fall_through: true,
-                                        });
-                                    }
-                                    (Token::Separator(':'), _) => break value,
-                                    other => {
-                                        return Err(Error::Unexpected(other, "case separator"))
-                                    }
+                                let _ = lexer.skip(Token::Separator(','));
+                                if lexer.skip(Token::Separator(':')) {
+                                    break value;
                                 }
+                                cases.push(crate::SwitchCase {
+                                    value,
+                                    body: Vec::new(),
+                                    fall_through: true,
+                                });
                             };
 
                             let mut body = Vec::new();

--- a/tests/in/quad.wgsl
+++ b/tests/in/quad.wgsl
@@ -7,7 +7,10 @@ struct VertexOutput {
 };
 
 [[stage(vertex)]]
-fn main([[location(0)]] pos : vec2<f32>, [[location(1)]] uv : vec2<f32>) -> VertexOutput {
+fn main(
+  [[location(0)]] pos : vec2<f32>,
+  [[location(1)]] uv : vec2<f32>,
+) -> VertexOutput {
   return VertexOutput(uv, vec4<f32>(c_scale * pos, 0.0, 1.0));
 }
 

--- a/tests/in/skybox.wgsl
+++ b/tests/in/skybox.wgsl
@@ -20,7 +20,7 @@ fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> VertexOutput {
         f32(tmp1) * 4.0 - 1.0,
         f32(tmp2) * 4.0 - 1.0,
         0.0,
-        1.0
+        1.0,
     );
 
     let inv_model_view = transpose(mat3x3<f32>(r_data.view.x.xyz, r_data.view.y.xyz, r_data.view.z.xyz));


### PR DESCRIPTION
Matches https://github.com/gpuweb/gpuweb/pull/1493

First, I tried to build a helper `ArgumentList` class to contain the logic of argument iteration, but it turns out to be quite hairy. I ended up with this approach where `Lexer` just have a few helpers to deal with the parens and trailing commas, and it seems to be mostly ok.