### PR TITLE
Unify back::msl push constants map and sizes buffer

### DIFF
--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -80,6 +80,32 @@ pub struct PushConstantsMap {
     pub cs_buffer: Option<Slot>,
 }
 
+#[derive(Clone, Debug, Default, Hash, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+pub struct PerStageResources {
+    #[cfg_attr(feature = "deserialize", serde(default))]
+    pub push_constant_buffer: Option<Slot>,
+
+    /// The slot of a buffer that contains an array of `u32`,
+    /// one for the size of each bound buffer that contains a runtime array,
+    /// in order of [`GlobalVariable`] declarations.
+    #[cfg_attr(feature = "deserialize", serde(default))]
+    pub sizes_buffer: Option<Slot>,
+}
+
+#[derive(Clone, Debug, Default, Hash, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+pub struct PerStageMap {
+    #[cfg_attr(feature = "deserialize", serde(default))]
+    pub vs: PerStageResources,
+    #[cfg_attr(feature = "deserialize", serde(default))]
+    pub fs: PerStageResources,
+    #[cfg_attr(feature = "deserialize", serde(default))]
+    pub cs: PerStageResources,
+}
+
 enum ResolvedBinding {
     BuiltIn(crate::BuiltIn),
     Attribute(u32),
@@ -131,6 +157,8 @@ pub enum EntryPointError {
     MissingBinding(BindSource),
     #[error("mapping for push constants at stage {0:?} is missing")]
     MissingPushConstants(crate::ShaderStage),
+    #[error("mapping for sizes buffer for stage {0:?} is missing")]
+    MissingSizesBuffer(crate::ShaderStage),
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -149,18 +177,14 @@ pub struct Options {
     pub lang_version: (u8, u8),
     /// Binding model mapping to Metal.
     pub binding_map: BindingMap,
-    /// Push constants mapping to Metal.
-    pub push_constants_map: PushConstantsMap,
+    /// Map of per-stage resources (e.g. push constants) to slots
+    pub per_stage_map: PerStageMap,
     /// Samplers to be inlined into the code.
     pub inline_samplers: Vec<sampler::InlineSampler>,
     /// Make it possible to link different stages via SPIRV-Cross.
     pub spirv_cross_compatibility: bool,
     /// Don't panic on missing bindings, instead generate invalid MSL.
     pub fake_missing_bindings: bool,
-    /// The slot of a buffer that contains an array of `u32`,
-    /// one for the size of each bound buffer that contains a runtime array,
-    /// in order of [`GlobalVariable`] declarations.
-    pub sizes_buffer_binding: Option<Slot>,
 }
 
 impl Default for Options {
@@ -168,11 +192,10 @@ impl Default for Options {
         Options {
             lang_version: (1, 0),
             binding_map: BindingMap::default(),
-            push_constants_map: PushConstantsMap::default(),
+            per_stage_map: PerStageMap::default(),
             inline_samplers: Vec::new(),
             spirv_cross_compatibility: false,
             fake_missing_bindings: true,
-            sizes_buffer_binding: None,
         }
     }
 }
@@ -263,9 +286,9 @@ impl Options {
         stage: crate::ShaderStage,
     ) -> Result<ResolvedBinding, EntryPointError> {
         let slot = match stage {
-            crate::ShaderStage::Vertex => self.push_constants_map.vs_buffer,
-            crate::ShaderStage::Fragment => self.push_constants_map.fs_buffer,
-            crate::ShaderStage::Compute => self.push_constants_map.cs_buffer,
+            crate::ShaderStage::Vertex => self.per_stage_map.vs.push_constant_buffer,
+            crate::ShaderStage::Fragment => self.per_stage_map.fs.push_constant_buffer,
+            crate::ShaderStage::Compute => self.per_stage_map.cs.push_constant_buffer,
         };
         match slot {
             Some(slot) => Ok(ResolvedBinding::Resource(BindTarget {
@@ -280,6 +303,32 @@ impl Options {
                 interpolation: None,
             }),
             None => Err(EntryPointError::MissingPushConstants(stage)),
+        }
+    }
+
+    fn resolve_sizes_buffer(
+        &self,
+        stage: crate::ShaderStage,
+    ) -> Result<ResolvedBinding, EntryPointError> {
+        let slot = match stage {
+            crate::ShaderStage::Vertex => self.per_stage_map.vs.sizes_buffer,
+            crate::ShaderStage::Fragment => self.per_stage_map.fs.sizes_buffer,
+            crate::ShaderStage::Compute => self.per_stage_map.cs.sizes_buffer,
+        };
+
+        match slot {
+            Some(slot) => Ok(ResolvedBinding::Resource(BindTarget {
+                buffer: Some(slot),
+                texture: None,
+                sampler: None,
+                mutable: false,
+            })),
+            None if self.fake_missing_bindings => Ok(ResolvedBinding::User {
+                prefix: "fake",
+                index: 0,
+                interpolation: None,
+            }),
+            None => Err(EntryPointError::MissingSizesBuffer(stage)),
         }
     }
 }

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -71,18 +71,6 @@ pub type BindingMap = std::collections::BTreeMap<BindSource, BindTarget>;
 #[derive(Clone, Debug, Default, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
-pub struct PushConstantsMap {
-    #[cfg_attr(feature = "deserialize", serde(default))]
-    pub vs_buffer: Option<Slot>,
-    #[cfg_attr(feature = "deserialize", serde(default))]
-    pub fs_buffer: Option<Slot>,
-    #[cfg_attr(feature = "deserialize", serde(default))]
-    pub cs_buffer: Option<Slot>,
-}
-
-#[derive(Clone, Debug, Default, Hash, Eq, Ord, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
-#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct PerStageResources {
     #[cfg_attr(feature = "deserialize", serde(default))]
     pub push_constant_buffer: Option<Slot>,

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1,6 +1,6 @@
 use super::{
-    keywords::RESERVED, sampler as sm, BindTarget, Error, LocationMode, Options, PipelineOptions,
-    ResolvedBinding, TranslationInfo,
+    keywords::RESERVED, sampler as sm, Error, LocationMode, Options, PipelineOptions,
+    TranslationInfo,
 };
 use crate::{
     arena::{Arena, Handle},

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -2133,17 +2133,11 @@ impl<W: Write> Writer<W> {
             }
 
             if !self.runtime_sized_buffers.is_empty() {
-                let resolved = if let Some(slot) = options.sizes_buffer_binding {
-                    ResolvedBinding::Resource(BindTarget {
-                        buffer: Some(slot),
-                        mutable: false,
-                        ..Default::default()
-                    })
-                } else {
-                    ResolvedBinding::User {
-                        prefix: "fake",
-                        index: 0,
-                        interpolation: None,
+                let resolved = match options.resolve_sizes_buffer(ep.stage) {
+                    Ok(resolved) => resolved,
+                    Err(e) => {
+                        info.entry_point_names.push(Err(e));
+                        continue;
                     }
                 };
 

--- a/tests/in/access.param.ron
+++ b/tests/in/access.param.ron
@@ -9,11 +9,13 @@
 		binding_map: {
 			(stage: Vertex, group: 0, binding: 0): (buffer: Some(0), mutable: true),
 		},
-		push_constants_map: (
+		per_stage_map: (
+			vs: (
+				sizes_buffer: Some(24),
+			),
 		),
 		inline_samplers: [],
 		spirv_cross_compatibility: false,
 		fake_missing_bindings: false,
-        sizes_buffer_binding: Some(24),
 	),
 )

--- a/tests/in/boids.param.ron
+++ b/tests/in/boids.param.ron
@@ -12,7 +12,10 @@
 			(stage: Compute, group: 0, binding: 1): (buffer: Some(1), mutable: true),
 			(stage: Compute, group: 0, binding: 2): (buffer: Some(2), mutable: true),
 		},
-		push_constants_map: (
+		per_stage_map: (
+			cs: (
+				sizes_buffer: Some(3),
+			)
 		),
 		inline_samplers: [],
 		spirv_cross_compatibility: false,

--- a/tests/in/skybox.param.ron
+++ b/tests/in/skybox.param.ron
@@ -12,7 +12,7 @@
 			(stage: Fragment, group: 0, binding: 1): (texture: Some(0)),
 			(stage: Fragment, group: 0, binding: 2): (sampler: Some(Inline(0))),
 		},
-		push_constants_map: (
+		per_stage_map: (
 		),
 		inline_samplers: [
 			(

--- a/tests/out/boids.msl
+++ b/tests/out/boids.msl
@@ -32,7 +32,7 @@ kernel void main1(
 , constant SimParams& params [[buffer(0)]]
 , constant Particles& particlesSrc [[buffer(1)]]
 , device Particles& particlesDst [[buffer(2)]]
-, constant _mslBufferSizes& _buffer_sizes [[user(fake0)]]
+, constant _mslBufferSizes& _buffer_sizes [[buffer(3)]]
 ) {
     metal::float2 vPos;
     metal::float2 vVel;


### PR DESCRIPTION
This allows the sizes buffer slots to be tightly packed.