### PR TITLE
Include the type arena in `ResolveContext`, since it's always needed.

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -78,17 +78,16 @@ impl<'a> Program<'a> {
     ) -> Result<&'b TypeInner, ErrorKind> {
         let resolve_ctx = ResolveContext {
             constants: &self.module.constants,
+            types: &self.module.types,
             global_vars: &self.module.global_variables,
             local_vars: &context.locals,
             functions: &self.module.functions,
             arguments: &context.arguments,
         };
-        match context.typifier.grow(
-            handle,
-            &context.expressions,
-            &mut self.module.types,
-            &resolve_ctx,
-        ) {
+        match context
+            .typifier
+            .grow(handle, &context.expressions, &resolve_ctx)
+        {
             //TODO: better error report
             Err(error) => Err(ErrorKind::SemanticError(
                 meta,
@@ -106,17 +105,16 @@ impl<'a> Program<'a> {
     ) -> Result<Handle<Type>, ErrorKind> {
         let resolve_ctx = ResolveContext {
             constants: &self.module.constants,
+            types: &self.module.types,
             global_vars: &self.module.global_variables,
             local_vars: &context.locals,
             functions: &self.module.functions,
             arguments: &context.arguments,
         };
-        match context.typifier.grow(
-            handle,
-            &context.expressions,
-            &mut self.module.types,
-            &resolve_ctx,
-        ) {
+        match context
+            .typifier
+            .grow(handle, &context.expressions, &resolve_ctx)
+        {
             //TODO: better error report
             Err(error) => Err(ErrorKind::SemanticError(
                 meta,

--- a/src/front/mod.rs
+++ b/src/front/mod.rs
@@ -97,12 +97,11 @@ impl Typifier {
         &mut self,
         expr_handle: Handle<crate::Expression>,
         expressions: &Arena<crate::Expression>,
-        types: &mut Arena<crate::Type>,
         ctx: &ResolveContext,
     ) -> Result<(), ResolveError> {
         if self.resolutions.len() <= expr_handle.index() {
             for (eh, expr) in expressions.iter().skip(self.resolutions.len()) {
-                let resolution = ctx.resolve(expr, types, |h| &self.resolutions[h.index()])?;
+                let resolution = ctx.resolve(expr, |h| &self.resolutions[h.index()])?;
                 log::debug!("Resolving {:?} = {:?} : {:?}", eh, expr, resolution);
                 self.resolutions.push(resolution);
             }

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -294,15 +294,13 @@ impl<'a> ExpressionContext<'a, '_, '_> {
     ) -> Result<&crate::TypeInner, Error<'a>> {
         let resolve_ctx = ResolveContext {
             constants: self.constants,
+            types: self.types,
             global_vars: self.global_vars,
             local_vars: self.local_vars,
             functions: self.functions,
             arguments: self.arguments,
         };
-        match self
-            .typifier
-            .grow(handle, self.expressions, self.types, &resolve_ctx)
-        {
+        match self.typifier.grow(handle, self.expressions, &resolve_ctx) {
             Err(e) => Err(Error::InvalidResolve(e)),
             Ok(()) => Ok(self.typifier.get(handle, self.types)),
         }

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -111,6 +111,7 @@ pub enum ResolveError {
 
 pub struct ResolveContext<'a> {
     pub constants: &'a Arena<crate::Constant>,
+    pub types: &'a Arena<crate::Type>,
     pub global_vars: &'a Arena<crate::GlobalVariable>,
     pub local_vars: &'a Arena<crate::LocalVariable>,
     pub functions: &'a Arena<crate::Function>,
@@ -121,10 +122,10 @@ impl<'a> ResolveContext<'a> {
     pub fn resolve(
         &self,
         expr: &crate::Expression,
-        types: &'a Arena<crate::Type>,
         past: impl Fn(Handle<crate::Expression>) -> &'a TypeResolution,
     ) -> Result<TypeResolution, ResolveError> {
         use crate::TypeInner as Ti;
+        let types = self.types;
         Ok(match *expr {
             crate::Expression::Access { base, .. } => match *past(base).inner_with(types) {
                 Ti::Array { base, .. } => TypeResolution::Handle(base),
@@ -144,37 +145,39 @@ impl<'a> ResolveContext<'a> {
                     width,
                     class,
                 }),
-                Ti::Pointer { base, class } => TypeResolution::Value(match types[base].inner {
-                    Ti::Array { base, .. } => Ti::Pointer { base, class },
-                    Ti::Vector {
-                        size: _,
-                        kind,
-                        width,
-                    } => Ti::ValuePointer {
-                        size: None,
-                        kind,
-                        width,
-                        class,
-                    },
-                    // Matrices are only dynamically indexed behind a pointer
-                    Ti::Matrix {
-                        columns: _,
-                        rows,
-                        width,
-                    } => Ti::ValuePointer {
-                        kind: crate::ScalarKind::Float,
-                        size: Some(rows),
-                        width,
-                        class,
-                    },
-                    ref other => {
-                        log::error!("Access sub-type {:?}", other);
-                        return Err(ResolveError::InvalidSubAccess {
-                            ty: base,
-                            indexed: false,
-                        });
-                    }
-                }),
+                Ti::Pointer { base, class } => {
+                    TypeResolution::Value(match types[base].inner {
+                        Ti::Array { base, .. } => Ti::Pointer { base, class },
+                        Ti::Vector {
+                            size: _,
+                            kind,
+                            width,
+                        } => Ti::ValuePointer {
+                            size: None,
+                            kind,
+                            width,
+                            class,
+                        },
+                        // Matrices are only dynamically indexed behind a pointer
+                        Ti::Matrix {
+                            columns: _,
+                            rows,
+                            width,
+                        } => Ti::ValuePointer {
+                            kind: crate::ScalarKind::Float,
+                            size: Some(rows),
+                            width,
+                            class,
+                        },
+                        ref other => {
+                            log::error!("Access sub-type {:?}", other);
+                            return Err(ResolveError::InvalidSubAccess {
+                                ty: base,
+                                indexed: false,
+                            });
+                        }
+                    })
+                }
                 ref other => {
                     log::error!("Access type {:?}", other);
                     return Err(ResolveError::InvalidAccess {


### PR DESCRIPTION
This removes a bunch of parameter passing, and I think there's only one type arena that is meaningful in these cases anyway.