### PR TITLE
reorder namer assignment order to preserve names for reflection

### DIFF
--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -701,7 +701,7 @@ impl Program<'_> {
                 let ty = self.module.global_variables[arg.handle].ty;
 
                 members.push(StructMember {
-                    name: None,
+                    name: arg.name.clone(),
                     ty,
                     binding: Some(arg.binding.clone()),
                     offset: span,

--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -407,7 +407,7 @@ impl Program<'_> {
             });
 
             let handle = self.module.global_variables.append(GlobalVariable {
-                name: name.as_ref().map(|n| format!("gen_entry_{}", n)),
+                name: name.clone(),
                 class: StorageClass::Private,
                 binding: None,
                 ty,

--- a/tests/out/210-bevy-2d-shader-frag.wgsl
+++ b/tests/out/210-bevy-2d-shader-frag.wgsl
@@ -4,27 +4,27 @@ struct ColorMaterial_color {
 };
 
 struct FragmentOutput {
-    [[location(0), interpolate(perspective)]] member: vec4<f32>;
+    [[location(0), interpolate(perspective)]] o_Target: vec4<f32>;
 };
 
-var<private> gen_entry_v_Uv: vec2<f32>;
-var<private> gen_entry_o_Target: vec4<f32>;
+var<private> v_Uv: vec2<f32>;
+var<private> o_Target: vec4<f32>;
 [[group(1), binding(0)]]
 var<uniform> global: ColorMaterial_color;
 
-fn main() {
+fn main1() {
     var color: vec4<f32>;
 
     let _e4: vec4<f32> = global.Color;
     color = _e4;
     let _e6: vec4<f32> = color;
-    gen_entry_o_Target = _e6;
+    o_Target = _e6;
     return;
 }
 
 [[stage(fragment)]]
-fn main1() -> FragmentOutput {
-    main();
-    let _e1: vec4<f32> = gen_entry_o_Target;
+fn main() -> FragmentOutput {
+    main1();
+    let _e1: vec4<f32> = o_Target;
     return FragmentOutput(_e1);
 }

--- a/tests/out/210-bevy-2d-shader-vert.wgsl
+++ b/tests/out/210-bevy-2d-shader-vert.wgsl
@@ -14,14 +14,14 @@ struct Sprite_size {
 };
 
 struct VertexOutput {
-    [[location(0), interpolate(perspective)]] member: vec2<f32>;
-    [[builtin(position)]] member1: vec4<f32>;
+    [[location(0), interpolate(perspective)]] v_Uv: vec2<f32>;
+    [[builtin(position)]] member: vec4<f32>;
 };
 
-var<private> gen_entry_Vertex_Position: vec3<f32>;
-var<private> gen_entry_Vertex_Normal: vec3<f32>;
-var<private> gen_entry_Vertex_Uv: vec2<f32>;
-var<private> gen_entry_v_Uv: vec2<f32>;
+var<private> Vertex_Position1: vec3<f32>;
+var<private> Vertex_Normal: vec3<f32>;
+var<private> Vertex_Uv1: vec2<f32>;
+var<private> v_Uv: vec2<f32>;
 [[group(0), binding(0)]]
 var<uniform> global: Camera;
 [[group(2), binding(0)]]
@@ -30,12 +30,12 @@ var<uniform> global1: Transform;
 var<uniform> global2: Sprite_size;
 var<private> gl_Position: vec4<f32>;
 
-fn main() {
+fn main1() {
     var position: vec3<f32>;
 
-    let _e10: vec2<f32> = gen_entry_Vertex_Uv;
-    gen_entry_v_Uv = _e10;
-    let _e11: vec3<f32> = gen_entry_Vertex_Position;
+    let _e10: vec2<f32> = Vertex_Uv1;
+    v_Uv = _e10;
+    let _e11: vec3<f32> = Vertex_Position1;
     let _e12: vec2<f32> = global2.size;
     position = (_e11 * vec3<f32>(_e12, 1.0));
     let _e18: mat4x4<f32> = global.ViewProj;
@@ -46,11 +46,11 @@ fn main() {
 }
 
 [[stage(vertex)]]
-fn main1([[location(0), interpolate(perspective)]] Vertex_Position: vec3<f32>, [[location(2), interpolate(perspective)]] Vertex_Uv: vec2<f32>) -> VertexOutput {
-    gen_entry_Vertex_Position = Vertex_Position;
-    gen_entry_Vertex_Uv = Vertex_Uv;
-    main();
-    let _e5: vec2<f32> = gen_entry_v_Uv;
+fn main([[location(0), interpolate(perspective)]] Vertex_Position: vec3<f32>, [[location(2), interpolate(perspective)]] Vertex_Uv: vec2<f32>) -> VertexOutput {
+    Vertex_Position1 = Vertex_Position;
+    Vertex_Uv1 = Vertex_Uv;
+    main1();
+    let _e5: vec2<f32> = v_Uv;
     let _e7: vec4<f32> = gl_Position;
     return VertexOutput(_e5, _e7);
 }

--- a/tests/out/210-bevy-shader-vert.wgsl
+++ b/tests/out/210-bevy-shader-vert.wgsl
@@ -9,51 +9,51 @@ struct Transform {
 };
 
 struct VertexOutput {
-    [[location(0), interpolate(perspective)]] member: vec3<f32>;
-    [[location(1), interpolate(perspective)]] member1: vec3<f32>;
-    [[location(2), interpolate(perspective)]] member2: vec2<f32>;
-    [[builtin(position)]] member3: vec4<f32>;
+    [[location(0), interpolate(perspective)]] v_Position: vec3<f32>;
+    [[location(1), interpolate(perspective)]] v_Normal: vec3<f32>;
+    [[location(2), interpolate(perspective)]] v_Uv: vec2<f32>;
+    [[builtin(position)]] member: vec4<f32>;
 };
 
-var<private> gen_entry_Vertex_Position: vec3<f32>;
-var<private> gen_entry_Vertex_Normal: vec3<f32>;
-var<private> gen_entry_Vertex_Uv: vec2<f32>;
-var<private> gen_entry_v_Position: vec3<f32>;
-var<private> gen_entry_v_Normal: vec3<f32>;
-var<private> gen_entry_v_Uv: vec2<f32>;
+var<private> Vertex_Position1: vec3<f32>;
+var<private> Vertex_Normal1: vec3<f32>;
+var<private> Vertex_Uv1: vec2<f32>;
+var<private> v_Position: vec3<f32>;
+var<private> v_Normal: vec3<f32>;
+var<private> v_Uv: vec2<f32>;
 [[group(0), binding(0)]]
 var<uniform> global: Camera;
 [[group(2), binding(0)]]
 var<uniform> global1: Transform;
 var<private> gl_Position: vec4<f32>;
 
-fn main() {
+fn main1() {
     let _e10: mat4x4<f32> = global1.Model;
-    let _e11: vec3<f32> = gen_entry_Vertex_Normal;
-    gen_entry_v_Normal = (_e10 * vec4<f32>(_e11, 1.0)).xyz;
+    let _e11: vec3<f32> = Vertex_Normal1;
+    v_Normal = (_e10 * vec4<f32>(_e11, 1.0)).xyz;
     let _e16: mat4x4<f32> = global1.Model;
-    let _e24: vec3<f32> = gen_entry_Vertex_Normal;
-    gen_entry_v_Normal = (mat3x3<f32>(_e16[0].xyz, _e16[1].xyz, _e16[2].xyz) * _e24);
+    let _e24: vec3<f32> = Vertex_Normal1;
+    v_Normal = (mat3x3<f32>(_e16[0].xyz, _e16[1].xyz, _e16[2].xyz) * _e24);
     let _e26: mat4x4<f32> = global1.Model;
-    let _e27: vec3<f32> = gen_entry_Vertex_Position;
-    gen_entry_v_Position = (_e26 * vec4<f32>(_e27, 1.0)).xyz;
-    let _e32: vec2<f32> = gen_entry_Vertex_Uv;
-    gen_entry_v_Uv = _e32;
+    let _e27: vec3<f32> = Vertex_Position1;
+    v_Position = (_e26 * vec4<f32>(_e27, 1.0)).xyz;
+    let _e32: vec2<f32> = Vertex_Uv1;
+    v_Uv = _e32;
     let _e34: mat4x4<f32> = global.ViewProj;
-    let _e35: vec3<f32> = gen_entry_v_Position;
+    let _e35: vec3<f32> = v_Position;
     gl_Position = (_e34 * vec4<f32>(_e35, 1.0));
     return;
 }
 
 [[stage(vertex)]]
-fn main1([[location(0), interpolate(perspective)]] Vertex_Position: vec3<f32>, [[location(1), interpolate(perspective)]] Vertex_Normal: vec3<f32>, [[location(2), interpolate(perspective)]] Vertex_Uv: vec2<f32>) -> VertexOutput {
-    gen_entry_Vertex_Position = Vertex_Position;
-    gen_entry_Vertex_Normal = Vertex_Normal;
-    gen_entry_Vertex_Uv = Vertex_Uv;
-    main();
-    let _e7: vec3<f32> = gen_entry_v_Position;
-    let _e9: vec3<f32> = gen_entry_v_Normal;
-    let _e11: vec2<f32> = gen_entry_v_Uv;
+fn main([[location(0), interpolate(perspective)]] Vertex_Position: vec3<f32>, [[location(1), interpolate(perspective)]] Vertex_Normal: vec3<f32>, [[location(2), interpolate(perspective)]] Vertex_Uv: vec2<f32>) -> VertexOutput {
+    Vertex_Position1 = Vertex_Position;
+    Vertex_Normal1 = Vertex_Normal;
+    Vertex_Uv1 = Vertex_Uv;
+    main1();
+    let _e7: vec3<f32> = v_Position;
+    let _e9: vec3<f32> = v_Normal;
+    let _e11: vec2<f32> = v_Uv;
     let _e13: vec4<f32> = gl_Position;
     return VertexOutput(_e7, _e9, _e11, _e13);
 }

--- a/tests/out/246-collatz-comp.wgsl
+++ b/tests/out/246-collatz-comp.wgsl
@@ -41,7 +41,7 @@ fn collatz_iterations(n: u32) -> u32 {
     return _e35;
 }
 
-fn main() {
+fn main1() {
     var index: u32;
 
     let _e3: vec3<u32> = gl_GlobalInvocationID;
@@ -56,8 +56,8 @@ fn main() {
 }
 
 [[stage(compute), workgroup_size(1, 1, 1)]]
-fn main1([[builtin(global_invocation_id)]] param: vec3<u32>) {
+fn main([[builtin(global_invocation_id)]] param: vec3<u32>) {
     gl_GlobalInvocationID = param;
-    main();
+    main1();
     return;
 }

--- a/tests/out/277-casting-vert.wgsl
+++ b/tests/out/277-casting-vert.wgsl
@@ -1,10 +1,10 @@
-fn main() {
+fn main1() {
     var a: f32 = 1.0;
 
 }
 
 [[stage(vertex)]]
-fn main1() {
-    main();
+fn main() {
+    main1();
     return;
 }

--- a/tests/out/280-matrix-cast-vert.wgsl
+++ b/tests/out/280-matrix-cast-vert.wgsl
@@ -1,4 +1,4 @@
-fn main() {
+fn main1() {
     var a: mat4x4<f32>;
 
     let _e2: vec4<f32> = vec4<f32>(f32(1));
@@ -7,7 +7,7 @@ fn main() {
 }
 
 [[stage(vertex)]]
-fn main1() {
-    main();
+fn main() {
+    main1();
     return;
 }

--- a/tests/out/484-preprocessor-if-vert.wgsl
+++ b/tests/out/484-preprocessor-if-vert.wgsl
@@ -1,9 +1,9 @@
-fn main() {
+fn main1() {
     return;
 }
 
 [[stage(vertex)]]
-fn main1() {
-    main();
+fn main() {
+    main1();
     return;
 }

--- a/tests/out/800-out-of-bounds-panic-vert.wgsl
+++ b/tests/out/800-out-of-bounds-panic-vert.wgsl
@@ -9,34 +9,34 @@ struct VertexPushConstants {
 };
 
 struct VertexOutput {
-    [[location(0), interpolate(perspective)]] member: vec4<f32>;
-    [[builtin(position)]] member1: vec4<f32>;
+    [[location(0), interpolate(perspective)]] frag_color: vec4<f32>;
+    [[builtin(position)]] member: vec4<f32>;
 };
 
 [[group(0), binding(0)]]
 var<uniform> global: Globals;
 var<push_constant> global1: VertexPushConstants;
-var<private> gen_entry_position: vec2<f32>;
-var<private> gen_entry_color: vec4<f32>;
-var<private> gen_entry_frag_color: vec4<f32>;
+var<private> position1: vec2<f32>;
+var<private> color1: vec4<f32>;
+var<private> frag_color: vec4<f32>;
 var<private> gl_Position: vec4<f32>;
 
-fn main() {
-    let _e7: vec4<f32> = gen_entry_color;
-    gen_entry_frag_color = _e7;
+fn main1() {
+    let _e7: vec4<f32> = color1;
+    frag_color = _e7;
     let _e9: mat4x4<f32> = global.view_matrix;
     let _e10: mat4x4<f32> = global1.world_matrix;
-    let _e12: vec2<f32> = gen_entry_position;
+    let _e12: vec2<f32> = position1;
     gl_Position = ((_e9 * _e10) * vec4<f32>(_e12, 0.0, 1.0));
     return;
 }
 
 [[stage(vertex)]]
-fn main1([[location(0), interpolate(perspective)]] position: vec2<f32>, [[location(1), interpolate(perspective)]] color: vec4<f32>) -> VertexOutput {
-    gen_entry_position = position;
-    gen_entry_color = color;
-    main();
-    let _e5: vec4<f32> = gen_entry_frag_color;
+fn main([[location(0), interpolate(perspective)]] position: vec2<f32>, [[location(1), interpolate(perspective)]] color: vec4<f32>) -> VertexOutput {
+    position1 = position;
+    color1 = color;
+    main1();
+    let _e5: vec4<f32> = frag_color;
     let _e7: vec4<f32> = gl_Position;
     return VertexOutput(_e5, _e7);
 }

--- a/tests/out/896-push-constant-vert.wgsl
+++ b/tests/out/896-push-constant-vert.wgsl
@@ -5,12 +5,12 @@ struct PushConstants {
 
 var<push_constant> c: PushConstants;
 
-fn main() {
+fn main1() {
     return;
 }
 
 [[stage(vertex)]]
-fn main1() {
-    main();
+fn main() {
+    main1();
     return;
 }

--- a/tests/out/901-lhs-field-select-vert.wgsl
+++ b/tests/out/901-lhs-field-select-vert.wgsl
@@ -1,4 +1,4 @@
-fn main() {
+fn main1() {
     var a: vec4<f32> = vec4<f32>(1.0, 1.0, 1.0, 1.0);
 
     a.x = 2.0;
@@ -6,7 +6,7 @@ fn main() {
 }
 
 [[stage(vertex)]]
-fn main1() {
-    main();
+fn main() {
+    main1();
     return;
 }

--- a/tests/out/932-for-loop-if-vert.wgsl
+++ b/tests/out/932-for-loop-if-vert.wgsl
@@ -1,4 +1,4 @@
-fn main() {
+fn main1() {
     var i: i32 = 0;
 
     loop {
@@ -17,7 +17,7 @@ fn main() {
 }
 
 [[stage(vertex)]]
-fn main1() {
-    main();
+fn main() {
+    main1();
     return;
 }

--- a/tests/out/bevy-pbr-frag.wgsl
+++ b/tests/out/bevy-pbr-frag.wgsl
@@ -6,7 +6,7 @@ struct PointLight {
 
 struct DirectionalLight {
     direction: vec4<f32>;
-    color1: vec4<f32>;
+    color: vec4<f32>;
 };
 
 [[block]]
@@ -53,14 +53,14 @@ struct StandardMaterial_emissive {
 };
 
 struct FragmentOutput {
-    [[location(0), interpolate(perspective)]] member: vec4<f32>;
+    [[location(0), interpolate(perspective)]] o_Target: vec4<f32>;
 };
 
-var<private> gen_entry_v_WorldPosition: vec3<f32>;
-var<private> gen_entry_v_WorldNormal: vec3<f32>;
-var<private> gen_entry_v_Uv: vec2<f32>;
-var<private> gen_entry_v_WorldTangent: vec4<f32>;
-var<private> gen_entry_o_Target: vec4<f32>;
+var<private> v_WorldPosition1: vec3<f32>;
+var<private> v_WorldNormal1: vec3<f32>;
+var<private> v_Uv1: vec2<f32>;
+var<private> v_WorldTangent1: vec4<f32>;
+var<private> o_Target: vec4<f32>;
 [[group(0), binding(0)]]
 var<uniform> global: CameraViewProj;
 [[group(0), binding(1)]]
@@ -315,9 +315,9 @@ fn Fd_Burley(roughness6: f32, NoV4: f32, NoL4: f32, LoH4: f32) -> f32 {
     return ((_e74 * _e75) * (1.0 / 3.1415927410125732));
 }
 
-fn EnvBRDFApprox(f0_7: vec3<f32>, perceptual_roughness1: f32, NoV6: f32) -> vec3<f32> {
+fn EnvBRDFApprox(f0_7: vec3<f32>, perceptual_roughness: f32, NoV6: f32) -> vec3<f32> {
     var f0_8: vec3<f32>;
-    var perceptual_roughness2: f32;
+    var perceptual_roughness1: f32;
     var NoV7: f32;
     var c0_: vec4<f32> = vec4<f32>(-1.0, -0.027499999850988388, -0.5720000267028809, 0.02199999988079071);
     var c1_: vec4<f32> = vec4<f32>(1.0, 0.042500000447034836, 1.0399999618530273, -0.03999999910593033);
@@ -326,9 +326,9 @@ fn EnvBRDFApprox(f0_7: vec3<f32>, perceptual_roughness1: f32, NoV6: f32) -> vec3
     var AB: vec2<f32>;
 
     f0_8 = f0_7;
-    perceptual_roughness2 = perceptual_roughness1;
+    perceptual_roughness1 = perceptual_roughness;
     NoV7 = NoV6;
-    let _e62: f32 = perceptual_roughness2;
+    let _e62: f32 = perceptual_roughness1;
     let _e64: vec4<f32> = c0_;
     let _e66: vec4<f32> = c1_;
     r = ((vec4<f32>(_e62) * _e64) + _e66);
@@ -359,29 +359,29 @@ fn perceptualRoughnessToRoughness(perceptualRoughness: f32) -> f32 {
     return (_e47 * _e48);
 }
 
-fn reinhard(color2: vec3<f32>) -> vec3<f32> {
-    var color3: vec3<f32>;
+fn reinhard(color: vec3<f32>) -> vec3<f32> {
+    var color1: vec3<f32>;
 
-    color3 = color2;
-    let _e42: vec3<f32> = color3;
-    let _e45: vec3<f32> = color3;
+    color1 = color;
+    let _e42: vec3<f32> = color1;
+    let _e45: vec3<f32> = color1;
     return (_e42 / (vec3<f32>(1.0) + _e45));
 }
 
-fn reinhard_extended(color4: vec3<f32>, max_white: f32) -> vec3<f32> {
-    var color5: vec3<f32>;
+fn reinhard_extended(color2: vec3<f32>, max_white: f32) -> vec3<f32> {
+    var color3: vec3<f32>;
     var max_white1: f32;
     var numerator: vec3<f32>;
 
-    color5 = color4;
+    color3 = color2;
     max_white1 = max_white;
-    let _e44: vec3<f32> = color5;
-    let _e47: vec3<f32> = color5;
+    let _e44: vec3<f32> = color3;
+    let _e47: vec3<f32> = color3;
     let _e48: f32 = max_white1;
     let _e49: f32 = max_white1;
     numerator = (_e44 * (vec3<f32>(1.0) + (_e47 / vec3<f32>((_e48 * _e49)))));
     let _e56: vec3<f32> = numerator;
-    let _e59: vec3<f32> = color5;
+    let _e59: vec3<f32> = color3;
     return (_e56 / (vec3<f32>(1.0) + _e59));
 }
 
@@ -409,34 +409,34 @@ fn change_luminance(c_in: vec3<f32>, l_out: f32) -> vec3<f32> {
     return (_e48 * (_e49 / _e50));
 }
 
-fn reinhard_luminance(color6: vec3<f32>) -> vec3<f32> {
-    var color7: vec3<f32>;
+fn reinhard_luminance(color4: vec3<f32>) -> vec3<f32> {
+    var color5: vec3<f32>;
     var l_old: f32;
     var l_new: f32;
 
-    color7 = color6;
-    let _e43: vec3<f32> = color7;
+    color5 = color4;
+    let _e43: vec3<f32> = color5;
     let _e44: f32 = luminance(_e43);
     l_old = _e44;
     let _e46: f32 = l_old;
     let _e48: f32 = l_old;
     l_new = (_e46 / (1.0 + _e48));
-    let _e54: vec3<f32> = color7;
+    let _e54: vec3<f32> = color5;
     let _e55: f32 = l_new;
     let _e56: vec3<f32> = change_luminance(_e54, _e55);
     return _e56;
 }
 
-fn reinhard_extended_luminance(color8: vec3<f32>, max_white_l: f32) -> vec3<f32> {
-    var color9: vec3<f32>;
+fn reinhard_extended_luminance(color6: vec3<f32>, max_white_l: f32) -> vec3<f32> {
+    var color7: vec3<f32>;
     var max_white_l1: f32;
     var l_old1: f32;
     var numerator1: f32;
     var l_new1: f32;
 
-    color9 = color8;
+    color7 = color6;
     max_white_l1 = max_white_l;
-    let _e45: vec3<f32> = color9;
+    let _e45: vec3<f32> = color7;
     let _e46: f32 = luminance(_e45);
     l_old1 = _e46;
     let _e48: f32 = l_old1;
@@ -447,7 +447,7 @@ fn reinhard_extended_luminance(color8: vec3<f32>, max_white_l: f32) -> vec3<f32>
     let _e58: f32 = numerator1;
     let _e60: f32 = l_old1;
     l_new1 = (_e58 / (1.0 + _e60));
-    let _e66: vec3<f32> = color9;
+    let _e66: vec3<f32> = color7;
     let _e67: f32 = l_new1;
     let _e68: vec3<f32> = change_luminance(_e66, _e67);
     return _e68;
@@ -489,7 +489,7 @@ fn point_light(light: PointLight, roughness8: f32, NdotV: f32, N: vec3<f32>, V1:
     F0_1 = F0_;
     diffuseColor1 = diffuseColor;
     let _e56: PointLight = light1;
-    let _e59: vec3<f32> = gen_entry_v_WorldPosition;
+    let _e59: vec3<f32> = v_WorldPosition1;
     light_to_frag = (_e56.pos.xyz - _e59.xyz);
     let _e63: vec3<f32> = light_to_frag;
     let _e64: vec3<f32> = light_to_frag;
@@ -640,21 +640,21 @@ fn dir_light(light2: DirectionalLight, roughness10: f32, NdotV2: f32, normal: ve
     let _e119: vec3<f32> = diffuse1;
     let _e121: DirectionalLight = light3;
     let _e125: f32 = NoL7;
-    return (((_e118 + _e119) * _e121.color1.xyz) * _e125);
+    return (((_e118 + _e119) * _e121.color.xyz) * _e125);
 }
 
-fn main() {
+fn main1() {
     var output_color: vec4<f32>;
     var metallic_roughness: vec4<f32>;
-    var metallic1: f32;
-    var perceptual_roughness3: f32;
+    var metallic: f32;
+    var perceptual_roughness2: f32;
     var roughness12: f32;
     var N2: vec3<f32>;
     var T: vec3<f32>;
     var B: vec3<f32>;
     var TBN: mat3x3<f32>;
     var occlusion: f32;
-    var emissive1: vec4<f32>;
+    var emissive: vec4<f32>;
     var V3: vec3<f32>;
     var NdotV4: f32;
     var F0_4: vec3<f32>;
@@ -669,28 +669,28 @@ fn main() {
     let _e40: vec4<f32> = global3.base_color;
     output_color = _e40;
     let _e42: vec4<f32> = output_color;
-    let _e43: vec2<f32> = gen_entry_v_Uv;
+    let _e43: vec2<f32> = v_Uv1;
     let _e44: vec4<f32> = textureSample(StandardMaterial_base_color_texture, StandardMaterial_base_color_texture_sampler, _e43);
     output_color = (_e42 * _e44);
-    let _e46: vec2<f32> = gen_entry_v_Uv;
+    let _e46: vec2<f32> = v_Uv1;
     let _e47: vec4<f32> = textureSample(StandardMaterial_metallic_roughness_texture, StandardMaterial_metallic_roughness_texture_sampler, _e46);
     metallic_roughness = _e47;
     let _e49: f32 = global5.metallic;
     let _e50: vec4<f32> = metallic_roughness;
-    metallic1 = (_e49 * _e50.z);
+    metallic = (_e49 * _e50.z);
     let _e54: f32 = global4.perceptual_roughness;
     let _e55: vec4<f32> = metallic_roughness;
-    perceptual_roughness3 = (_e54 * _e55.y);
-    let _e60: f32 = perceptual_roughness3;
+    perceptual_roughness2 = (_e54 * _e55.y);
+    let _e60: f32 = perceptual_roughness2;
     let _e61: f32 = perceptualRoughnessToRoughness(_e60);
     roughness12 = _e61;
-    let _e63: vec3<f32> = gen_entry_v_WorldNormal;
+    let _e63: vec3<f32> = v_WorldNormal1;
     N2 = normalize(_e63);
-    let _e66: vec4<f32> = gen_entry_v_WorldTangent;
+    let _e66: vec4<f32> = v_WorldTangent1;
     T = normalize(_e66.xyz);
     let _e70: vec3<f32> = N2;
     let _e71: vec3<f32> = T;
-    let _e73: vec4<f32> = gen_entry_v_WorldTangent;
+    let _e73: vec4<f32> = v_WorldTangent1;
     B = (cross(_e70, _e71) * _e73.w);
     let _e78: bool = gl_FrontFacing;
     let _e79: vec3<f32> = N2;
@@ -709,36 +709,36 @@ fn main() {
     let _e95: vec3<f32> = N2;
     TBN = mat3x3<f32>(_e93, _e94, _e95);
     let _e98: mat3x3<f32> = TBN;
-    let _e99: vec2<f32> = gen_entry_v_Uv;
+    let _e99: vec2<f32> = v_Uv1;
     let _e100: vec4<f32> = textureSample(StandardMaterial_normal_map, StandardMaterial_normal_map_sampler, _e99);
     N2 = (_e98 * normalize(((_e100.xyz * 2.0) - vec3<f32>(1.0))));
-    let _e109: vec2<f32> = gen_entry_v_Uv;
+    let _e109: vec2<f32> = v_Uv1;
     let _e110: vec4<f32> = textureSample(StandardMaterial_occlusion_texture, StandardMaterial_occlusion_texture_sampler, _e109);
     occlusion = _e110.x;
     let _e113: vec4<f32> = global7.emissive;
-    emissive1 = _e113;
-    let _e115: vec4<f32> = emissive1;
-    let _e117: vec4<f32> = emissive1;
-    let _e119: vec2<f32> = gen_entry_v_Uv;
+    emissive = _e113;
+    let _e115: vec4<f32> = emissive;
+    let _e117: vec4<f32> = emissive;
+    let _e119: vec2<f32> = v_Uv1;
     let _e120: vec4<f32> = textureSample(StandardMaterial_emissive_texture, StandardMaterial_emissive_texture_sampler, _e119);
     let _e122: vec3<f32> = (_e117.xyz * _e120.xyz);
-    emissive1.x = _e122.x;
-    emissive1.y = _e122.y;
-    emissive1.z = _e122.z;
+    emissive.x = _e122.x;
+    emissive.y = _e122.y;
+    emissive.z = _e122.z;
     let _e129: vec4<f32> = global1.CameraPos;
-    let _e131: vec3<f32> = gen_entry_v_WorldPosition;
+    let _e131: vec3<f32> = v_WorldPosition1;
     V3 = normalize((_e129.xyz - _e131.xyz));
     let _e136: vec3<f32> = N2;
     let _e137: vec3<f32> = V3;
     NdotV4 = max(dot(_e136, _e137), 0.00009999999747378752);
     let _e143: f32 = global6.reflectance;
     let _e145: f32 = global6.reflectance;
-    let _e148: f32 = metallic1;
+    let _e148: f32 = metallic;
     let _e152: vec4<f32> = output_color;
-    let _e154: f32 = metallic1;
+    let _e154: f32 = metallic;
     F0_4 = (vec3<f32>((((0.1599999964237213 * _e143) * _e145) * (1.0 - _e148))) + (_e152.xyz * vec3<f32>(_e154)));
     let _e159: vec4<f32> = output_color;
-    let _e162: f32 = metallic1;
+    let _e162: f32 = metallic;
     diffuseColor4 = (_e159.xyz * vec3<f32>((1.0 - _e162)));
     let _e167: vec3<f32> = V3;
     let _e169: vec3<f32> = N2;
@@ -802,7 +802,7 @@ fn main() {
     let _e255: vec3<f32> = EnvBRDFApprox(_e252, 1.0, _e254);
     diffuse_ambient = _e255;
     let _e260: vec3<f32> = F0_4;
-    let _e261: f32 = perceptual_roughness3;
+    let _e261: f32 = perceptual_roughness2;
     let _e262: f32 = NdotV4;
     let _e263: vec3<f32> = EnvBRDFApprox(_e260, _e261, _e262);
     specular_ambient = _e263;
@@ -823,7 +823,7 @@ fn main() {
     output_color.z = _e286.z;
     let _e293: vec4<f32> = output_color;
     let _e295: vec4<f32> = output_color;
-    let _e297: vec4<f32> = emissive1;
+    let _e297: vec4<f32> = emissive;
     let _e299: vec4<f32> = output_color;
     let _e302: vec3<f32> = (_e295.xyz + (_e297.xyz * _e299.w));
     output_color.x = _e302.x;
@@ -837,18 +837,18 @@ fn main() {
     output_color.y = _e315.y;
     output_color.z = _e315.z;
     let _e322: vec4<f32> = output_color;
-    gen_entry_o_Target = _e322;
+    o_Target = _e322;
     return;
 }
 
 [[stage(fragment)]]
-fn main1([[location(0), interpolate(perspective)]] v_WorldPosition: vec3<f32>, [[location(1), interpolate(perspective)]] v_WorldNormal: vec3<f32>, [[location(2), interpolate(perspective)]] v_Uv: vec2<f32>, [[location(3), interpolate(perspective)]] v_WorldTangent: vec4<f32>, [[builtin(front_facing)]] param: bool) -> FragmentOutput {
-    gen_entry_v_WorldPosition = v_WorldPosition;
-    gen_entry_v_WorldNormal = v_WorldNormal;
-    gen_entry_v_Uv = v_Uv;
-    gen_entry_v_WorldTangent = v_WorldTangent;
+fn main([[location(0), interpolate(perspective)]] v_WorldPosition: vec3<f32>, [[location(1), interpolate(perspective)]] v_WorldNormal: vec3<f32>, [[location(2), interpolate(perspective)]] v_Uv: vec2<f32>, [[location(3), interpolate(perspective)]] v_WorldTangent: vec4<f32>, [[builtin(front_facing)]] param: bool) -> FragmentOutput {
+    v_WorldPosition1 = v_WorldPosition;
+    v_WorldNormal1 = v_WorldNormal;
+    v_Uv1 = v_Uv;
+    v_WorldTangent1 = v_WorldTangent;
     gl_FrontFacing = param;
-    main();
-    let _e11: vec4<f32> = gen_entry_o_Target;
+    main1();
+    let _e11: vec4<f32> = o_Target;
     return FragmentOutput(_e11);
 }

--- a/tests/out/bevy-pbr-vert.wgsl
+++ b/tests/out/bevy-pbr-vert.wgsl
@@ -9,44 +9,44 @@ struct Transform {
 };
 
 struct VertexOutput {
-    [[location(0), interpolate(perspective)]] member: vec3<f32>;
-    [[location(1), interpolate(perspective)]] member1: vec3<f32>;
-    [[location(2), interpolate(perspective)]] member2: vec2<f32>;
-    [[location(3), interpolate(perspective)]] member3: vec4<f32>;
-    [[builtin(position)]] member4: vec4<f32>;
+    [[location(0), interpolate(perspective)]] v_WorldPosition: vec3<f32>;
+    [[location(1), interpolate(perspective)]] v_WorldNormal: vec3<f32>;
+    [[location(2), interpolate(perspective)]] v_Uv: vec2<f32>;
+    [[location(3), interpolate(perspective)]] v_WorldTangent: vec4<f32>;
+    [[builtin(position)]] member: vec4<f32>;
 };
 
-var<private> gen_entry_Vertex_Position: vec3<f32>;
-var<private> gen_entry_Vertex_Normal: vec3<f32>;
-var<private> gen_entry_Vertex_Uv: vec2<f32>;
-var<private> gen_entry_Vertex_Tangent: vec4<f32>;
-var<private> gen_entry_v_WorldPosition: vec3<f32>;
-var<private> gen_entry_v_WorldNormal: vec3<f32>;
-var<private> gen_entry_v_Uv: vec2<f32>;
+var<private> Vertex_Position1: vec3<f32>;
+var<private> Vertex_Normal1: vec3<f32>;
+var<private> Vertex_Uv1: vec2<f32>;
+var<private> Vertex_Tangent1: vec4<f32>;
+var<private> v_WorldPosition: vec3<f32>;
+var<private> v_WorldNormal: vec3<f32>;
+var<private> v_Uv: vec2<f32>;
 [[group(0), binding(0)]]
 var<uniform> global: CameraViewProj;
-var<private> gen_entry_v_WorldTangent: vec4<f32>;
+var<private> v_WorldTangent: vec4<f32>;
 [[group(2), binding(0)]]
 var<uniform> global1: Transform;
 var<private> gl_Position: vec4<f32>;
 
-fn main() {
+fn main1() {
     var world_position: vec4<f32>;
 
     let _e12: mat4x4<f32> = global1.Model;
-    let _e13: vec3<f32> = gen_entry_Vertex_Position;
+    let _e13: vec3<f32> = Vertex_Position1;
     world_position = (_e12 * vec4<f32>(_e13, 1.0));
     let _e18: vec4<f32> = world_position;
-    gen_entry_v_WorldPosition = _e18.xyz;
+    v_WorldPosition = _e18.xyz;
     let _e20: mat4x4<f32> = global1.Model;
-    let _e28: vec3<f32> = gen_entry_Vertex_Normal;
-    gen_entry_v_WorldNormal = (mat3x3<f32>(_e20[0].xyz, _e20[1].xyz, _e20[2].xyz) * _e28);
-    let _e30: vec2<f32> = gen_entry_Vertex_Uv;
-    gen_entry_v_Uv = _e30;
+    let _e28: vec3<f32> = Vertex_Normal1;
+    v_WorldNormal = (mat3x3<f32>(_e20[0].xyz, _e20[1].xyz, _e20[2].xyz) * _e28);
+    let _e30: vec2<f32> = Vertex_Uv1;
+    v_Uv = _e30;
     let _e31: mat4x4<f32> = global1.Model;
-    let _e39: vec4<f32> = gen_entry_Vertex_Tangent;
-    let _e42: vec4<f32> = gen_entry_Vertex_Tangent;
-    gen_entry_v_WorldTangent = vec4<f32>((mat3x3<f32>(_e31[0].xyz, _e31[1].xyz, _e31[2].xyz) * _e39.xyz), _e42.w);
+    let _e39: vec4<f32> = Vertex_Tangent1;
+    let _e42: vec4<f32> = Vertex_Tangent1;
+    v_WorldTangent = vec4<f32>((mat3x3<f32>(_e31[0].xyz, _e31[1].xyz, _e31[2].xyz) * _e39.xyz), _e42.w);
     let _e46: mat4x4<f32> = global.ViewProj;
     let _e47: vec4<f32> = world_position;
     gl_Position = (_e46 * _e47);
@@ -54,16 +54,16 @@ fn main() {
 }
 
 [[stage(vertex)]]
-fn main1([[location(0), interpolate(perspective)]] Vertex_Position: vec3<f32>, [[location(1), interpolate(perspective)]] Vertex_Normal: vec3<f32>, [[location(2), interpolate(perspective)]] Vertex_Uv: vec2<f32>, [[location(3), interpolate(perspective)]] Vertex_Tangent: vec4<f32>) -> VertexOutput {
-    gen_entry_Vertex_Position = Vertex_Position;
-    gen_entry_Vertex_Normal = Vertex_Normal;
-    gen_entry_Vertex_Uv = Vertex_Uv;
-    gen_entry_Vertex_Tangent = Vertex_Tangent;
-    main();
-    let _e9: vec3<f32> = gen_entry_v_WorldPosition;
-    let _e11: vec3<f32> = gen_entry_v_WorldNormal;
-    let _e13: vec2<f32> = gen_entry_v_Uv;
-    let _e15: vec4<f32> = gen_entry_v_WorldTangent;
+fn main([[location(0), interpolate(perspective)]] Vertex_Position: vec3<f32>, [[location(1), interpolate(perspective)]] Vertex_Normal: vec3<f32>, [[location(2), interpolate(perspective)]] Vertex_Uv: vec2<f32>, [[location(3), interpolate(perspective)]] Vertex_Tangent: vec4<f32>) -> VertexOutput {
+    Vertex_Position1 = Vertex_Position;
+    Vertex_Normal1 = Vertex_Normal;
+    Vertex_Uv1 = Vertex_Uv;
+    Vertex_Tangent1 = Vertex_Tangent;
+    main1();
+    let _e9: vec3<f32> = v_WorldPosition;
+    let _e11: vec3<f32> = v_WorldNormal;
+    let _e13: vec2<f32> = v_Uv;
+    let _e15: vec4<f32> = v_WorldTangent;
     let _e17: vec4<f32> = gl_Position;
     return VertexOutput(_e9, _e11, _e13, _e15, _e17);
 }

--- a/tests/out/boids.Compute.glsl
+++ b/tests/out/boids.Compute.glsl
@@ -37,8 +37,8 @@ void main() {
     vec2 colVel;
     int cMassCount = 0;
     int cVelCount = 0;
-    vec2 pos1;
-    vec2 vel1;
+    vec2 pos;
+    vec2 vel;
     uint i = 0u;
     uint index = global_invocation_id.x;
     if ((index >= 1500u)) {
@@ -62,35 +62,35 @@ void main() {
         }
         uint _expr42 = i;
         vec2 _expr45 = _group_0_binding_1.particles[_expr42].pos;
-        pos1 = _expr45;
+        pos = _expr45;
         uint _expr47 = i;
         vec2 _expr50 = _group_0_binding_1.particles[_expr47].vel;
-        vel1 = _expr50;
-        vec2 _expr51 = pos1;
+        vel = _expr50;
+        vec2 _expr51 = pos;
         vec2 _expr52 = vPos;
         float _expr55 = _group_0_binding_0.rule1Distance;
         if ((distance(_expr51, _expr52) < _expr55)) {
             vec2 _expr57 = cMass;
-            vec2 _expr58 = pos1;
+            vec2 _expr58 = pos;
             cMass = (_expr57 + _expr58);
             int _expr60 = cMassCount;
             cMassCount = (_expr60 + 1);
         }
-        vec2 _expr63 = pos1;
+        vec2 _expr63 = pos;
         vec2 _expr64 = vPos;
         float _expr67 = _group_0_binding_0.rule2Distance;
         if ((distance(_expr63, _expr64) < _expr67)) {
             vec2 _expr69 = colVel;
-            vec2 _expr70 = pos1;
+            vec2 _expr70 = pos;
             vec2 _expr71 = vPos;
             colVel = (_expr69 - (_expr70 - _expr71));
         }
-        vec2 _expr74 = pos1;
+        vec2 _expr74 = pos;
         vec2 _expr75 = vPos;
         float _expr78 = _group_0_binding_0.rule3Distance;
         if ((distance(_expr74, _expr75) < _expr78)) {
             vec2 _expr80 = cVel;
-            vec2 _expr81 = vel1;
+            vec2 _expr81 = vel;
             cVel = (_expr80 + _expr81);
             int _expr83 = cVelCount;
             cVelCount = (_expr83 + 1);

--- a/tests/out/boids.msl
+++ b/tests/out/boids.msl
@@ -41,8 +41,8 @@ kernel void main1(
     metal::float2 colVel;
     int cMassCount = 0;
     int cVelCount = 0;
-    metal::float2 pos1;
-    metal::float2 vel1;
+    metal::float2 pos;
+    metal::float2 vel;
     metal::uint i = 0u;
     uint index = global_invocation_id.x;
     if (index >= NUM_PARTICLES) {
@@ -72,35 +72,35 @@ kernel void main1(
         }
         metal::uint _e42 = i;
         metal::float2 _e45 = particlesSrc.particles[_e42].pos;
-        pos1 = _e45;
+        pos = _e45;
         metal::uint _e47 = i;
         metal::float2 _e50 = particlesSrc.particles[_e47].vel;
-        vel1 = _e50;
-        metal::float2 _e51 = pos1;
+        vel = _e50;
+        metal::float2 _e51 = pos;
         metal::float2 _e52 = vPos;
         float _e55 = params.rule1Distance;
         if (metal::distance(_e51, _e52) < _e55) {
             metal::float2 _e57 = cMass;
-            metal::float2 _e58 = pos1;
+            metal::float2 _e58 = pos;
             cMass = _e57 + _e58;
             int _e60 = cMassCount;
             cMassCount = _e60 + 1;
         }
-        metal::float2 _e63 = pos1;
+        metal::float2 _e63 = pos;
         metal::float2 _e64 = vPos;
         float _e67 = params.rule2Distance;
         if (metal::distance(_e63, _e64) < _e67) {
             metal::float2 _e69 = colVel;
-            metal::float2 _e70 = pos1;
+            metal::float2 _e70 = pos;
             metal::float2 _e71 = vPos;
             colVel = _e69 - (_e70 - _e71);
         }
-        metal::float2 _e74 = pos1;
+        metal::float2 _e74 = pos;
         metal::float2 _e75 = vPos;
         float _e78 = params.rule3Distance;
         if (metal::distance(_e74, _e75) < _e78) {
             metal::float2 _e80 = cVel;
-            metal::float2 _e81 = vel1;
+            metal::float2 _e81 = vel;
             cVel = _e80 + _e81;
             int _e83 = cVelCount;
             cVelCount = _e83 + 1;

--- a/tests/out/boids.wgsl
+++ b/tests/out/boids.wgsl
@@ -37,8 +37,8 @@ fn main([[builtin(global_invocation_id)]] global_invocation_id: vec3<u32>) {
     var colVel: vec2<f32>;
     var cMassCount: i32 = 0;
     var cVelCount: i32 = 0;
-    var pos1: vec2<f32>;
-    var vel1: vec2<f32>;
+    var pos: vec2<f32>;
+    var vel: vec2<f32>;
     var i: u32 = 0u;
 
     let index: u32 = global_invocation_id.x;
@@ -63,35 +63,35 @@ fn main([[builtin(global_invocation_id)]] global_invocation_id: vec3<u32>) {
         }
         let _e42: u32 = i;
         let _e45: vec2<f32> = particlesSrc.particles[_e42].pos;
-        pos1 = _e45;
+        pos = _e45;
         let _e47: u32 = i;
         let _e50: vec2<f32> = particlesSrc.particles[_e47].vel;
-        vel1 = _e50;
-        let _e51: vec2<f32> = pos1;
+        vel = _e50;
+        let _e51: vec2<f32> = pos;
         let _e52: vec2<f32> = vPos;
         let _e55: f32 = params.rule1Distance;
         if ((distance(_e51, _e52) < _e55)) {
             let _e57: vec2<f32> = cMass;
-            let _e58: vec2<f32> = pos1;
+            let _e58: vec2<f32> = pos;
             cMass = (_e57 + _e58);
             let _e60: i32 = cMassCount;
             cMassCount = (_e60 + 1);
         }
-        let _e63: vec2<f32> = pos1;
+        let _e63: vec2<f32> = pos;
         let _e64: vec2<f32> = vPos;
         let _e67: f32 = params.rule2Distance;
         if ((distance(_e63, _e64) < _e67)) {
             let _e69: vec2<f32> = colVel;
-            let _e70: vec2<f32> = pos1;
+            let _e70: vec2<f32> = pos;
             let _e71: vec2<f32> = vPos;
             colVel = (_e69 - (_e70 - _e71));
         }
-        let _e74: vec2<f32> = pos1;
+        let _e74: vec2<f32> = pos;
         let _e75: vec2<f32> = vPos;
         let _e78: f32 = params.rule3Distance;
         if ((distance(_e74, _e75) < _e78)) {
             let _e80: vec2<f32> = cVel;
-            let _e81: vec2<f32> = vel1;
+            let _e81: vec2<f32> = vel;
             cVel = (_e80 + _e81);
             let _e83: i32 = cVelCount;
             cVelCount = (_e83 + 1);

--- a/tests/out/interface.msl
+++ b/tests/out/interface.msl
@@ -12,7 +12,7 @@ struct FragmentOutput {
 };
 
 struct vertex1Input {
-    metal::uint color1 [[attribute(10)]];
+    metal::uint color [[attribute(10)]];
 };
 struct vertex1Output {
     metal::float4 position [[position]];
@@ -23,8 +23,8 @@ vertex vertex1Output vertex1(
 , metal::uint vertex_index [[vertex_id]]
 , metal::uint instance_index [[instance_id]]
 ) {
-    const auto color1 = varyings.color1;
-    metal::uint tmp = (vertex_index + instance_index) + color1;
+    const auto color = varyings.color;
+    metal::uint tmp = (vertex_index + instance_index) + color;
     const auto _tmp = VertexOutput {metal::float4(1.0), static_cast<float>(tmp)};
     return vertex1Output { _tmp.position, _tmp.varying };
 }
@@ -43,12 +43,12 @@ fragment fragment1Output fragment1(
 , metal::float4 position [[position]]
 , bool front_facing [[front_facing]]
 , metal::uint sample_index [[sample_id]]
-, metal::uint sample_mask1 [[sample_mask]]
+, metal::uint sample_mask [[sample_mask]]
 ) {
     const VertexOutput in = { position, varyings1.varying };
-    metal::uint mask = sample_mask1 & (1u << sample_index);
-    float color2 = front_facing ? 0.0 : 1.0;
-    const auto _tmp = FragmentOutput {in.varying, mask, color2};
+    metal::uint mask = sample_mask & (1u << sample_index);
+    float color1 = front_facing ? 0.0 : 1.0;
+    const auto _tmp = FragmentOutput {in.varying, mask, color1};
     return fragment1Output { _tmp.depth, _tmp.sample_mask, _tmp.color };
 }
 

--- a/tests/out/interface.wgsl
+++ b/tests/out/interface.wgsl
@@ -10,16 +10,16 @@ struct FragmentOutput {
 };
 
 [[stage(vertex)]]
-fn vertex([[builtin(vertex_index)]] vertex_index: u32, [[builtin(instance_index)]] instance_index: u32, [[location(10)]] color1: u32) -> VertexOutput {
-    let tmp: u32 = ((vertex_index + instance_index) + color1);
+fn vertex([[builtin(vertex_index)]] vertex_index: u32, [[builtin(instance_index)]] instance_index: u32, [[location(10)]] color: u32) -> VertexOutput {
+    let tmp: u32 = ((vertex_index + instance_index) + color);
     return VertexOutput(vec4<f32>(1.0), f32(tmp));
 }
 
 [[stage(fragment)]]
-fn fragment(in: VertexOutput, [[builtin(front_facing)]] front_facing: bool, [[builtin(sample_index)]] sample_index: u32, [[builtin(sample_mask)]] sample_mask1: u32) -> FragmentOutput {
-    let mask: u32 = (sample_mask1 & (1u << sample_index));
-    let color2: f32 = select(0.0, 1.0, front_facing);
-    return FragmentOutput(in.varying, mask, color2);
+fn fragment(in: VertexOutput, [[builtin(front_facing)]] front_facing: bool, [[builtin(sample_index)]] sample_index: u32, [[builtin(sample_mask)]] sample_mask: u32) -> FragmentOutput {
+    let mask: u32 = (sample_mask & (1u << sample_index));
+    let color1: f32 = select(0.0, 1.0, front_facing);
+    return FragmentOutput(in.varying, mask, color1);
 }
 
 [[stage(compute), workgroup_size(1, 1, 1)]]

--- a/tests/out/math-functions-vert.wgsl
+++ b/tests/out/math-functions-vert.wgsl
@@ -1,4 +1,4 @@
-fn main() {
+fn main1() {
     var a: vec4<f32> = vec4<f32>(1.0, 1.0, 1.0, 1.0);
     var b: vec4<f32> = vec4<f32>(2.0, 2.0, 2.0, 2.0);
     var m: mat4x4<f32>;
@@ -141,7 +141,7 @@ fn main() {
 }
 
 [[stage(vertex)]]
-fn main1() {
-    main();
+fn main() {
+    main1();
     return;
 }

--- a/tests/out/quad-glsl.wgsl
+++ b/tests/out/quad-glsl.wgsl
@@ -1,45 +1,45 @@
 struct VertexOutput {
-    [[location(0), interpolate(perspective)]] member: vec2<f32>;
-    [[builtin(position)]] member1: vec4<f32>;
+    [[location(0), interpolate(perspective)]] v_uv: vec2<f32>;
+    [[builtin(position)]] member: vec4<f32>;
 };
 
 struct FragmentOutput {
-    [[location(0), interpolate(perspective)]] member2: vec4<f32>;
+    [[location(0), interpolate(perspective)]] o_color: vec4<f32>;
 };
 
-var<private> gen_entry_a_pos: vec2<f32>;
-var<private> gen_entry_a_uv: vec2<f32>;
-var<private> gen_entry_v_uv: vec2<f32>;
+var<private> a_pos1: vec2<f32>;
+var<private> a_uv1: vec2<f32>;
+var<private> v_uv: vec2<f32>;
 var<private> gl_Position: vec4<f32>;
-var<private> gen_entry_v_uv1: vec2<f32>;
-var<private> gen_entry_o_color: vec4<f32>;
+var<private> v_uv1: vec2<f32>;
+var<private> o_color: vec4<f32>;
 
-fn vert_main() {
-    let _e4: vec2<f32> = gen_entry_a_uv;
-    gen_entry_v_uv = _e4;
-    let _e6: vec2<f32> = gen_entry_a_pos;
+fn vert_main1() {
+    let _e4: vec2<f32> = a_uv1;
+    v_uv = _e4;
+    let _e6: vec2<f32> = a_pos1;
     gl_Position = vec4<f32>((1.2000000476837158 * _e6), 0.0, 1.0);
     return;
 }
 
-fn frag_main() {
-    gen_entry_o_color = vec4<f32>(1.0, 1.0, 1.0, 1.0);
+fn frag_main1() {
+    o_color = vec4<f32>(1.0, 1.0, 1.0, 1.0);
     return;
 }
 
 [[stage(vertex)]]
-fn vert_main1([[location(0), interpolate(perspective)]] a_pos: vec2<f32>, [[location(1), interpolate(perspective)]] a_uv: vec2<f32>) -> VertexOutput {
-    gen_entry_a_pos = a_pos;
-    gen_entry_a_uv = a_uv;
-    vert_main();
-    let _e5: vec2<f32> = gen_entry_v_uv;
+fn vert_main([[location(0), interpolate(perspective)]] a_pos: vec2<f32>, [[location(1), interpolate(perspective)]] a_uv: vec2<f32>) -> VertexOutput {
+    a_pos1 = a_pos;
+    a_uv1 = a_uv;
+    vert_main1();
+    let _e5: vec2<f32> = v_uv;
     let _e7: vec4<f32> = gl_Position;
     return VertexOutput(_e5, _e7);
 }
 
 [[stage(fragment)]]
-fn frag_main1() -> FragmentOutput {
-    frag_main();
-    let _e1: vec4<f32> = gen_entry_o_color;
+fn frag_main() -> FragmentOutput {
+    frag_main1();
+    let _e1: vec4<f32> = o_color;
     return FragmentOutput(_e1);
 }

--- a/tests/out/quad-vert.Vertex.glsl
+++ b/tests/out/quad-vert.Vertex.glsl
@@ -4,15 +4,15 @@ precision highp float;
 
 struct type10 {
     vec2 member;
-    vec4 gen_gl_Position1;
-    float gen_gl_PointSize1;
-    float gen_gl_ClipDistance1[1];
-    float gen_gl_CullDistance1[1];
+    vec4 gen_gl_Position;
+    float gen_gl_PointSize;
+    float gen_gl_ClipDistance[1];
+    float gen_gl_CullDistance[1];
 };
 
 vec2 v_uv = vec2(0, 0);
 
-vec2 a_uv = vec2(0, 0);
+vec2 a_uv1 = vec2(0, 0);
 
 struct gen_gl_PerVertex_block_0 {
     vec4 gen_gl_Position;
@@ -21,26 +21,26 @@ struct gen_gl_PerVertex_block_0 {
     float gen_gl_CullDistance[1];
 } perVertexStruct;
 
-vec2 a_pos = vec2(0, 0);
+vec2 a_pos1 = vec2(0, 0);
 
 layout(location = 1) in vec2 _p2vs_location1;
 layout(location = 0) in vec2 _p2vs_location0;
 smooth out vec2 _vs2fs_location0;
 
-void main1() {
-    vec2 _expr12 = a_uv;
+void main2() {
+    vec2 _expr12 = a_uv1;
     v_uv = _expr12;
-    vec2 _expr13 = a_pos;
+    vec2 _expr13 = a_pos1;
     perVertexStruct.gen_gl_Position = vec4(_expr13.x, _expr13.y, 0.0, 1.0);
     return;
 }
 
 void main() {
-    vec2 a_uv1 = _p2vs_location1;
-    vec2 a_pos1 = _p2vs_location0;
-    a_uv = a_uv1;
-    a_pos = a_pos1;
-    main1();
+    vec2 a_uv = _p2vs_location1;
+    vec2 a_pos = _p2vs_location0;
+    a_uv1 = a_uv;
+    a_pos1 = a_pos;
+    main2();
     vec2 _expr10 = v_uv;
     vec4 _expr11 = perVertexStruct.gen_gl_Position;
     float _expr12 = perVertexStruct.gen_gl_PointSize;
@@ -48,7 +48,7 @@ void main() {
     float _expr14[] = perVertexStruct.gen_gl_CullDistance;
     type10 _tmp_return = type10(_expr10, _expr11, _expr12, _expr13, _expr14);
     _vs2fs_location0 = _tmp_return.member;
-    gl_Position = _tmp_return.gen_gl_Position1;
+    gl_Position = _tmp_return.gen_gl_Position;
     return;
 }
 

--- a/tests/out/quad-vert.msl
+++ b/tests/out/quad-vert.msl
@@ -12,55 +12,55 @@ struct gl_PerVertex {
 };
 struct type10 {
     metal::float2 member;
-    metal::float4 gl_Position1;
-    float gl_PointSize1;
-    type6 gl_ClipDistance1;
-    type6 gl_CullDistance1;
+    metal::float4 gl_Position;
+    float gl_PointSize;
+    type6 gl_ClipDistance;
+    type6 gl_CullDistance;
 };
 constant metal::float4 const_type4_ = {0.0, 0.0, 0.0, 1.0};
 constant type6 const_type6_ = {0.0};
 constant gl_PerVertex const_gl_PerVertex = {const_type4_, 1.0, const_type6_, const_type6_};
 
-void main1(
+void main2(
     thread metal::float2& v_uv,
-    thread metal::float2 const& a_uv,
+    thread metal::float2 const& a_uv1,
     thread gl_PerVertex& perVertexStruct,
-    thread metal::float2 const& a_pos
+    thread metal::float2 const& a_pos1
 ) {
-    metal::float2 _e12 = a_uv;
+    metal::float2 _e12 = a_uv1;
     v_uv = _e12;
-    metal::float2 _e13 = a_pos;
+    metal::float2 _e13 = a_pos1;
     perVertexStruct.gl_Position = metal::float4(_e13.x, _e13.y, 0.0, 1.0);
     return;
 }
 
-struct main2Input {
-    metal::float2 a_uv1 [[attribute(1)]];
-    metal::float2 a_pos1 [[attribute(0)]];
+struct main1Input {
+    metal::float2 a_uv [[attribute(1)]];
+    metal::float2 a_pos [[attribute(0)]];
 };
-struct main2Output {
+struct main1Output {
     metal::float2 member [[user(loc0), center_perspective]];
-    metal::float4 gl_Position1 [[position]];
-    float gl_PointSize1 [[point_size]];
-    float gl_ClipDistance1 [[clip_distance]] [1];
+    metal::float4 gl_Position [[position]];
+    float gl_PointSize [[point_size]];
+    float gl_ClipDistance [[clip_distance]] [1];
 };
-vertex main2Output main2(
-  main2Input varyings [[stage_in]]
+vertex main1Output main1(
+  main1Input varyings [[stage_in]]
 ) {
     metal::float2 v_uv = {};
-    metal::float2 a_uv = {};
+    metal::float2 a_uv1 = {};
     gl_PerVertex perVertexStruct = const_gl_PerVertex;
-    metal::float2 a_pos = {};
-    const auto a_uv1 = varyings.a_uv1;
-    const auto a_pos1 = varyings.a_pos1;
-    a_uv = a_uv1;
-    a_pos = a_pos1;
-    main1(v_uv, a_uv, perVertexStruct, a_pos);
+    metal::float2 a_pos1 = {};
+    const auto a_uv = varyings.a_uv;
+    const auto a_pos = varyings.a_pos;
+    a_uv1 = a_uv;
+    a_pos1 = a_pos;
+    main2(v_uv, a_uv1, perVertexStruct, a_pos1);
     metal::float2 _e10 = v_uv;
     metal::float4 _e11 = perVertexStruct.gl_Position;
     float _e12 = perVertexStruct.gl_PointSize;
     type6 _e13 = perVertexStruct.gl_ClipDistance;
     type6 _e14 = perVertexStruct.gl_CullDistance;
     const auto _tmp = type10 {_e10, _e11, _e12, _e13, _e14};
-    return main2Output { _tmp.member, _tmp.gl_Position1, _tmp.gl_PointSize1, {_tmp.gl_ClipDistance1.inner[0]} };
+    return main1Output { _tmp.member, _tmp.gl_Position, _tmp.gl_PointSize, {_tmp.gl_ClipDistance.inner[0]} };
 }

--- a/tests/out/quad-vert.wgsl
+++ b/tests/out/quad-vert.wgsl
@@ -5,27 +5,27 @@ struct gl_PerVertex {
 
 struct VertexOutput {
     [[location(0), interpolate(perspective)]] member: vec2<f32>;
-    [[builtin(position)]] gl_Position1: vec4<f32>;
+    [[builtin(position)]] gl_Position: vec4<f32>;
 };
 
 var<private> v_uv: vec2<f32>;
-var<private> a_uv: vec2<f32>;
+var<private> a_uv1: vec2<f32>;
 var<private> perVertexStruct: gl_PerVertex = gl_PerVertex(vec4<f32>(0.0, 0.0, 0.0, 1.0), );
-var<private> a_pos: vec2<f32>;
+var<private> a_pos1: vec2<f32>;
 
-fn main() {
-    let _e12: vec2<f32> = a_uv;
+fn main1() {
+    let _e12: vec2<f32> = a_uv1;
     v_uv = _e12;
-    let _e13: vec2<f32> = a_pos;
+    let _e13: vec2<f32> = a_pos1;
     perVertexStruct.gl_Position = vec4<f32>(_e13.x, _e13.y, 0.0, 1.0);
     return;
 }
 
 [[stage(vertex)]]
-fn main1([[location(1)]] a_uv1: vec2<f32>, [[location(0)]] a_pos1: vec2<f32>) -> VertexOutput {
-    a_uv = a_uv1;
-    a_pos = a_pos1;
-    main();
+fn main([[location(1)]] a_uv: vec2<f32>, [[location(0)]] a_pos: vec2<f32>) -> VertexOutput {
+    a_uv1 = a_uv;
+    a_pos1 = a_pos;
+    main1();
     let _e10: vec2<f32> = v_uv;
     let _e11: vec4<f32> = perVertexStruct.gl_Position;
     return VertexOutput(_e10, _e11);

--- a/tests/out/quad.Fragment.glsl
+++ b/tests/out/quad.Fragment.glsl
@@ -13,8 +13,8 @@ smooth in vec2 _vs2fs_location0;
 layout(location = 0) out vec4 _fs2p_location0;
 
 void main() {
-    vec2 uv2 = _vs2fs_location0;
-    vec4 color = texture(_group_0_binding_0, vec2(uv2));
+    vec2 uv1 = _vs2fs_location0;
+    vec4 color = texture(_group_0_binding_0, vec2(uv1));
     if ((color.w == 0.0)) {
         discard;
     }

--- a/tests/out/quad.Vertex.glsl
+++ b/tests/out/quad.Vertex.glsl
@@ -13,8 +13,8 @@ smooth out vec2 _vs2fs_location0;
 
 void main() {
     vec2 pos = _p2vs_location0;
-    vec2 uv1 = _p2vs_location1;
-    VertexOutput _tmp_return = VertexOutput(uv1, vec4((1.2 * pos), 0.0, 1.0));
+    vec2 uv = _p2vs_location1;
+    VertexOutput _tmp_return = VertexOutput(uv, vec4((1.2 * pos), 0.0, 1.0));
     _vs2fs_location0 = _tmp_return.uv;
     gl_Position = _tmp_return.position;
     return;

--- a/tests/out/quad.hlsl
+++ b/tests/out/quad.hlsl
@@ -10,22 +10,22 @@ struct VertexOutput {
 
 struct VertexInput {
     float2 pos1 : LOC0;
-    float2 uv3 : LOC1;
+    float2 uv2 : LOC1;
 };
 
 struct FragmentInput {
-    float2 uv4 : LOC0;
+    float2 uv3 : LOC0;
 };
 
 VertexOutput vert_main(VertexInput vertexinput)
 {
-    const VertexOutput vertexoutput1 = { vertexinput.uv3, float4((c_scale * vertexinput.pos1), 0.0, 1.0) };
+    const VertexOutput vertexoutput1 = { vertexinput.uv2, float4((c_scale * vertexinput.pos1), 0.0, 1.0) };
     return vertexoutput1;
 }
 
 float4 frag_main(FragmentInput fragmentinput) : SV_Target0
 {
-    float4 color = u_texture.Sample(u_sampler, fragmentinput.uv4);
+    float4 color = u_texture.Sample(u_sampler, fragmentinput.uv3);
     if ((color.w == 0.0)) {
         discard;
     }

--- a/tests/out/quad.msl
+++ b/tests/out/quad.msl
@@ -9,7 +9,7 @@ struct VertexOutput {
 
 struct main1Input {
     metal::float2 pos [[attribute(0)]];
-    metal::float2 uv1 [[attribute(1)]];
+    metal::float2 uv [[attribute(1)]];
 };
 struct main1Output {
     metal::float2 uv [[user(loc0), center_perspective]];
@@ -19,14 +19,14 @@ vertex main1Output main1(
   main1Input varyings [[stage_in]]
 ) {
     const auto pos = varyings.pos;
-    const auto uv1 = varyings.uv1;
-    const auto _tmp = VertexOutput {uv1, metal::float4(c_scale * pos, 0.0, 1.0)};
+    const auto uv = varyings.uv;
+    const auto _tmp = VertexOutput {uv, metal::float4(c_scale * pos, 0.0, 1.0)};
     return main1Output { _tmp.uv, _tmp.position };
 }
 
 
 struct main2Input {
-    metal::float2 uv2 [[user(loc0), center_perspective]];
+    metal::float2 uv1 [[user(loc0), center_perspective]];
 };
 struct main2Output {
     metal::float4 member1 [[color(0)]];
@@ -36,8 +36,8 @@ fragment main2Output main2(
 , metal::texture2d<float, metal::access::sample> u_texture [[user(fake0)]]
 , metal::sampler u_sampler [[user(fake0)]]
 ) {
-    const auto uv2 = varyings1.uv2;
-    metal::float4 color = u_texture.sample(u_sampler, uv2);
+    const auto uv1 = varyings1.uv1;
+    metal::float4 color = u_texture.sample(u_sampler, uv1);
     if (color.w == 0.0) {
         metal::discard_fragment();
     }

--- a/tests/out/quad.wgsl
+++ b/tests/out/quad.wgsl
@@ -11,13 +11,13 @@ var u_texture: texture_2d<f32>;
 var u_sampler: sampler;
 
 [[stage(vertex)]]
-fn main([[location(0)]] pos: vec2<f32>, [[location(1)]] uv1: vec2<f32>) -> VertexOutput {
-    return VertexOutput(uv1, vec4<f32>((c_scale * pos), 0.0, 1.0));
+fn main([[location(0)]] pos: vec2<f32>, [[location(1)]] uv: vec2<f32>) -> VertexOutput {
+    return VertexOutput(uv, vec4<f32>((c_scale * pos), 0.0, 1.0));
 }
 
 [[stage(fragment)]]
-fn main1([[location(0), interpolate(perspective)]] uv2: vec2<f32>) -> [[location(0)]] vec4<f32> {
-    let color: vec4<f32> = textureSample(u_texture, u_sampler, uv2);
+fn main1([[location(0), interpolate(perspective)]] uv1: vec2<f32>) -> [[location(0)]] vec4<f32> {
+    let color: vec4<f32> = textureSample(u_texture, u_sampler, uv1);
     if ((color.w == 0.0)) {
         discard;
     }

--- a/tests/out/shadow.Fragment.glsl
+++ b/tests/out/shadow.Fragment.glsl
@@ -35,7 +35,7 @@ float fetch_shadow(uint light_id, vec4 homogeneous_coords) {
 void main() {
     vec3 raw_normal = _vs2fs_location0;
     vec4 position = _vs2fs_location1;
-    vec3 color1 = vec3(0.05, 0.05, 0.05);
+    vec3 color = vec3(0.05, 0.05, 0.05);
     uint i = 0u;
     vec3 normal = normalize(raw_normal);
     while(true) {
@@ -50,12 +50,12 @@ void main() {
         float _expr25 = fetch_shadow(_expr22, (light.proj * position));
         vec3 light_dir = normalize((light.pos.xyz - position.xyz));
         float diffuse = max(0.0, dot(normal, light_dir));
-        vec3 _expr34 = color1;
-        color1 = (_expr34 + ((_expr25 * diffuse) * light.color.xyz));
+        vec3 _expr34 = color;
+        color = (_expr34 + ((_expr25 * diffuse) * light.color.xyz));
         uint _expr40 = i;
         i = (_expr40 + 1u);
     }
-    vec3 _expr43 = color1;
+    vec3 _expr43 = color;
     _fs2p_location0 = vec4(_expr43, 1.0);
     return;
 }

--- a/tests/out/shadow.msl
+++ b/tests/out/shadow.msl
@@ -51,7 +51,7 @@ fragment fs_mainOutput fs_main(
 ) {
     const auto raw_normal = varyings.raw_normal;
     const auto position = varyings.position;
-    metal::float3 color1 = c_ambient;
+    metal::float3 color = c_ambient;
     metal::uint i = 0u;
     metal::float3 normal = metal::normalize(raw_normal);
     bool loop_init = true;
@@ -72,9 +72,9 @@ fragment fs_mainOutput fs_main(
         float _e25 = fetch_shadow(_e22, light.proj * position, t_shadow, sampler_shadow);
         metal::float3 light_dir = metal::normalize(light.pos.xyz - position.xyz);
         float diffuse = metal::max(0.0, metal::dot(normal, light_dir));
-        metal::float3 _e34 = color1;
-        color1 = _e34 + ((_e25 * diffuse) * light.color.xyz);
+        metal::float3 _e34 = color;
+        color = _e34 + ((_e25 * diffuse) * light.color.xyz);
     }
-    metal::float3 _e43 = color1;
+    metal::float3 _e43 = color;
     return fs_mainOutput { metal::float4(_e43, 1.0) };
 }

--- a/tests/out/shadow.wgsl
+++ b/tests/out/shadow.wgsl
@@ -38,7 +38,7 @@ fn fetch_shadow(light_id: u32, homogeneous_coords: vec4<f32>) -> f32 {
 
 [[stage(fragment)]]
 fn fs_main([[location(0), interpolate(perspective)]] raw_normal: vec3<f32>, [[location(1), interpolate(perspective)]] position: vec4<f32>) -> [[location(0)]] vec4<f32> {
-    var color1: vec3<f32> = vec3<f32>(0.05, 0.05, 0.05);
+    var color: vec3<f32> = vec3<f32>(0.05, 0.05, 0.05);
     var i: u32 = 0u;
 
     let normal: vec3<f32> = normalize(raw_normal);
@@ -54,13 +54,13 @@ fn fs_main([[location(0), interpolate(perspective)]] raw_normal: vec3<f32>, [[lo
         let _e25: f32 = fetch_shadow(_e22, (light.proj * position));
         let light_dir: vec3<f32> = normalize((light.pos.xyz - position.xyz));
         let diffuse: f32 = max(0.0, dot(normal, light_dir));
-        let _e34: vec3<f32> = color1;
-        color1 = (_e34 + ((_e25 * diffuse) * light.color.xyz));
+        let _e34: vec3<f32> = color;
+        color = (_e34 + ((_e25 * diffuse) * light.color.xyz));
         continuing {
             let _e40: u32 = i;
             i = (_e40 + 1u);
         }
     }
-    let _e43: vec3<f32> = color1;
+    let _e43: vec3<f32> = color;
     return vec4<f32>(_e43, 1.0);
 }

--- a/tests/out/swizzle_write-frag.wgsl
+++ b/tests/out/swizzle_write-frag.wgsl
@@ -1,4 +1,4 @@
-fn main() {
+fn main1() {
     var x: vec3<f32> = vec3<f32>(2.0, 2.0, 2.0);
 
     let _e3: vec3<f32> = x;
@@ -14,7 +14,7 @@ fn main() {
 }
 
 [[stage(fragment)]]
-fn main1() {
-    main();
+fn main() {
+    main1();
     return;
 }


### PR DESCRIPTION
Previously, namer was processing the module in such order, that names of entry points and bindings were pretty much guaranteed to be non-unique, resulting with additional numeral postfix. This resulted in bugs when specifying wgpu render pipeline, as the entry point name didn't match. Additionaly, binding names are often inspected through shader reflection to determine which buffers to bind, so it's good idea to preserve those as well.

This change modifies the order of operations in the namer, such that important names are processed first, and collisions are resolved by modifying names of private symbols.

Additionaly, because struct members essentially have their own namespace, those are no longer deduplicated globally, and are uniquely named only in scope of given struct. That both aids reflection and helps with debugging translated shaders.