### PR TITLE
[msl] make sizes buffer local to each function

### DIFF
--- a/tests/out/collatz.msl
+++ b/tests/out/collatz.msl
@@ -11,8 +11,7 @@ struct PrimeIndices {
 };
 
 metal::uint collatz_iterations(
-    metal::uint n_base,
-    constant _mslBufferSizes& _buffer_sizes
+    metal::uint n_base
 ) {
     metal::uint n;
     metal::uint i = 0u;
@@ -36,9 +35,8 @@ struct main1Input {
 kernel void main1(
   metal::uint3 global_id [[thread_position_in_grid]]
 , device PrimeIndices& v_indices [[user(fake0)]]
-, constant _mslBufferSizes& _buffer_sizes [[user(fake0)]]
 ) {
-    metal::uint _e9 = collatz_iterations(v_indices.data[global_id.x], _buffer_sizes);
+    metal::uint _e9 = collatz_iterations(v_indices.data[global_id.x]);
     v_indices.data[global_id.x] = _e9;
     return;
 }

--- a/tests/out/shadow.msl
+++ b/tests/out/shadow.msl
@@ -24,8 +24,7 @@ float fetch_shadow(
     metal::uint light_id,
     metal::float4 homogeneous_coords,
     metal::depth2d_array<float, metal::access::sample> t_shadow,
-    metal::sampler sampler_shadow,
-    constant _mslBufferSizes& _buffer_sizes
+    metal::sampler sampler_shadow
 ) {
     if (homogeneous_coords.w <= 0.0) {
         return 1.0;
@@ -47,7 +46,6 @@ fragment fs_mainOutput fs_main(
 , constant Lights& s_lights [[user(fake0)]]
 , metal::depth2d_array<float, metal::access::sample> t_shadow [[user(fake0)]]
 , metal::sampler sampler_shadow [[user(fake0)]]
-, constant _mslBufferSizes& _buffer_sizes [[user(fake0)]]
 ) {
     const auto raw_normal = varyings.raw_normal;
     const auto position = varyings.position;
@@ -63,7 +61,7 @@ fragment fs_mainOutput fs_main(
             break;
         }
         Light _e21 = s_lights.data[i];
-        float _e25 = fetch_shadow(i, _e21.proj * position, t_shadow, sampler_shadow, _buffer_sizes);
+        float _e25 = fetch_shadow(i, _e21.proj * position, t_shadow, sampler_shadow);
         color1 = color1 + ((_e25 * metal::max(0.0, metal::dot(metal::normalize(raw_normal), metal::normalize(_e21.pos.xyz - position.xyz)))) * _e21.color.xyz);
     }
     return fs_mainOutput { metal::float4(color1, 1.0) };

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -303,7 +303,11 @@ fn convert_spv(name: &str, adjust_coordinate_space: bool, targets: Targets) {
 #[cfg(feature = "spv-in")]
 #[test]
 fn convert_spv_quad_vert() {
-    convert_spv("quad-vert", false, Targets::METAL | Targets::GLSL | Targets::WGSL);
+    convert_spv(
+        "quad-vert",
+        false,
+        Targets::METAL | Targets::GLSL | Targets::WGSL,
+    );
 }
 
 #[cfg(feature = "spv-in")]


### PR DESCRIPTION
Another (big) follow-up to #825
The original code was written in a way that doesn't consider entry points truly independent. We'd globally figure out if the sizes buffer is needed anywhere, and then blindly use it on all functions and entry points. This doesn't work if, say, the pipeline layout doesn't include some of the globals used by the program.
Instead, this PR determines, for each function, whether or not the sizes buffer is needed.