### PR TITLE
[glsl-in] Deduplicate constants so array types match

### DIFF
--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -1032,7 +1032,7 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
             }
         };
 
-        let handle = self.program.module.constants.append(Constant {
+        let handle = self.program.module.constants.fetch_or_append(Constant {
             name: None,
             specialization: None,
             inner: ConstantInner::Scalar { width, value },


### PR DESCRIPTION
This fixes GLSL shaders like:
```glsl
#version 450 core

void foo(int i[3]) {}

void main() {
    int array[3];
    foo(array);
}
```

Previous error:
<pre><font color="#F66151"><b>error</b></font><b>: Unknown function &apos;foo&apos;</b>
  <font color="#12488B">┌─</font> array.vert:7:5
  <font color="#12488B">│</font>
<font color="#12488B">7</font> <font color="#12488B">│</font>     <font color="#C01C28">foo(array)</font>;
  <font color="#12488B">│</font>     <font color="#C01C28">^^^^^^^^^^</font>
</pre>