### PR TITLE
[wgsl-in] use AccessIndex for accesses using constant index

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -765,7 +765,7 @@ impl<W: Write> Writer<W> {
                         write!(self.out, "[{}]", index)?;
                     }
                     crate::TypeInner::Array { .. } => {
-                        write!(self.out, "[{}]", index)?;
+                        write!(self.out, ".{}[{}]", WRAPPED_ARRAY_FIELD, index)?;
                     }
                     _ => {
                         // unexpected indexing, should fail validation

--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -233,13 +233,21 @@ impl<'a> Lexer<'a> {
         token
     }
 
-    pub(super) fn expect(&mut self, expected: Token<'a>) -> Result<(), Error<'a>> {
+    pub(super) fn expect_span(
+        &mut self,
+        expected: Token<'a>,
+    ) -> Result<std::ops::Range<usize>, Error<'a>> {
         let next = self.next();
         if next.0 == expected {
-            Ok(())
+            Ok(next.1)
         } else {
             Err(Error::Unexpected(next, ExpectedToken::Token(expected)))
         }
+    }
+
+    pub(super) fn expect(&mut self, expected: Token<'a>) -> Result<(), Error<'a>> {
+        self.expect_span(expected)?;
+        Ok(())
     }
 
     pub(super) fn expect_generic_paren(&mut self, expected: char) -> Result<(), Error<'a>> {

--- a/tests/out/access.msl
+++ b/tests/out/access.msl
@@ -28,7 +28,7 @@ vertex fooOutput foo(
     type6 c;
     float baz = foo1;
     foo1 = 1.0;
-    metal::float4 _e9 = bar.matrix[3u];
+    metal::float4 _e9 = bar.matrix[3];
     float b = _e9.x;
     int a = bar.data[(1 + (_buffer_sizes.size0 - 64 - 4) / 4) - 1u];
     for(int _i=0; _i<5; ++_i) c.inner[_i] = type6 {a, static_cast<int>(b), 3, 4, 5}.inner[_i];

--- a/tests/out/access.wgsl
+++ b/tests/out/access.wgsl
@@ -14,7 +14,7 @@ fn foo([[builtin(vertex_index)]] vi: u32) -> [[builtin(position)]] vec4<f32> {
 
     let baz: f32 = foo1;
     foo1 = 1.0;
-    let _e9: vec4<f32> = bar.matrix[3u];
+    let _e9: vec4<f32> = bar.matrix[3];
     let b: f32 = _e9.x;
     let a: i32 = bar.data[(arrayLength(&bar.data) - 1u)];
     c = array<i32,5>(a, i32(b), 3, 4, 5);

--- a/tests/out/globals.spvasm
+++ b/tests/out/globals.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 20
+; Bound: 21
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
@@ -22,11 +22,12 @@ OpDecorate %11 ArrayStride 4
 %12 = OpVariable  %13  Workgroup
 %16 = OpTypeFunction %2
 %18 = OpTypePointer Workgroup %10
+%19 = OpConstant  %6  3
 %15 = OpFunction  %2  None %16
 %14 = OpLabel
 OpBranch %17
 %17 = OpLabel
-%19 = OpAccessChain  %18  %12 %7
-OpStore %19 %9
+%20 = OpAccessChain  %18  %12 %19
+OpStore %20 %9
 OpReturn
 OpFunctionEnd


### PR DESCRIPTION
This change allows constant index expressions parsed by wgsl-in to be consumed by spv-out. Otherwise, the access is always treated as dynamic. Those accesses are often generated by `glsl-in -> wgsl-out` translation for matrix cast expression, which previously prevented those shaders to be further translated into spirv.

The msl-out change is also required, as this change surfaced a bug when generating those const accesses, emitting incorrect code from snapshot tests.