### PR TITLE
Validator::validate: Remove bogus comment.

### DIFF
--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -264,7 +264,6 @@ impl Validator {
             }
         }
 
-        // doing after the globals, so that `type_flags` is ready
         for (handle, ty) in module.types.iter() {
             let ty_info = self
                 .validate_type(handle, &module.types, &module.constants)


### PR DESCRIPTION
This comment claims that the following work is being done after global
validation, but it actually appears before global validation.