### PR TITLE
Improve error messages for missing I/O bindings.

### DIFF
--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -729,7 +729,7 @@ impl Writer {
                 }
                 Instruction::type_int(id, bits, signedness)
             }
-            crate::ScalarKind::Float => {
+            Sk::Float => {
                 if bits == 64 {
                     self.capabilities.insert(spirv::Capability::Float64);
                 }

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -905,7 +905,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                     log::trace!("\t\t\tlooking up expr {:?}", base_id);
                     let mut acex = {
                         // the base type has to be a pointer,
-                        // so we derefernce it here for the traversal
+                        // so we dereference it here for the traversal
                         let lexp = self.lookup_expression.lookup(base_id)?;
                         let lty = self.lookup_type.lookup(lexp.type_id)?;
                         AccessExpression {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -891,7 +891,7 @@ pub enum Expression {
         arg1: Option<Handle<Expression>>,
         arg2: Option<Handle<Expression>>,
     },
-    /// Cast a simply type to another kind.
+    /// Cast a simple type to another kind.
     As {
         /// Source expression, which can only be a scalar or a vector.
         expr: Handle<Expression>,

--- a/src/valid/interface.rs
+++ b/src/valid/interface.rs
@@ -45,6 +45,8 @@ pub enum VaryingError {
     InvalidBuiltInStage(crate::BuiltIn),
     #[error("BuiltIn type for {0:?} is invalid")]
     InvalidBuiltInType(crate::BuiltIn),
+    #[error("Entry point arguments and return values must all have bindings")]
+    MissingBinding,
     #[error("Struct member {0} is missing a binding")]
     MemberMissingBinding(u32),
     #[error("Multiple bindings at location {location} are present")]
@@ -276,7 +278,7 @@ impl VaryingContext<'_> {
                             }
                         }
                     }
-                    _ => return Err(VaryingError::InvalidType(self.ty)),
+                    _ => return Err(VaryingError::MissingBinding),
                 }
                 Ok(())
             }


### PR DESCRIPTION
The `apply_common_default_interpolation` helper function would panic if bindings
were missing, but missing bindings should be something that front ends can count
on validation to detect, so the helper should just return silently.

The validator returned `InvalidType` errors for missing bindings, apparently
because variables without bindings must be structs that do have bindings. But
this is unhelpful when you've just forgotten to label an argument. So this patch
adds a new, more specific, `VaryingError` variant.
