### PR TITLE
[spv-in] work around sign differences in OpIAdd and OpISubtract

### DIFF
--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -693,6 +693,16 @@ impl super::Validator {
                     }
                 };
                 if !good {
+                    log::error!(
+                        "Left: {:?} of type {:?}",
+                        function.expressions[left],
+                        left_inner
+                    );
+                    log::error!(
+                        "Right: {:?} of type {:?}",
+                        function.expressions[right],
+                        right_inner
+                    );
                     return Err(ExpressionError::InvalidBinaryOperandTypes(op, left, right));
                 }
                 ShaderStages::all()


### PR DESCRIPTION
Part of  #620, covering the add and subtract