### PR TITLE
Permit dynamic indexing of arrays and matrices only behind a pointer.

### DIFF
--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -183,6 +183,28 @@ impl crate::Expression {
             _ => false,
         }
     }
+
+    /// Return true if this expression is a dynamic array index, for [`Access`].
+    ///
+    /// This method returns true if this expression is a dynamically computed
+    /// index, and as such can only be used to index matrices and arrays when
+    /// they appear behind a pointer. See the documentation for [`Access`] for
+    /// details.
+    ///
+    /// Note, this does not check the _type_ of the given expression. It's up to
+    /// the caller to establish that the `Access` expression is well-typed
+    /// through other means, like [`ResolveContext`].
+    ///
+    /// [`Access`]: crate::Expression::Access
+    /// [`ResolveContext`]: crate::proc::ResolveContext
+    pub fn is_dynamic_index(&self, module: &crate::Module) -> bool {
+        if let Self::Constant(handle) = *self {
+            let constant = &module.constants[handle];
+            constant.specialization.is_some()
+        } else {
+            true
+        }
+    }
 }
 
 impl crate::SampleLevel {

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -128,7 +128,15 @@ impl<'a> ResolveContext<'a> {
         let types = self.types;
         Ok(match *expr {
             crate::Expression::Access { base, .. } => match *past(base).inner_with(types) {
+                // Arrays and matrices can only be indexed dynamically behind a
+                // pointer, but that's a validation error, not a type error, so
+                // go ahead provide a type here.
                 Ti::Array { base, .. } => TypeResolution::Handle(base),
+                Ti::Matrix { rows, width, .. } => TypeResolution::Value(Ti::Vector {
+                    size: rows,
+                    kind: crate::ScalarKind::Float,
+                    width,
+                }),
                 Ti::Vector {
                     size: _,
                     kind,

--- a/tests/in/access.wgsl
+++ b/tests/in/access.wgsl
@@ -15,9 +15,9 @@ fn foo([[builtin(vertex_index)]] vi: u32) -> [[builtin(position)]] vec4<f32> {
 	let b = bar.matrix[index].x;
 
 	let a = bar.data[arrayLength(&bar.data) - 1u];
-	
-	let array = array<i32, 5>(a, i32(b), 3, 4, 5);
-	let value = array[vi];
+
+	var c: array<i32, 5> = array<i32, 5>(a, i32(b), 3, 4, 5);
+	let value = c[vi];
 
 	return vec4<f32>(vec4<i32>(value));
 }

--- a/tests/out/access.msl
+++ b/tests/out/access.msl
@@ -24,5 +24,7 @@ vertex fooOutput foo(
 , device Bar& bar [[buffer(0)]]
 , constant _mslBufferSizes& _buffer_sizes [[buffer(24)]]
 ) {
-    return fooOutput { static_cast<float4>(metal::int4(type5 {bar.data[(1 + (_buffer_sizes.size0 - 64 - 4) / 4) - 1u], static_cast<int>(bar.matrix[3u].x), 3, 4, 5}.inner[vi])) };
+    type5 c;
+    for(int _i=0; _i<5; ++_i) c.inner[_i] = type5 {bar.data[(1 + (_buffer_sizes.size0 - 64 - 4) / 4) - 1u], static_cast<int>(bar.matrix[3u].x), 3, 4, 5}.inner[_i];
+    return fooOutput { static_cast<float4>(metal::int4(c.inner[vi])) };
 }

--- a/tests/out/access.spvasm
+++ b/tests/out/access.spvasm
@@ -6,14 +6,15 @@ OpCapability Shader
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Vertex %24 "foo" %19 %22
+OpEntryPoint Vertex %26 "foo" %21 %24
 OpSource GLSL 450
 OpName %14 "Bar"
 OpMemberName %14 0 "matrix"
 OpMemberName %14 1 "data"
 OpName %16 "bar"
-OpName %19 "vi"
-OpName %24 "foo"
+OpName %18 "c"
+OpName %21 "vi"
+OpName %26 "foo"
 OpDecorate %13 ArrayStride 4
 OpDecorate %14 Block
 OpMemberDecorate %14 0 Offset 0
@@ -23,8 +24,8 @@ OpMemberDecorate %14 1 Offset 64
 OpDecorate %15 ArrayStride 4
 OpDecorate %16 DescriptorSet 0
 OpDecorate %16 Binding 0
-OpDecorate %19 BuiltIn VertexIndex
-OpDecorate %22 BuiltIn Position
+OpDecorate %21 BuiltIn VertexIndex
+OpDecorate %24 BuiltIn Position
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 0
 %3 = OpConstant  %4  3
@@ -41,39 +42,39 @@ OpDecorate %22 BuiltIn Position
 %15 = OpTypeArray %7 %6
 %17 = OpTypePointer StorageBuffer %14
 %16 = OpVariable  %17  StorageBuffer
-%20 = OpTypePointer Input %4
-%19 = OpVariable  %20  Input
-%23 = OpTypePointer Output %11
-%22 = OpVariable  %23  Output
-%25 = OpTypeFunction %2
-%27 = OpTypePointer StorageBuffer %10
-%28 = OpTypePointer StorageBuffer %11
-%29 = OpConstant  %4  0
-%33 = OpTypePointer StorageBuffer %13
-%36 = OpTypePointer StorageBuffer %7
-%41 = OpTypePointer Function %15
-%44 = OpTypePointer Function %7
+%19 = OpTypePointer Function %15
+%22 = OpTypePointer Input %4
+%21 = OpVariable  %22  Input
+%25 = OpTypePointer Output %11
+%24 = OpVariable  %25  Output
+%27 = OpTypeFunction %2
+%29 = OpTypePointer StorageBuffer %10
+%30 = OpTypePointer StorageBuffer %11
+%31 = OpConstant  %4  0
+%35 = OpTypePointer StorageBuffer %13
+%38 = OpTypePointer StorageBuffer %7
+%43 = OpTypePointer Function %7
 %46 = OpTypeVector %7 4
-%24 = OpFunction  %2  None %25
-%18 = OpLabel
-%42 = OpVariable  %41  Function
-%21 = OpLoad  %4  %19
-OpBranch %26
-%26 = OpLabel
-%30 = OpAccessChain  %28  %16 %29 %3
-%31 = OpLoad  %11  %30
-%32 = OpCompositeExtract  %12  %31 0
-%34 = OpArrayLength  %4  %16 1
-%35 = OpISub  %4  %34 %5
-%37 = OpAccessChain  %36  %16 %5 %35
-%38 = OpLoad  %7  %37
-%39 = OpConvertFToS  %7  %32
-%40 = OpCompositeConstruct  %15  %38 %39 %8 %9 %6
-OpStore %42 %40
-%43 = OpAccessChain  %44  %42 %21
-%45 = OpLoad  %7  %43
+%26 = OpFunction  %2  None %27
+%20 = OpLabel
+%18 = OpVariable  %19  Function
+%23 = OpLoad  %4  %21
+OpBranch %28
+%28 = OpLabel
+%32 = OpAccessChain  %30  %16 %31 %3
+%33 = OpLoad  %11  %32
+%34 = OpCompositeExtract  %12  %33 0
+%36 = OpArrayLength  %4  %16 1
+%37 = OpISub  %4  %36 %5
+%39 = OpAccessChain  %38  %16 %5 %37
+%40 = OpLoad  %7  %39
+%41 = OpConvertFToS  %7  %34
+%42 = OpCompositeConstruct  %15  %40 %41 %8 %9 %6
+OpStore %18 %42
+%44 = OpAccessChain  %43  %18 %23
+%45 = OpLoad  %7  %44
 %47 = OpCompositeConstruct  %46  %45 %45 %45 %45
 %48 = OpConvertSToF  %11  %47
-OpStore %22 %48
+OpStore %24 %48
 OpReturn
 OpFunctionEnd

--- a/tests/out/access.wgsl
+++ b/tests/out/access.wgsl
@@ -9,9 +9,11 @@ var<storage> bar: [[access(read_write)]] Bar;
 
 [[stage(vertex)]]
 fn foo([[builtin(vertex_index)]] vi: u32) -> [[builtin(position)]] vec4<f32> {
+    var c: array<i32,5>;
+
     let b: f32 = bar.matrix[3u].x;
     let a: i32 = bar.data[(arrayLength(&bar.data) - 1u)];
-    let array: array<i32,5> = array<i32,5>(a, i32(b), 3, 4, 5);
-    let value: i32 = array[vi];
+    c = array<i32,5>(a, i32(b), 3, 4, 5);
+    let value: i32 = c[vi];
     return vec4<f32>(vec4<i32>(value));
 }


### PR DESCRIPTION
This makes Naga IR validation impose the restrictions added to WGSL in
gpuweb/gpuweb#1801.

Remove code in the SPIR-V writer to spill arrays to temporary variables in order
to index them dynamically. If such IR is encountered, treat it as a failure of
validation.

(This simplifies #916 a little bit, so I took it on first.)