### PR TITLE
[glsl-in] small usability fixes

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -235,7 +235,17 @@ impl Context {
     /// Add variable to current scope
     pub fn add_local_var(&mut self, name: String, handle: Handle<Expression>) {
         if let Some(current) = self.scopes.last_mut() {
-            (*current).insert(name, handle);
+            let expr = self
+                .expressions
+                .append(Expression::Load { pointer: handle });
+            (*current).insert(name, expr);
+        }
+    }
+
+    /// Add function argument to current scope
+    pub fn add_function_arg(&mut self, name: String, expr: Handle<Expression>) {
+        if let Some(current) = self.scopes.last_mut() {
+            (*current).insert(name, expr);
         }
     }
 

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -131,6 +131,35 @@ impl Program<'_> {
                             Err(ErrorKind::SemanticError("Bad call to texture".into()))
                         }
                     }
+                    "textureLod" => {
+                        if fc.args.len() != 3 {
+                            return Err(ErrorKind::WrongNumberArgs(name, 3, fc.args.len()));
+                        }
+                        if let Some(sampler) = fc.args[0].sampler {
+                            Ok(ExpressionRule {
+                                expression: self.context.expressions.append(
+                                    Expression::ImageSample {
+                                        image: fc.args[0].expression,
+                                        sampler,
+                                        coordinate: fc.args[1].expression,
+                                        array_index: None, //TODO
+                                        offset: None,      //TODO
+                                        level: SampleLevel::Exact(fc.args[2].expression),
+                                        depth_ref: None,
+                                    },
+                                ),
+                                sampler: None,
+                                statements: fc
+                                    .args
+                                    .into_iter()
+                                    .map(|a| a.statements)
+                                    .flatten()
+                                    .collect(),
+                            })
+                        } else {
+                            Err(ErrorKind::SemanticError("Bad call to textureLod".into()))
+                        }
+                    }
                     "ceil" | "round" | "floor" | "fract" | "trunc" | "sin" | "abs" | "sqrt"
                     | "inversesqrt" | "exp" | "exp2" | "sign" | "transpose" | "inverse"
                     | "normalize" => {

--- a/src/front/glsl/mod.rs
+++ b/src/front/glsl/mod.rs
@@ -1,3 +1,7 @@
+pub use error::ErrorKind;
+pub use parser::Token;
+pub use token::TokenMetadata;
+
 use crate::{FastHashMap, Module, ShaderStage};
 
 mod lex;

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -1052,7 +1052,7 @@ pomelo! {
         for (pos, arg) in args.into_iter().enumerate() {
             if let Some(name) = arg.name.clone() {
                 let exp = extra.context.expressions.append(Expression::FunctionArgument(pos as u32));
-                extra.context.add_local_var(name, exp);
+                extra.context.add_function_arg(name, exp);
             }
             extra.context.arguments.push(arg);
         }

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -1079,8 +1079,8 @@ pomelo! {
         FunctionArgument { name: Some(n.1), ty, binding: None }
     }
     // parameter_declarator ::= type_specifier(ty) Identifier(ident) array_specifier;
-    parameter_declaration ::= parameter_declarator;
-    parameter_declaration ::= parameter_type_specifier(ty) {
+    parameter_declaration ::= In? parameter_declarator(arg) { arg };
+    parameter_declaration ::= In? parameter_type_specifier(ty) {
         FunctionArgument { name: None, ty, binding: None }
     }
 


### PR DESCRIPTION
- Export some type to allow for error handling for the user
- Load local variables
- Fix type constructors with a single argument
- Add `textureLod` function
- Add support for the `in` keyword in function parameters