### PR TITLE
[spv-in] Handle `Op::LogicalEqual`

### DIFF
--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -1874,6 +1874,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                 | Op::FUnordLessThanEqual
                 | Op::FOrdGreaterThanEqual
                 | Op::FUnordGreaterThanEqual
+                | Op::LogicalEqual
                 | Op::LogicalNotEqual => {
                     inst.expect(5)?;
                     let operator = map_binary_operator(inst.op)?;


### PR DESCRIPTION
Looks like we just missed this one.
Needed for something like
```glsl
void main() {
    bool y = true;
    bool n = false;
    colour = vec4(vec3(y == n), 1.0);
}
```