### PR TITLE
Improve docs for `TypeInner`, `valid::TypeFlags`, and some internal types.

### DIFF
--- a/src/back/spv/mod.rs
+++ b/src/back/spv/mod.rs
@@ -127,14 +127,26 @@ impl Function {
     }
 }
 
+/// A SPIR-V type constructed during code generation.
+///
+/// In the process of writing SPIR-V, we need to synthesize various types for
+/// intermediate results and such. However, it's inconvenient to use
+/// `crate::Type` or `crate::TypeInner` for these, as the IR module is immutable
+/// so we can't ever create a `Handle<Type>` to refer to them. So for local use
+/// in the SPIR-V writer, we have this home-grown type enum that covers only the
+/// cases we need (for example, it doesn't cover structs).
 #[derive(Debug, PartialEq, Hash, Eq, Copy, Clone)]
 enum LocalType {
+    /// A scalar, vector, or pointer to one of those.
     Value {
+        /// If `None`, this represents a scalar type. If `Some`, this represents
+        /// a vector type of the given size.
         vector_size: Option<crate::VectorSize>,
         kind: crate::ScalarKind,
         width: crate::Bytes,
         pointer_class: Option<spirv::StorageClass>,
     },
+    /// A matrix of floating-point values.
     Matrix {
         columns: crate::VectorSize,
         rows: crate::VectorSize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,8 +164,8 @@ pub(crate) type NamedExpressions = FastHashMap<Handle<Expression>, String>;
 /// HLSL: Attribute earlydepthstencil
 ///
 /// For more, see:
-///   - https://www.khronos.org/opengl/wiki/Early_Fragment_Test#Explicit_specification
-///   - https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/sm5-attributes-earlydepthstencil
+///   - <https://www.khronos.org/opengl/wiki/Early_Fragment_Test#Explicit_specification>
+///   - <https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/sm5-attributes-earlydepthstencil>
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
@@ -180,8 +180,8 @@ pub struct EarlyDepthTest {
 /// HLSL: SV_Depth/SV_DepthGreaterEqual/SV_DepthLessEqual
 ///
 /// For more, see:
-///   - https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_conservative_depth.txt
-///   - https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics#system-value-semantics
+///   - <https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_conservative_depth.txt>
+///   - <https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics#system-value-semantics>
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]

--- a/src/proc/layouter.rs
+++ b/src/proc/layouter.rs
@@ -14,7 +14,7 @@ pub struct TypeLayout {
 
 /// Helper processor that derives the sizes of all types.
 /// It uses the default layout algorithm/table, described in
-/// https://github.com/gpuweb/gpuweb/issues/1393
+/// <https://github.com/gpuweb/gpuweb/issues/1393>
 #[derive(Debug, Default)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]

--- a/src/valid/type.rs
+++ b/src/valid/type.rs
@@ -5,16 +5,45 @@ use crate::{
 };
 
 bitflags::bitflags! {
+    /// Flags associated with [`Type`]s by [`Validator`].
+    ///
+    /// [`Type`]: crate::Type
+    /// [`Validator`]: crate::valid::Validator
     #[repr(transparent)]
     pub struct TypeFlags: u8 {
         /// Can be used for data variables.
+        ///
+        /// This flag is required on types of local variables, function
+        /// arguments, array elements, and struct members.
+        ///
+        /// This includes all types except `Image`, `Sampler`, `ValuePointer`,
+        /// and some `Pointer` types.
         const DATA = 0x1;
-        /// The data type has known size.
+
+        /// The data type has a size known by pipeline creation time.
+        ///
+        /// Unsized types are quite restricted. The only unsized types permitted
+        /// by Naga, other than the non-[`DATA`] types like [`Image`] and
+        /// [`Sampler`], are dynamically-sized [`Array`s], and [`Struct`s] whose
+        /// last members are such arrays. See the documentation for those types
+        /// for details.
+        ///
+        /// [`DATA`]: TypeFlags::DATA
+        /// [`Image`]: crate::Type::Image
+        /// [`Sampler`]: crate::Type::Sampler
+        /// [`Array`]: crate::Type::Array
+        /// [`Struct`]: crate::Type::struct
         const SIZED = 0x2;
+
         /// Can be be used for interfacing between pipeline stages.
+        ///
+        /// This includes non-bool scalars and vectors, matrices, and structs
+        /// and arrays containing only interface types.
         const INTERFACE = 0x4;
+
         /// Can be used for host-shareable structures.
         const HOST_SHARED = 0x8;
+
         /// This is a top-level host-shareable type.
         const TOP_LEVEL = 0x10;
     }


### PR DESCRIPTION
This is dependent on #916 (some of the claims depend on those changes landing).

GitHub doesn't seem to have a concept of one PR depending upon another, so just look at the last commit to see the changes unique to this PR.