### PR TITLE
Add `.` to the workspace's default members. Test with no features.

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -19,7 +19,13 @@ jobs:
       - uses: actions-rs/cargo@v1
         name: Default test
         with:
+          # Our intention here is to test `naga` with no features enabled. But
+          # since `cli` is the default package, a plain `cargo test` will build
+          # `naga` with the features requested in `cli/Cargo.toml`. Passing
+          # `--package naga` causes us to use the default features in the
+          # top-level `Cargo.toml` instead.
           command: test
+          args: --package naga
       - uses: actions-rs/cargo@v1
         name: Test all features
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,4 +52,8 @@ rspirv = "0.7"
 
 [workspace]
 members = [".", "cli"]
-default-members = ["cli"]
+
+# Include "cli", so that `cargo run` runs the CLI by default. Include ".", so
+# that `cargo test` includes naga's own tests by default (but note, using the
+# features that `cli/Cargo.toml` requests).
+default-members = [".", "cli"]


### PR DESCRIPTION
Naga is now a workspace with `naga` and `cli` as its two members. The default
package for cargo commands is `cli`, so that `cargo run` will just run the CLI.

However, this has a few unexpected consequences:

- Now `cargo test` will just try to run `cli`'s tests, of which there are none.
  Adding `"."` to the `default-members` list in the workspace's `Cargo.toml`
  seems to fix this, without breaking `cargo run`.

- Even with `"."` added to `default-members`, `cargo test` will build `naga` by
  default with the features requested for it in `cli/Cargo.toml`: all the front
  and back ends, but no `serialize` or `deserialize`. This means that our CI job
  meant to verify no-feature builds isn't doing that job any more. We need to
  pass `--package naga` to `cargo test` to make it test naga directly.