### PR TITLE
Insert attribute glsl location qualifier for opengl ES 3.0

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -106,7 +106,7 @@ impl Version {
 
     /// Checks if the version supports explicit `layout(location=)` qualifiers.
     fn supports_explicit_locations(&self) -> bool {
-        *self >= Version::Embedded(310) || *self >= Version::Desktop(410)
+        *self >= Version::Embedded(300) || *self >= Version::Desktop(410)
     }
 }
 
@@ -825,7 +825,9 @@ impl<'a, W: Write> Writer<'a, W> {
                 }
 
                 // Write the storage class
-                if self.options.version.supports_explicit_locations() {
+                if !emit_interpolation_and_auxiliary
+                    && self.options.version.supports_explicit_locations()
+                {
                     write!(self.out, "layout(location = {}) ", location)?;
                 }
 

--- a/tests/out/quad-vert.Vertex.glsl
+++ b/tests/out/quad-vert.Vertex.glsl
@@ -21,7 +21,7 @@ struct gen_gl_PerVertex_block_0 {
 vec2 a_pos = vec2(0, 0);
 layout(location = 1) in vec2 _p2vs_location1;
 layout(location = 0) in vec2 _p2vs_location0;
-smooth layout(location = 0) out vec2 _vs2fs_location0;
+smooth out vec2 _vs2fs_location0;
 
 void main1() {
     v_uv = a_uv;

--- a/tests/out/quad.Fragment.glsl
+++ b/tests/out/quad.Fragment.glsl
@@ -9,7 +9,7 @@ struct VertexOutput {
 
 uniform highp sampler2D _group_0_binding_0;
 
-smooth layout(location = 0) in vec2 _vs2fs_location0;
+smooth in vec2 _vs2fs_location0;
 layout(location = 0) out vec4 _fs2p_location0;
 
 void main() {

--- a/tests/out/quad.Vertex.glsl
+++ b/tests/out/quad.Vertex.glsl
@@ -9,7 +9,7 @@ struct VertexOutput {
 
 layout(location = 0) in vec2 _p2vs_location0;
 layout(location = 1) in vec2 _p2vs_location1;
-smooth layout(location = 0) out vec2 _vs2fs_location0;
+smooth out vec2 _vs2fs_location0;
 
 void main() {
     vec2 pos = _p2vs_location0;

--- a/tests/out/shadow.Fragment.glsl
+++ b/tests/out/shadow.Fragment.glsl
@@ -16,8 +16,8 @@ readonly buffer Lights_block_1 {
 } _group_0_binding_1;
 uniform highp sampler2DArrayShadow _group_0_binding_2;
 
-smooth layout(location = 0) in vec3 _vs2fs_location0;
-smooth layout(location = 1) in vec4 _vs2fs_location1;
+smooth in vec3 _vs2fs_location0;
+smooth in vec4 _vs2fs_location1;
 layout(location = 0) out vec4 _fs2p_location0;
 
 float fetch_shadow(uint light_id, vec4 homogeneous_coords) {

--- a/tests/out/skybox.Fragment.glsl
+++ b/tests/out/skybox.Fragment.glsl
@@ -9,7 +9,7 @@ struct VertexOutput {
 
 uniform highp samplerCube _group_0_binding_1;
 
-smooth layout(location = 0) in vec3 _vs2fs_location0;
+smooth in vec3 _vs2fs_location0;
 layout(location = 0) out vec4 _fs2p_location0;
 
 void main() {

--- a/tests/out/skybox.Vertex.glsl
+++ b/tests/out/skybox.Vertex.glsl
@@ -11,7 +11,7 @@ uniform Data_block_0 {
     mat4x4 proj_inv;
     mat4x4 view;
 } _group_0_binding_0;
-smooth layout(location = 0) out vec3 _vs2fs_location0;
+smooth out vec3 _vs2fs_location0;
 
 void main() {
     uint vertex_index = uint(gl_VertexID);


### PR DESCRIPTION
GLSL ES 3.0 allows location to be specified on attributes. This is not allowed for varyings, hence the extra guard against interpolations.

This change fixes wgpu's Cube example in WebGL2 (and possibly others, but I haven't tested that yet), particularily on MacOS, where the driver likes to assign locations out of order.