### PR TITLE
[glsl-out] Handle uninitialized global variables

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -756,7 +756,14 @@ impl<'a, W: Write> Writer<'a, W> {
 
         // Finally write the global name and end the global with a `;` and a newline
         // Leading space is important
-        writeln!(self.out, " {};", self.get_global_name(handle, global))?;
+        let global_name = self.get_global_name(handle, global);
+        let global_str =
+            if let Some(default_value) = zero_init_value_str(&self.module.types[global.ty].inner) {
+                format!("{} = {}", global_name, default_value)
+            } else {
+                global_name
+            };
+        writeln!(self.out, " {};", global_str)?;
         writeln!(self.out)?;
 
         Ok(())
@@ -1290,7 +1297,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     }
 
                     // Write `break;` if the block isn't fallthrough
-                    if case.fall_through {
+                    if !case.fall_through {
                         writeln!(self.out, "{}break;", INDENT.repeat(indent + 2))?;
                     }
                 }
@@ -1358,17 +1365,50 @@ impl<'a, W: Write> Writer<'a, W> {
                             let value = value.unwrap();
                             match self.module.types[result.ty].inner {
                                 crate::TypeInner::Struct { ref members, .. } => {
+                                    let (mut is_temp_struct_used, mut return_struct) = (false, "");
+                                    if let Expression::Compose { .. } = ctx.expressions[value] {
+                                        is_temp_struct_used = true;
+                                        return_struct = "_tmp_return";
+                                        write!(
+                                            self.out,
+                                            "{} {} = ",
+                                            &self.names[&NameKey::Type(result.ty)],
+                                            return_struct
+                                        )?;
+                                        self.write_expr(value, ctx)?;
+                                        writeln!(self.out, ";")?;
+                                        write!(self.out, "{}", INDENT.repeat(indent))?;
+                                    }
                                     for (index, member) in members.iter().enumerate() {
+                                        // TODO: handle builtin in better way 
+                                        if let Some(Binding::BuiltIn(builtin)) = member.binding {
+                                            match builtin {
+                                                crate::BuiltIn::ClipDistance
+                                                | crate::BuiltIn::CullDistance
+                                                | crate::BuiltIn::PointSize => {
+                                                    if self.options.version.is_es() {
+                                                        continue;
+                                                    }
+                                                }
+                                                _ => {}
+                                            }
+                                        }
+
                                         let varying_name = VaryingName {
                                             binding: member.binding.as_ref().unwrap(),
                                             stage: ep.stage,
                                             output: true,
                                         };
+                                        let field_name = self.names
+                                            [&NameKey::StructMember(result.ty, index as u32)]
+                                            .clone();
                                         write!(self.out, "{} = ", varying_name)?;
-                                        self.write_expr(value, ctx)?;
-                                        let field_name = &self.names
-                                            [&NameKey::StructMember(result.ty, index as u32)];
-                                        writeln!(self.out, ".{};", field_name)?;
+
+                                        if !is_temp_struct_used {
+                                            self.write_expr(value, ctx)?;
+                                        }
+
+                                        writeln!(self.out, "{}.{};", return_struct, &field_name)?;
                                         write!(self.out, "{}", INDENT.repeat(indent))?;
                                     }
                                 }
@@ -2296,5 +2336,28 @@ fn glsl_storage_access(storage_access: StorageAccess) -> Option<&'static str> {
         Some("writeonly")
     } else {
         None
+    }
+}
+
+/// Helper function that return string with default zero initialization for supported types
+fn zero_init_value_str(inner: &TypeInner) -> Option<String> {
+    match *inner {
+        TypeInner::Scalar { kind, .. } => match kind {
+            ScalarKind::Bool => Some(String::from("false")),
+            _ => Some(String::from("0")),
+        },
+        TypeInner::Vector { size, kind, width } => {
+            if let Ok(scalar_string) = glsl_scalar(kind, width) {
+                let vec_type = format!("{}vec{}", scalar_string.prefix, size as u8);
+                match size {
+                    crate::VectorSize::Bi => Some(format!("{}(0, 0)", vec_type)),
+                    crate::VectorSize::Tri => Some(format!("{}(0, 0, 0)", vec_type)),
+                    crate::VectorSize::Quad => Some(format!("{}(0, 0, 0, 0)", vec_type)),
+                }
+            } else {
+                None
+            }
+        }
+        _ => None,
     }
 }

--- a/tests/out/quad-vert.Vertex.glsl
+++ b/tests/out/quad-vert.Vertex.glsl
@@ -1,0 +1,48 @@
+#version 310 es
+
+precision highp float;
+
+struct type10 {
+    vec2 member;
+    vec4 gen_gl_Position1;
+    float gen_gl_PointSize1;
+    float gen_gl_ClipDistance1[1];
+    float gen_gl_CullDistance1[1];
+};
+
+vec2 v_uv = vec2(0, 0);
+
+vec2 a_uv = vec2(0, 0);
+
+struct gen_gl_PerVertex_block_0 {
+    vec4 gen_gl_Position;
+    float gen_gl_PointSize;
+    float gen_gl_ClipDistance[1];
+    float gen_gl_CullDistance[1];
+} perVertexStruct;
+
+vec2 a_pos = vec2(0, 0);
+
+layout(location = 1) in vec2 _p2vs_location1;
+layout(location = 0) in vec2 _p2vs_location0;
+smooth layout(location = 0) out vec2 _vs2fs_location0;
+
+void main1() {
+    v_uv = a_uv;
+    vec2 _expr13 = a_pos;
+    perVertexStruct.gen_gl_Position = vec4(_expr13[0], _expr13[1], 0.0, 1.0);
+    return;
+}
+
+void main() {
+    vec2 a_uv1 = _p2vs_location1;
+    vec2 a_pos1 = _p2vs_location0;
+    a_uv = a_uv1;
+    a_pos = a_pos1;
+    main1();
+    type10 _tmp_return = type10(v_uv, perVertexStruct.gen_gl_Position, perVertexStruct.gen_gl_PointSize, perVertexStruct.gen_gl_ClipDistance, perVertexStruct.gen_gl_CullDistance);
+    _vs2fs_location0 = _tmp_return.member;
+    gl_Position = _tmp_return.gen_gl_Position1;
+    return;
+}
+

--- a/tests/out/quad.Vertex.glsl
+++ b/tests/out/quad.Vertex.glsl
@@ -14,8 +14,9 @@ smooth layout(location = 0) out vec2 _vs2fs_location0;
 void main() {
     vec2 pos = _p2vs_location0;
     vec2 uv1 = _p2vs_location1;
-    _vs2fs_location0 = VertexOutput(uv1, vec4((1.2 * pos), 0.0, 1.0)).uv;
-    gl_Position = VertexOutput(uv1, vec4((1.2 * pos), 0.0, 1.0)).position;
+    VertexOutput _tmp_return = VertexOutput(uv1, vec4((1.2 * pos), 0.0, 1.0));
+    _vs2fs_location0 = _tmp_return.uv;
+    gl_Position = _tmp_return.position;
     return;
 }
 

--- a/tests/out/skybox.Vertex.glsl
+++ b/tests/out/skybox.Vertex.glsl
@@ -21,8 +21,9 @@ void main() {
     tmp1_ = (int(vertex_index) / 2);
     tmp2_ = (int(vertex_index) & 1);
     vec4 _expr24 = vec4(((float(tmp1_) * 4.0) - 1.0), ((float(tmp2_) * 4.0) - 1.0), 0.0, 1.0);
-    gl_Position = VertexOutput(_expr24, (transpose(mat3x3(_group_0_binding_0.view[0].xyz, _group_0_binding_0.view[1].xyz, _group_0_binding_0.view[2].xyz)) * (_group_0_binding_0.proj_inv * _expr24).xyz)).position;
-    _vs2fs_location0 = VertexOutput(_expr24, (transpose(mat3x3(_group_0_binding_0.view[0].xyz, _group_0_binding_0.view[1].xyz, _group_0_binding_0.view[2].xyz)) * (_group_0_binding_0.proj_inv * _expr24).xyz)).uv;
+    VertexOutput _tmp_return = VertexOutput(_expr24, (transpose(mat3x3(_group_0_binding_0.view[0].xyz, _group_0_binding_0.view[1].xyz, _group_0_binding_0.view[2].xyz)) * (_group_0_binding_0.proj_inv * _expr24).xyz));
+    gl_Position = _tmp_return.position;
+    _vs2fs_location0 = _tmp_return.uv;
     return;
 }
 

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -296,7 +296,7 @@ fn convert_spv(name: &str, adjust_coordinate_space: bool, targets: Targets) {
 #[cfg(feature = "spv-in")]
 #[test]
 fn convert_spv_quad_vert() {
-    convert_spv("quad-vert", false, Targets::METAL);
+    convert_spv("quad-vert", false, Targets::METAL | Targets::GLSL);
 }
 
 #[cfg(feature = "spv-in")]


### PR DESCRIPTION
With this patch we can run patched `wgpu_glyph` (#812) with GL and Naga.

Fix #812

**cross:**
![image](https://user-images.githubusercontent.com/3227317/117219105-3d3abe80-ae0d-11eb-872c-b50c421ba0cb.png)

naga:
![image](https://user-images.githubusercontent.com/3227317/117219239-8e4ab280-ae0d-11eb-98a6-3c8227680276.png)

At least it stop crashing :smile:.