### PR TITLE
Fix nightly clippy suggestions

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -853,7 +853,7 @@ impl<W: Write> Writer<W> {
                                 members,
                                 span,
                                 index as usize,
-                                &context.module,
+                                context.module,
                             ),
                             _ => None,
                         }
@@ -2080,7 +2080,7 @@ impl<W: Write> Writer<W> {
                         _ => continue,
                     };
                     varying_count += 1;
-                    let name = &self.names[&name_key];
+                    let name = &self.names[name_key];
                     let ty_name = TypeContext {
                         handle: ty,
                         arena: &module.types,
@@ -2177,7 +2177,7 @@ impl<W: Write> Writer<W> {
                     Some(ref binding @ &crate::Binding::BuiltIn(..)) => binding,
                     _ => continue,
                 };
-                let name = &self.names[&name_key];
+                let name = &self.names[name_key];
                 let ty_name = TypeContext {
                     handle: ty,
                     arena: &module.types,

--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -121,13 +121,13 @@ impl<'a> Program<'a> {
             constants: &self.module.constants,
             types: &self.module.types,
             global_vars: &self.module.global_variables,
-            local_vars: &context.locals,
+            local_vars: context.locals,
             functions: &self.module.functions,
-            arguments: &context.arguments,
+            arguments: context.arguments,
         };
         match context
             .typifier
-            .grow(handle, &context.expressions, &resolve_ctx)
+            .grow(handle, context.expressions, &resolve_ctx)
         {
             //TODO: better error report
             Err(error) => Err(ErrorKind::SemanticError(
@@ -148,13 +148,13 @@ impl<'a> Program<'a> {
             constants: &self.module.constants,
             types: &self.module.types,
             global_vars: &self.module.global_variables,
-            local_vars: &context.locals,
+            local_vars: context.locals,
             functions: &self.module.functions,
-            arguments: &context.arguments,
+            arguments: context.arguments,
         };
         match context
             .typifier
-            .grow(handle, &context.expressions, &resolve_ctx)
+            .grow(handle, context.expressions, &resolve_ctx)
         {
             //TODO: better error report
             Err(error) => Err(ErrorKind::SemanticError(
@@ -286,11 +286,11 @@ impl<'function> Context<'function> {
     }
 
     pub fn emit_start(&mut self) {
-        self.emitter.start(&self.expressions)
+        self.emitter.start(self.expressions)
     }
 
     pub fn emit_flush(&mut self, body: &mut Block) {
-        body.extend(self.emitter.finish(&self.expressions))
+        body.extend(self.emitter.finish(self.expressions))
     }
 
     pub fn add_expression(&mut self, expr: Expression, body: &mut Block) -> Handle<Expression> {

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -513,9 +513,8 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
             // TODO: Should we try to make constants here?
             // This is mostly a hack because we don't yet support adding
             // bodies to entry points for variable initialization
-            let maybe_constant = init
-                .clone()
-                .and_then(|(root, meta)| self.program.solve_constant(ctx.ctx, root, meta).ok());
+            let maybe_constant =
+                init.and_then(|(root, meta)| self.program.solve_constant(ctx.ctx, root, meta).ok());
 
             let pointer = ctx.add_var(self.program, ty, name, maybe_constant, meta)?;
 
@@ -1283,7 +1282,7 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
                                 let expr = self.parse_expression(ctx, body)?;
                                 let (root, meta) =
                                     ctx.lower_expect(self.program, expr, false, body)?;
-                                let constant = self.program.solve_constant(&ctx, root, meta)?;
+                                let constant = self.program.solve_constant(ctx, root, meta)?;
 
                                 match self.program.module.constants[constant].inner {
                                     ConstantInner::Scalar {

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -2215,7 +2215,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                 } => {
                     if let [S::Break] = reject[..] {
                         // uplift "accept" into the parent
-                        let extracted = mem::replace(accept, Vec::new());
+                        let extracted = mem::take(accept);
                         statements.splice(i + 1..i + 1, extracted.into_iter());
                     } else {
                         self.patch_statements(reject)?;
@@ -2229,7 +2229,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                 } => {
                     if cases.is_empty() {
                         // uplift "default" into the parent
-                        let extracted = mem::replace(default, Vec::new());
+                        let extracted = mem::take(default);
                         statements.splice(i + 1..i + 1, extracted.into_iter());
                     } else {
                         for case in cases.iter_mut() {

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1511,8 +1511,8 @@ impl Parser {
                 (to_type, from_type) => {
                     return Err(Error::BadTypeCast {
                         span: arguments_span,
-                        from_type: from_type.to_wgsl(&ctx.types, &ctx.constants),
-                        to_type: to_type.to_wgsl(&ctx.types, &ctx.constants),
+                        from_type: from_type.to_wgsl(ctx.types, ctx.constants),
+                        to_type: to_type.to_wgsl(ctx.types, ctx.constants),
                     });
                 }
             }
@@ -1542,14 +1542,9 @@ impl Parser {
         let inner = match first_token_span {
             (Token::Word("true"), _) => crate::ConstantInner::boolean(true),
             (Token::Word("false"), _) => crate::ConstantInner::boolean(false),
-            (
-                Token::Number {
-                    ref value,
-                    ref ty,
-                    ref width,
-                },
-                _,
-            ) => Self::get_constant_inner(*value, *ty, *width, first_token_span)?,
+            (Token::Number { value, ty, width }, _) => {
+                Self::get_constant_inner(value, ty, width, first_token_span)?
+            }
             (Token::Word(name), name_span) => {
                 // look for an existing constant first
                 for (handle, var) in const_arena.iter() {
@@ -3213,7 +3208,7 @@ impl Parser {
             }
             (Token::Word("fn"), _) => {
                 let (function, name) =
-                    self.parse_function_decl(lexer, module, &lookup_global_expression)?;
+                    self.parse_function_decl(lexer, module, lookup_global_expression)?;
                 match stage {
                     Some(stage) => module.entry_points.push(crate::EntryPoint {
                         name: name.to_string(),

--- a/src/proc/interpolator.rs
+++ b/src/proc/interpolator.rs
@@ -55,8 +55,8 @@ impl crate::Module {
                 //
                 // So, temporarily swap the member list out its type, assign appropriate
                 // interpolations to its members, and then swap the list back in.
-                use std::mem::replace;
-                let mut members = replace(m, vec![]);
+                use std::mem;
+                let mut members = mem::take(m);
 
                 for member in &mut members {
                     default_binding_or_struct(&mut member.binding, member.ty, types);
@@ -68,7 +68,7 @@ impl crate::Module {
                 match types.get_mut(ty).inner {
                     TypeInner::Struct {
                         members: ref mut m, ..
-                    } => replace(m, members),
+                    } => mem::replace(m, members),
                     _ => unreachable!("ty must be a struct"),
                 };
 

--- a/src/valid/interface.rs
+++ b/src/valid/interface.rs
@@ -413,7 +413,7 @@ impl super::Validator {
             crate::ShaderStage::Compute => ShaderStages::COMPUTE,
         };
 
-        let info = self.validate_function(&ep.function, module, &mod_info)?;
+        let info = self.validate_function(&ep.function, module, mod_info)?;
 
         if !info.available_stages.contains(stage_bit) {
             return Err(EntryPointError::ForbiddenStageOperations);


### PR DESCRIPTION
Most of code suggestions are found by new `clippy` lints - [mem_replace_with_default ](https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_default) and [needless_borrow](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow).