### PR TITLE
[glsl-in] Fix builtin type and add support for precision qualifiers

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -955,6 +955,7 @@ pub enum TypeQualifier {
     WorkGroupSize(usize, u32),
     Sampling(Sampling),
     Layout(StructLayout),
+    Precision(Precision),
     EarlyFragmentTests,
 }
 
@@ -982,6 +983,14 @@ pub enum StorageQualifier {
 pub enum StructLayout {
     Std140,
     Std430,
+}
+
+// TODO: Encode precision hints in the IR
+#[derive(Debug, Clone, PartialEq, Copy)]
+pub enum Precision {
+    Low,
+    Medium,
+    High,
 }
 
 #[derive(Debug, Clone, PartialEq, Copy)]

--- a/src/front/glsl/lex.rs
+++ b/src/front/glsl/lex.rs
@@ -1,4 +1,5 @@
 use super::{
+    ast::Precision,
     token::{SourceMetadata, Token, TokenValue},
     types::parse_type,
 };
@@ -58,6 +59,7 @@ impl<'a> Iterator for Lexer<'a> {
             PPTokenValue::Float(float) => TokenValue::FloatConstant(float),
             PPTokenValue::Ident(ident) => {
                 match ident.as_str() {
+                    // Qualifiers
                     "layout" => TokenValue::Layout,
                     "in" => TokenValue::In,
                     "out" => TokenValue::Out,
@@ -70,6 +72,10 @@ impl<'a> Iterator for Lexer<'a> {
                     "sample" => TokenValue::Sampling(crate::Sampling::Sample),
                     "const" => TokenValue::Const,
                     "inout" => TokenValue::InOut,
+                    "precision" => TokenValue::Precision,
+                    "highp" => TokenValue::PrecisionQualifier(Precision::High),
+                    "mediump" => TokenValue::PrecisionQualifier(Precision::Medium),
+                    "lowp" => TokenValue::PrecisionQualifier(Precision::Low),
                     // values
                     "true" => TokenValue::BoolConstant(true),
                     "false" => TokenValue::BoolConstant(false),

--- a/src/front/glsl/parser_tests.rs
+++ b/src/front/glsl/parser_tests.rs
@@ -246,6 +246,15 @@ fn declarations() {
         &entry_points,
     )
     .unwrap();
+
+    let _program = parse_program(
+        r#"
+        #version 450
+        precision highp float;
+        "#,
+        &entry_points,
+    )
+    .unwrap();
 }
 
 #[test]

--- a/src/front/glsl/token.rs
+++ b/src/front/glsl/token.rs
@@ -1,5 +1,6 @@
 pub use pp_rs::token::{Float, Integer, PreprocessorError};
 
+use super::ast::Precision;
 use crate::{Interpolation, Sampling, Type};
 use std::{fmt, ops::Range};
 
@@ -57,6 +58,8 @@ pub enum TokenValue {
     Const,
     Interpolation(Interpolation),
     Sampling(Sampling),
+    Precision,
+    PrecisionQualifier(Precision),
 
     Continue,
     Break,

--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -302,6 +302,7 @@ impl Program<'_> {
         let mut location = None;
         let mut sampling = None;
         let mut layout = None;
+        let mut precision = None;
 
         for &(ref qualifier, meta) in qualifiers {
             match *qualifier {
@@ -350,7 +351,12 @@ impl Program<'_> {
                     meta,
                     "Cannot use more than one layout qualifier per declaration"
                 ),
-
+                TypeQualifier::Precision(ref p) => qualifier_arm!(
+                    p,
+                    precision,
+                    meta,
+                    "Cannot use more than one precision qualifier per declaration"
+                ),
                 _ => {
                     return Err(ErrorKind::SemanticError(
                         meta,

--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -94,7 +94,7 @@ impl Program<'_> {
             ),
             "gl_VertexIndex" => add_builtin(
                 TypeInner::Scalar {
-                    kind: ScalarKind::Sint,
+                    kind: ScalarKind::Uint,
                     width: 4,
                 },
                 BuiltIn::VertexIndex,
@@ -103,7 +103,7 @@ impl Program<'_> {
             ),
             "gl_InstanceIndex" => add_builtin(
                 TypeInner::Scalar {
-                    kind: ScalarKind::Sint,
+                    kind: ScalarKind::Uint,
                     width: 4,
                 },
                 BuiltIn::InstanceIndex,
@@ -123,7 +123,7 @@ impl Program<'_> {
             "gl_FrontFacing" => add_builtin(
                 TypeInner::Scalar {
                     kind: ScalarKind::Bool,
-                    width: 1,
+                    width: crate::BOOL_WIDTH,
                 },
                 BuiltIn::FrontFacing,
                 false,


### PR DESCRIPTION
Corrects the `VertexIndex` and `InstanceIndex` to be uint and adds support for parsing precision qualifiers and statements

Fixes #1001
Fixes #1002
Fixes #1003