### PR TITLE
Add `MathFunction::Refract`

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1941,6 +1941,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     Mf::Normalize => "normalize",
                     Mf::FaceForward => "faceforward",
                     Mf::Reflect => "reflect",
+                    Mf::Refract => "refract",
                     // computational
                     Mf::Sign => "sign",
                     Mf::Fma => "fma",

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1023,6 +1023,7 @@ impl<W: Write> Writer<W> {
                     Mf::Normalize => "normalize",
                     Mf::FaceForward => "faceforward",
                     Mf::Reflect => "reflect",
+                    Mf::Refract => "refract",
                     // computational
                     Mf::Sign => "sign",
                     Mf::Fma => "fma",

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1821,6 +1821,7 @@ impl Writer {
                     Mf::Normalize => MathOp::Ext(spirv::GLOp::Normalize),
                     Mf::FaceForward => MathOp::Ext(spirv::GLOp::FaceForward),
                     Mf::Reflect => MathOp::Ext(spirv::GLOp::Reflect),
+                    Mf::Refract => MathOp::Ext(spirv::GLOp::Refract),
                     // exponent
                     Mf::Exp => MathOp::Ext(spirv::GLOp::Exp),
                     Mf::Exp2 => MathOp::Ext(spirv::GLOp::Exp2),

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -1737,6 +1737,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                         Glo::Normalize => Mf::Normalize,
                         Glo::FaceForward => Mf::FaceForward,
                         Glo::Reflect => Mf::Reflect,
+                        Glo::Refract => Mf::Refract,
                         _ => return Err(Error::UnsupportedExtInst(inst_id)),
                     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -630,6 +630,7 @@ pub enum MathFunction {
     Normalize,
     FaceForward,
     Reflect,
+    Refract,
     // computational
     Sign,
     Fma,

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -150,6 +150,7 @@ impl super::MathFunction {
             Self::Normalize => 1,
             Self::FaceForward => 3,
             Self::Reflect => 2,
+            Self::Refract => 3,
             // computational
             Self::Sign => 1,
             Self::Fma => 3,

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -561,7 +561,8 @@ impl<'a> ResolveContext<'a> {
                     },
                     Mf::Normalize |
                     Mf::FaceForward |
-                    Mf::Reflect => res_arg.clone(),
+                    Mf::Reflect |
+                    Mf::Refract => res_arg.clone(),
                     // computational
                     Mf::Sign |
                     Mf::Fma |

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -964,6 +964,47 @@ impl super::Validator {
                             ));
                         }
                     }
+                    Mf::Refract => {
+                        let (arg1_ty, arg2_ty) = match (arg1_ty, arg2_ty) {
+                            (Some(ty1), Some(ty2)) => (ty1, ty2),
+                            _ => return Err(ExpressionError::WrongArgumentCount(fun)),
+                        };
+
+                        match *arg_ty {
+                            Ti::Vector {
+                                kind: Sk::Float, ..
+                            } => {}
+                            _ => return Err(ExpressionError::InvalidArgumentType(fun, 0, arg)),
+                        }
+
+                        if arg1_ty != arg_ty {
+                            return Err(ExpressionError::InvalidArgumentType(
+                                fun,
+                                1,
+                                arg1.unwrap(),
+                            ));
+                        }
+
+                        match (arg_ty, arg2_ty) {
+                            (
+                                &Ti::Vector {
+                                    width: vector_width,
+                                    ..
+                                },
+                                &Ti::Scalar {
+                                    width: scalar_width,
+                                    kind: Sk::Float,
+                                },
+                            ) if vector_width == scalar_width => {}
+                            _ => {
+                                return Err(ExpressionError::InvalidArgumentType(
+                                    fun,
+                                    2,
+                                    arg2.unwrap(),
+                                ))
+                            }
+                        }
+                    }
                     Mf::Normalize => {
                         if arg1_ty.is_some() | arg2_ty.is_some() {
                             return Err(ExpressionError::WrongArgumentCount(fun));


### PR DESCRIPTION
This doesn't seem to be in wgsl (yet?) but it's in glsl, spv and metal so I think it's reasonable to add it into the IR.

Here's an glsl example:
```glsl
#version 450

layout(location = 0) out vec4 colour;

void main() {
    vec3 incidence = vec3(0.0, 1.0, 0.0);
    vec3 normal = vec3(0.0, 1.0, 0.0);
    float ior = 1.0;
    colour = vec4(refract(incidence, normal, ior), 1.0);
}
```