### PR TITLE
Require dynamically sized arrays to appear in 'storage' memory.

### DIFF
--- a/src/valid/interface.rs
+++ b/src/valid/interface.rs
@@ -346,9 +346,11 @@ impl super::Validator {
                 };
                 (access, TypeFlags::empty(), true)
             }
-            crate::StorageClass::Private | crate::StorageClass::WorkGroup => {
-                (crate::StorageAccess::empty(), TypeFlags::DATA, false)
-            }
+            crate::StorageClass::Private | crate::StorageClass::WorkGroup => (
+                crate::StorageAccess::empty(),
+                TypeFlags::DATA | TypeFlags::SIZED,
+                false,
+            ),
             crate::StorageClass::PushConstant => {
                 if !self.capabilities.contains(Capabilities::PUSH_CONSTANT) {
                     return Err(GlobalVariableError::UnsupportedCapability(
@@ -357,7 +359,7 @@ impl super::Validator {
                 }
                 (
                     crate::StorageAccess::LOAD,
-                    TypeFlags::DATA | TypeFlags::HOST_SHARED,
+                    TypeFlags::DATA | TypeFlags::HOST_SHARED | TypeFlags::SIZED,
                     false,
                 )
             }

--- a/src/valid/type.rs
+++ b/src/valid/type.rs
@@ -294,8 +294,12 @@ impl super::Validator {
 
                         TypeFlags::SIZED
                     }
-                    //Note: this will be detected at the struct level
-                    crate::ArraySize::Dynamic => TypeFlags::empty(),
+                    crate::ArraySize::Dynamic => {
+                        // Non-SIZED types may only appear as the last element of a structure.
+                        // This is enforced by checks for SIZED-ness for all compound types,
+                        // and a special case for structs.
+                        TypeFlags::empty()
+                    }
                 };
 
                 let base_mask = TypeFlags::HOST_SHARED | TypeFlags::INTERFACE;


### PR DESCRIPTION
WGSL requires that runtime-sized arrays appear only as the last member of a
structure in in the `storage` storage class. It seems to me that Naga should
enforce this restriction on its own IR as well.