### PR TITLE
glsl: Replace todo!() with a NotImplemented error

### DIFF
--- a/src/front/glsl/error.rs
+++ b/src/front/glsl/error.rs
@@ -58,8 +58,8 @@ pub enum ErrorKind {
     InvalidVersion(SourceMetadata, u64),
     #[error("Expected {}, found {0}", join_with_comma(.1))]
     InvalidToken(Token, Vec<ExpectedToken>),
-    #[error("Not implemented {0}")]
-    NotImplemented(&'static str),
+    #[error("Not implemented: {1}")]
+    NotImplemented(SourceMetadata, &'static str),
     #[error("Unknown variable: {1}")]
     UnknownVariable(SourceMetadata, String),
     #[error("Unknown type: {1}")]
@@ -82,6 +82,7 @@ impl ErrorKind {
             ErrorKind::UnknownVariable(metadata, _)
             | ErrorKind::InvalidProfile(metadata, _)
             | ErrorKind::InvalidVersion(metadata, _)
+            | ErrorKind::NotImplemented(metadata, _)
             | ErrorKind::UnknownLayoutQualifier(metadata, _)
             | ErrorKind::SemanticError(metadata, _)
             | ErrorKind::UnknownField(metadata, _) => Some(metadata),

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -797,7 +797,10 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
                             //TODO: declaration
                             // type_qualifier IDENTIFIER SEMICOLON
                             // type_qualifier IDENTIFIER identifier_list SEMICOLON
-                            todo!()
+                            Err(ErrorKind::NotImplemented(
+                                token.meta,
+                                "variable qualifier",
+                            ))
                         }
                     }
                     TokenValue::Semicolon => {


### PR DESCRIPTION
So we can get a source location rather than a panic.