### PR TITLE
TypeInner::span: Tolerate bad array length constants for now.

### DIFF
--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -94,7 +94,8 @@ impl super::TypeInner {
             } => {
                 let count = match size {
                     super::ArraySize::Constant(handle) => {
-                        constants[handle].to_array_length().unwrap()
+                        // Bad array lengths will be caught during validation.
+                        constants[handle].to_array_length().unwrap_or(1)
                     }
                     // A dynamically-sized array has to have at least one element
                     super::ArraySize::Dynamic => 1,

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -1,4 +1,6 @@
-#[cfg(feature = "wgsl-in")]
+//! Tests for the WGSL front end.
+#![cfg(feature = "wgsl-in")]
+
 fn check(input: &str, snapshot: &str) {
     let output = naga::front::wgsl::parse_str(input)
         .expect_err("expected parser error")
@@ -15,7 +17,6 @@ fn check(input: &str, snapshot: &str) {
     }
 }
 
-#[cfg(feature = "wgsl-in")]
 #[test]
 fn function_without_identifier() {
     check(
@@ -30,7 +31,6 @@ fn function_without_identifier() {
     );
 }
 
-#[cfg(feature = "wgsl-in")]
 #[test]
 fn invalid_integer() {
     check(
@@ -45,7 +45,6 @@ fn invalid_integer() {
     );
 }
 
-#[cfg(feature = "wgsl-in")]
 #[test]
 fn invalid_float() {
     check(
@@ -60,7 +59,6 @@ fn invalid_float() {
     );
 }
 
-#[cfg(feature = "wgsl-in")]
 #[test]
 fn invalid_scalar_width() {
     check(


### PR DESCRIPTION
If an array has a bogus length constant (a boolean, say), `TypeInner::span` will panic. However, the problem will be caught in validation, and this function is needed in front ends, which should never panic on invalid input.

This PR also moves `tests/errors.rs` to `tests/wgsl-errors.rs` and makes the entire file conditional on the `wgsl-in` feature, before adding some integration tests.