### PR TITLE
Don't print the module in converter if no output is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Front-end       |       Status       | Feature | Notes |
 --------------- | ------------------ | ------- | ----- |
 SPIR-V (binary) | :white_check_mark: | spv-in  |       |
 WGSL            | :white_check_mark: | wgsl-in |       |
-GLSL            | :ok:               | glsl-in | Vulkan flavor is expected |
+GLSL            | :construction:     | glsl-in | Vulkan flavor is expected |
 Rust            |                    |         |       |
 
 Back-end        |       Status       | Feature  | Notes |
@@ -36,7 +36,8 @@ DOT (GraphViz)  | :ok:               | dot-out  | Not a shading language |
 
 Naga includes a default binary target "convert", which allows to test the conversion of different code paths.
 ```bash
-cargo run --features spv-in -- my_shader.spv # dump the IR module to debug output
+cargo run --features wgsl-in -- my_shader.wgsl # validate only
+cargo run --features spv-in -- my_shader.spv - # dump the IR module to debug output
 cargo run --features spv-in,msl-out -- my_shader.spv my_shader.metal --flow-dir flow-dir # convert the SPV to Metal, also dump the SPIR-V flow graph to `flow-dir`
 cargo run --features wgsl-in,glsl-out -- my_shader.wgsl my_shader.vert --profile es310 # convert the WGSL to GLSL vertex stage under ES 3.20 profile
 ```

--- a/bin/convert.rs
+++ b/bin/convert.rs
@@ -23,10 +23,10 @@ trait PrettyResult {
 }
 
 fn print_err(error: impl Error) {
-    println!("{}:", error);
+    eprintln!("{}:", error);
     let mut e = error.source();
     while let Some(source) = e {
-        println!("\t{}", source);
+        eprintln!("\t{}", source);
         e = source.source();
     }
 }
@@ -174,7 +174,6 @@ fn main() {
     };
 
     // validate the IR
-    #[allow(unused_variables)]
     let info =
         match naga::valid::Validator::new(naga::valid::ValidationFlags::all()).validate(&module) {
             Ok(info) => Some(info),
@@ -187,11 +186,20 @@ fn main() {
     let output_path = match output_path {
         Some(ref string) => string,
         None => {
-            println!("{:#?}", module);
-            println!("{:#?}", info);
+            if info.is_some() {
+                println!("Validation successful");
+            }
             return;
         }
     };
+    if output_path == "-" {
+        println!("{:#?}", module);
+        if let Some(info) = info {
+            println!();
+            println!("{:#?}", info);
+        }
+        return;
+    }
 
     match Path::new(output_path)
         .extension()


### PR DESCRIPTION
This is follow-up from https://github.com/gfx-rs/naga/pull/742#discussion_r617075895
It contains a number of small but important improvements, especially now that the binary is a part of the upcoming release, and people may use it via `cargo install naga`:
  - if no output argument is specified, we only validate the module, we don't print the IR out
  - if it's a success, we are explicitly printing "Validation successful" now. Otherwise it's not obvious if something happened or not.
  - to print the IR out, one would specify "-" as the output. That is similar to existing tools, like the Metal compiler (where it's treated as "accept input from stdin").
  - the validation errors are printed in stderr, so that they don't get mixed into the console output. One can redirect the IR into a file and still see the validation errors in the console