### PR TITLE
Support u8 and i8 constants

### DIFF
--- a/src/valid/type.rs
+++ b/src/valid/type.rs
@@ -137,7 +137,11 @@ impl super::Validator {
             crate::ScalarKind::Float => {
                 width == 4 || (width == 8 && self.capabilities.contains(Capabilities::FLOAT64))
             }
-            crate::ScalarKind::Sint | crate::ScalarKind::Uint => width == 4,
+            crate::ScalarKind::Sint | crate::ScalarKind::Uint => {
+                width == 4
+                    || (width == 1/* TODO?: && self.capabilities.contains(Capabilities::INT8)? */)
+                    || (width == 2/* TODO?: && self.capabilities.contains(Capabilities::INT16) */)
+            }
         }
     }
 


### PR DESCRIPTION
If we want to keep this as a targeted change, this PR could be considered complete, however it might be more correct to add int8 and int16 capabilities.

This is part of fixing some issues caused using the wgpu naga validation with [rust-gpu](https://github.com/EmbarkStudios/rust-gpu), specifically. However, this does not block any work there, since we can just not validate.

This still doesn't get the rust-gpu compute example passing, because we now get:
```
Function [1] 'compute_shader::collatz' is invalid: 
        Expression [29] is invalid
        Used by a statement before it was introduced into the scope by any of the dominating blocks
```
which I haven't debugged (some way to link these error expressions with their spir-v id in error message would be extremely welcome, so that you can at least hope to debug naga itself).