### PR TITLE
Set bake_ref_count to 1 for Expression::Load

### DIFF
--- a/src/back/mod.rs
+++ b/src/back/mod.rs
@@ -28,6 +28,8 @@ impl crate::Expression {
             crate::Expression::ImageSample { .. } | crate::Expression::ImageLoad { .. } => 1,
             // derivatives use the control flow
             crate::Expression::Derivative { .. } => 1,
+            // load can depend on state that changes during program flow
+            crate::Expression::Load { .. } => 1,
             // cache expressions that are referenced multiple times
             _ => 2,
         }

--- a/tests/out/access.msl
+++ b/tests/out/access.msl
@@ -24,5 +24,7 @@ vertex fooOutput foo(
 , device Bar& bar [[buffer(0)]]
 , constant _mslBufferSizes& _buffer_sizes [[buffer(24)]]
 ) {
-    return fooOutput { static_cast<float4>(metal::int4(type5 {bar.data[(1 + (_buffer_sizes.size0 - 64 - 4) / 4) - 1u], static_cast<int>(bar.matrix[3u].x), 3, 4, 5}.inner[vi])) };
+    metal::float4 _e5 = bar.matrix[3u];
+    int _e13 = bar.data[(1 + (_buffer_sizes.size0 - 64 - 4) / 4) - 1u];
+    return fooOutput { static_cast<float4>(metal::int4(type5 {_e13, static_cast<int>(_e5.x), 3, 4, 5}.inner[vi])) };
 }

--- a/tests/out/access.wgsl
+++ b/tests/out/access.wgsl
@@ -9,5 +9,7 @@ var<storage> bar: [[access(read_write)]] Bar;
 
 [[stage(vertex)]]
 fn foo([[builtin(vertex_index)]] vi: u32) -> [[builtin(position)]] vec4<f32> {
-    return vec4<f32>(vec4<i32>(array<i32,5>(bar.data[(arrayLength(&bar.data) - 1u)], i32(bar.matrix[3u].x), 3, 4, 5)[vi]));
+    let _e5: vec4<f32> = bar.matrix[3u];
+    let _e13: i32 = bar.data[(arrayLength(&bar.data) - 1u)];
+    return vec4<f32>(vec4<i32>(array<i32,5>(_e13, i32(_e5.x), 3, 4, 5)[vi]));
 }

--- a/tests/out/boids.Compute.glsl
+++ b/tests/out/boids.Compute.glsl
@@ -43,56 +43,108 @@ void main() {
     if((global_invocation_id.x >= 1500u)) {
         return;
     }
-    vPos = _group_0_binding_1.particles[global_invocation_id.x].pos;
-    vVel = _group_0_binding_1.particles[global_invocation_id.x].vel;
+    vec2 _expr10 = _group_0_binding_1.particles[global_invocation_id.x].pos;
+    vPos = _expr10;
+    vec2 _expr15 = _group_0_binding_1.particles[global_invocation_id.x].vel;
+    vVel = _expr15;
     cMass = vec2(0.0, 0.0);
     cVel = vec2(0.0, 0.0);
     colVel = vec2(0.0, 0.0);
     while(true) {
-        if((i >= 1500u)) {
+        uint _expr37 = i;
+        if((_expr37 >= 1500u)) {
             break;
         }
-        if((i == global_invocation_id.x)) {
+        uint _expr39 = i;
+        if((_expr39 == global_invocation_id.x)) {
             continue;
         }
-        pos1 = _group_0_binding_1.particles[i].pos;
-        vel1 = _group_0_binding_1.particles[i].vel;
-        if((distance(pos1, vPos) < _group_0_binding_0.rule1Distance)) {
-            cMass = (cMass + pos1);
-            cMassCount = (cMassCount + 1);
+        uint _expr42 = i;
+        vec2 _expr45 = _group_0_binding_1.particles[_expr42].pos;
+        pos1 = _expr45;
+        uint _expr47 = i;
+        vec2 _expr50 = _group_0_binding_1.particles[_expr47].vel;
+        vel1 = _expr50;
+        vec2 _expr51 = pos1;
+        vec2 _expr52 = vPos;
+        float _expr55 = _group_0_binding_0.rule1Distance;
+        if((distance(_expr51, _expr52) < _expr55)) {
+            vec2 _expr57 = cMass;
+            vec2 _expr58 = pos1;
+            cMass = (_expr57 + _expr58);
+            int _expr60 = cMassCount;
+            cMassCount = (_expr60 + 1);
         }
-        if((distance(pos1, vPos) < _group_0_binding_0.rule2Distance)) {
-            colVel = (colVel - (pos1 - vPos));
+        vec2 _expr63 = pos1;
+        vec2 _expr64 = vPos;
+        float _expr67 = _group_0_binding_0.rule2Distance;
+        if((distance(_expr63, _expr64) < _expr67)) {
+            vec2 _expr69 = colVel;
+            vec2 _expr70 = pos1;
+            vec2 _expr71 = vPos;
+            colVel = (_expr69 - (_expr70 - _expr71));
         }
-        if((distance(pos1, vPos) < _group_0_binding_0.rule3Distance)) {
-            cVel = (cVel + vel1);
-            cVelCount = (cVelCount + 1);
+        vec2 _expr74 = pos1;
+        vec2 _expr75 = vPos;
+        float _expr78 = _group_0_binding_0.rule3Distance;
+        if((distance(_expr74, _expr75) < _expr78)) {
+            vec2 _expr80 = cVel;
+            vec2 _expr81 = vel1;
+            cVel = (_expr80 + _expr81);
+            int _expr83 = cVelCount;
+            cVelCount = (_expr83 + 1);
         }
-        i = (i + 1u);
+        uint _expr86 = i;
+        i = (_expr86 + 1u);
     }
-    if((cMassCount > 0)) {
-        cMass = ((cMass / vec2(float(cMassCount))) - vPos);
+    int _expr89 = cMassCount;
+    if((_expr89 > 0)) {
+        vec2 _expr92 = cMass;
+        int _expr93 = cMassCount;
+        vec2 _expr97 = vPos;
+        cMass = ((_expr92 / vec2(float(_expr93))) - _expr97);
     }
-    if((cVelCount > 0)) {
-        cVel = (cVel / vec2(float(cVelCount)));
+    int _expr99 = cVelCount;
+    if((_expr99 > 0)) {
+        vec2 _expr102 = cVel;
+        int _expr103 = cVelCount;
+        cVel = (_expr102 / vec2(float(_expr103)));
     }
-    vVel = (((vVel + (cMass * _group_0_binding_0.rule1Scale)) + (colVel * _group_0_binding_0.rule2Scale)) + (cVel * _group_0_binding_0.rule3Scale));
-    vVel = (normalize(vVel) * clamp(length(vVel), 0.0, 0.1));
-    vPos = (vPos + (vVel * _group_0_binding_0.deltaT));
-    if((vPos.x < -1.0)) {
+    vec2 _expr107 = vVel;
+    vec2 _expr108 = cMass;
+    float _expr110 = _group_0_binding_0.rule1Scale;
+    vec2 _expr113 = colVel;
+    float _expr115 = _group_0_binding_0.rule2Scale;
+    vec2 _expr118 = cVel;
+    float _expr120 = _group_0_binding_0.rule3Scale;
+    vVel = (((_expr107 + (_expr108 * _expr110)) + (_expr113 * _expr115)) + (_expr118 * _expr120));
+    vec2 _expr123 = vVel;
+    vec2 _expr125 = vVel;
+    vVel = (normalize(_expr123) * clamp(length(_expr125), 0.0, 0.1));
+    vec2 _expr131 = vPos;
+    vec2 _expr132 = vVel;
+    float _expr134 = _group_0_binding_0.deltaT;
+    vPos = (_expr131 + (_expr132 * _expr134));
+    vec2 _expr137 = vPos;
+    if((_expr137.x < -1.0)) {
         vPos.x = 1.0;
     }
-    if((vPos.x > 1.0)) {
+    vec2 _expr143 = vPos;
+    if((_expr143.x > 1.0)) {
         vPos.x = -1.0;
     }
-    if((vPos.y < -1.0)) {
+    vec2 _expr149 = vPos;
+    if((_expr149.y < -1.0)) {
         vPos.y = 1.0;
     }
-    if((vPos.y > 1.0)) {
+    vec2 _expr155 = vPos;
+    if((_expr155.y > 1.0)) {
         vPos.y = -1.0;
     }
-    _group_0_binding_2.particles[global_invocation_id.x].pos = vPos;
-    _group_0_binding_2.particles[global_invocation_id.x].vel = vVel;
+    vec2 _expr164 = vPos;
+    _group_0_binding_2.particles[global_invocation_id.x].pos = _expr164;
+    vec2 _expr168 = vVel;
+    _group_0_binding_2.particles[global_invocation_id.x].vel = _expr168;
     return;
 }
 

--- a/tests/out/boids.msl
+++ b/tests/out/boids.msl
@@ -47,59 +47,111 @@ kernel void main1(
     if (global_invocation_id.x >= NUM_PARTICLES) {
         return;
     }
-    vPos = particlesSrc.particles[global_invocation_id.x].pos;
-    vVel = particlesSrc.particles[global_invocation_id.x].vel;
+    metal::float2 _e10 = particlesSrc.particles[global_invocation_id.x].pos;
+    vPos = _e10;
+    metal::float2 _e15 = particlesSrc.particles[global_invocation_id.x].vel;
+    vVel = _e15;
     cMass = metal::float2(0.0, 0.0);
     cVel = metal::float2(0.0, 0.0);
     colVel = metal::float2(0.0, 0.0);
     bool loop_init = true;
     while(true) {
         if (!loop_init) {
-            i = i + 1u;
+            metal::uint _e86 = i;
+            i = _e86 + 1u;
         }
         loop_init = false;
-        if (i >= NUM_PARTICLES) {
+        metal::uint _e37 = i;
+        if (_e37 >= NUM_PARTICLES) {
             break;
         }
-        if (i == global_invocation_id.x) {
+        metal::uint _e39 = i;
+        if (_e39 == global_invocation_id.x) {
             continue;
         }
-        pos1 = particlesSrc.particles[i].pos;
-        vel1 = particlesSrc.particles[i].vel;
-        if (metal::distance(pos1, vPos) < params.rule1Distance) {
-            cMass = cMass + pos1;
-            cMassCount = cMassCount + 1;
+        metal::uint _e42 = i;
+        metal::float2 _e45 = particlesSrc.particles[_e42].pos;
+        pos1 = _e45;
+        metal::uint _e47 = i;
+        metal::float2 _e50 = particlesSrc.particles[_e47].vel;
+        vel1 = _e50;
+        metal::float2 _e51 = pos1;
+        metal::float2 _e52 = vPos;
+        float _e55 = params.rule1Distance;
+        if (metal::distance(_e51, _e52) < _e55) {
+            metal::float2 _e57 = cMass;
+            metal::float2 _e58 = pos1;
+            cMass = _e57 + _e58;
+            int _e60 = cMassCount;
+            cMassCount = _e60 + 1;
         }
-        if (metal::distance(pos1, vPos) < params.rule2Distance) {
-            colVel = colVel - (pos1 - vPos);
+        metal::float2 _e63 = pos1;
+        metal::float2 _e64 = vPos;
+        float _e67 = params.rule2Distance;
+        if (metal::distance(_e63, _e64) < _e67) {
+            metal::float2 _e69 = colVel;
+            metal::float2 _e70 = pos1;
+            metal::float2 _e71 = vPos;
+            colVel = _e69 - (_e70 - _e71);
         }
-        if (metal::distance(pos1, vPos) < params.rule3Distance) {
-            cVel = cVel + vel1;
-            cVelCount = cVelCount + 1;
+        metal::float2 _e74 = pos1;
+        metal::float2 _e75 = vPos;
+        float _e78 = params.rule3Distance;
+        if (metal::distance(_e74, _e75) < _e78) {
+            metal::float2 _e80 = cVel;
+            metal::float2 _e81 = vel1;
+            cVel = _e80 + _e81;
+            int _e83 = cVelCount;
+            cVelCount = _e83 + 1;
         }
     }
-    if (cMassCount > 0) {
-        cMass = (cMass / metal::float2(static_cast<float>(cMassCount))) - vPos;
+    int _e89 = cMassCount;
+    if (_e89 > 0) {
+        metal::float2 _e92 = cMass;
+        int _e93 = cMassCount;
+        metal::float2 _e97 = vPos;
+        cMass = (_e92 / metal::float2(static_cast<float>(_e93))) - _e97;
     }
-    if (cVelCount > 0) {
-        cVel = cVel / metal::float2(static_cast<float>(cVelCount));
+    int _e99 = cVelCount;
+    if (_e99 > 0) {
+        metal::float2 _e102 = cVel;
+        int _e103 = cVelCount;
+        cVel = _e102 / metal::float2(static_cast<float>(_e103));
     }
-    vVel = ((vVel + (cMass * params.rule1Scale)) + (colVel * params.rule2Scale)) + (cVel * params.rule3Scale);
-    vVel = metal::normalize(vVel) * metal::clamp(metal::length(vVel), 0.0, 0.1);
-    vPos = vPos + (vVel * params.deltaT);
-    if (vPos.x < -1.0) {
+    metal::float2 _e107 = vVel;
+    metal::float2 _e108 = cMass;
+    float _e110 = params.rule1Scale;
+    metal::float2 _e113 = colVel;
+    float _e115 = params.rule2Scale;
+    metal::float2 _e118 = cVel;
+    float _e120 = params.rule3Scale;
+    vVel = ((_e107 + (_e108 * _e110)) + (_e113 * _e115)) + (_e118 * _e120);
+    metal::float2 _e123 = vVel;
+    metal::float2 _e125 = vVel;
+    vVel = metal::normalize(_e123) * metal::clamp(metal::length(_e125), 0.0, 0.1);
+    metal::float2 _e131 = vPos;
+    metal::float2 _e132 = vVel;
+    float _e134 = params.deltaT;
+    vPos = _e131 + (_e132 * _e134);
+    metal::float2 _e137 = vPos;
+    if (_e137.x < -1.0) {
         vPos.x = 1.0;
     }
-    if (vPos.x > 1.0) {
+    metal::float2 _e143 = vPos;
+    if (_e143.x > 1.0) {
         vPos.x = -1.0;
     }
-    if (vPos.y < -1.0) {
+    metal::float2 _e149 = vPos;
+    if (_e149.y < -1.0) {
         vPos.y = 1.0;
     }
-    if (vPos.y > 1.0) {
+    metal::float2 _e155 = vPos;
+    if (_e155.y > 1.0) {
         vPos.y = -1.0;
     }
-    particlesDst.particles[global_invocation_id.x].pos = vPos;
-    particlesDst.particles[global_invocation_id.x].vel = vVel;
+    metal::float2 _e164 = vPos;
+    particlesDst.particles[global_invocation_id.x].pos = _e164;
+    metal::float2 _e168 = vVel;
+    particlesDst.particles[global_invocation_id.x].vel = _e168;
     return;
 }

--- a/tests/out/boids.wgsl
+++ b/tests/out/boids.wgsl
@@ -44,57 +44,109 @@ fn main([[builtin(global_invocation_id)]] global_invocation_id: vec3<u32>) {
     if ((global_invocation_id.x >= NUM_PARTICLES)) {
         return;
     }
-    vPos = particlesSrc.particles[global_invocation_id.x].pos;
-    vVel = particlesSrc.particles[global_invocation_id.x].vel;
+    let _e10: vec2<f32> = particlesSrc.particles[global_invocation_id.x].pos;
+    vPos = _e10;
+    let _e15: vec2<f32> = particlesSrc.particles[global_invocation_id.x].vel;
+    vVel = _e15;
     cMass = vec2<f32>(0.0, 0.0);
     cVel = vec2<f32>(0.0, 0.0);
     colVel = vec2<f32>(0.0, 0.0);
     loop {
-        if ((i >= NUM_PARTICLES)) {
+        let _e37: u32 = i;
+        if ((_e37 >= NUM_PARTICLES)) {
             break;
         }
-        if ((i == global_invocation_id.x)) {
+        let _e39: u32 = i;
+        if ((_e39 == global_invocation_id.x)) {
             continue;
         }
-        pos1 = particlesSrc.particles[i].pos;
-        vel1 = particlesSrc.particles[i].vel;
-        if ((distance(pos1, vPos) < params.rule1Distance)) {
-            cMass = (cMass + pos1);
-            cMassCount = (cMassCount + 1);
+        let _e42: u32 = i;
+        let _e45: vec2<f32> = particlesSrc.particles[_e42].pos;
+        pos1 = _e45;
+        let _e47: u32 = i;
+        let _e50: vec2<f32> = particlesSrc.particles[_e47].vel;
+        vel1 = _e50;
+        let _e51: vec2<f32> = pos1;
+        let _e52: vec2<f32> = vPos;
+        let _e55: f32 = params.rule1Distance;
+        if ((distance(_e51, _e52) < _e55)) {
+            let _e57: vec2<f32> = cMass;
+            let _e58: vec2<f32> = pos1;
+            cMass = (_e57 + _e58);
+            let _e60: i32 = cMassCount;
+            cMassCount = (_e60 + 1);
         }
-        if ((distance(pos1, vPos) < params.rule2Distance)) {
-            colVel = (colVel - (pos1 - vPos));
+        let _e63: vec2<f32> = pos1;
+        let _e64: vec2<f32> = vPos;
+        let _e67: f32 = params.rule2Distance;
+        if ((distance(_e63, _e64) < _e67)) {
+            let _e69: vec2<f32> = colVel;
+            let _e70: vec2<f32> = pos1;
+            let _e71: vec2<f32> = vPos;
+            colVel = (_e69 - (_e70 - _e71));
         }
-        if ((distance(pos1, vPos) < params.rule3Distance)) {
-            cVel = (cVel + vel1);
-            cVelCount = (cVelCount + 1);
+        let _e74: vec2<f32> = pos1;
+        let _e75: vec2<f32> = vPos;
+        let _e78: f32 = params.rule3Distance;
+        if ((distance(_e74, _e75) < _e78)) {
+            let _e80: vec2<f32> = cVel;
+            let _e81: vec2<f32> = vel1;
+            cVel = (_e80 + _e81);
+            let _e83: i32 = cVelCount;
+            cVelCount = (_e83 + 1);
         }
         continuing {
-            i = (i + 1u);
+            let _e86: u32 = i;
+            i = (_e86 + 1u);
         }
     }
-    if ((cMassCount > 0)) {
-        cMass = ((cMass / vec2<f32>(f32(cMassCount))) - vPos);
+    let _e89: i32 = cMassCount;
+    if ((_e89 > 0)) {
+        let _e92: vec2<f32> = cMass;
+        let _e93: i32 = cMassCount;
+        let _e97: vec2<f32> = vPos;
+        cMass = ((_e92 / vec2<f32>(f32(_e93))) - _e97);
     }
-    if ((cVelCount > 0)) {
-        cVel = (cVel / vec2<f32>(f32(cVelCount)));
+    let _e99: i32 = cVelCount;
+    if ((_e99 > 0)) {
+        let _e102: vec2<f32> = cVel;
+        let _e103: i32 = cVelCount;
+        cVel = (_e102 / vec2<f32>(f32(_e103)));
     }
-    vVel = (((vVel + (cMass * params.rule1Scale)) + (colVel * params.rule2Scale)) + (cVel * params.rule3Scale));
-    vVel = (normalize(vVel) * clamp(length(vVel), 0.0, 0.1));
-    vPos = (vPos + (vVel * params.deltaT));
-    if ((vPos.x < -1.0)) {
+    let _e107: vec2<f32> = vVel;
+    let _e108: vec2<f32> = cMass;
+    let _e110: f32 = params.rule1Scale;
+    let _e113: vec2<f32> = colVel;
+    let _e115: f32 = params.rule2Scale;
+    let _e118: vec2<f32> = cVel;
+    let _e120: f32 = params.rule3Scale;
+    vVel = (((_e107 + (_e108 * _e110)) + (_e113 * _e115)) + (_e118 * _e120));
+    let _e123: vec2<f32> = vVel;
+    let _e125: vec2<f32> = vVel;
+    vVel = (normalize(_e123) * clamp(length(_e125), 0.0, 0.1));
+    let _e131: vec2<f32> = vPos;
+    let _e132: vec2<f32> = vVel;
+    let _e134: f32 = params.deltaT;
+    vPos = (_e131 + (_e132 * _e134));
+    let _e137: vec2<f32> = vPos;
+    if ((_e137.x < -1.0)) {
         vPos.x = 1.0;
     }
-    if ((vPos.x > 1.0)) {
+    let _e143: vec2<f32> = vPos;
+    if ((_e143.x > 1.0)) {
         vPos.x = -1.0;
     }
-    if ((vPos.y < -1.0)) {
+    let _e149: vec2<f32> = vPos;
+    if ((_e149.y < -1.0)) {
         vPos.y = 1.0;
     }
-    if ((vPos.y > 1.0)) {
+    let _e155: vec2<f32> = vPos;
+    if ((_e155.y > 1.0)) {
         vPos.y = -1.0;
     }
-    particlesDst.particles[global_invocation_id.x].pos = vPos;
-    particlesDst.particles[global_invocation_id.x].vel = vVel;
+    let _e164: vec2<f32> = vPos;
+    particlesDst.particles[global_invocation_id.x].pos = _e164;
+    let _e168: vec2<f32> = vVel;
+    particlesDst.particles[global_invocation_id.x].vel = _e168;
     return;
 }

--- a/tests/out/collatz.msl
+++ b/tests/out/collatz.msl
@@ -17,17 +17,23 @@ metal::uint collatz_iterations(
     metal::uint i = 0u;
     n = n_base;
     while(true) {
-        if (n <= 1u) {
+        metal::uint _e5 = n;
+        if (_e5 <= 1u) {
             break;
         }
-        if ((n % 2u) == 0u) {
-            n = n / 2u;
+        metal::uint _e8 = n;
+        if ((_e8 % 2u) == 0u) {
+            metal::uint _e13 = n;
+            n = _e13 / 2u;
         } else {
-            n = (3u * n) + 1u;
+            metal::uint _e17 = n;
+            n = (3u * _e17) + 1u;
         }
-        i = i + 1u;
+        metal::uint _e21 = i;
+        i = _e21 + 1u;
     }
-    return i;
+    metal::uint _e24 = i;
+    return _e24;
 }
 
 struct main1Input {
@@ -36,7 +42,8 @@ kernel void main1(
   metal::uint3 global_id [[thread_position_in_grid]]
 , device PrimeIndices& v_indices [[user(fake0)]]
 ) {
-    metal::uint _e9 = collatz_iterations(v_indices.data[global_id.x]);
+    metal::uint _e8 = v_indices.data[global_id.x];
+    metal::uint _e9 = collatz_iterations(_e8);
     v_indices.data[global_id.x] = _e9;
     return;
 }

--- a/tests/out/collatz.wgsl
+++ b/tests/out/collatz.wgsl
@@ -12,22 +12,29 @@ fn collatz_iterations(n_base: u32) -> u32 {
 
     n = n_base;
     loop {
-        if ((n <= 1u)) {
+        let _e5: u32 = n;
+        if ((_e5 <= 1u)) {
             break;
         }
-        if (((n % 2u) == 0u)) {
-            n = (n / 2u);
+        let _e8: u32 = n;
+        if (((_e8 % 2u) == 0u)) {
+            let _e13: u32 = n;
+            n = (_e13 / 2u);
         } else {
-            n = ((3u * n) + 1u);
+            let _e17: u32 = n;
+            n = ((3u * _e17) + 1u);
         }
-        i = (i + 1u);
+        let _e21: u32 = i;
+        i = (_e21 + 1u);
     }
-    return i;
+    let _e24: u32 = i;
+    return _e24;
 }
 
 [[stage(compute), workgroup_size(1, 1, 1)]]
 fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
-    let _e9: u32 = collatz_iterations(v_indices.data[global_id.x]);
+    let _e8: u32 = v_indices.data[global_id.x];
+    let _e9: u32 = collatz_iterations(_e8);
     v_indices.data[global_id.x] = _e9;
     return;
 }

--- a/tests/out/interpolate.Vertex.glsl
+++ b/tests/out/interpolate.Vertex.glsl
@@ -28,14 +28,15 @@ void main() {
     out1.perspective = vec4(729.0, 1000.0, 1331.0, 1728.0);
     out1.perspective_centroid = 2197.0;
     out1.perspective_sample = 2744.0;
-    gl_Position = out1.position;
-    _vs2fs_location0 = out1.flat1;
-    _vs2fs_location1 = out1.linear;
-    _vs2fs_location2 = out1.linear_centroid;
-    _vs2fs_location3 = out1.linear_sample;
-    _vs2fs_location4 = out1.perspective;
-    _vs2fs_location5 = out1.perspective_centroid;
-    _vs2fs_location6 = out1.perspective_sample;
+    FragmentInput _expr30 = out1;
+    gl_Position = _expr30.position;
+    _vs2fs_location0 = _expr30.flat1;
+    _vs2fs_location1 = _expr30.linear;
+    _vs2fs_location2 = _expr30.linear_centroid;
+    _vs2fs_location3 = _expr30.linear_sample;
+    _vs2fs_location4 = _expr30.perspective;
+    _vs2fs_location5 = _expr30.perspective_centroid;
+    _vs2fs_location6 = _expr30.perspective_sample;
     return;
 }
 

--- a/tests/out/interpolate.msl
+++ b/tests/out/interpolate.msl
@@ -33,7 +33,8 @@ vertex main1Output main1(
     out.perspective = metal::float4(729.0, 1000.0, 1331.0, 1728.0);
     out.perspective_centroid = 2197.0;
     out.perspective_sample = 2744.0;
-    const auto _tmp = out;
+    FragmentInput _e30 = out;
+    const auto _tmp = _e30;
     return main1Output { _tmp.position, _tmp.flat, _tmp.linear, _tmp.linear_centroid, _tmp.linear_sample, _tmp.perspective, _tmp.perspective_centroid, _tmp.perspective_sample };
 }
 

--- a/tests/out/interpolate.wgsl
+++ b/tests/out/interpolate.wgsl
@@ -21,7 +21,8 @@ fn main() -> FragmentInput {
     out.perspective = vec4<f32>(729.0, 1000.0, 1331.0, 1728.0);
     out.perspective_centroid = 2197.0;
     out.perspective_sample = 2744.0;
-    return out;
+    let _e30: FragmentInput = out;
+    return _e30;
 }
 
 [[stage(fragment)]]

--- a/tests/out/quad-vert.Vertex.glsl
+++ b/tests/out/quad-vert.Vertex.glsl
@@ -28,7 +28,8 @@ layout(location = 0) in vec2 _p2vs_location0;
 smooth layout(location = 0) out vec2 _vs2fs_location0;
 
 void main1() {
-    v_uv = a_uv;
+    vec2 _expr12 = a_uv;
+    v_uv = _expr12;
     vec2 _expr13 = a_pos;
     perVertexStruct.gen_gl_Position = vec4(_expr13.x, _expr13.y, 0.0, 1.0);
     return;
@@ -40,7 +41,12 @@ void main() {
     a_uv = a_uv1;
     a_pos = a_pos1;
     main1();
-    type10 _tmp_return = type10(v_uv, perVertexStruct.gen_gl_Position, perVertexStruct.gen_gl_PointSize, perVertexStruct.gen_gl_ClipDistance, perVertexStruct.gen_gl_CullDistance);
+    vec2 _expr10 = v_uv;
+    vec4 _expr11 = perVertexStruct.gen_gl_Position;
+    float _expr12 = perVertexStruct.gen_gl_PointSize;
+    [1] _expr13 = perVertexStruct.gen_gl_ClipDistance;
+    [1] _expr14 = perVertexStruct.gen_gl_CullDistance;
+    type10 _tmp_return = type10(_expr10, _expr11, _expr12, _expr13, _expr14);
     _vs2fs_location0 = _tmp_return.member;
     gl_Position = _tmp_return.gen_gl_Position1;
     return;

--- a/tests/out/quad-vert.msl
+++ b/tests/out/quad-vert.msl
@@ -27,7 +27,8 @@ void main1(
     thread gl_PerVertex& perVertexStruct,
     thread metal::float2 const& a_pos
 ) {
-    v_uv = a_uv;
+    metal::float2 _e12 = a_uv;
+    v_uv = _e12;
     metal::float2 _e13 = a_pos;
     perVertexStruct.gl_Position = metal::float4(_e13.x, _e13.y, 0.0, 1.0);
     return;
@@ -55,6 +56,11 @@ vertex main2Output main2(
     a_uv = a_uv1;
     a_pos = a_pos1;
     main1(v_uv, a_uv, perVertexStruct, a_pos);
-    const auto _tmp = type10 {v_uv, perVertexStruct.gl_Position, perVertexStruct.gl_PointSize, perVertexStruct.gl_ClipDistance, perVertexStruct.gl_CullDistance};
+    metal::float2 _e10 = v_uv;
+    metal::float4 _e11 = perVertexStruct.gl_Position;
+    float _e12 = perVertexStruct.gl_PointSize;
+    type6 _e13 = perVertexStruct.gl_ClipDistance;
+    type6 _e14 = perVertexStruct.gl_CullDistance;
+    const auto _tmp = type10 {_e10, _e11, _e12, _e13, _e14};
     return main2Output { _tmp.member, _tmp.gl_Position1, _tmp.gl_PointSize1, {_tmp.gl_ClipDistance1.inner[0]} };
 }

--- a/tests/out/quad-vert.wgsl
+++ b/tests/out/quad-vert.wgsl
@@ -14,7 +14,8 @@ var<private> perVertexStruct: gl_PerVertex;
 var<private> a_pos: vec2<f32>;
 
 fn main() {
-    v_uv = a_uv;
+    let _e12: vec2<f32> = a_uv;
+    v_uv = _e12;
     let _e13: vec2<f32> = a_pos;
     perVertexStruct.gl_Position = vec4<f32>(_e13.x, _e13.y, 0.0, 1.0);
     return;
@@ -25,5 +26,10 @@ fn main1([[location(1)]] a_uv1: vec2<f32>, [[location(0)]] a_pos1: vec2<f32>) ->
     a_uv = a_uv1;
     a_pos = a_pos1;
     main();
-    return VertexOutput(v_uv, perVertexStruct.gl_Position);
+    let _e10: vec2<f32> = v_uv;
+    let _e11: vec4<f32> = perVertexStruct.gl_Position;
+    let _e12: f32 = perVertexStruct.gl_PointSize;
+    let _e13: array<f32,1u> = perVertexStruct.gl_ClipDistance;
+    let _e14: array<f32,1u> = perVertexStruct.gl_CullDistance;
+    return VertexOutput(_e10, _e11);
 }

--- a/tests/out/shadow.Fragment.glsl
+++ b/tests/out/shadow.Fragment.glsl
@@ -36,15 +36,22 @@ void main() {
     vec3 color1 = vec3(0.05, 0.05, 0.05);
     uint i = 0u;
     while(true) {
-        if((i >= min(_group_0_binding_0.num_lights.x, 10u))) {
+        uint _expr12 = i;
+        uvec4 _expr14 = _group_0_binding_0.num_lights;
+        if((_expr12 >= min(_expr14.x, 10u))) {
             break;
         }
-        Light _expr21 = _group_0_binding_1.data[i];
-        float _expr25 = fetch_shadow(i, (_expr21.proj * position));
-        color1 = (color1 + ((_expr25 * max(0.0, dot(normalize(raw_normal), normalize((_expr21.pos.xyz - position.xyz))))) * _expr21.color.xyz));
-        i = (i + 1u);
+        uint _expr19 = i;
+        Light _expr21 = _group_0_binding_1.data[_expr19];
+        uint _expr22 = i;
+        float _expr25 = fetch_shadow(_expr22, (_expr21.proj * position));
+        vec3 _expr34 = color1;
+        color1 = (_expr34 + ((_expr25 * max(0.0, dot(normalize(raw_normal), normalize((_expr21.pos.xyz - position.xyz))))) * _expr21.color.xyz));
+        uint _expr40 = i;
+        i = (_expr40 + 1u);
     }
-    _fs2p_location0 = vec4(color1, 1.0);
+    vec3 _expr43 = color1;
+    _fs2p_location0 = vec4(_expr43, 1.0);
     return;
 }
 

--- a/tests/out/shadow.msl
+++ b/tests/out/shadow.msl
@@ -54,15 +54,22 @@ fragment fs_mainOutput fs_main(
     bool loop_init = true;
     while(true) {
         if (!loop_init) {
-            i = i + 1u;
+            metal::uint _e40 = i;
+            i = _e40 + 1u;
         }
         loop_init = false;
-        if (i >= metal::min(u_globals.num_lights.x, c_max_lights)) {
+        metal::uint _e12 = i;
+        metal::uint4 _e14 = u_globals.num_lights;
+        if (_e12 >= metal::min(_e14.x, c_max_lights)) {
             break;
         }
-        Light _e21 = s_lights.data[i];
-        float _e25 = fetch_shadow(i, _e21.proj * position, t_shadow, sampler_shadow);
-        color1 = color1 + ((_e25 * metal::max(0.0, metal::dot(metal::normalize(raw_normal), metal::normalize(_e21.pos.xyz - position.xyz)))) * _e21.color.xyz);
+        metal::uint _e19 = i;
+        Light _e21 = s_lights.data[_e19];
+        metal::uint _e22 = i;
+        float _e25 = fetch_shadow(_e22, _e21.proj * position, t_shadow, sampler_shadow);
+        metal::float3 _e34 = color1;
+        color1 = _e34 + ((_e25 * metal::max(0.0, metal::dot(metal::normalize(raw_normal), metal::normalize(_e21.pos.xyz - position.xyz)))) * _e21.color.xyz);
     }
-    return fs_mainOutput { metal::float4(color1, 1.0) };
+    metal::float3 _e43 = color1;
+    return fs_mainOutput { metal::float4(_e43, 1.0) };
 }

--- a/tests/out/shadow.wgsl
+++ b/tests/out/shadow.wgsl
@@ -40,15 +40,22 @@ fn fs_main([[location(0), interpolate(perspective)]] raw_normal: vec3<f32>, [[lo
     var i: u32 = 0u;
 
     loop {
-        if ((i >= min(u_globals.num_lights.x, c_max_lights))) {
+        let _e12: u32 = i;
+        let _e14: vec4<u32> = u_globals.num_lights;
+        if ((_e12 >= min(_e14.x, c_max_lights))) {
             break;
         }
-        let _e21: Light = s_lights.data[i];
-        let _e25: f32 = fetch_shadow(i, (_e21.proj * position));
-        color1 = (color1 + ((_e25 * max(0.0, dot(normalize(raw_normal), normalize((_e21.pos.xyz - position.xyz))))) * _e21.color.xyz));
+        let _e19: u32 = i;
+        let _e21: Light = s_lights.data[_e19];
+        let _e22: u32 = i;
+        let _e25: f32 = fetch_shadow(_e22, (_e21.proj * position));
+        let _e34: vec3<f32> = color1;
+        color1 = (_e34 + ((_e25 * max(0.0, dot(normalize(raw_normal), normalize((_e21.pos.xyz - position.xyz))))) * _e21.color.xyz));
         continuing {
-            i = (i + 1u);
+            let _e40: u32 = i;
+            i = (_e40 + 1u);
         }
     }
-    return vec4<f32>(color1, 1.0);
+    let _e43: vec3<f32> = color1;
+    return vec4<f32>(_e43, 1.0);
 }

--- a/tests/out/skybox.Vertex.glsl
+++ b/tests/out/skybox.Vertex.glsl
@@ -20,8 +20,14 @@ void main() {
     int tmp2_;
     tmp1_ = (int(vertex_index) / 2);
     tmp2_ = (int(vertex_index) & 1);
-    vec4 _expr24 = vec4(((float(tmp1_) * 4.0) - 1.0), ((float(tmp2_) * 4.0) - 1.0), 0.0, 1.0);
-    VertexOutput _tmp_return = VertexOutput(_expr24, (transpose(mat3x3(_group_0_binding_0.view[0].xyz, _group_0_binding_0.view[1].xyz, _group_0_binding_0.view[2].xyz)) * (_group_0_binding_0.proj_inv * _expr24).xyz));
+    int _expr10 = tmp1_;
+    int _expr16 = tmp2_;
+    vec4 _expr24 = vec4(((float(_expr10) * 4.0) - 1.0), ((float(_expr16) * 4.0) - 1.0), 0.0, 1.0);
+    vec4 _expr27 = _group_0_binding_0.view[0];
+    vec4 _expr31 = _group_0_binding_0.view[1];
+    vec4 _expr35 = _group_0_binding_0.view[2];
+    mat4x4 _expr40 = _group_0_binding_0.proj_inv;
+    VertexOutput _tmp_return = VertexOutput(_expr24, (transpose(mat3x3(_expr27.xyz, _expr31.xyz, _expr35.xyz)) * (_expr40 * _expr24).xyz));
     gl_Position = _tmp_return.position;
     _vs2fs_location0 = _tmp_return.uv;
     return;

--- a/tests/out/skybox.msl
+++ b/tests/out/skybox.msl
@@ -24,8 +24,14 @@ vertex vs_mainOutput vs_main(
     int tmp2_;
     tmp1_ = static_cast<int>(vertex_index) / 2;
     tmp2_ = static_cast<int>(vertex_index) & 1;
-    metal::float4 _e24 = metal::float4((static_cast<float>(tmp1_) * 4.0) - 1.0, (static_cast<float>(tmp2_) * 4.0) - 1.0, 0.0, 1.0);
-    const auto _tmp = VertexOutput {_e24, metal::transpose(metal::float3x3(r_data.view[0].xyz, r_data.view[1].xyz, r_data.view[2].xyz)) * (r_data.proj_inv * _e24).xyz};
+    int _e10 = tmp1_;
+    int _e16 = tmp2_;
+    metal::float4 _e24 = metal::float4((static_cast<float>(_e10) * 4.0) - 1.0, (static_cast<float>(_e16) * 4.0) - 1.0, 0.0, 1.0);
+    metal::float4 _e27 = r_data.view[0];
+    metal::float4 _e31 = r_data.view[1];
+    metal::float4 _e35 = r_data.view[2];
+    metal::float4x4 _e40 = r_data.proj_inv;
+    const auto _tmp = VertexOutput {_e24, metal::transpose(metal::float3x3(_e27.xyz, _e31.xyz, _e35.xyz)) * (_e40 * _e24).xyz};
     return vs_mainOutput { _tmp.position, _tmp.uv };
 }
 

--- a/tests/out/skybox.wgsl
+++ b/tests/out/skybox.wgsl
@@ -23,8 +23,14 @@ fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> VertexOutput {
 
     tmp1_ = (i32(vertex_index) / 2);
     tmp2_ = (i32(vertex_index) & 1);
-    let _e24: vec4<f32> = vec4<f32>(((f32(tmp1_) * 4.0) - 1.0), ((f32(tmp2_) * 4.0) - 1.0), 0.0, 1.0);
-    return VertexOutput(_e24, (transpose(mat3x3<f32>(r_data.view[0].xyz, r_data.view[1].xyz, r_data.view[2].xyz)) * (r_data.proj_inv * _e24).xyz));
+    let _e10: i32 = tmp1_;
+    let _e16: i32 = tmp2_;
+    let _e24: vec4<f32> = vec4<f32>(((f32(_e10) * 4.0) - 1.0), ((f32(_e16) * 4.0) - 1.0), 0.0, 1.0);
+    let _e27: vec4<f32> = r_data.view[0];
+    let _e31: vec4<f32> = r_data.view[1];
+    let _e35: vec4<f32> = r_data.view[2];
+    let _e40: mat4x4<f32> = r_data.proj_inv;
+    return VertexOutput(_e24, (transpose(mat3x3<f32>(_e27.xyz, _e31.xyz, _e35.xyz)) * (_e40 * _e24).xyz));
 }
 
 [[stage(fragment)]]

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -288,6 +288,10 @@ fn convert_wgsl() {
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::WGSL,
         ),
         (
+            "baked_load",
+            Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,
+        ),
+        (
             "standard",
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::WGSL,
         ),


### PR DESCRIPTION
This fixes #910 by forcing `Load` expressions to be baked at the time they are emitted, so that they take on the value at that time rather than at the time when they are used.

I would be happy to add some tests, but I haven't been able to figure out how the `tests/{in,out}` test cases are actually run.