### PR TITLE
Use Cow more effectively.

### DIFF
--- a/src/back/dot/mod.rs
+++ b/src/back/dot/mod.rs
@@ -9,10 +9,7 @@ use crate::{
     valid::{FunctionInfo, ModuleInfo},
 };
 
-use std::{
-    borrow::Cow,
-    fmt::{Error as FmtError, Write as _},
-};
+use std::fmt::{Error as FmtError, Write as _};
 
 #[derive(Default)]
 struct StatementGraph {
@@ -177,16 +174,16 @@ fn write_fun(
             E::Access { base, index } => {
                 edges.insert("base", base);
                 edges.insert("index", index);
-                (Cow::Borrowed("Access"), 1)
+                ("Access".into(), 1)
             }
             E::AccessIndex { base, index } => {
                 edges.insert("base", base);
-                (Cow::Owned(format!("AccessIndex[{}]", index)), 1)
+                (format!("AccessIndex[{}]", index).into(), 1)
             }
-            E::Constant(_) => (Cow::Borrowed("Constant"), 2),
+            E::Constant(_) => ("Constant".into(), 2),
             E::Splat { size, value } => {
                 edges.insert("value", value);
-                (Cow::Owned(format!("Splat{:?}", size)), 3)
+                (format!("Splat{:?}", size).into(), 3)
             }
             E::Swizzle {
                 size,
@@ -194,27 +191,24 @@ fn write_fun(
                 pattern,
             } => {
                 edges.insert("vector", vector);
-                (
-                    Cow::Owned(format!("Swizzle{:?}", &pattern[..size as usize])),
-                    3,
-                )
+                (format!("Swizzle{:?}", &pattern[..size as usize]).into(), 3)
             }
             E::Compose { ref components, .. } => {
                 payload = Some(Payload::Arguments(components));
-                (Cow::Borrowed("Compose"), 3)
+                ("Compose".into(), 3)
             }
-            E::FunctionArgument(index) => (Cow::Owned(format!("Argument[{}]", index)), 1),
+            E::FunctionArgument(index) => (format!("Argument[{}]", index).into(), 1),
             E::GlobalVariable(h) => {
                 payload = Some(Payload::Global(h));
-                (Cow::Borrowed("Global"), 2)
+                ("Global".into(), 2)
             }
             E::LocalVariable(h) => {
                 payload = Some(Payload::Local(h));
-                (Cow::Borrowed("Local"), 1)
+                ("Local".into(), 1)
             }
             E::Load { pointer } => {
                 edges.insert("pointer", pointer);
-                (Cow::Borrowed("Load"), 4)
+                ("Load".into(), 4)
             }
             E::ImageSample {
                 image,
@@ -248,7 +242,7 @@ fn write_fun(
                 if let Some(expr) = depth_ref {
                     edges.insert("depth_ref", expr);
                 }
-                (Cow::Borrowed("ImageSample"), 5)
+                ("ImageSample".into(), 5)
             }
             E::ImageLoad {
                 image,
@@ -264,7 +258,7 @@ fn write_fun(
                 if let Some(expr) = index {
                     edges.insert("index", expr);
                 }
-                (Cow::Borrowed("ImageLoad"), 5)
+                ("ImageLoad".into(), 5)
             }
             E::ImageQuery { image, query } => {
                 edges.insert("image", image);
@@ -273,20 +267,20 @@ fn write_fun(
                         if let Some(expr) = level {
                             edges.insert("level", expr);
                         }
-                        Cow::Borrowed("ImageSize")
+                        std::borrow::Cow::from("ImageSize")
                     }
-                    _ => Cow::Owned(format!("{:?}", query)),
+                    _ => format!("{:?}", query).into(),
                 };
                 (args, 7)
             }
             E::Unary { op, expr } => {
                 edges.insert("expr", expr);
-                (Cow::Owned(format!("{:?}", op)), 6)
+                (format!("{:?}", op).into(), 6)
             }
             E::Binary { op, left, right } => {
                 edges.insert("left", left);
                 edges.insert("right", right);
-                (Cow::Owned(format!("{:?}", op)), 6)
+                (format!("{:?}", op).into(), 6)
             }
             E::Select {
                 condition,
@@ -296,15 +290,15 @@ fn write_fun(
                 edges.insert("condition", condition);
                 edges.insert("accept", accept);
                 edges.insert("reject", reject);
-                (Cow::Borrowed("Select"), 3)
+                ("Select".into(), 3)
             }
             E::Derivative { axis, expr } => {
                 edges.insert("", expr);
-                (Cow::Owned(format!("d{:?}", axis)), 8)
+                (format!("d{:?}", axis).into(), 8)
             }
             E::Relational { fun, argument } => {
                 edges.insert("arg", argument);
-                (Cow::Owned(format!("{:?}", fun)), 6)
+                (format!("{:?}", fun).into(), 6)
             }
             E::Math {
                 fun,
@@ -319,7 +313,7 @@ fn write_fun(
                 if let Some(expr) = arg2 {
                     edges.insert("arg2", expr);
                 }
-                (Cow::Owned(format!("{:?}", fun)), 7)
+                (format!("{:?}", fun).into(), 7)
             }
             E::As {
                 kind,
@@ -331,12 +325,12 @@ fn write_fun(
                     Some(width) => format!("Convert<{:?},{}>", kind, width),
                     None => format!("Bitcast<{:?}>", kind),
                 };
-                (Cow::Owned(string), 3)
+                (string.into(), 3)
             }
-            E::Call(_function) => (Cow::Borrowed("Call"), 4),
+            E::Call(_function) => ("Call".into(), 4),
             E::ArrayLength(expr) => {
                 edges.insert("", expr);
-                (Cow::Borrowed("ArrayLength"), 7)
+                ("ArrayLength".into(), 7)
             }
         };
 

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -25,6 +25,7 @@ use codespan_reporting::{
     },
 };
 use std::{
+    borrow::Cow,
     io::{self, Write},
     iter,
     num::NonZeroU32,
@@ -140,7 +141,10 @@ impl<'a> Error<'a> {
                     expected,
                     &source[unexpected_span.clone()],
                 ),
-                labels: vec![(unexpected_span.clone(), format!("expected {}", expected))],
+                labels: vec![(
+                    unexpected_span.clone(),
+                    format!("expected {}", expected).into(),
+                )],
                 notes: vec![],
             },
             Error::BadInteger(ref bad_span) => ParseError {
@@ -148,7 +152,7 @@ impl<'a> Error<'a> {
                     "expected integer literal, found `{}`",
                     &source[bad_span.clone()],
                 ),
-                labels: vec![(bad_span.clone(), "expected integer".to_string())],
+                labels: vec![(bad_span.clone(), "expected integer".into())],
                 notes: vec![],
             },
             Error::BadFloat(ref bad_span) => ParseError {
@@ -156,15 +160,12 @@ impl<'a> Error<'a> {
                     "expected floating-point literal, found `{}`",
                     &source[bad_span.clone()],
                 ),
-                labels: vec![(
-                    bad_span.clone(),
-                    "expected floating-point literal".to_string(),
-                )],
+                labels: vec![(bad_span.clone(), "expected floating-point literal".into())],
                 notes: vec![],
             },
             Error::BadScalarWidth(ref bad_span, width) => ParseError {
                 message: format!("invalid width of `{}` for literal", width,),
-                labels: vec![(bad_span.clone(), "invalid width".to_string())],
+                labels: vec![(bad_span.clone(), "invalid width".into())],
                 notes: vec!["valid width is 32".to_string()],
             },
             Error::BadAccessor(ref accessor_span) => ParseError {
@@ -172,12 +173,12 @@ impl<'a> Error<'a> {
                     "invalid field accessor `{}`",
                     &source[accessor_span.clone()],
                 ),
-                labels: vec![(accessor_span.clone(), "invalid accessor".to_string())],
+                labels: vec![(accessor_span.clone(), "invalid accessor".into())],
                 notes: vec![],
             },
             Error::UnknownIdent(ref ident_span, ident) => ParseError {
                 message: format!("unknown identifier: '{}'", ident),
-                labels: vec![(ident_span.clone(), "unknown identifier".to_string())],
+                labels: vec![(ident_span.clone(), "unknown identifier".into())],
                 notes: vec![],
             },
             ref error => ParseError {
@@ -543,7 +544,7 @@ struct ParsedVariable<'a> {
 #[derive(Clone, Debug)]
 pub struct ParseError {
     message: String,
-    labels: Vec<(Span, String)>,
+    labels: Vec<(Span, Cow<'static, str>)>,
     notes: Vec<String>,
 }
 


### PR DESCRIPTION
`Cow<'a, str>` implements `From<String>` and `From<&'a str>`, which makes creating them a bit nicer. And it seems like `Cow` is the right fit for the labels in `wgsl::ParseError`, which are sometimes fixed strings and sometimes formatted.