### PR TITLE
Validate matrix component-wise ops correctly

### DIFF
--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -576,7 +576,15 @@ impl super::Validator {
                 let left_inner = resolver.resolve(left)?;
                 let right_inner = resolver.resolve(right)?;
                 let good = match op {
-                    Bo::Add | Bo::Subtract | Bo::Divide | Bo::Modulo => match *left_inner {
+                    Bo::Add | Bo::Subtract => match *left_inner {
+                        Ti::Scalar { kind, .. } | Ti::Vector { kind, .. } => match kind {
+                            Sk::Uint | Sk::Sint | Sk::Float => left_inner == right_inner,
+                            Sk::Bool => false,
+                        },
+                        Ti::Matrix { .. } => left_inner == right_inner,
+                        _ => false,
+                    },
+                    Bo::Divide | Bo::Modulo => match *left_inner {
                         Ti::Scalar { kind, .. } | Ti::Vector { kind, .. } => match kind {
                             Sk::Uint | Sk::Sint | Sk::Float => left_inner == right_inner,
                             Sk::Bool => false,


### PR DESCRIPTION
This wgsl currently fails validation (with error `Expression [43] is invalid Operation Add can't work with [21] and [42]`):

```

[[stage(vertex)]]
fn main() -> [[location(0)]] f32 {
    let a = mat4x4<f32>(
        vec4<f32>(0., 0., 0., 0.),
        vec4<f32>(0., 0., 0., 0.),
        vec4<f32>(0., 0., 0., 0.),
        vec4<f32>(0., 0., 0., 0.),
    );
    let b = mat4x4<f32>(
        vec4<f32>(0., 0., 0., 0.),
        vec4<f32>(0., 0., 0., 0.),
        vec4<f32>(0., 0., 0., 0.),
        vec4<f32>(0., 0., 0., 0.),
    );
    let c: mat4x4<f32> = a + b;
    return c.x.x;
}
```

According to the spec (https://www.w3.org/TR/WGSL/#arithmetic-expr) component-wise addition should work.