### PR TITLE
Fixed compile-time error in spv fuzzer test.

### DIFF
--- a/fuzz/fuzz_targets/spv_parser.rs
+++ b/fuzz/fuzz_targets/spv_parser.rs
@@ -1,7 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use naga::front::spv::Parser;
-use naga::front::spv::Options;
+use naga::front::spv::{Parser, Options};
 
 fuzz_target!(|data: Vec<u32>| {
     // Ensure the parser can handle potentially malformed data without crashing.

--- a/fuzz/fuzz_targets/spv_parser.rs
+++ b/fuzz/fuzz_targets/spv_parser.rs
@@ -1,8 +1,10 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use naga::front::spv::Parser;
+use naga::front::spv::Options;
 
 fuzz_target!(|data: Vec<u32>| {
     // Ensure the parser can handle potentially malformed data without crashing.
-    let _result = Parser::new(data.into_iter()).parse();
+    let options = Options::default();
+    let _result = Parser::new(data.into_iter(), &options).parse();
 });


### PR DESCRIPTION
Hi, naga team.

I found compile-time error in spv_parser.rs fuzzer test.
Could you review and accept my changes, pls?

error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> fuzz_targets/spv_parser.rs:7:19
    |
7   |     let _result = Parser::new(data.into_iter()).parse();
    |                   ^^^^^^^^^^^ ---------------- supplied 1 argument
    |                   |
    |                   expected 2 arguments
    |
note: associated function defined here
   --> /Users/evgeny.proydakov/repository/naga/src/front/spv/mod.rs:411:12
    |
411 |     pub fn new(data: I, options: &Options) -> Self {
    |            ^^^

error: aborting due to previous error

Best regards, Proydakov Evgeny.