### PR TITLE
Fix testing infrastructure

### DIFF
--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Generate report
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '--tests --all-features'
+          args: '--tests --all-features --workspace'
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -24,7 +24,7 @@ jobs:
         name: Test all features
         with:
           command: test
-          args: --all-features
+          args: --all-features --workspace
       - name: Check snapshots
         run: git diff --exit-code -- tests/out
   clippy:
@@ -41,4 +41,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-features -- -D warnings
+          args: --all-features --workspace -- -D warnings

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ SNAPSHOTS_OUT=tests/out
 
 all:
 	cargo fmt
-	cargo test --all-features
-	cargo clippy --all-features
+	cargo test --all-features --workspace
+	cargo clippy --all-features --workspace -- -D warnings
 
 clean:
 	rm *.metal *.air *.metallib *.vert *.frag *.comp *.spv
@@ -69,4 +69,3 @@ validate-hlsl: $(SNAPSHOTS_OUT)/*.hlsl
 		echo "Validating" $${file#"$(SNAPSHOTS_OUT)/"};\
 		dxc $${file} -T cs_6_0;\
 	done
-

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cargo run --features wgsl-in,glsl-out -- my_shader.wgsl my_shader.vert --profile
 
 ## Development workflow
 
-The main instrument aiding the development is the good old `cargo test --all-features`,
+The main instrument aiding the development is the good old `cargo test --all-features --workspace`,
 which will run the unit tests, and also update all the snapshots. You'll see these
 changes in git before committing the code.
 


### PR DESCRIPTION
One thing that we missed in #938. Currently, `cargo run --all-features` running 0 tests.