### PR TITLE
Add several additional ops to the spirv frontend.

### DIFF
--- a/src/front/spv/convert.rs
+++ b/src/front/spv/convert.rs
@@ -14,8 +14,8 @@ pub(super) fn map_binary_operator(word: spirv::Op) -> Result<crate::BinaryOperat
         Op::UDiv | Op::SDiv | Op::FDiv => Ok(BinaryOperator::Divide),
         Op::UMod | Op::SMod | Op::FMod => Ok(BinaryOperator::Modulo),
         // Relational and Logical Instructions
-        Op::IEqual | Op::FOrdEqual | Op::FUnordEqual => Ok(BinaryOperator::Equal),
-        Op::INotEqual | Op::FOrdNotEqual | Op::FUnordNotEqual => Ok(BinaryOperator::NotEqual),
+        Op::IEqual | Op::FOrdEqual | Op::FUnordEqual | Op::LogicalEqual => Ok(BinaryOperator::Equal),
+        Op::INotEqual | Op::FOrdNotEqual | Op::FUnordNotEqual | Op::LogicalNotEqual => Ok(BinaryOperator::NotEqual),
         Op::ULessThan | Op::SLessThan | Op::FOrdLessThan | Op::FUnordLessThan => {
             Ok(BinaryOperator::Less)
         }

--- a/src/front/spv/convert.rs
+++ b/src/front/spv/convert.rs
@@ -14,8 +14,12 @@ pub(super) fn map_binary_operator(word: spirv::Op) -> Result<crate::BinaryOperat
         Op::UDiv | Op::SDiv | Op::FDiv => Ok(BinaryOperator::Divide),
         Op::UMod | Op::SMod | Op::FMod => Ok(BinaryOperator::Modulo),
         // Relational and Logical Instructions
-        Op::IEqual | Op::FOrdEqual | Op::FUnordEqual | Op::LogicalEqual => Ok(BinaryOperator::Equal),
-        Op::INotEqual | Op::FOrdNotEqual | Op::FUnordNotEqual | Op::LogicalNotEqual => Ok(BinaryOperator::NotEqual),
+        Op::IEqual | Op::FOrdEqual | Op::FUnordEqual | Op::LogicalEqual => {
+            Ok(BinaryOperator::Equal)
+        }
+        Op::INotEqual | Op::FOrdNotEqual | Op::FUnordNotEqual | Op::LogicalNotEqual => {
+            Ok(BinaryOperator::NotEqual)
+        }
         Op::ULessThan | Op::SLessThan | Op::FOrdLessThan | Op::FUnordLessThan => {
             Ok(BinaryOperator::Less)
         }

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -1620,7 +1620,9 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                 | Op::ConvertSToF
                 | Op::ConvertUToF
                 | Op::ConvertFToU
-                | Op::ConvertFToS => {
+                | Op::ConvertFToS
+                | Op::UConvert
+                | Op::SConvert => {
                     inst.expect_at_least(4)?;
                     let result_type_id = self.next()?;
                     let result_id = self.next()?;
@@ -1848,7 +1850,8 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                 | Op::FOrdLessThanEqual
                 | Op::FUnordLessThanEqual
                 | Op::FOrdGreaterThanEqual
-                | Op::FUnordGreaterThanEqual => {
+                | Op::FUnordGreaterThanEqual
+                | Op::LogicalNotEqual => {
                     inst.expect(5)?;
                     let operator = map_binary_operator(inst.op)?;
                     self.parse_expr_binary_op(expressions, operator)?;

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -1997,16 +1997,6 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                     let structure_id = self.next()?;
                     let member_index = self.next()?;
 
-                    // Validate that all the types are correct.
-                    let result_type = self.lookup_type.lookup(result_type_id)?;
-                    match type_arena[result_type.handle].inner {
-                        crate::TypeInner::Scalar {
-                            kind: crate::ScalarKind::Uint,
-                            width: 4,
-                        } => {}
-                        _ => return Err(Error::InvalidParameter(Op::ArrayLength)),
-                    }
-
                     // We're assuming that the validation pass, if it's run, will catch if the
                     // wrong types or parameters are supplied here.
 

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -885,7 +885,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                         },
                     );
                 }
-                Op::AccessChain => {
+                Op::AccessChain | Op::InBoundsAccessChain => {
                     struct AccessExpression {
                         base_handle: Handle<crate::Expression>,
                         type_id: spirv::Word,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -813,6 +813,10 @@ pub enum Expression {
     /// Result of calling another function.
     Call(Handle<Function>),
     /// Get the length of an array.
+    /// The expression must resolve to a pointer to an array with a dynamic size.
+    ///
+    /// This doesn't match the semantics of spirv's `OpArrayLength`, which must be passed
+    /// a pointer to a structure containing a runtime array in its' last field.
     ArrayLength(Handle<Expression>),
 }
 


### PR DESCRIPTION
This PR adds support for the `Int8`, `Int16`, and `Int64` capabilities to the spirv frontend, as well as support for `OpArrayLength`, `OpCopyMemory`, `OpInBoundsAccessChain`, `OpLogicalNotEqual`, and `OpLogicalEqual`.