### PR TITLE
Remove alignment from struct IR

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -663,7 +663,7 @@ impl<'a, W: Write> Writer<'a, W> {
             // glsl has no pointer types so just write types as normal and loads are skipped
             TypeInner::Pointer { base, .. } => self.write_type(base),
             TypeInner::Struct {
-                level: crate::StructLevel::Root,
+                top_level: true,
                 ref members,
                 span: _,
             } => self.write_struct(true, ty, members),
@@ -743,8 +743,7 @@ impl<'a, W: Write> Writer<'a, W> {
         if let Some(storage_class) = glsl_storage_class(global.class) {
             write!(self.out, "{} ", storage_class)?;
         } else if let TypeInner::Struct {
-            level: crate::StructLevel::Root,
-            ..
+            top_level: true, ..
         } = self.module.types[global.ty].inner
         {
             write!(self.out, "struct ")?;

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -916,11 +916,11 @@ impl Writer {
                 }
             }
             crate::TypeInner::Struct {
-                ref level,
+                top_level,
                 ref members,
                 span: _,
             } => {
-                if let crate::StructLevel::Root = *level {
+                if top_level {
                     self.decorate(id, Decoration::Block, &[]);
                 }
 

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -7,7 +7,7 @@ use crate::{
     valid::{FunctionInfo, ModuleInfo},
     Arena, ArraySize, Binding, Constant, Expression, FastHashMap, Function, GlobalVariable, Handle,
     ImageClass, ImageDimension, Interpolation, Module, SampleLevel, Sampling, ScalarKind,
-    ScalarValue, ShaderStage, Statement, StorageFormat, StructLevel, StructMember, Type, TypeInner,
+    ScalarValue, ShaderStage, Statement, StorageFormat, StructMember, Type, TypeInner,
 };
 use bit_set::BitSet;
 use std::fmt::Write;
@@ -94,11 +94,12 @@ impl<W: Write> Writer<W> {
         // Write all structs
         for (handle, ty) in module.types.iter() {
             if let TypeInner::Struct {
-                level, ref members, ..
+                top_level,
+                ref members,
+                ..
             } = ty.inner
             {
-                let block = level == StructLevel::Root;
-                self.write_struct(module, handle, block, members)?;
+                self.write_struct(module, handle, top_level, members)?;
                 writeln!(self.out)?;
             }
         }

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -521,46 +521,34 @@ pomelo! {
         if i.1 == "gl_PerVertex" {
             None
         } else {
-            let level = if t.is_empty() {
-                //TODO
-                crate::StructLevel::Normal { alignment: crate::Alignment::new(1).unwrap() }
-            } else {
-                crate::StructLevel::Root
-            };
             Some(VarDeclaration {
-                type_qualifiers: t,
                 ids_initializers: vec![(None, None)],
                 ty: extra.module.types.fetch_or_append(Type{
                     name: Some(i.1),
                     inner: TypeInner::Struct {
-                        level,
+                        top_level: !t.is_empty(),
                         members: sdl,
                         span: 0, //TODO
                     },
                 }),
+                type_qualifiers: t,
             })
         }
     }
 
     declaration ::= type_qualifier(t) Identifier(i1) LeftBrace
         struct_declaration_list(sdl) RightBrace Identifier(i2) Semicolon {
-        let level = if t.is_empty() {
-            //TODO
-            crate::StructLevel::Normal { alignment: crate::Alignment::new(1).unwrap() }
-        } else {
-            crate::StructLevel::Root
-        };
         Some(VarDeclaration {
-            type_qualifiers: t,
             ids_initializers: vec![(Some(i2.1), None)],
             ty: extra.module.types.fetch_or_append(Type{
                 name: Some(i1.1),
                 inner: TypeInner::Struct {
-                    level,
+                    top_level: !t.is_empty(),
                     members: sdl,
                     span: 0, //TODO
                 },
             }),
+            type_qualifiers: t,
         })
     }
 
@@ -761,7 +749,7 @@ pomelo! {
         Type{
             name: Some(i.1),
             inner: TypeInner::Struct {
-                level: crate::StructLevel::Normal { alignment: crate::Alignment::new(1).unwrap() },
+                top_level: false,
                 members: vec![],
                 span: 0,
             }

--- a/src/front/spv/function.rs
+++ b/src/front/spv/function.rs
@@ -353,9 +353,7 @@ impl<I: Iterator<Item = u32>> super::Parser<I> {
                     let ty = module.types.append(crate::Type {
                         name: None,
                         inner: crate::TypeInner::Struct {
-                            level: crate::StructLevel::Normal {
-                                alignment: crate::Alignment::new(1).unwrap(),
-                            },
+                            top_level: false,
                             members,
                             span: 0xFFFF, // shouldn't matter
                         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@ pub use crate::arena::{Arena, Handle, Range};
 use std::{
     collections::{HashMap, HashSet},
     hash::BuildHasherDefault,
-    num::NonZeroU32,
 };
 
 #[cfg(feature = "deserialize")]
@@ -169,7 +168,6 @@ pub enum BuiltIn {
 
 /// Number of bytes per scalar.
 pub type Bytes = u8;
-pub type Alignment = NonZeroU32;
 
 /// Number of components in a vector.
 #[repr(u8)]
@@ -358,18 +356,6 @@ pub enum ImageClass {
     Storage(StorageFormat),
 }
 
-/// Qualifier of the type level, at which a struct can be used.
-#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "deserialize", derive(Deserialize))]
-pub enum StructLevel {
-    /// This is a root level struct, it can't be nested inside
-    /// other composite types.
-    Root,
-    /// This is a normal struct, and it has to be aligned for nesting.
-    Normal { alignment: Alignment },
-}
-
 /// A data type declared in the module.
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
@@ -420,8 +406,9 @@ pub enum TypeInner {
     },
     /// User-defined structure.
     Struct {
-        level: StructLevel,
+        top_level: bool,
         members: Vec<StructMember>,
+        //TODO: should this be unaligned?
         span: u32,
     },
     /// Possibly multidimensional array of texels.

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -1,10 +1,12 @@
 //! Module processing functionality.
 
 mod interpolator;
+mod layouter;
 mod namer;
 mod terminator;
 mod typifier;
 
+pub use layouter::{Alignment, InvalidBaseType, Layouter, TypeLayout};
 pub use namer::{EntryPointIndex, NameKey, Namer};
 pub use terminator::ensure_block_returns;
 pub use typifier::{ResolveContext, ResolveError, TypeResolution};

--- a/src/valid/interface.rs
+++ b/src/valid/interface.rs
@@ -262,7 +262,7 @@ impl VaryingContext<'_> {
                 match self.types[self.ty].inner {
                     //TODO: check the member types
                     crate::TypeInner::Struct {
-                        level: crate::StructLevel::Normal { .. },
+                        top_level: false,
                         ref members,
                         ..
                     } => {
@@ -303,7 +303,7 @@ impl super::Validator {
                 }
                 (
                     crate::StorageAccess::all(),
-                    TypeFlags::DATA | TypeFlags::HOST_SHARED | TypeFlags::BLOCK,
+                    TypeFlags::DATA | TypeFlags::HOST_SHARED | TypeFlags::TOP_LEVEL,
                     true,
                 )
             }
@@ -315,7 +315,10 @@ impl super::Validator {
                 }
                 (
                     crate::StorageAccess::empty(),
-                    TypeFlags::DATA | TypeFlags::SIZED | TypeFlags::HOST_SHARED | TypeFlags::BLOCK,
+                    TypeFlags::DATA
+                        | TypeFlags::SIZED
+                        | TypeFlags::HOST_SHARED
+                        | TypeFlags::TOP_LEVEL,
                     true,
                 )
             }

--- a/tests/out/collatz.ron
+++ b/tests/out/collatz.ron
@@ -18,7 +18,7 @@
         (
             name: Some("PrimeIndices"),
             inner: Struct(
-                level: Root,
+                top_level: true,
                 members: [
                     (
                         name: Some("data"),

--- a/tests/out/shadow.ron
+++ b/tests/out/shadow.ron
@@ -102,7 +102,7 @@
         (
             name: Some("Globals"),
             inner: Struct(
-                level: Root,
+                top_level: true,
                 members: [
                     (
                         name: Some("num_lights"),
@@ -146,9 +146,7 @@
         (
             name: Some("Light"),
             inner: Struct(
-                level: Normal(
-                    alignment: 16,
-                ),
+                top_level: false,
                 members: [
                     (
                         name: Some("proj"),
@@ -183,7 +181,7 @@
         (
             name: Some("Lights"),
             inner: Struct(
-                level: Root,
+                top_level: true,
                 members: [
                     (
                         name: Some("data"),

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -120,7 +120,7 @@ fn invalid_arrays() {
             type Bad = array<Block, 4>;
         "#:
         Err(naga::valid::ValidationError::Type {
-            error: naga::valid::TypeError::NestedBlock,
+            error: naga::valid::TypeError::NestedTopLevel,
             ..
         })
     }


### PR DESCRIPTION
Fixes #867
Pretty much reverts #663
Cleans up the code according to https://github.com/gpuweb/gpuweb/pull/1560
Refactors the layouter (again) to be re-used by both WGSL-in and SPV-in.

The line of thought is the following:
  1. array alignment needs to be based on the base type
  1. which makes it the first type that need to know the alignment of a base type
  1. except for the structure, which already has the alignment in IR
  1. should array have an alignment in IR as well? that would be unfortunate, the structure one also doesn't appear to be very useful or helpful to anybody.
  1. maybe we can remove the struct alignment from the IR? then we can make the layouter look up the base types for both arrays and structures
  1. dine