### PR TITLE
[msl-out] wrap arrays in structs so that they can be returned by functions

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -576,10 +576,10 @@ impl<W: Write> Writer<W> {
                             base: pointer_base,
                             class,
                         } => match context.module.types[pointer_base].inner {
-                            crate::TypeInner::Array { .. } => {
-                                class == crate::StorageClass::Function
-                                    || class == crate::StorageClass::Private
-                            }
+                            crate::TypeInner::Array {
+                                size: crate::ArraySize::Constant(_),
+                                ..
+                            } => true,
                             _ => false,
                         },
                         _ => false,

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -578,7 +578,7 @@ impl<W: Write> Writer<W> {
                     write!(self.out, ",")?;
                 }
                 self.put_expression(component, context, false)?;
-                write!(self.out, ".inner[{}]", j)?;
+                write!(self.out, ".{}[{}]", WRAPPED_ARRAY_FIELD, j)?;
             }
             write!(self.out, "}}")?;
         } else {
@@ -614,8 +614,8 @@ impl<W: Write> Writer<W> {
                         crate::TypeInner::Pointer {
                             base: pointer_base,
                             class,
-                        } => match &context.module.types[pointer_base].inner {
-                            &crate::TypeInner::Array { .. } => {
+                        } => match context.module.types[pointer_base].inner {
+                            crate::TypeInner::Array { .. } => {
                                 class == crate::StorageClass::Function
                                     || class == crate::StorageClass::Private
                             }
@@ -1194,7 +1194,11 @@ impl<W: Write> Writer<W> {
                                     if j != 0 {
                                         write!(self.out, ",")?;
                                     }
-                                    write!(self.out, "{}.{}.inner[{}]", tmp, name, j)?;
+                                    write!(
+                                        self.out,
+                                        "{}.{}.{}[{}]",
+                                        tmp, name, WRAPPED_ARRAY_FIELD, j
+                                    )?;
                                 }
                                 write!(self.out, "}}")?;
                             } else {
@@ -2016,11 +2020,11 @@ impl<W: Write> Writer<W> {
                         {
                             continue;
                         }
-                        let array_len = match &module.types[ty].inner {
+                        let array_len = match module.types[ty].inner {
                             crate::TypeInner::Array {
                                 size: crate::ArraySize::Constant(handle),
                                 ..
-                            } => module.constants[*handle].to_array_length(),
+                            } => module.constants[handle].to_array_length(),
                             _ => None,
                         };
                         let resolved = options.resolve_local_binding(binding, out_mode)?;

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -566,8 +566,7 @@ impl<W: Write> Writer<W> {
                     match *context.info[base].ty.inner_with(&context.module.types) {
                         crate::TypeInner::Array { .. } => true,
                         crate::TypeInner::Pointer {
-                            base: pointer_base,
-                            class,
+                            base: pointer_base, ..
                         } => match context.module.types[pointer_base].inner {
                             crate::TypeInner::Array {
                                 size: crate::ArraySize::Constant(_),

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -81,12 +81,9 @@ impl<'a> Display for TypeContext<'a> {
             }
             crate::TypeInner::Pointer { base, class } => {
                 let sub = Self {
-                    arena: self.arena,
-                    names: self.names,
                     handle: base,
-                    usage: self.usage,
-                    access: self.access,
                     first_time: false,
+                    ..*self
                 };
                 let class_name = match class.get_name(self.usage) {
                     Some(name) => name,
@@ -127,12 +124,9 @@ impl<'a> Display for TypeContext<'a> {
             }
             crate::TypeInner::Array { base, .. } => {
                 let sub = Self {
-                    arena: self.arena,
-                    names: self.names,
                     handle: base,
-                    usage: self.usage,
-                    access: self.access,
                     first_time: false,
+                    ..*self
                 };
                 // Array lengths go at the end of the type definition,
                 // so just print the element type here.
@@ -626,10 +620,9 @@ impl<W: Write> Writer<W> {
 
                 self.put_expression(base, context, false)?;
                 if accessing_wrapped_array {
-                    write!(self.out, ".{}[", WRAPPED_ARRAY_FIELD)?;
-                } else {
-                    write!(self.out, "[")?;
+                    write!(self.out, ".{}", WRAPPED_ARRAY_FIELD)?;
                 }
+                write!(self.out, "[")?;
                 self.put_expression(index, context, true)?;
                 write!(self.out, "]")?;
             }

--- a/tests/out/access.msl
+++ b/tests/out/access.msl
@@ -1,7 +1,9 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-typedef int type3[5];
+struct type3 {
+    int inner[5];
+};
 
 struct fooInput {
 };
@@ -11,5 +13,5 @@ struct fooOutput {
 vertex fooOutput foo(
   metal::uint vi [[vertex_id]]
 ) {
-    return fooOutput { static_cast<float4>(int4(type3 {1, 2, 3, 4, 5}[vi])) };
+    return fooOutput { static_cast<float4>(int4(type3 {1, 2, 3, 4, 5}.inner[vi])) };
 }

--- a/tests/out/quad-vert.msl
+++ b/tests/out/quad-vert.msl
@@ -51,6 +51,6 @@ vertex main2Output main2(
     a_uv = a_uv1;
     a_pos = a_pos1;
     main1(v_uv, a_uv, _, a_pos);
-    const auto _tmp = type10 {v_uv, _.gl_Position, _.gl_PointSize, {_.gl_ClipDistance.inner[0]}};
+    const auto _tmp = type10 {v_uv, _.gl_Position, _.gl_PointSize, _.gl_ClipDistance};
     return main2Output { _tmp.member, _tmp.gl_Position1, _tmp.gl_PointSize1, {_tmp.gl_ClipDistance1.inner[0]} };
 }

--- a/tests/out/quad-vert.msl
+++ b/tests/out/quad-vert.msl
@@ -37,7 +37,7 @@ struct main2Output {
     metal::float2 member [[user(loc0), center_perspective]];
     metal::float4 gl_Position1 [[position]];
     float gl_PointSize1 [[point_size]];
-    type6 gl_ClipDistance1 [[clip_distance]];
+    float gl_ClipDistance1 [[clip_distance]] [1];
 };
 vertex main2Output main2(
   main2Input varyings [[stage_in]]
@@ -51,6 +51,6 @@ vertex main2Output main2(
     a_uv = a_uv1;
     a_pos = a_pos1;
     main1(v_uv, a_uv, _, a_pos);
-    const auto _tmp = type10 {v_uv, _.gl_Position, _.gl_PointSize, {_.gl_ClipDistance[0]}};
-    return main2Output { _tmp.member, _tmp.gl_Position1, _tmp.gl_PointSize1, {_tmp.gl_ClipDistance1[0]} };
+    const auto _tmp = type10 {v_uv, _.gl_Position, _.gl_PointSize, {_.gl_ClipDistance.inner[0]}};
+    return main2Output { _tmp.member, _tmp.gl_Position1, _tmp.gl_PointSize1, {_tmp.gl_ClipDistance1.inner[0]} };
 }

--- a/tests/out/quad-vert.msl
+++ b/tests/out/quad-vert.msl
@@ -1,7 +1,9 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-typedef float type6[1u];
+struct type6 {
+    float inner[1u];
+};
 struct gl_PerVertex {
     metal::float4 gl_Position;
     float gl_PointSize;


### PR DESCRIPTION
This fixes https://github.com/gfx-rs/naga/issues/741. Unfortunately it currently breaks the `quad-vert.msl` snapshot with this error:
```
Validating quad-vert.msl
<stdin>:40:30: error: type 'type6' is not valid for attribute 'clip_distance'
    type6 gl_ClipDistance1 [[clip_distance]];
                             ^~~~~~~~~~~~~
<stdin>:42:8: error: invalid return type 'main2Output' for vertex function
vertex main2Output main2(
       ^
<stdin>:54:86: error: type 'type6' does not provide a subscript operator
    const auto _tmp = type10 {v_uv, _.gl_Position, _.gl_PointSize, {_.gl_ClipDistance[0]}};
                                                                    ~~~~~~~~~~~~~~~~~^~
3 errors generated.
```
This right solution to fix this test would be for `gl_ClipDistance` to be treated as a `float` instead of a `float[1]` in `msl-out`.
