### PR TITLE
Don't treat pointers as data.

### DIFF
--- a/src/valid/type.rs
+++ b/src/valid/type.rs
@@ -52,6 +52,15 @@ bitflags::bitflags! {
 
         /// This type can be passed as a function argument.
         const ARGUMENT = 0x40;
+
+        /// A WGSL [constructible] type.
+        ///
+        /// The constructible types are scalars, vectors, matrices, fixed-size
+        /// arrays of constructible types, and structs whose members are all
+        /// constructible.
+        ///
+        /// [constructible]: https://gpuweb.github.io/gpuweb/wgsl/#constructible
+        const CONSTRUCTIBLE = 0x80;
     }
 }
 
@@ -237,6 +246,7 @@ impl super::Validator {
                         | TypeFlags::SIZED
                         | TypeFlags::COPY
                         | TypeFlags::ARGUMENT
+                        | TypeFlags::CONSTRUCTIBLE
                         | shareable,
                     width as u32,
                 )
@@ -257,6 +267,7 @@ impl super::Validator {
                         | TypeFlags::COPY
                         | TypeFlags::HOST_SHAREABLE
                         | TypeFlags::ARGUMENT
+                        | TypeFlags::CONSTRUCTIBLE
                         | shareable,
                     count * (width as u32),
                 )
@@ -275,7 +286,8 @@ impl super::Validator {
                         | TypeFlags::SIZED
                         | TypeFlags::COPY
                         | TypeFlags::HOST_SHAREABLE
-                        | TypeFlags::ARGUMENT,
+                        | TypeFlags::ARGUMENT
+                        | TypeFlags::CONSTRUCTIBLE,
                     count * (width as u32),
                 )
             }
@@ -467,7 +479,7 @@ impl super::Validator {
                             return Err(TypeError::NonPositiveArrayLength(const_handle));
                         }
 
-                        TypeFlags::SIZED | TypeFlags::ARGUMENT
+                        TypeFlags::SIZED | TypeFlags::ARGUMENT | TypeFlags::CONSTRUCTIBLE
                     }
                     crate::ArraySize::Dynamic => {
                         // Non-SIZED types may only appear as the last element of a structure.
@@ -495,7 +507,8 @@ impl super::Validator {
                         | TypeFlags::COPY
                         | TypeFlags::HOST_SHAREABLE
                         | TypeFlags::IO_SHAREABLE
-                        | TypeFlags::ARGUMENT,
+                        | TypeFlags::ARGUMENT
+                        | TypeFlags::CONSTRUCTIBLE,
                     1,
                 );
                 ti.uniform_layout = Ok(Some(UNIFORM_MIN_ALIGNMENT));

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -1029,6 +1029,43 @@ fn invalid_functions() {
         })
         if function_name == "unacceptable_ptr_space" && argument_name == "arg"
     }
+
+    check_validation! {
+        "
+        struct AFloat {
+          said_float: f32
+        };
+        @group(0) @binding(0)
+        var<storage> float: AFloat;
+
+        fn return_pointer() -> ptr<storage, f32> {
+           return &float.said_float;
+        }
+        ":
+        Err(naga::valid::ValidationError::Function {
+            name: function_name,
+            error: naga::valid::FunctionError::NonConstructibleReturnType,
+            ..
+        })
+        if function_name == "return_pointer"
+    }
+
+    check_validation! {
+        "
+        @group(0) @binding(0)
+        var<storage> atom: atomic<u32>;
+
+        fn return_atomic() -> atomic<u32> {
+           return atom;
+        }
+        ":
+        Err(naga::valid::ValidationError::Function {
+            name: function_name,
+            error: naga::valid::FunctionError::NonConstructibleReturnType,
+            ..
+        })
+        if function_name == "return_atomic"
+    }
 }
 
 #[test]


### PR DESCRIPTION
All commits should be CI-clean.

- Don't allow pointers in return values.

- [wgsl-in]: Use a `matches!` expression for brevity.

- Don't permit `Expression::Select` to operate on pointers. At the moment, Naga
  doesn't support anything like SPIR-V's 'variable pointers'.

- Naga `TypeInner::Pointer` types are not `TypeFlags::DATA`.

  Change `Validator::validate_type` not to mark pointers with the
  `TypeFlags::Data` flag. The `TypeFlags::DATA` flag is supposed to correspond to
  WGSL's concept of a 'plain type': a scalar, atomic, or composite type, excluding
  textures, samplers, and pointers.

  With this change, there is no type where `TypeFlags::DATA` and
  `TypeFlags::INTERFACE` differ, but I'm not removing anything in this PR, because
  I think we'll want to re-introduce a different distinction between them soon.
