### PR TITLE
[spv-in,spv-out] Handle outer product

### DIFF
--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1815,6 +1815,13 @@ impl Writer {
                         arg0_id,
                         arg1_id,
                     )),
+                    Mf::Outer => MathOp::Custom(Instruction::binary(
+                        spirv::Op::OuterProduct,
+                        result_type_id,
+                        id,
+                        arg0_id,
+                        arg1_id,
+                    )),
                     Mf::Cross => MathOp::Ext(spirv::GLOp::Cross),
                     Mf::Distance => MathOp::Ext(spirv::GLOp::Distance),
                     Mf::Length => MathOp::Ext(spirv::GLOp::Length),
@@ -1848,7 +1855,7 @@ impl Writer {
                         arg0_id,
                     )),
                     Mf::Determinant => MathOp::Ext(spirv::GLOp::Determinant),
-                    Mf::Outer | Mf::ReverseBits | Mf::CountOneBits => {
+                    Mf::ReverseBits | Mf::CountOneBits => {
                         log::error!("unimplemented math function {:?}", fun);
                         return Err(Error::FeatureNotImplemented("math function"));
                     }

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -1426,6 +1426,29 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                         },
                     );
                 }
+                Op::OuterProduct => {
+                    inst.expect(5)?;
+
+                    let result_type_id = self.next()?;
+                    let result_id = self.next()?;
+                    let left_id = self.next()?;
+                    let right_id = self.next()?;
+                    let left_lexp = self.lookup_expression.lookup(left_id)?;
+                    let right_lexp = self.lookup_expression.lookup(right_id)?;
+                    let expr = crate::Expression::Math {
+                        fun: crate::MathFunction::Outer,
+                        arg: left_lexp.handle,
+                        arg1: Some(right_lexp.handle),
+                        arg2: None,
+                    };
+                    self.lookup_expression.insert(
+                        result_id,
+                        LookupExpression {
+                            handle: expressions.append(expr),
+                            type_id: result_type_id,
+                        },
+                    );
+                }
                 // Bitwise instructions
                 Op::Not => {
                     inst.expect(4)?;


### PR DESCRIPTION
Test case:
```glsl
#version 450

layout(location = 0) out vec4 colour;

void main() {
    vec3 a = vec3(1.0);
    vec3 b = vec3(2.0);

    mat3 z = outerProduct(a, b);

    colour = vec4(cross(a, b), 1.0);
}
```