### PR TITLE
[wgsl-in] Improve wgsl lexer error messages

### DIFF
--- a/src/front/wgsl/conv.rs
+++ b/src/front/wgsl/conv.rs
@@ -1,17 +1,17 @@
-use super::Error;
+use super::{Error, Span};
 
-pub fn map_storage_class(word: &str) -> Result<crate::StorageClass, Error<'_>> {
+pub fn map_storage_class(word: &str, span: Span) -> Result<crate::StorageClass, Error<'_>> {
     match word {
         "private" => Ok(crate::StorageClass::Private),
         "workgroup" => Ok(crate::StorageClass::WorkGroup),
         "uniform" => Ok(crate::StorageClass::Uniform),
         "storage" => Ok(crate::StorageClass::Storage),
         "push_constant" => Ok(crate::StorageClass::PushConstant),
-        _ => Err(Error::UnknownStorageClass(word)),
+        _ => Err(Error::UnknownStorageClass(span)),
     }
 }
 
-pub fn map_built_in(word: &str) -> Result<crate::BuiltIn, Error<'_>> {
+pub fn map_built_in(word: &str, span: Span) -> Result<crate::BuiltIn, Error<'_>> {
     Ok(match word {
         "position" => crate::BuiltIn::Position,
         // vertex
@@ -28,37 +28,37 @@ pub fn map_built_in(word: &str) -> Result<crate::BuiltIn, Error<'_>> {
         "local_invocation_index" => crate::BuiltIn::LocalInvocationIndex,
         "workgroup_id" => crate::BuiltIn::WorkGroupId,
         "workgroup_size" => crate::BuiltIn::WorkGroupSize,
-        _ => return Err(Error::UnknownBuiltin(word)),
+        _ => return Err(Error::UnknownBuiltin(span)),
     })
 }
 
-pub fn map_shader_stage(word: &str) -> Result<crate::ShaderStage, Error<'_>> {
+pub fn map_shader_stage(word: &str, span: Span) -> Result<crate::ShaderStage, Error<'_>> {
     match word {
         "vertex" => Ok(crate::ShaderStage::Vertex),
         "fragment" => Ok(crate::ShaderStage::Fragment),
         "compute" => Ok(crate::ShaderStage::Compute),
-        _ => Err(Error::UnknownShaderStage(word)),
+        _ => Err(Error::UnknownShaderStage(span)),
     }
 }
 
-pub fn map_interpolation(word: &str) -> Result<crate::Interpolation, Error<'_>> {
+pub fn map_interpolation(word: &str, span: Span) -> Result<crate::Interpolation, Error<'_>> {
     match word {
         "linear" => Ok(crate::Interpolation::Linear),
         "flat" => Ok(crate::Interpolation::Flat),
         "perspective" => Ok(crate::Interpolation::Perspective),
-        _ => Err(Error::UnknownAttribute(word)),
+        _ => Err(Error::UnknownAttribute(span)),
     }
 }
 
-pub fn map_sampling(word: &str) -> Result<crate::Sampling, Error<'_>> {
+pub fn map_sampling(word: &str, span: Span) -> Result<crate::Sampling, Error<'_>> {
     match word {
         "centroid" => Ok(crate::Sampling::Centroid),
         "sample" => Ok(crate::Sampling::Sample),
-        _ => Err(Error::UnknownAttribute(word)),
+        _ => Err(Error::UnknownAttribute(span)),
     }
 }
 
-pub fn map_storage_format(word: &str) -> Result<crate::StorageFormat, Error<'_>> {
+pub fn map_storage_format(word: &str, span: Span) -> Result<crate::StorageFormat, Error<'_>> {
     use crate::StorageFormat as Sf;
     Ok(match word {
         "r8unorm" => Sf::R8Unorm,
@@ -93,7 +93,7 @@ pub fn map_storage_format(word: &str) -> Result<crate::StorageFormat, Error<'_>>
         "rgba32uint" => Sf::Rgba32Uint,
         "rgba32sint" => Sf::Rgba32Sint,
         "rgba32float" => Sf::Rgba32Float,
-        _ => return Err(Error::UnknownStorageFormat(word)),
+        _ => return Err(Error::UnknownStorageFormat(span)),
     })
 }
 
@@ -196,12 +196,15 @@ pub fn map_standard_fun(word: &str) -> Option<crate::MathFunction> {
     })
 }
 
-pub fn map_conservative_depth(word: &str) -> Result<crate::ConservativeDepth, Error<'_>> {
+pub fn map_conservative_depth(
+    word: &str,
+    span: Span,
+) -> Result<crate::ConservativeDepth, Error<'_>> {
     use crate::ConservativeDepth as Cd;
     match word {
         "greater_equal" => Ok(Cd::GreaterEqual),
         "less_equal" => Ok(Cd::LessEqual),
         "unchanged" => Ok(Cd::Unchanged),
-        _ => Err(Error::UnknownConservativeDepth(word)),
+        _ => Err(Error::UnknownConservativeDepth(span)),
     }
 }

--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -1,4 +1,4 @@
-use super::{conv, Error, Span, Token, TokenSpan};
+use super::{conv, Error, ExpectedToken, Span, Token, TokenSpan};
 
 fn _consume_str<'a>(input: &'a str, what: &str) -> Option<&'a str> {
     if input.starts_with(what) {
@@ -171,6 +171,25 @@ impl<'a> Lexer<'a> {
         self.source.len() - self.input.len()..self.source.len()
     }
 
+    /// Calls the function with a lexer and returns the result of the function as well as the span for everything the function parsed
+    ///
+    /// # Examples
+    /// ```ignore
+    /// let lexer = Lexer::new("5");
+    /// let (value, span) = lexer.capture_span(Lexer::next_uint_literal);
+    /// assert_eq!(value, 5);
+    /// ```
+    #[inline]
+    pub fn capture_span<T, E>(
+        &mut self,
+        inner: impl FnOnce(&mut Self) -> Result<T, E>,
+    ) -> Result<(T, Span), E> {
+        let start = self.current_byte_offset();
+        let res = inner(self)?;
+        let end = self.current_byte_offset();
+        Ok((res, start..end))
+    }
+
     fn peek_token_and_rest(&mut self) -> (TokenSpan<'a>, &'a str) {
         let mut cloned = self.clone();
         let token = cloned.next();
@@ -219,24 +238,7 @@ impl<'a> Lexer<'a> {
         if next.0 == expected {
             Ok(())
         } else {
-            let description = match expected {
-                Token::Separator(_) => "separator",
-                Token::DoubleColon => "::",
-                Token::Paren(_) => "paren",
-                Token::DoubleParen(_) => "double paren",
-                Token::Number { .. } => "number",
-                Token::String(string) => string,
-                Token::Word(word) => word,
-                Token::Operation(_) => "operation",
-                Token::LogicalOperation(_) => "logical op",
-                Token::ShiftOperation(_) => "shift op",
-                Token::Arrow => "->",
-                Token::Unknown(_) => "unknown",
-                Token::UnterminatedString => "string",
-                Token::Trivia => "trivia",
-                Token::End => "",
-            };
-            Err(Error::Unexpected(next, description))
+            Err(Error::Unexpected(next, ExpectedToken::Token(expected)))
         }
     }
 
@@ -245,10 +247,14 @@ impl<'a> Lexer<'a> {
         if next.0 == Token::Paren(expected) {
             Ok(())
         } else {
-            Err(Error::Unexpected(next, "paren"))
+            Err(Error::Unexpected(
+                next,
+                ExpectedToken::Token(Token::Paren(expected)),
+            ))
         }
     }
 
+    /// If the next token matches it is skipped and true is returned
     pub(super) fn skip(&mut self, what: Token<'_>) -> bool {
         let (peeked_token, rest) = self.peek_token_and_rest();
         if peeked_token.0 == what {
@@ -262,55 +268,81 @@ impl<'a> Lexer<'a> {
     pub(super) fn next_ident_with_span(&mut self) -> Result<(&'a str, Span), Error<'a>> {
         match self.next() {
             (Token::Word(word), span) => Ok((word, span)),
-            other => Err(Error::Unexpected(other, "identifier")),
+            other => Err(Error::Unexpected(other, ExpectedToken::Identifier)),
         }
     }
 
     pub(super) fn next_ident(&mut self) -> Result<&'a str, Error<'a>> {
         match self.next() {
             (Token::Word(word), _) => Ok(word),
-            other => Err(Error::Unexpected(other, "identifier")),
+            other => Err(Error::Unexpected(other, ExpectedToken::Identifier)),
         }
     }
 
     fn _next_float_literal(&mut self) -> Result<f32, Error<'a>> {
         match self.next() {
-            (Token::Number { value, .. }, span) => value.parse().map_err(|_| Error::BadFloat(span)),
-            other => Err(Error::Unexpected(other, "floating-point literal")),
+            (Token::Number { value, .. }, span) => {
+                value.parse().map_err(|e| Error::BadFloat(span, e))
+            }
+            other => Err(Error::Unexpected(other, ExpectedToken::Float)),
         }
     }
 
     pub(super) fn next_uint_literal(&mut self) -> Result<u32, Error<'a>> {
         match self.next() {
             (Token::Number { value, .. }, span) => {
-                value.parse().map_err(|_| Error::BadInteger(span))
+                let v = value.parse();
+                v.map_err(|e| Error::BadU32(span, e))
             }
-            other => Err(Error::Unexpected(other, "unsigned integer literal")),
+            other => Err(Error::Unexpected(other, ExpectedToken::Uint)),
         }
     }
 
     pub(super) fn next_sint_literal(&mut self) -> Result<i32, Error<'a>> {
         match self.next() {
             (Token::Number { value, .. }, span) => {
-                value.parse().map_err(|_| Error::BadInteger(span))
+                value.parse().map_err(|e| Error::BadI32(span, e))
             }
-            other => Err(Error::Unexpected(other, "signed integer literal")),
+            other => Err(Error::Unexpected(other, ExpectedToken::Sint)),
         }
     }
 
+    /// Parses a generic scalar type, for example `<f32>`.
     pub(super) fn next_scalar_generic(
         &mut self,
     ) -> Result<(crate::ScalarKind, crate::Bytes), Error<'a>> {
         self.expect_generic_paren('<')?;
-        let word = self.next_ident()?;
-        let pair = conv::get_scalar_type(word).ok_or(Error::UnknownScalarType(word))?;
+        let pair = match self.next() {
+            (Token::Word(word), span) => {
+                conv::get_scalar_type(word).ok_or(Error::UnknownScalarType(span))
+            }
+            (_, span) => Err(Error::UnknownScalarType(span)),
+        }?;
+        self.expect_generic_paren('>')?;
+        Ok(pair)
+    }
+
+    /// Parses a generic scalar type, for example `<f32>`.
+    ///
+    /// Returns the span covering the inner type, excluding the brackets.
+    pub(super) fn next_scalar_generic_with_span(
+        &mut self,
+    ) -> Result<(crate::ScalarKind, crate::Bytes, Span), Error<'a>> {
+        self.expect_generic_paren('<')?;
+        let pair = match self.next() {
+            (Token::Word(word), span) => conv::get_scalar_type(word)
+                .map(|(a, b)| (a, b, span.clone()))
+                .ok_or(Error::UnknownScalarType(span)),
+            (_, span) => Err(Error::UnknownScalarType(span)),
+        }?;
         self.expect_generic_paren('>')?;
         Ok(pair)
     }
 
     pub(super) fn next_format_generic(&mut self) -> Result<crate::StorageFormat, Error<'a>> {
         self.expect(Token::Paren('<'))?;
-        let format = conv::map_storage_format(self.next_ident()?)?;
+        let (ident, ident_span) = self.next_ident_with_span()?;
+        let format = conv::map_storage_format(ident, ident_span)?;
         self.expect(Token::Paren('>'))?;
         Ok(format)
     }

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -28,7 +28,7 @@ use std::{
     borrow::Cow,
     io::{self, Write},
     iter,
-    num::NonZeroU32,
+    num::{NonZeroU32, ParseFloatError, ParseIntError},
     ops,
 };
 use thiserror::Error;
@@ -59,60 +59,100 @@ pub enum Token<'a> {
     End,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum ExpectedToken<'a> {
+    Token(Token<'a>),
+    Identifier,
+    Float,
+    Uint,
+    Sint,
+    Constant,
+    /// Expected: constant, parenthesized expression, identifier
+    PrimaryExpression,
+    /// Expected: ']]', ','
+    AttributeSeparator,
+    /// Expected: '}', identifier
+    FieldName,
+    /// Expected: ']]', 'access', 'stride'
+    TypeAttribute,
+    /// Expected: ';', '{', word
+    Statement,
+    /// Expected: 'case', 'default', '}'
+    SwitchItem,
+    /// Expected: ',', ')'
+    WorkgroupSizeSeparator,
+    /// Expected: 'struct', 'let', 'var', 'type', ';', 'fn', eof
+    GlobalItem,
+    /// Expected: ']]', 'size', 'align'
+    StructAttribute,
+}
+
 #[derive(Clone, Debug, Error)]
 pub enum Error<'a> {
     #[error("")]
-    Unexpected(TokenSpan<'a>, &'a str),
+    Unexpected(TokenSpan<'a>, ExpectedToken<'a>),
     #[error("")]
-    BadInteger(Span),
+    BadU32(Span, ParseIntError),
     #[error("")]
-    BadFloat(Span),
+    BadI32(Span, ParseIntError),
+    #[error("")]
+    BadFloat(Span, ParseFloatError),
     #[error("")]
     BadScalarWidth(Span, &'a str),
     #[error("")]
     BadAccessor(Span),
-    #[error("bad texture {0}`")]
-    BadTexture(&'a str),
+    #[error("bad texture`")]
+    BadTexture(Span),
     #[error("bad texture coordinate")]
     BadCoordinate,
-    #[error("invalid type cast to `{0}`")]
-    BadTypeCast(&'a str),
+    #[error("invalid type cast")]
+    BadTypeCast {
+        span: Span,
+        from_type: String,
+        to_type: String,
+    },
+    #[error("bad texture sample type. Only f32, i32 and u32 are valid")]
+    BadTextureSampleType {
+        span: Span,
+        kind: crate::ScalarKind,
+        width: u8,
+    },
     #[error(transparent)]
     InvalidResolve(ResolveError),
     #[error("for(;;) initializer is not an assignment or a function call")]
-    InvalidForInitializer,
+    InvalidForInitializer(Span),
     #[error("resource type {0:?} is invalid")]
     InvalidResourceType(Handle<crate::Type>),
     #[error("unknown import: `{0}`")]
     UnknownImport(&'a str),
-    #[error("unknown storage class: `{0}`")]
-    UnknownStorageClass(&'a str),
-    #[error("unknown attribute: `{0}`")]
-    UnknownAttribute(&'a str),
+    #[error("unknown storage class")]
+    UnknownStorageClass(Span),
+    #[error("unknown attribute")]
+    UnknownAttribute(Span),
     #[error("unknown scalar kind: `{0}`")]
     UnknownScalarKind(&'a str),
-    #[error("unknown builtin: `{0}`")]
-    UnknownBuiltin(&'a str),
+    #[error("unknown builtin")]
+    UnknownBuiltin(Span),
     #[error("unknown access: `{0}`")]
     UnknownAccess(&'a str),
-    #[error("unknown shader stage: `{0}`")]
-    UnknownShaderStage(&'a str),
+    #[error("unknown shader stage")]
+    UnknownShaderStage(Span),
     #[error("unknown identifier: `{1}`")]
     UnknownIdent(Span, &'a str),
-    #[error("unknown scalar type: `{0}`")]
-    UnknownScalarType(&'a str),
-    #[error("unknown type: `{0}`")]
-    UnknownType(&'a str),
+    #[error("unknown scalar type")]
+    UnknownScalarType(Span),
+    #[error("unknown type")]
+    UnknownType(Span),
     #[error("unknown function: `{0}`")]
     UnknownFunction(&'a str),
-    #[error("unknown storage format: `{0}`")]
-    UnknownStorageFormat(&'a str),
-    #[error("unknown conservative depth: `{0}`")]
-    UnknownConservativeDepth(&'a str),
+    #[error("unknown storage format")]
+    UnknownStorageFormat(Span),
+    #[error("unknown conservative depth")]
+    UnknownConservativeDepth(Span),
     #[error("array stride must not be 0")]
-    ZeroStride,
-    #[error("struct member size or array must not be 0")]
-    ZeroSizeOrAlign,
+    ZeroStride(Span),
+    #[error("struct member size or alignment must not be 0")]
+    ZeroSizeOrAlign(Span),
     #[error("not a composite type: {0:?}")]
     NotCompositeType(Handle<crate::Type>),
     #[error("Input/output binding is not consistent: location {0:?}, built-in {1:?}, interpolation {2:?}, and sampling {3:?}")]
@@ -135,38 +175,85 @@ pub enum Error<'a> {
 impl<'a> Error<'a> {
     fn as_parse_error(&self, source: &'a str) -> ParseError {
         match *self {
-            Error::Unexpected((_, ref unexpected_span), expected) => ParseError {
-                message: format!(
-                    "expected {}, found '{}'",
-                    expected,
-                    &source[unexpected_span.clone()],
-                ),
-                labels: vec![(
-                    unexpected_span.clone(),
-                    format!("expected {}", expected).into(),
-                )],
-                notes: vec![],
+            Error::Unexpected((_, ref unexpected_span), expected) => {
+                let expected_str = match expected {
+                        ExpectedToken::Token(token) => {
+                            match token {
+                                Token::Separator(c) => format!("'{}'", c),
+                                Token::DoubleColon => "'::'".to_string(),
+                                Token::Paren(c) => format!("'{}'", c),
+                                Token::DoubleParen(c) => format!("'{}{}'", c, c),
+                                Token::Number { value, .. } => {
+                                    format!("number ({})", value)
+                                }
+                                Token::String(s) => format!("string literal ('{}')", s.to_string()),
+                                Token::Word(s) => s.to_string(),
+                                Token::Operation(c) => format!("operation ('{}')", c),
+                                Token::LogicalOperation(c) => format!("logical operation ('{}')", c),
+                                Token::ShiftOperation(c) => format!("bitshift ('{}{}')", c, c),
+                                Token::Arrow => "->".to_string(),
+                                Token::Unknown(c) => format!("unkown ('{}')", c),
+                                Token::UnterminatedString => "unterminated string".to_string(),
+                                Token::Trivia => "trivia".to_string(),
+                                Token::End => "end".to_string(),
+                            }
+                        }
+                        ExpectedToken::Identifier => "identifier".to_string(),
+                        ExpectedToken::Float => "floating point literal".to_string(),
+                        ExpectedToken::Uint => "non-negative integer literal".to_string(),
+                        ExpectedToken::Sint => "integer literal".to_string(),
+                        ExpectedToken::Constant => "constant".to_string(),
+                        ExpectedToken::PrimaryExpression => "expression".to_string(),
+                        ExpectedToken::AttributeSeparator => "attribute separator (',') or an end of the attribute list (']]')".to_string(),
+                        ExpectedToken::FieldName => "field name or a closing curly bracket to signify the end of the struct".to_string(),
+                        ExpectedToken::TypeAttribute => "type attribute ('access' or 'stride') or and of the attribute list (']]')".to_string(),
+                        ExpectedToken::Statement => "statement".to_string(),
+                        ExpectedToken::SwitchItem => "switch item ('case' or 'default') or a closing curly bracket to signify the end of the switch statement ('}')".to_string(),
+                        ExpectedToken::WorkgroupSizeSeparator => "workgroup size separator (',') or a closing parenthesis".to_string(),
+                        ExpectedToken::GlobalItem => "global item ('struct', 'let', 'var', 'type', ';', 'fn') or the end of the file".to_string(),
+                        ExpectedToken::StructAttribute => "struct attribute ('size' or 'align') or an end of the attribute list (']]')".to_string(),
+                    };
+                    ParseError {
+                    message: format!(
+                        "expected {}, found '{}'",
+                        expected_str,
+                        &source[unexpected_span.clone()],
+                    ),
+                    labels: vec![(
+                        unexpected_span.clone(),
+                        format!("expected {}", expected_str).into(),
+                    )],
+                    notes: vec![],
+                }
             },
-            Error::BadInteger(ref bad_span) => ParseError {
+            Error::BadU32(ref bad_span, ref err) => ParseError {
+                message: format!(
+                    "expected non-negative integer literal, found `{}`",
+                    &source[bad_span.clone()],
+                ),
+                labels: vec![(bad_span.clone(), "expected positive integer".into())],
+                notes: vec![err.to_string()],
+            },
+            Error::BadI32(ref bad_span, ref err) => ParseError {
                 message: format!(
                     "expected integer literal, found `{}`",
                     &source[bad_span.clone()],
                 ),
                 labels: vec![(bad_span.clone(), "expected integer".into())],
-                notes: vec![],
+                notes: vec![err.to_string()],
             },
-            Error::BadFloat(ref bad_span) => ParseError {
+            Error::BadFloat(ref bad_span, ref err) => ParseError {
                 message: format!(
                     "expected floating-point literal, found `{}`",
                     &source[bad_span.clone()],
                 ),
                 labels: vec![(bad_span.clone(), "expected floating-point literal".into())],
-                notes: vec![],
+                notes: vec![err.to_string()],
             },
             Error::BadScalarWidth(ref bad_span, width) => ParseError {
                 message: format!("invalid width of `{}` for literal", width,),
                 labels: vec![(bad_span.clone(), "invalid width".into())],
-                notes: vec!["valid width is 32".to_string()],
+                notes: vec!["valid widths are 8, 16, 32, 64".to_string()],
             },
             Error::BadAccessor(ref accessor_span) => ParseError {
                 message: format!(
@@ -181,12 +268,308 @@ impl<'a> Error<'a> {
                 labels: vec![(ident_span.clone(), "unknown identifier".into())],
                 notes: vec![],
             },
+            Error::UnknownScalarType(ref bad_span) => ParseError {
+                message: format!("unknown scalar type: '{}'", &source[bad_span.clone()]),
+                labels: vec![(bad_span.clone(), "unknown scalar type".into())],
+                notes: vec!["Valid scalar types are f16, f32, f64, i8, i16, i32, i64, u8, u16, u32, u64, bool".into()],
+            },
+            Error::BadTextureSampleType { ref span, kind, width } => ParseError {
+                message: format!("texture sample type must be one of f32, i32 or u32, but found {}", kind.to_wgsl(width)),
+                labels: vec![(span.clone(), "must be one of f32, i32 or u32".into())],
+                notes: vec![],
+            },
+            Error::BadTexture(ref bad_span) => ParseError {
+                message: format!("expected an image, but found '{}' which is not an image", &source[bad_span.clone()]),
+                labels: vec![(bad_span.clone(), "not an image".into())],
+                notes: vec![],
+            },
+            Error::BadTypeCast { ref span, ref from_type, ref to_type } => {
+                let msg = format!("cannot cast a {} to a {}", from_type, to_type);
+                ParseError {
+                    message: msg.clone(),
+                    labels: vec![(span.clone(), msg.into())],
+                    notes: vec![],
+                }
+            },
+            Error::InvalidForInitializer(ref bad_span) => ParseError {
+                message: format!("for(;;) initializer is not an assignment or a function call: '{}'", &source[bad_span.clone()]),
+                labels: vec![(bad_span.clone(), "not an assignment or function call".into())],
+                notes: vec![],
+            },
+            Error::UnknownStorageClass(ref bad_span) => ParseError {
+                message: format!("unknown storage class: '{}'", &source[bad_span.clone()]),
+                labels: vec![(bad_span.clone(), "unknown storage class".into())],
+                notes: vec![],
+            },
+            Error::UnknownAttribute(ref bad_span) => ParseError {
+                message: format!("unknown attribute: '{}'", &source[bad_span.clone()]),
+                labels: vec![(bad_span.clone(), "unknown attribute".into())],
+                notes: vec![],
+            },
+            Error::UnknownBuiltin(ref bad_span) => ParseError {
+                message: format!("unknown builtin: '{}'", &source[bad_span.clone()]),
+                labels: vec![(bad_span.clone(), "unknown builtin".into())],
+                notes: vec![],
+            },
+            Error::UnknownShaderStage(ref bad_span) => ParseError {
+                message: format!("unknown shader stage: '{}'", &source[bad_span.clone()]),
+                labels: vec![(bad_span.clone(), "unknown shader stage".into())],
+                notes: vec![],
+            },
+            Error::UnknownStorageFormat(ref bad_span) => ParseError {
+                message: format!("unknown storage format: '{}'", &source[bad_span.clone()]),
+                labels: vec![(bad_span.clone(), "unknown storage format".into())],
+                notes: vec![],
+            },
+            Error::UnknownConservativeDepth(ref bad_span) => ParseError {
+                message: format!("unknown conservative depth: '{}'", &source[bad_span.clone()]),
+                labels: vec![(bad_span.clone(), "unknown conservative depth".into())],
+                notes: vec![],
+            },
+            Error::UnknownType(ref bad_span) => ParseError {
+                message: format!("unknown type: '{}'", &source[bad_span.clone()]),
+                labels: vec![(bad_span.clone(), "unknown type".into())],
+                notes: vec![],
+            },
+            Error::ZeroStride(ref bad_span) => ParseError {
+                message: "array stride must not be zero".to_string(),
+                labels: vec![(bad_span.clone(), "array stride must not be zero".into())],
+                notes: vec![],
+            },
+            Error::ZeroSizeOrAlign(ref bad_span) => ParseError {
+                message: "struct member size or alignment must not be 0".to_string(),
+                labels: vec![(bad_span.clone(), "struct member size or alignment must not be 0".into())],
+                notes: vec![],
+            },
+
             ref error => ParseError {
                 message: error.to_string(),
                 labels: vec![],
                 notes: vec![],
             },
         }
+    }
+}
+
+impl crate::StorageFormat {
+    pub fn to_wgsl(&self) -> &str {
+        use crate::StorageFormat as Sf;
+        match *self {
+            Sf::R8Unorm => "r8unorm",
+            Sf::R8Snorm => "r8snorm",
+            Sf::R8Uint => "r8uint",
+            Sf::R8Sint => "r8sint",
+            Sf::R16Uint => "r16uint",
+            Sf::R16Sint => "r16sint",
+            Sf::R16Float => "r16float",
+            Sf::Rg8Unorm => "rg8unorm",
+            Sf::Rg8Snorm => "rg8snorm",
+            Sf::Rg8Uint => "rg8uint",
+            Sf::Rg8Sint => "rg8sint",
+            Sf::R32Uint => "r32uint",
+            Sf::R32Sint => "r32sint",
+            Sf::R32Float => "r32float",
+            Sf::Rg16Uint => "rg16uint",
+            Sf::Rg16Sint => "rg16sint",
+            Sf::Rg16Float => "rg16float",
+            Sf::Rgba8Unorm => "rgba8unorm",
+            Sf::Rgba8Snorm => "rgba8snorm",
+            Sf::Rgba8Uint => "rgba8uint",
+            Sf::Rgba8Sint => "rgba8sint",
+            Sf::Rgb10a2Unorm => "rgb10a2unorm",
+            Sf::Rg11b10Float => "rg11b10float",
+            Sf::Rg32Uint => "rg32uint",
+            Sf::Rg32Sint => "rg32sint",
+            Sf::Rg32Float => "rg32float",
+            Sf::Rgba16Uint => "rgba16uint",
+            Sf::Rgba16Sint => "rgba16sint",
+            Sf::Rgba16Float => "rgba16float",
+            Sf::Rgba32Uint => "rgba32uint",
+            Sf::Rgba32Sint => "rgba32sint",
+            Sf::Rgba32Float => "rgba32float",
+        }
+    }
+}
+
+impl crate::TypeInner {
+    /// Formats the type as it is written in wgsl.
+    ///
+    /// For example `vec3<f32>`.
+    ///
+    /// Note: The names of a `TypeInner::Struct` is not known. Therefore this method will simply return "struct" for them.
+    pub fn to_wgsl(
+        &self,
+        types: &Arena<crate::Type>,
+        constants: &Arena<crate::Constant>,
+    ) -> String {
+        match *self {
+            crate::TypeInner::Scalar { kind, width } => kind.to_wgsl(width),
+            crate::TypeInner::Vector { size, kind, width } => {
+                format!("vec{}<{}>", size as u32, kind.to_wgsl(width))
+            }
+            crate::TypeInner::Matrix {
+                columns,
+                rows,
+                width,
+            } => {
+                format!(
+                    "mat{}x{}<{}>",
+                    columns as u32,
+                    rows as u32,
+                    crate::ScalarKind::Float.to_wgsl(width),
+                )
+            }
+            crate::TypeInner::Pointer { base, .. } => {
+                let base = &types[base];
+                let name = base.name.as_deref().unwrap_or("unknown");
+                format!("*{}", name)
+            }
+            crate::TypeInner::ValuePointer { kind, width, .. } => {
+                format!("*{}", kind.to_wgsl(width))
+            }
+            crate::TypeInner::Array { base, size, .. } => {
+                let member_type = &types[base];
+                let base = member_type.name.as_deref().unwrap_or("unknown");
+                match size {
+                    crate::ArraySize::Constant(size) => {
+                        let size = constants[size].name.as_deref().unwrap_or("unknown");
+                        format!("{}[{}]", base, size)
+                    }
+                    crate::ArraySize::Dynamic => format!("{}[]", base),
+                }
+            }
+            crate::TypeInner::Struct { .. } => {
+                // TODO: Actually output the struct?
+                "struct".to_string()
+            }
+            crate::TypeInner::Image {
+                dim,
+                arrayed,
+                class,
+            } => {
+                let dim_suffix = match dim {
+                    crate::ImageDimension::D1 => "_1d",
+                    crate::ImageDimension::D2 => "_2d",
+                    crate::ImageDimension::D3 => "_3d",
+                    crate::ImageDimension::Cube => "_cube",
+                };
+                let array_suffix = if arrayed { "_array" } else { "" };
+
+                let class_suffix = match class {
+                    crate::ImageClass::Sampled { multi: true, .. } => "_multisampled",
+                    crate::ImageClass::Depth => "_depth",
+                    _ => "",
+                };
+
+                let type_in_brackets = match class {
+                    crate::ImageClass::Sampled { kind, .. } => {
+                        // Note: The only valid widths are 4 bytes wide.
+                        // The lexer has already verified this, so we can safely assume it here.
+                        // https://gpuweb.github.io/gpuweb/wgsl/#sampled-texture-type
+                        let element_type = kind.to_wgsl(4);
+                        format!("<{}>", element_type)
+                    }
+                    crate::ImageClass::Depth => String::new(),
+                    crate::ImageClass::Storage(format) => {
+                        format!("<{}>", format.to_wgsl())
+                    }
+                };
+
+                format!(
+                    "texture{}{}{}{}",
+                    class_suffix, dim_suffix, array_suffix, type_in_brackets
+                )
+            }
+            crate::TypeInner::Sampler { .. } => "sampler".to_string(),
+        }
+    }
+}
+
+mod type_inner_tests {
+    #[test]
+    fn to_wgsl() {
+        let mut types = crate::Arena::new();
+        let mut constants = crate::Arena::new();
+        let c = constants.append(crate::Constant {
+            name: Some("C".to_string()),
+            specialization: None,
+            inner: crate::ConstantInner::Scalar {
+                width: 4,
+                value: crate::ScalarValue::Uint(32),
+            },
+        });
+
+        let mytype1 = types.append(crate::Type {
+            name: Some("MyType1".to_string()),
+            inner: crate::TypeInner::Struct {
+                top_level: true,
+                members: vec![],
+                span: 0,
+            },
+        });
+        let mytype2 = types.append(crate::Type {
+            name: Some("MyType2".to_string()),
+            inner: crate::TypeInner::Struct {
+                top_level: true,
+                members: vec![],
+                span: 0,
+            },
+        });
+
+        let array = crate::TypeInner::Array {
+            base: mytype1,
+            stride: 4,
+            size: crate::ArraySize::Constant(c),
+        };
+        assert_eq!(array.to_wgsl(&types, &constants), "MyType1[C]");
+
+        let mat = crate::TypeInner::Matrix {
+            rows: crate::VectorSize::Quad,
+            columns: crate::VectorSize::Bi,
+            width: 8,
+        };
+        assert_eq!(mat.to_wgsl(&types, &constants), "mat2x4<f64>");
+
+        let ptr = crate::TypeInner::Pointer {
+            base: mytype2,
+            class: crate::StorageClass::Storage,
+        };
+        assert_eq!(ptr.to_wgsl(&types, &constants), "*MyType2");
+
+        let img1 = crate::TypeInner::Image {
+            dim: crate::ImageDimension::D2,
+            arrayed: false,
+            class: crate::ImageClass::Sampled {
+                kind: crate::ScalarKind::Float,
+                multi: true,
+            },
+        };
+        assert_eq!(
+            img1.to_wgsl(&types, &constants),
+            "texture_multisampled_2d<f32>"
+        );
+
+        let img2 = crate::TypeInner::Image {
+            dim: crate::ImageDimension::Cube,
+            arrayed: true,
+            class: crate::ImageClass::Depth,
+        };
+        assert_eq!(img2.to_wgsl(&types, &constants), "texture_depth_cube_array");
+    }
+}
+
+impl crate::ScalarKind {
+    /// Format a scalar kind+width as a type is written in wgsl.
+    ///
+    /// Examples: `f32`, `u64`, `bool`.
+    fn to_wgsl(&self, width: u8) -> String {
+        let prefix = match *self {
+            crate::ScalarKind::Sint => "i",
+            crate::ScalarKind::Uint => "u",
+            crate::ScalarKind::Float => "f",
+            crate::ScalarKind::Bool => return "bool".to_string(),
+        };
+        format!("{}{}", prefix, width * 8)
     }
 }
 
@@ -311,12 +694,12 @@ impl<'a> ExpressionContext<'a, '_, '_> {
         image_name: &'a str,
         span: Span,
     ) -> Result<SamplingContext, Error<'a>> {
-        let image = self.lookup_ident.lookup(image_name, span)?;
+        let image = self.lookup_ident.lookup(image_name, span.clone())?;
         Ok(SamplingContext {
             image,
             arrayed: match *self.resolve_type(image)? {
                 crate::TypeInner::Image { arrayed, .. } => arrayed,
-                _ => return Err(Error::BadTexture(image_name)),
+                _ => return Err(Error::BadTexture(span)),
             },
         })
     }
@@ -473,7 +856,12 @@ struct BindingParser {
 }
 
 impl BindingParser {
-    fn parse<'a>(&mut self, lexer: &mut Lexer<'a>, name: &'a str) -> Result<(), Error<'a>> {
+    fn parse<'a>(
+        &mut self,
+        lexer: &mut Lexer<'a>,
+        name: &'a str,
+        name_span: Span,
+    ) -> Result<(), Error<'a>> {
         match name {
             "location" => {
                 lexer.expect(Token::Paren('('))?;
@@ -482,21 +870,21 @@ impl BindingParser {
             }
             "builtin" => {
                 lexer.expect(Token::Paren('('))?;
-                let raw = lexer.next_ident()?;
-                self.built_in = Some(conv::map_built_in(raw)?);
+                let (raw, span) = lexer.next_ident_with_span()?;
+                self.built_in = Some(conv::map_built_in(raw, span)?);
                 lexer.expect(Token::Paren(')'))?;
             }
             "interpolate" => {
                 lexer.expect(Token::Paren('('))?;
-                let raw = lexer.next_ident()?;
-                self.interpolation = Some(conv::map_interpolation(raw)?);
+                let (raw, span) = lexer.next_ident_with_span()?;
+                self.interpolation = Some(conv::map_interpolation(raw, span)?);
                 if lexer.skip(Token::Separator(',')) {
-                    let raw = lexer.next_ident()?;
-                    self.sampling = Some(conv::map_sampling(raw)?);
+                    let (raw, span) = lexer.next_ident_with_span()?;
+                    self.sampling = Some(conv::map_sampling(raw, span)?);
                 }
                 lexer.expect(Token::Paren(')'))?;
             }
-            _ => return Err(Error::UnknownAttribute(name)),
+            _ => return Err(Error::UnknownAttribute(name_span)),
         }
         Ok(())
     }
@@ -639,15 +1027,15 @@ impl Parser {
             'i' => word
                 .parse()
                 .map(crate::ScalarValue::Sint)
-                .map_err(|_| Error::BadInteger(span.clone()))?,
+                .map_err(|e| Error::BadI32(span.clone(), e))?,
             'u' => word
                 .parse()
                 .map(crate::ScalarValue::Uint)
-                .map_err(|_| Error::BadInteger(span.clone()))?,
+                .map_err(|e| Error::BadU32(span.clone(), e))?,
             'f' => word
                 .parse()
                 .map(crate::ScalarValue::Float)
-                .map_err(|_| Error::BadFloat(span.clone()))?,
+                .map_err(|e| Error::BadFloat(span.clone(), e))?,
             _ => unreachable!(),
         };
         Ok(crate::ConstantInner::Scalar {
@@ -656,9 +1044,9 @@ impl Parser {
                 4
             } else {
                 match width.parse::<crate::Bytes>() {
-                    Ok(bits) => bits / 8,
-                    Err(_) => return Err(Error::BadScalarWidth(span, width)),
-                }
+                    Ok(bits) if (bits % 8) == 0 => Ok(bits / 8),
+                    _ => Err(Error::BadScalarWidth(span, width)),
+                }?
             },
         })
     }
@@ -946,12 +1334,12 @@ impl Parser {
                 "textureLoad" => {
                     lexer.open_arguments()?;
                     let (image_name, image_span) = lexer.next_ident_with_span()?;
-                    let image = ctx.lookup_ident.lookup(image_name, image_span)?;
+                    let image = ctx.lookup_ident.lookup(image_name, image_span.clone())?;
                     lexer.expect(Token::Separator(','))?;
                     let coordinate = self.parse_general_expression(lexer, ctx.reborrow())?;
                     let (class, arrayed) = match *ctx.resolve_type(image)? {
                         crate::TypeInner::Image { class, arrayed, .. } => (class, arrayed),
-                        _ => return Err(Error::BadTexture(image_name)),
+                        _ => return Err(Error::BadTexture(image_span)),
                     };
                     let array_index = if arrayed {
                         lexer.expect(Token::Separator(','))?;
@@ -1067,13 +1455,18 @@ impl Parser {
             },
         };
 
-        lexer.open_arguments()?;
         let mut components = Vec::new();
-        let mut last_component = self.parse_general_expression(lexer, ctx.reborrow())?;
-        while lexer.next_argument()? {
-            components.push(last_component);
-            last_component = self.parse_general_expression(lexer, ctx.reborrow())?;
-        }
+        let (last_component, arguments_span) = lexer.capture_span(|lexer| {
+            lexer.open_arguments()?;
+            let mut last_component = self.parse_general_expression(lexer, ctx.reborrow())?;
+
+            while lexer.next_argument()? {
+                components.push(last_component);
+                last_component = self.parse_general_expression(lexer, ctx.reborrow())?;
+            }
+
+            Ok(last_component)
+        })?;
 
         let expr = if components.is_empty()
             && ty_resolution.inner_with(ctx.types).scalar_kind().is_some()
@@ -1083,6 +1476,7 @@ impl Parser {
             // Use it to insert into the right maps,
             // and then grab it again immutably.
             ctx.resolve_type(last_component)?;
+
             match (
                 ty_resolution.inner_with(ctx.types),
                 ctx.typifier.get(last_component, ctx.types),
@@ -1112,8 +1506,12 @@ impl Parser {
                         convert: Some(width),
                     }
                 }
-                _ => {
-                    return Err(Error::BadTypeCast(type_name));
+                (to_type, from_type) => {
+                    return Err(Error::BadTypeCast {
+                        span: arguments_span,
+                        from_type: from_type.to_wgsl(&ctx.types, &ctx.constants),
+                        to_type: to_type.to_wgsl(&ctx.types, &ctx.constants),
+                    });
                 }
             }
         } else {
@@ -1150,7 +1548,7 @@ impl Parser {
                 },
                 _,
             ) => Self::get_constant_inner(*value, *ty, *width, first_token_span)?,
-            (Token::Word(name), _) => {
+            (Token::Word(name), name_span) => {
                 // look for an existing constant first
                 for (handle, var) in const_arena.iter() {
                     match var.name {
@@ -1164,6 +1562,7 @@ impl Parser {
                 let composite_ty = self.parse_type_decl_name(
                     lexer,
                     name,
+                    name_span,
                     None,
                     TypeAttributes::default(),
                     type_arena,
@@ -1182,7 +1581,7 @@ impl Parser {
                     components,
                 }
             }
-            other => return Err(Error::Unexpected(other, "constant")),
+            other => return Err(Error::Unexpected(other, ExpectedToken::Constant)),
         };
 
         let handle = if let Some(name) = register_name {
@@ -1251,7 +1650,7 @@ impl Parser {
                     return Err(Error::UnknownIdent(span, word));
                 }
             }
-            other => return Err(Error::Unexpected(other, "primary expression")),
+            other => return Err(Error::Unexpected(other, ExpectedToken::PrimaryExpression)),
         };
         self.scopes.pop();
         Ok(handle)
@@ -1577,8 +1976,8 @@ impl Parser {
         self.scopes.push(Scope::VariableDecl);
         let mut class = None;
         if lexer.skip(Token::Paren('<')) {
-            let class_str = lexer.next_ident()?;
-            class = Some(conv::map_storage_class(class_str)?);
+            let (class_str, span) = lexer.next_ident_with_span()?;
+            class = Some(conv::map_storage_class(class_str, span)?);
             lexer.expect(Token::Paren('>'))?;
         }
         let name = lexer.next_ident()?;
@@ -1627,27 +2026,38 @@ impl Parser {
                         (Token::Separator(','), _) if !ready => {
                             ready = true;
                         }
-                        (Token::Word(word), _) if ready => {
+                        (Token::Word(word), word_span) if ready => {
                             match word {
                                 "size" => {
                                     lexer.expect(Token::Paren('('))?;
-                                    let value = lexer.next_uint_literal()?;
+                                    let (value, span) =
+                                        lexer.capture_span(Lexer::next_uint_literal)?;
                                     lexer.expect(Token::Paren(')'))?;
-                                    size =
-                                        Some(NonZeroU32::new(value).ok_or(Error::ZeroSizeOrAlign)?);
+                                    size = Some(
+                                        NonZeroU32::new(value)
+                                            .ok_or(Error::ZeroSizeOrAlign(span))?,
+                                    );
                                 }
                                 "align" => {
                                     lexer.expect(Token::Paren('('))?;
-                                    let value = lexer.next_uint_literal()?;
+                                    let (value, span) =
+                                        lexer.capture_span(Lexer::next_uint_literal)?;
                                     lexer.expect(Token::Paren(')'))?;
-                                    align =
-                                        Some(NonZeroU32::new(value).ok_or(Error::ZeroSizeOrAlign)?);
+                                    align = Some(
+                                        NonZeroU32::new(value)
+                                            .ok_or(Error::ZeroSizeOrAlign(span))?,
+                                    );
                                 }
-                                _ => bind_parser.parse(lexer, word)?,
+                                _ => bind_parser.parse(lexer, word, word_span)?,
                             }
                             ready = false;
                         }
-                        other => return Err(Error::Unexpected(other, "attribute separator")),
+                        other if ready => {
+                            return Err(Error::Unexpected(other, ExpectedToken::StructAttribute))
+                        }
+                        other => {
+                            return Err(Error::Unexpected(other, ExpectedToken::AttributeSeparator))
+                        }
                     }
                 }
                 self.scopes.pop();
@@ -1659,7 +2069,7 @@ impl Parser {
                     let span = Layouter::round_up(alignment, offset);
                     return Ok((members, span));
                 }
-                other => return Err(Error::Unexpected(other, "field name")),
+                other => return Err(Error::Unexpected(other, ExpectedToken::FieldName)),
             };
             lexer.expect(Token::Separator(':'))?;
             let (ty, _access) = self.parse_type_decl(lexer, None, type_arena, const_arena)?;
@@ -1790,7 +2200,8 @@ impl Parser {
             }
             "ptr" => {
                 lexer.expect_generic_paren('<')?;
-                let class = conv::map_storage_class(lexer.next_ident()?)?;
+                let (ident, span) = lexer.next_ident_with_span()?;
+                let class = conv::map_storage_class(ident, span)?;
                 lexer.expect(Token::Separator(','))?;
                 let (base, _access) = self.parse_type_decl(lexer, None, type_arena, const_arena)?;
                 lexer.expect_generic_paren('>')?;
@@ -1817,7 +2228,8 @@ impl Parser {
             "sampler" => crate::TypeInner::Sampler { comparison: false },
             "sampler_comparison" => crate::TypeInner::Sampler { comparison: true },
             "texture_1d" => {
-                let (kind, _) = lexer.next_scalar_generic()?;
+                let (kind, width, span) = lexer.next_scalar_generic_with_span()?;
+                Self::check_texture_sample_type(kind, width, span)?;
                 crate::TypeInner::Image {
                     dim: crate::ImageDimension::D1,
                     arrayed: false,
@@ -1825,7 +2237,8 @@ impl Parser {
                 }
             }
             "texture_1d_array" => {
-                let (kind, _) = lexer.next_scalar_generic()?;
+                let (kind, width, span) = lexer.next_scalar_generic_with_span()?;
+                Self::check_texture_sample_type(kind, width, span)?;
                 crate::TypeInner::Image {
                     dim: crate::ImageDimension::D1,
                     arrayed: true,
@@ -1833,7 +2246,8 @@ impl Parser {
                 }
             }
             "texture_2d" => {
-                let (kind, _) = lexer.next_scalar_generic()?;
+                let (kind, width, span) = lexer.next_scalar_generic_with_span()?;
+                Self::check_texture_sample_type(kind, width, span)?;
                 crate::TypeInner::Image {
                     dim: crate::ImageDimension::D2,
                     arrayed: false,
@@ -1841,7 +2255,8 @@ impl Parser {
                 }
             }
             "texture_2d_array" => {
-                let (kind, _) = lexer.next_scalar_generic()?;
+                let (kind, width, span) = lexer.next_scalar_generic_with_span()?;
+                Self::check_texture_sample_type(kind, width, span)?;
                 crate::TypeInner::Image {
                     dim: crate::ImageDimension::D2,
                     arrayed: true,
@@ -1849,7 +2264,8 @@ impl Parser {
                 }
             }
             "texture_3d" => {
-                let (kind, _) = lexer.next_scalar_generic()?;
+                let (kind, width, span) = lexer.next_scalar_generic_with_span()?;
+                Self::check_texture_sample_type(kind, width, span)?;
                 crate::TypeInner::Image {
                     dim: crate::ImageDimension::D3,
                     arrayed: false,
@@ -1857,7 +2273,8 @@ impl Parser {
                 }
             }
             "texture_cube" => {
-                let (kind, _) = lexer.next_scalar_generic()?;
+                let (kind, width, span) = lexer.next_scalar_generic_with_span()?;
+                Self::check_texture_sample_type(kind, width, span)?;
                 crate::TypeInner::Image {
                     dim: crate::ImageDimension::Cube,
                     arrayed: false,
@@ -1865,7 +2282,8 @@ impl Parser {
                 }
             }
             "texture_cube_array" => {
-                let (kind, _) = lexer.next_scalar_generic()?;
+                let (kind, width, span) = lexer.next_scalar_generic_with_span()?;
+                Self::check_texture_sample_type(kind, width, span)?;
                 crate::TypeInner::Image {
                     dim: crate::ImageDimension::Cube,
                     arrayed: true,
@@ -1873,7 +2291,8 @@ impl Parser {
                 }
             }
             "texture_multisampled_2d" => {
-                let (kind, _) = lexer.next_scalar_generic()?;
+                let (kind, width, span) = lexer.next_scalar_generic_with_span()?;
+                Self::check_texture_sample_type(kind, width, span)?;
                 crate::TypeInner::Image {
                     dim: crate::ImageDimension::D2,
                     arrayed: false,
@@ -1881,7 +2300,8 @@ impl Parser {
                 }
             }
             "texture_multisampled_2d_array" => {
-                let (kind, _) = lexer.next_scalar_generic()?;
+                let (kind, width, span) = lexer.next_scalar_generic_with_span()?;
+                Self::check_texture_sample_type(kind, width, span)?;
                 crate::TypeInner::Image {
                     dim: crate::ImageDimension::D2,
                     arrayed: true,
@@ -1952,11 +2372,26 @@ impl Parser {
         }))
     }
 
+    fn check_texture_sample_type(
+        kind: crate::ScalarKind,
+        width: u8,
+        span: Span,
+    ) -> Result<(), Error<'static>> {
+        use crate::ScalarKind::*;
+        // Validate according to https://gpuweb.github.io/gpuweb/wgsl/#sampled-texture-type
+        match (kind, width) {
+            (Float, 4) | (Sint, 4) | (Uint, 4) => Ok(()),
+            _ => Err(Error::BadTextureSampleType { span, kind, width }),
+        }
+    }
+
     /// Parse type declaration of a given name and attribute.
+    #[allow(clippy::too_many_arguments)]
     fn parse_type_decl_name<'a>(
         &mut self,
         lexer: &mut Lexer<'a>,
         name: &'a str,
+        name_span: Span,
         debug_name: Option<&'a str>,
         attribute: TypeAttributes,
         type_arena: &mut Arena<crate::Type>,
@@ -1970,7 +2405,7 @@ impl Parser {
                         name: debug_name.map(|s| s.to_string()),
                         inner,
                     }),
-                    None => return Err(Error::UnknownType(name)),
+                    None => return Err(Error::UnknownType(name_span)),
                 }
             }
         })
@@ -2002,22 +2437,29 @@ impl Parser {
                     }
                     (Token::Word("stride"), _) => {
                         lexer.expect(Token::Paren('('))?;
-                        attribute.stride = Some(
-                            NonZeroU32::new(lexer.next_uint_literal()?).ok_or(Error::ZeroStride)?,
-                        );
+                        let (stride, span) = lexer.capture_span(Lexer::next_uint_literal)?;
+                        attribute.stride =
+                            Some(NonZeroU32::new(stride).ok_or(Error::ZeroStride(span))?);
                         lexer.expect(Token::Paren(')'))?;
                     }
                     (Token::DoubleParen(']'), _) => break,
-                    other => return Err(Error::Unexpected(other, "type attribute")),
+                    other => return Err(Error::Unexpected(other, ExpectedToken::TypeAttribute)),
                 }
             }
             self.scopes.pop();
         }
 
         let storage_access = attribute.access;
-        let name = lexer.next_ident()?;
-        let handle =
-            self.parse_type_decl_name(lexer, name, debug_name, attribute, type_arena, const_arena)?;
+        let (name, name_span) = lexer.next_ident_with_span()?;
+        let handle = self.parse_type_decl_name(
+            lexer,
+            name,
+            name_span,
+            debug_name,
+            attribute,
+            type_arena,
+            const_arena,
+        )?;
         self.scopes.pop();
         Ok((handle, storage_access))
     }
@@ -2083,7 +2525,7 @@ impl Parser {
                 return Ok(());
             }
             (Token::Word(word), _) => word,
-            other => return Err(Error::Unexpected(other, "statement")),
+            other => return Err(Error::Unexpected(other, ExpectedToken::Statement)),
         };
 
         self.scopes.push(Scope::Statement);
@@ -2292,7 +2734,7 @@ impl Parser {
                             default = self.parse_block(lexer, context.reborrow(), false)?;
                         }
                         (Token::Paren('}'), _) => break,
-                        other => return Err(Error::Unexpected(other, "switch item")),
+                        other => return Err(Error::Unexpected(other, ExpectedToken::SwitchItem)),
                     }
                 }
 
@@ -2325,16 +2767,19 @@ impl Parser {
                 lexer.expect(Token::Paren('('))?;
                 if !lexer.skip(Token::Separator(';')) {
                     let num_statements = block.len();
-                    self.parse_statement(
-                        lexer,
-                        context.reborrow(),
-                        block,
-                        is_uniform_control_flow,
-                    )?;
+                    let (_, span) = lexer.capture_span(|lexer| {
+                        self.parse_statement(
+                            lexer,
+                            context.reborrow(),
+                            block,
+                            is_uniform_control_flow,
+                        )
+                    })?;
+
                     if block.len() != num_statements {
                         match *block.last().unwrap() {
                             crate::Statement::Store { .. } | crate::Statement::Call { .. } => {}
-                            _ => return Err(Error::InvalidForInitializer),
+                            _ => return Err(Error::InvalidForInitializer(span)),
                         }
                     }
                 };
@@ -2392,12 +2837,14 @@ impl Parser {
                 emitter.start(context.expressions);
                 lexer.open_arguments()?;
                 let (image_name, image_span) = lexer.next_ident_with_span()?;
-                let image = context.lookup_ident.lookup(image_name, image_span)?;
+                let image = context
+                    .lookup_ident
+                    .lookup(image_name, image_span.clone())?;
                 lexer.expect(Token::Separator(','))?;
                 let mut expr_context = context.as_expression(block, &mut emitter);
                 let arrayed = match *expr_context.resolve_type(image)? {
                     crate::TypeInner::Image { arrayed, .. } => arrayed,
-                    _ => return Err(Error::BadTexture(image_name)),
+                    _ => return Err(Error::BadTexture(image_span)),
                 };
                 let coordinate = self.parse_general_expression(lexer, expr_context)?;
                 let array_index = if arrayed {
@@ -2467,14 +2914,14 @@ impl Parser {
         let mut bind_parser = BindingParser::default();
         self.scopes.push(Scope::Attribute);
         loop {
-            let word = lexer.next_ident()?;
-            bind_parser.parse(lexer, word)?;
+            let (word, span) = lexer.next_ident_with_span()?;
+            bind_parser.parse(lexer, word, span)?;
             match lexer.next() {
                 (Token::DoubleParen(']'), _) => {
                     break;
                 }
                 (Token::Separator(','), _) => {}
-                other => return Err(Error::Unexpected(other, "attribute separator")),
+                other => return Err(Error::Unexpected(other, ExpectedToken::AttributeSeparator)),
             }
         }
         self.scopes.pop();
@@ -2503,7 +2950,10 @@ impl Parser {
         let mut ready = true;
         while !lexer.skip(Token::Paren(')')) {
             if !ready {
-                return Err(Error::Unexpected(lexer.next(), "comma"));
+                return Err(Error::Unexpected(
+                    lexer.next(),
+                    ExpectedToken::Token(Token::Separator(',')),
+                ));
             }
             let binding = self.parse_varying_binding(lexer)?;
             let (param_name, param_type, _access) =
@@ -2581,26 +3031,27 @@ impl Parser {
             let (mut bind_index, mut bind_group) = (None, None);
             self.scopes.push(Scope::Attribute);
             loop {
-                match lexer.next_ident()? {
-                    "binding" => {
+                match lexer.next_ident_with_span()? {
+                    ("binding", _) => {
                         lexer.expect(Token::Paren('('))?;
                         bind_index = Some(lexer.next_uint_literal()?);
                         lexer.expect(Token::Paren(')'))?;
                     }
-                    "block" => {
+                    ("block", _) => {
                         is_block = true;
                     }
-                    "group" => {
+                    ("group", _) => {
                         lexer.expect(Token::Paren('('))?;
                         bind_group = Some(lexer.next_uint_literal()?);
                         lexer.expect(Token::Paren(')'))?;
                     }
-                    "stage" => {
+                    ("stage", _) => {
                         lexer.expect(Token::Paren('('))?;
-                        stage = Some(conv::map_shader_stage(lexer.next_ident()?)?);
+                        let (ident, ident_span) = lexer.next_ident_with_span()?;
+                        stage = Some(conv::map_shader_stage(ident, ident_span)?);
                         lexer.expect(Token::Paren(')'))?;
                     }
-                    "workgroup_size" => {
+                    ("workgroup_size", _) => {
                         lexer.expect(Token::Paren('('))?;
                         for (i, size) in workgroup_size.iter_mut().enumerate() {
                             *size = lexer.next_uint_literal()?;
@@ -2610,7 +3061,7 @@ impl Parser {
                                 other => {
                                     return Err(Error::Unexpected(
                                         other,
-                                        "workgroup size separator",
+                                        ExpectedToken::WorkgroupSizeSeparator,
                                     ))
                                 }
                             }
@@ -2621,9 +3072,10 @@ impl Parser {
                             }
                         }
                     }
-                    "early_depth_test" => {
+                    ("early_depth_test", _) => {
                         let conservative = if lexer.skip(Token::Paren('(')) {
-                            let value = conv::map_conservative_depth(lexer.next_ident()?)?;
+                            let (ident, ident_span) = lexer.next_ident_with_span()?;
+                            let value = conv::map_conservative_depth(ident, ident_span)?;
                             lexer.expect(Token::Paren(')'))?;
                             Some(value)
                         } else {
@@ -2631,14 +3083,16 @@ impl Parser {
                         };
                         early_depth_test = Some(crate::EarlyDepthTest { conservative });
                     }
-                    word => return Err(Error::UnknownAttribute(word)),
+                    (_, word_span) => return Err(Error::UnknownAttribute(word_span)),
                 }
                 match lexer.next() {
                     (Token::DoubleParen(']'), _) => {
                         break;
                     }
                     (Token::Separator(','), _) => {}
-                    other => return Err(Error::Unexpected(other, "attribute separator")),
+                    other => {
+                        return Err(Error::Unexpected(other, ExpectedToken::AttributeSeparator))
+                    }
                 }
             }
             if let (Some(group), Some(index)) = (bind_group, bind_index) {
@@ -2763,7 +3217,7 @@ impl Parser {
                 }
             }
             (Token::End, _) => return Ok(false),
-            other => return Err(Error::Unexpected(other, "global item")),
+            other => return Err(Error::Unexpected(other, ExpectedToken::GlobalItem)),
         }
 
         match binding {

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -54,6 +54,8 @@ fn invalid_float() {
   │
 1 │ let scale: f32 = 1.1.;
   │                  ^^^^ expected floating-point literal
+  │
+  = note: invalid float literal
 
 "###,
     );
@@ -69,7 +71,21 @@ fn invalid_scalar_width() {
 1 │ let scale: f32 = 1.1f1000;
   │                  ^^^^^^^^ invalid width
   │
-  = note: valid width is 32
+  = note: valid widths are 8, 16, 32, 64
+
+"###,
+    );
+}
+
+#[test]
+fn invalid_texture_sample_type() {
+    check(
+        "let x: texture_2d<f16>;",
+        r###"error: texture sample type must be one of f32, i32 or u32, but found f16
+  ┌─ wgsl:1:19
+  │
+1 │ let x: texture_2d<f16>;
+  │                   ^^^ must be one of f32, i32 or u32
 
 "###,
     );


### PR DESCRIPTION
Improves error messages by adding spans for most wgsl lexer errors and adding more information to many messages to remove ambiguity.

For example:

**before**
```rust
error: expected paren, found '('
   ┌─ wgsl:49:13
   │
49 │         vec4(c)
   │             ^ expected paren
```
**after**
```rust
error: expected '<', found '('
   ┌─ wgsl:49:13
   │
49 │         vec4(c)
   │             ^ expected '<'
```

or
**before**
```rust
error: invalid type cast to `vec4`
```
**after**
```rust
error: cannot cast a struct to a vec4<f32>
   ┌─ wgsl:50:18
   │
50 │         vec4<f32>(in)
   │                  ^^^^ cannot cast a struct to a vec4<f32>
```

This also fixes a bug in which an integer or floating point constant with some invalid widths could be accepted. For example, the constant `3.0f33` was treated as an `f32` constant.

Some files are getting reallly large, maybe they should be split into several smaller ones?