### PR TITLE
[spv-in] Handle `Glo::MatrixInverse`

### DIFF
--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -1784,6 +1784,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                             Glo::Log2 => Mf::Log2,
                             Glo::Sqrt => Mf::Sqrt,
                             Glo::InverseSqrt => Mf::InverseSqrt,
+                            Glo::MatrixInverse => Mf::Inverse,
                             Glo::Determinant => Mf::Determinant,
                             Glo::Modf => Mf::Modf,
                             Glo::FMin | Glo::UMin | Glo::SMin | Glo::NMin => Mf::Min,


### PR DESCRIPTION
This is implemented on the glsl front and backends, the wgsl frontend and the spv backend thus far.