### PR TITLE
Add support for arrayLength to the wgsl frontend

### DIFF
--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -741,6 +741,11 @@ impl Parser {
                 accept,
                 reject,
             }
+        } else if name == "arrayLength" {
+            lexer.open_arguments()?;
+            let array = self.parse_singular_expression(lexer, ctx.reborrow())?;
+            lexer.close_arguments()?;
+            crate::Expression::ArrayLength(array)
         } else {
             // texture sampling
             match name {

--- a/src/front/wgsl/tests.rs
+++ b/src/front/wgsl/tests.rs
@@ -304,3 +304,27 @@ fn parse_struct_instantiation() {
     )
     .unwrap();
 }
+
+#[test]
+fn parse_array_length() {
+    parse_str(
+        "
+        [[block]]
+        struct Foo {
+            data: [[stride(4)]] array<u32>;
+        }; // this is used as both input and output for convenience
+
+        [[group(0), binding(0)]]
+        var<storage> foo: [[access(read_write)]] Foo;
+
+        [[group(0), binding(1)]]
+        var<storage> bar: [[access(read)]] array<u32>;
+
+        fn foo() {
+            var x: u32 = arrayLength(foo.data);
+            var y: u32 = arrayLength(bar);
+        }
+        ",
+    )
+    .unwrap();
+}

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -1098,7 +1098,17 @@ impl super::Validator {
             }
             E::Call(function) => other_infos[function.index()].available_stages,
             E::ArrayLength(expr) => match *resolver.resolve(expr)? {
-                Ti::Array { .. } => ShaderStages::all(),
+                Ti::Pointer { base, .. } => {
+                    if let Some(Ti::Array {
+                        size: crate::ArraySize::Dynamic,
+                        ..
+                    }) = resolver.types.try_get(base).map(|ty| &ty.inner)
+                    {
+                        ShaderStages::all()
+                    } else {
+                        return Err(ExpressionError::InvalidArrayType(expr));
+                    }
+                }
                 ref other => {
                     log::error!("Array length of {:?}", other);
                     return Err(ExpressionError::InvalidArrayType(expr));

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -1099,7 +1099,7 @@ impl super::Validator {
             E::Call(function) => other_infos[function.index()].available_stages,
             E::ArrayLength(expr) => match *resolver.resolve(expr)? {
                 Ti::Pointer { base, .. } => {
-                    if let Some(Ti::Array {
+                    if let Some(&Ti::Array {
                         size: crate::ArraySize::Dynamic,
                         ..
                     }) = resolver.types.try_get(base).map(|ty| &ty.inner)


### PR DESCRIPTION
This PR adds `arrayLength` support to the WGSL frontend.