### PR TITLE
[glsl-in] Compute shader fixes and additions

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -77,6 +77,9 @@ pub struct Program<'a> {
     pub profile: Profile,
     pub entry_points: &'a FastHashMap<String, ShaderStage>,
 
+    pub workgroup_size: [u32; 3],
+    pub early_fragment_tests: bool,
+
     pub lookup_function: FastHashMap<FunctionSignature, FunctionDeclaration>,
     pub lookup_type: FastHashMap<String, Handle<Type>>,
 
@@ -97,6 +100,9 @@ impl<'a> Program<'a> {
             version: 0,
             profile: Profile::Core,
             entry_points,
+
+            workgroup_size: [1; 3],
+            early_fragment_tests: false,
 
             lookup_function: FastHashMap::default(),
             lookup_type: FastHashMap::default(),
@@ -727,6 +733,7 @@ pub enum TypeQualifier {
     Interpolation(Interpolation),
     ResourceBinding(ResourceBinding),
     Location(u32),
+    WorkGroupSize(usize, u32),
     Sampling(Sampling),
     Layout(StructLayout),
     EarlyFragmentTests,

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -623,9 +623,13 @@ impl Program<'_> {
             self.module.entry_points.push(EntryPoint {
                 name,
                 stage,
-                // TODO
-                early_depth_test: None,
-                workgroup_size: [0; 3],
+                early_depth_test: Some(crate::EarlyDepthTest { conservative: None })
+                    .filter(|_| self.early_fragment_tests && stage == crate::ShaderStage::Fragment),
+                workgroup_size: if let crate::ShaderStage::Compute = stage {
+                    self.workgroup_size
+                } else {
+                    [0; 3]
+                },
                 function: Function {
                     arguments,
                     expressions,

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -239,6 +239,30 @@ impl Program<'_> {
                             body,
                         )))
                     }
+                    "mod" => {
+                        if args.len() != 2 {
+                            return Err(ErrorKind::wrong_function_args(name, 2, args.len(), meta));
+                        }
+
+                        let expr = if let Some(ScalarKind::Float) =
+                            self.resolve_type(ctx, args[0].0, args[1].1)?.scalar_kind()
+                        {
+                            Expression::Math {
+                                fun: MathFunction::Modf,
+                                arg: args[0].0,
+                                arg1: Some(args[1].0),
+                                arg2: None,
+                            }
+                        } else {
+                            Expression::Binary {
+                                op: BinaryOperator::Modulo,
+                                left: args[0].0,
+                                right: args[1].0,
+                            }
+                        };
+
+                        Ok(Some(ctx.add_expression(expr, body)))
+                    }
                     "pow" | "dot" | "max" => {
                         if args.len() != 2 {
                             return Err(ErrorKind::wrong_function_args(name, 2, args.len(), meta));

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -244,20 +244,27 @@ impl Program<'_> {
                             return Err(ErrorKind::wrong_function_args(name, 2, args.len(), meta));
                         }
 
+                        let (mut left, left_meta) = args[0];
+                        let (mut right, right_meta) = args[1];
+
+                        ctx.binary_implicit_conversion(
+                            self, &mut left, left_meta, &mut right, right_meta,
+                        )?;
+
                         let expr = if let Some(ScalarKind::Float) =
                             self.resolve_type(ctx, args[0].0, args[1].1)?.scalar_kind()
                         {
                             Expression::Math {
                                 fun: MathFunction::Modf,
-                                arg: args[0].0,
-                                arg1: Some(args[1].0),
+                                arg: left,
+                                arg1: Some(right),
                                 arg2: None,
                             }
                         } else {
                             Expression::Binary {
                                 op: BinaryOperator::Modulo,
-                                left: args[0].0,
-                                right: args[1].0,
+                                left,
+                                right,
                             }
                         };
 

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -539,7 +539,7 @@ impl Program<'_> {
                         .take(callee_len.saturating_sub(caller_len)),
                 );
 
-                for i in 0..callee_len.max(caller_len) {
+                for i in 0..callee_len.min(caller_len) {
                     let callee_use = function_arg_use[function.index()][i];
                     function_arg_use[caller.index()][i] |= callee_use
                 }

--- a/src/front/glsl/lex.rs
+++ b/src/front/glsl/lex.rs
@@ -62,6 +62,7 @@ impl<'a> Iterator for Lexer<'a> {
                     "in" => TokenValue::In,
                     "out" => TokenValue::Out,
                     "uniform" => TokenValue::Uniform,
+                    "buffer" => TokenValue::Buffer,
                     "flat" => TokenValue::Interpolation(crate::Interpolation::Flat),
                     "noperspective" => TokenValue::Interpolation(crate::Interpolation::Linear),
                     "smooth" => TokenValue::Interpolation(crate::Interpolation::Perspective),

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -527,8 +527,15 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
             let init = self
                 .bump_if(TokenValue::Assign)
                 .map::<Result<_>, _>(|_| {
-                    let (expr, init_meta) = self.parse_initializer(ty, ctx.ctx, ctx.body)?;
+                    let (mut expr, init_meta) = self.parse_initializer(ty, ctx.ctx, ctx.body)?;
+
+                    if let Some(kind) = self.program.module.types[ty].inner.scalar_kind() {
+                        ctx.ctx
+                            .implicit_conversion(self.program, &mut expr, init_meta, kind)?;
+                    }
+
                     meta = meta.union(&init_meta);
+
                     Ok((expr, init_meta))
                 })
                 .transpose()?;
@@ -542,7 +549,7 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
 
             let pointer = ctx.add_var(self.program, ty, name, maybe_constant, meta)?;
 
-            if let Some((value, _)) = init {
+            if let Some((value, _)) = init.filter(|_| maybe_constant.is_none()) {
                 ctx.flush_expressions();
                 ctx.body.push(Statement::Store { pointer, value });
             }

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -178,7 +178,7 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
         })
     }
 
-    fn parse_type_qualifiers(&mut self) -> Result<Vec<TypeQualifier>> {
+    fn parse_type_qualifiers(&mut self) -> Result<Vec<(TypeQualifier, SourceMetadata)>> {
         let mut qualifiers = Vec::new();
 
         while self.peek_type_qualifier() {
@@ -190,18 +190,21 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
                 continue;
             }
 
-            qualifiers.push(match token.value {
-                TokenValue::Interpolation(i) => TypeQualifier::Interpolation(i),
-                TokenValue::Const => TypeQualifier::StorageQualifier(StorageQualifier::Const),
-                TokenValue::In => TypeQualifier::StorageQualifier(StorageQualifier::Input),
-                TokenValue::Out => TypeQualifier::StorageQualifier(StorageQualifier::Output),
-                TokenValue::Uniform => TypeQualifier::StorageQualifier(
-                    StorageQualifier::StorageClass(StorageClass::Uniform),
-                ),
-                TokenValue::Sampling(s) => TypeQualifier::Sampling(s),
+            qualifiers.push((
+                match token.value {
+                    TokenValue::Interpolation(i) => TypeQualifier::Interpolation(i),
+                    TokenValue::Const => TypeQualifier::StorageQualifier(StorageQualifier::Const),
+                    TokenValue::In => TypeQualifier::StorageQualifier(StorageQualifier::Input),
+                    TokenValue::Out => TypeQualifier::StorageQualifier(StorageQualifier::Output),
+                    TokenValue::Uniform => TypeQualifier::StorageQualifier(
+                        StorageQualifier::StorageClass(StorageClass::Uniform),
+                    ),
+                    TokenValue::Sampling(s) => TypeQualifier::Sampling(s),
 
-                _ => unreachable!(),
-            })
+                    _ => unreachable!(),
+                },
+                token.meta,
+            ))
         }
 
         Ok(qualifiers)
@@ -209,7 +212,7 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
 
     fn parse_layout_qualifier_id_list(
         &mut self,
-        qualifiers: &mut Vec<TypeQualifier>,
+        qualifiers: &mut Vec<(TypeQualifier, SourceMetadata)>,
     ) -> Result<()> {
         // We need both of these to produce a ResourceBinding
         let mut group = None;
@@ -228,12 +231,10 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
         self.expect(TokenValue::RightParen)?;
 
         match (group, binding) {
-            (Some((group, _)), Some((binding, _))) => {
-                qualifiers.push(TypeQualifier::ResourceBinding(ResourceBinding {
-                    group,
-                    binding,
-                }))
-            }
+            (Some((group, group_meta)), Some((binding, binding_meta))) => qualifiers.push((
+                TypeQualifier::ResourceBinding(ResourceBinding { group, binding }),
+                group_meta.union(&binding_meta),
+            )),
             // Produce an error if we have one of group or binding but not the other
             (Some((_, meta)), None) => {
                 return Err(ErrorKind::SemanticError(
@@ -278,7 +279,7 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
 
     fn parse_layout_qualifier_id(
         &mut self,
-        qualifiers: &mut Vec<TypeQualifier>,
+        qualifiers: &mut Vec<(TypeQualifier, SourceMetadata)>,
         group: &mut Option<(u32, SourceMetadata)>,
         binding: &mut Option<(u32, SourceMetadata)>,
     ) -> Result<()> {
@@ -293,24 +294,42 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
                     let (value, end_meta) = self.parse_uint_constant()?;
                     token.meta = token.meta.union(&end_meta);
 
-                    match name.as_str() {
-                        "location" => qualifiers.push(TypeQualifier::Location(value)),
-                        "set" => *group = Some((value, end_meta)),
-                        "binding" => *binding = Some((value, end_meta)),
-                        _ => return Err(ErrorKind::UnknownLayoutQualifier(token.meta, name)),
-                    }
+                    qualifiers.push((
+                        match name.as_str() {
+                            "location" => TypeQualifier::Location(value),
+                            "set" => {
+                                *group = Some((value, end_meta));
+                                return Ok(());
+                            }
+                            "binding" => {
+                                *binding = Some((value, end_meta));
+                                return Ok(());
+                            }
+                            "local_size_x" => TypeQualifier::WorkGroupSize(0, value),
+                            "local_size_y" => TypeQualifier::WorkGroupSize(1, value),
+                            "local_size_z" => TypeQualifier::WorkGroupSize(2, value),
+                            _ => return Err(ErrorKind::UnknownLayoutQualifier(token.meta, name)),
+                        },
+                        token.meta,
+                    ))
                 } else {
                     match name.as_str() {
                         "push_constant" => {
-                            qualifiers.push(TypeQualifier::StorageQualifier(
-                                StorageQualifier::StorageClass(StorageClass::PushConstant),
+                            qualifiers.push((
+                                TypeQualifier::StorageQualifier(StorageQualifier::StorageClass(
+                                    StorageClass::PushConstant,
+                                )),
+                                token.meta,
                             ));
-                            qualifiers.push(TypeQualifier::Layout(StructLayout::Std430));
+                            qualifiers
+                                .push((TypeQualifier::Layout(StructLayout::Std430), token.meta));
                         }
-                        "std140" => qualifiers.push(TypeQualifier::Layout(StructLayout::Std140)),
-                        "std430" => qualifiers.push(TypeQualifier::Layout(StructLayout::Std430)),
+                        "std140" => qualifiers
+                            .push((TypeQualifier::Layout(StructLayout::Std140), token.meta)),
+                        "std430" => qualifiers
+                            .push((TypeQualifier::Layout(StructLayout::Std430), token.meta)),
                         "early_fragment_tests" => {
-                            qualifiers.push(TypeQualifier::EarlyFragmentTests)
+                            qualifiers.push((TypeQualifier::EarlyFragmentTests, token.meta))
                         }
                         _ => return Err(ErrorKind::UnknownLayoutQualifier(token.meta, name)),
                     }
@@ -686,7 +705,7 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
                 match token.value {
                     TokenValue::Identifier(ty_name) => {
                         if self.bump_if(TokenValue::LeftBrace).is_some() {
-                            self.parse_block_declaration(&qualifiers, ty_name, token.meta)
+                            self.parse_block_declaration(&qualifiers, ty_name)
                         } else {
                             //TODO: declaration
                             // type_qualifier IDENTIFIER SEMICOLON
@@ -694,7 +713,31 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
                             todo!()
                         }
                     }
-                    TokenValue::Semicolon => Ok(true),
+                    TokenValue::Semicolon => {
+                        for &(ref qualifier, meta) in qualifiers.iter() {
+                            match *qualifier {
+                                TypeQualifier::WorkGroupSize(i, value) => {
+                                    self.program.workgroup_size[i] = value
+                                }
+                                TypeQualifier::EarlyFragmentTests => {
+                                    self.program.early_fragment_tests = true;
+                                }
+                                TypeQualifier::StorageQualifier(_) => {
+                                    // TODO: Maybe add some checks here
+                                    // This is needed because of cases like
+                                    // layout(early_fragment_tests) in;
+                                }
+                                _ => {
+                                    return Err(ErrorKind::SemanticError(
+                                        meta,
+                                        "Qualifier not supported as standalone".into(),
+                                    ));
+                                }
+                            }
+                        }
+
+                        Ok(true)
+                    }
                     _ => Err(ErrorKind::InvalidToken(token)),
                 }
             }
@@ -706,15 +749,14 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
 
     fn parse_block_declaration(
         &mut self,
-        qualifiers: &[TypeQualifier],
+        qualifiers: &[(TypeQualifier, SourceMetadata)],
         ty_name: String,
-        meta: SourceMetadata,
     ) -> Result<bool> {
         let mut class = StorageClass::Private;
         let mut binding = None;
         let mut layout = None;
 
-        for qualifier in qualifiers {
+        for &(ref qualifier, meta) in qualifiers {
             match *qualifier {
                 TypeQualifier::StorageQualifier(StorageQualifier::StorageClass(c)) => {
                     if StorageClass::PushConstant == class && c == StorageClass::Uniform {
@@ -1628,7 +1670,7 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
 }
 
 struct DeclarationContext<'ctx, 'fun> {
-    qualifiers: Vec<TypeQualifier>,
+    qualifiers: Vec<(TypeQualifier, SourceMetadata)>,
     external: bool,
 
     ctx: &'ctx mut Context<'fun>,

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -173,6 +173,7 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
             | TokenValue::In
             | TokenValue::Out
             | TokenValue::Uniform
+            | TokenValue::Buffer
             | TokenValue::Layout => true,
             _ => false,
         })
@@ -198,6 +199,9 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
                     TokenValue::Out => TypeQualifier::StorageQualifier(StorageQualifier::Output),
                     TokenValue::Uniform => TypeQualifier::StorageQualifier(
                         StorageQualifier::StorageClass(StorageClass::Uniform),
+                    ),
+                    TokenValue::Buffer => TypeQualifier::StorageQualifier(
+                        StorageQualifier::StorageClass(StorageClass::Storage),
                     ),
                     TokenValue::Sampling(s) => TypeQualifier::Sampling(s),
 

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -12,8 +12,8 @@ use super::{
 };
 use crate::{
     arena::Handle, Arena, ArraySize, BinaryOperator, Block, Constant, ConstantInner, Expression,
-    Function, FunctionResult, GlobalVariable, ResourceBinding, ScalarValue, Statement,
-    StorageAccess, StorageClass, StructMember, SwitchCase, Type, TypeInner, UnaryOperator,
+    Function, FunctionResult, ResourceBinding, ScalarValue, Statement, StorageClass, StructMember,
+    SwitchCase, Type, TypeInner, UnaryOperator,
 };
 use core::convert::TryFrom;
 use std::{iter::Peekable, mem};
@@ -716,7 +716,7 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
                 match token.value {
                     TokenValue::Identifier(ty_name) => {
                         if self.bump_if(TokenValue::LeftBrace).is_some() {
-                            self.parse_block_declaration(&qualifiers, ty_name)
+                            self.parse_block_declaration(&qualifiers, ty_name, token.meta)
                         } else {
                             //TODO: declaration
                             // type_qualifier IDENTIFIER SEMICOLON
@@ -762,55 +762,8 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
         &mut self,
         qualifiers: &[(TypeQualifier, SourceMetadata)],
         ty_name: String,
+        mut meta: SourceMetadata,
     ) -> Result<bool> {
-        let mut class = StorageClass::Private;
-        let mut binding = None;
-        let mut layout = None;
-
-        for &(ref qualifier, meta) in qualifiers {
-            match *qualifier {
-                TypeQualifier::StorageQualifier(StorageQualifier::StorageClass(c)) => {
-                    if StorageClass::PushConstant == class && c == StorageClass::Uniform {
-                        // Ignore the Uniform qualifier if the class was already set to PushConstant
-                        continue;
-                    } else if StorageClass::Private != class {
-                        return Err(ErrorKind::SemanticError(
-                            meta,
-                            "Cannot use more than one storage qualifier per declaration".into(),
-                        ));
-                    }
-
-                    class = c;
-                }
-                TypeQualifier::ResourceBinding(ref r) => {
-                    if binding.is_some() {
-                        return Err(ErrorKind::SemanticError(
-                            meta,
-                            "Cannot use more than one storage qualifier per declaration".into(),
-                        ));
-                    }
-
-                    binding = Some(r.clone());
-                }
-                TypeQualifier::Layout(ref l) => {
-                    if layout.is_some() {
-                        return Err(ErrorKind::SemanticError(
-                            meta,
-                            "Cannot use more than one storage qualifier per declaration".into(),
-                        ));
-                    }
-
-                    layout = Some(l);
-                }
-                _ => {
-                    return Err(ErrorKind::SemanticError(
-                        meta,
-                        "Qualifier not supported in block declarations".into(),
-                    ));
-                }
-            }
-        }
-
         let mut members = Vec::new();
         let span = self.parse_struct_declaration_list(&mut members)?;
         self.expect(TokenValue::RightBrace)?;
@@ -829,7 +782,7 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
             TokenValue::Semicolon => None,
             TokenValue::Identifier(name) => {
                 if let Some(size) = self.parse_array_specifier()? {
-                    ty = self.program.module.types.append(Type {
+                    ty = self.program.module.types.fetch_or_append(Type {
                         name: None,
                         inner: TypeInner::Array {
                             base: ty,
@@ -847,25 +800,15 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
             }
             _ => return Err(ErrorKind::InvalidToken(token)),
         };
+        meta = meta.union(&token.meta);
 
-        let handle = self.program.module.global_variables.append(GlobalVariable {
-            name: name.clone(),
-            class,
-            binding,
+        let handle = self.program.add_global_var(VarDeclaration {
+            qualifiers,
             ty,
+            name,
             init: None,
-            storage_access: StorageAccess::empty(),
-        });
-
-        if let Some(k) = name {
-            self.program.global_variables.push((
-                k,
-                GlobalLookup {
-                    kind: GlobalLookupKind::Variable(handle),
-                    entry_arg: None,
-                },
-            ));
-        }
+            meta,
+        })?;
 
         for (i, k) in members
             .into_iter()
@@ -877,6 +820,7 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
                 GlobalLookup {
                     kind: GlobalLookupKind::BlockSelect(handle, i),
                     entry_arg: None,
+                    mutable: true,
                 },
             ));
         }
@@ -1557,7 +1501,7 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
                         let decl = VarDeclaration {
                             qualifiers: &qualifiers,
                             ty,
-                            name,
+                            name: Some(name),
                             init: None,
                             meta: meta.union(&end_meta),
                         };
@@ -1741,13 +1685,18 @@ impl<'ctx, 'fun> DeclarationContext<'ctx, 'fun> {
         let decl = VarDeclaration {
             qualifiers: &self.qualifiers,
             ty,
-            name,
+            name: Some(name),
             init,
             meta,
         };
 
         match self.external {
-            true => program.add_global_var(self.ctx, self.body, decl),
+            true => {
+                let handle = program.add_global_var(decl)?;
+                Ok(self
+                    .ctx
+                    .add_expression(Expression::GlobalVariable(handle), self.body))
+            }
             false => program.add_local_var(self.ctx, self.body, decl),
         }
     }

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -1026,8 +1026,11 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
             _ => self.parse_primary(ctx, body)?,
         };
 
-        // TODO: postfix inc/dec
-        while let TokenValue::LeftBracket | TokenValue::Dot = self.expect_peek()?.value {
+        while let TokenValue::LeftBracket
+        | TokenValue::Dot
+        | TokenValue::Increment
+        | TokenValue::Decrement = self.expect_peek()?.value
+        {
             let Token { value, meta } = self.bump()?;
 
             match value {
@@ -1046,6 +1049,26 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
                     base = ctx.hir_exprs.append(HirExpr {
                         kind: HirExprKind::Select { base, field },
                         meta: meta.union(&end_meta),
+                    })
+                }
+                TokenValue::Increment => {
+                    base = ctx.hir_exprs.append(HirExpr {
+                        kind: HirExprKind::IncDec {
+                            increment: true,
+                            postfix: true,
+                            expr: base,
+                        },
+                        meta,
+                    })
+                }
+                TokenValue::Decrement => {
+                    base = ctx.hir_exprs.append(HirExpr {
+                        kind: HirExprKind::IncDec {
+                            increment: false,
+                            postfix: true,
+                            expr: base,
+                        },
+                        meta,
                     })
                 }
                 _ => unreachable!(),
@@ -1079,6 +1102,24 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
                 ctx.hir_exprs.append(HirExpr {
                     kind,
                     meta: meta.union(&end_meta),
+                })
+            }
+            TokenValue::Increment | TokenValue::Decrement => {
+                let Token { value, meta } = self.bump()?;
+
+                let expr = self.parse_unary(ctx, body)?;
+
+                ctx.hir_exprs.append(HirExpr {
+                    kind: HirExprKind::IncDec {
+                        increment: match value {
+                            TokenValue::Increment => true,
+                            TokenValue::Decrement => false,
+                            _ => unreachable!(),
+                        },
+                        postfix: false,
+                        expr,
+                    },
+                    meta,
                 })
             }
             _ => self.parse_postfix(ctx, body)?,

--- a/src/front/glsl/token.rs
+++ b/src/front/glsl/token.rs
@@ -53,6 +53,7 @@ pub enum TokenValue {
     Out,
     InOut,
     Uniform,
+    Buffer,
     Const,
     Interpolation(Interpolation),
     Sampling(Sampling),

--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -104,6 +104,16 @@ impl Program<'_> {
                 false,
                 PrologueStage::VERTEX,
             ),
+            "gl_GlobalInvocationID" => add_builtin(
+                TypeInner::Vector {
+                    size: VectorSize::Tri,
+                    kind: ScalarKind::Uint,
+                    width: 4,
+                },
+                BuiltIn::GlobalInvocationId,
+                false,
+                PrologueStage::COMPUTE,
+            ),
             _ => Ok(None),
         }
     }

--- a/tests/in/glsl/246-collatz.comp
+++ b/tests/in/glsl/246-collatz.comp
@@ -1,0 +1,34 @@
+// AUTHOR: Unknown
+// ISSUE: #246
+// NOTE: Taken from the wgpu repo
+#version 450
+layout(local_size_x = 1) in;
+
+layout(set = 0, binding = 0) buffer PrimeIndices {
+    uint[] indices;
+}; // this is used as both input and output for convenience
+
+// The Collatz Conjecture states that for any integer n:
+// If n is even, n = n/2
+// If n is odd, n = 3n+1
+// And repeat this process for each new n, you will always eventually reach 1.
+// Though the conjecture has not been proven, no counterexample has ever been found.
+// This function returns how many times this recurrence needs to be applied to reach 1.
+uint collatz_iterations(uint n) {
+    uint i = 0;
+    while(n != 1) {
+        if (mod(n, 2) == 0) {
+            n = n / 2;
+        }
+        else {
+            n = (3 * n) + 1;
+        }
+        i++;
+    }
+    return i;
+}
+
+void main() {
+    uint index = gl_GlobalInvocationID.x;
+    indices[index] = collatz_iterations(indices[index]);
+}

--- a/tests/out/quad-glsl.wgsl
+++ b/tests/out/quad-glsl.wgsl
@@ -7,6 +7,7 @@ struct FragmentOutput {
     [[location(0), interpolate(perspective)]] member2: vec4<f32>;
 };
 
+var<private> c_scale: f32;
 var<private> a_pos: vec2<f32>;
 var<private> a_uv: vec2<f32>;
 var<private> v_uv: vec2<f32>;
@@ -15,10 +16,11 @@ var<private> v_uv1: vec2<f32>;
 var<private> o_color: vec4<f32>;
 
 fn vert_main() {
-    let _e2: vec2<f32> = a_pos;
-    let _e4: vec2<f32> = a_uv;
-    v_uv = _e4;
-    gl_Position = vec4<f32>((1.2000000476837158 * _e2), 0.0, 1.0);
+    let _e1: f32 = c_scale;
+    let _e3: vec2<f32> = a_pos;
+    let _e5: vec2<f32> = a_uv;
+    v_uv = _e5;
+    gl_Position = vec4<f32>((_e1 * _e3), 0.0, 1.0);
     return;
 }
 


### PR DESCRIPTION
Contains a bunch of bug fixes and implements more parts of the parser to
finally be able to parse the collatz compute shader and other compute
shaders.

When I started working on this I thought it would be a simple thing but
it proved more complex, here&rsquo;s a list of the things included in this PR

-   Add parsing for compute shader workgroup modifiers (fixes #246)
-   Add support for the buffer storage class (fixes #902)
-   Add mod function and use implicit conversions for it&rsquo;s arguments
-   Add implicit conversions for locals initializers
-   Add glGlobalInvocationID builtin
-   Fixes a panic when calculating global use
-   Refractor the way global and blocks are handled to reduce code
    duplication
-   Fixes unsized types being loaded
-   Fixes assignments for function arguments in validation
-   Generates the wgsl for the quad shader
-   Add the collatz shader to testing

Due to #945 the glsl snapshot folder isn&rsquo;t currently generating wgsl

Also due to load expressions being cached the produced wgsl isn&rsquo;t
correct but everything else looks okay, here&rsquo;s the wgsl for the collatz
shader

    [[block]]
    struct PrimeIndices {
        indices: [[stride(4)]] array<u32>;
    };

    [[group(0), binding(0)]]
    var<storage> global: [[access(read_write)]] PrimeIndices;
    var<private> gl_GlobalInvocationID: vec3<u32>;

    fn collatz_iterations(n: u32) -> u32 {
        var n1: u32;
        var i: u32;
        var local: u32;

        n1 = n;
        let _e4: u32 = n1;
        i = u32(0);
        loop {
            if (!((_e4 != u32(1)))) {
                break;
            }
            {
                if (((_e4 % u32(2)) == u32(0))) {
                    {
                        n1 = (_e4 / u32(2));
                    }
                } else {
                    {
                        n1 = ((u32(3) * _e4) + u32(1));
                    }
                }
                let _e28: u32 = i;
                local = _e28;
                i = (_e28 + 1u);
            }
        }
        return i;
    }

    fn main() {
        var index: u32;

        let _e6: u32 = index;
        index = gl_GlobalInvocationID.x;
        let _e12: u32 = collatz_iterations(global.indices[_e6]);
        global.indices[_e6] = _e12;
        return;
    }

    [[stage(compute), workgroup_size(1, 1, 1)]]
    fn main1([[builtin(global_invocation_id)]] param: vec3<u32>) {
        gl_GlobalInvocationID = param;
        main();
        return;
    }
