### PR TITLE
Handle texture/sampler function arguments

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1846,8 +1846,6 @@ impl<'a, W: Write> Writer<'a, W> {
                         write!(self.out, ")",)?;
                     }
                 }
-                // TODO: Why is this not implemented ???
-                // return Err(Error::Custom("ImageQuery not implemented".to_string()));
             }
             // `Unary` is pretty straightforward
             // "-" - for `Negate`

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -218,7 +218,7 @@ impl fmt::Display for VaryingName<'_> {
 }
 
 /// Shorthand result used internally by the backend
-type BackendResult = Result<(), Error>;
+type BackendResult<T = ()> = Result<T, Error>;
 
 /// A glsl compilation error.
 #[derive(Debug, Error)]
@@ -892,14 +892,42 @@ impl<'a, W: Write> Writer<'a, W> {
         };
         self.write_slice(arguments, |this, i, arg| {
             // Write the argument type
-            // `write_type` adds no trailing spaces
-            this.write_type(arg.ty)?;
+            match this.module.types[arg.ty].inner {
+                // We treat images separately because they might require
+                // writing the storage format
+                TypeInner::Image {
+                    dim,
+                    arrayed,
+                    class,
+                } => {
+                    // Write the storage format if needed
+                    if let TypeInner::Image {
+                        class: crate::ImageClass::Storage(format),
+                        ..
+                    } = this.module.types[arg.ty].inner
+                    {
+                        write!(this.out, "layout({}) ", glsl_storage_format(format))?;
+                    }
+
+                    // write the type
+                    //
+                    // This is way we need the leading space because `write_image_type` doesn't add
+                    // any spaces at the beginning or end
+                    this.write_image_type(dim, arrayed, class)?;
+                }
+                // glsl has no concept of samplers so we just ignore it
+                TypeInner::Sampler { .. } => return Ok(false),
+                // All other types are written by `write_type`
+                _ => {
+                    this.write_type(arg.ty)?;
+                }
+            }
 
             // Write the argument name
             // The leading space is important
             write!(this.out, " {}", &this.names[&ctx.argument_key(i)])?;
 
-            Ok(())
+            Ok(true)
         })?;
 
         // Close the parentheses and open braces to start the function body
@@ -995,14 +1023,16 @@ impl<'a, W: Write> Writer<'a, W> {
     /// # Notes
     /// - Adds no newlines or leading/trailing whitespace
     /// - The last element won't have a trailing `,`
-    fn write_slice<T, F: FnMut(&mut Self, u32, &T) -> BackendResult>(
+    fn write_slice<T, F: FnMut(&mut Self, u32, &T) -> BackendResult<bool>>(
         &mut self,
         data: &[T],
         mut f: F,
     ) -> BackendResult {
         // Loop trough `data` invoking `f` for each element
         for (i, item) in data.iter().enumerate() {
-            f(self, i as u32, item)?;
+            if !f(self, i as u32, item)? {
+                continue;
+            }
 
             // Only write a comma if isn't the last element
             if i != data.len().saturating_sub(1) {
@@ -1047,7 +1077,8 @@ impl<'a, W: Write> Writer<'a, W> {
 
                 // Write the comma separated constants
                 self.write_slice(components, |this, _, arg| {
-                    this.write_constant(&this.module.constants[*arg])
+                    this.write_constant(&this.module.constants[*arg])?;
+                    Ok(true)
                 })?;
 
                 write!(self.out, ")")?
@@ -1467,7 +1498,16 @@ impl<'a, W: Write> Writer<'a, W> {
                     self.named_expressions.insert(expr, name);
                 }
                 write!(self.out, "{}(", &self.names[&NameKey::Function(function)])?;
-                self.write_slice(arguments, |this, _, arg| this.write_expr(*arg, ctx))?;
+                self.write_slice(arguments, |this, i, arg| {
+                    let arg_ty = this.module.functions[function].arguments[i as usize].ty;
+                    if let TypeInner::Sampler { .. } = this.module.types[arg_ty].inner {
+                        return Ok(false);
+                    }
+
+                    this.write_expr(*arg, ctx)?;
+
+                    Ok(true)
+                })?;
                 writeln!(self.out, ");")?
             }
         }
@@ -1567,7 +1607,10 @@ impl<'a, W: Write> Writer<'a, W> {
                 self.write_type(ty)?;
 
                 write!(self.out, "(")?;
-                self.write_slice(components, |this, _, arg| this.write_expr(*arg, ctx))?;
+                self.write_slice(components, |this, _, arg| {
+                    this.write_expr(*arg, ctx)?;
+                    Ok(true)
+                })?;
                 write!(self.out, ")")?
             }
             // Function arguments are written as the argument name
@@ -1803,7 +1846,8 @@ impl<'a, W: Write> Writer<'a, W> {
                         write!(self.out, ")",)?;
                     }
                 }
-                return Err(Error::Custom("ImageQuery not implemented".to_string()));
+                // TODO: Why is this not implemented ???
+                // return Err(Error::Custom("ImageQuery not implemented".to_string()));
             }
             // `Unary` is pretty straightforward
             // "-" - for `Negate`

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -528,7 +528,7 @@ impl<W: Write> Writer<W> {
                 if let Some(storage_class) = storage_class_str(class) {
                     write!(self.out, "<{}>", storage_class)?;
                 }
-            },
+            }
             _ => {
                 return Err(Error::Unimplemented(format!(
                     "write_value_type {:?}",

--- a/src/front/spv/error.rs
+++ b/src/front/spv/error.rs
@@ -73,6 +73,8 @@ pub enum Error {
     InvalidBinding(spirv::Word),
     #[error("invalid global var {0:?}")]
     InvalidGlobalVar(crate::Expression),
+    #[error("invalid image/sampler expression {0:?}")]
+    InvalidImageExpression(crate::Expression),
     #[error("invalid image base type {0:?}")]
     InvalidImageBaseType(Handle<crate::Type>),
     #[error("invalid image {0:?}")]

--- a/src/front/spv/function.rs
+++ b/src/front/spv/function.rs
@@ -136,7 +136,7 @@ impl<I: Iterator<Item = u32>> super::Parser<I> {
         let mut flow_graph = FlowGraph::new();
 
         let mut function_info = FunctionInfo {
-            parameters_sampling: vec![None; fun.arguments.len()],
+            parameters_sampling: vec![super::image::SamplingFlags::empty(); fun.arguments.len()],
         };
 
         // Scan the blocks and add them as nodes

--- a/src/front/spv/function.rs
+++ b/src/front/spv/function.rs
@@ -193,7 +193,7 @@ impl<I: Iterator<Item = u32>> super::Parser<I> {
         // done
         let fun_handle = module.functions.append(fun);
         self.lookup_function.insert(fun_id, fun_handle);
-        self.function_info.insert(fun_handle, function_info);
+        self.function_info.push(function_info);
         if let Some(ep) = self.lookup_entry_point.remove(&fun_id) {
             // create a wrapping function
             let mut function = crate::Function {

--- a/src/front/spv/image.rs
+++ b/src/front/spv/image.rs
@@ -456,8 +456,7 @@ impl<I: Iterator<Item = u32>> super::Parser<I> {
                 global_arena[handle].ty
             }
             crate::Expression::FunctionArgument(i) => {
-                let flags = function_info.parameters_sampling[i as usize]
-                    .get_or_insert(SamplingFlags::empty());
+                let flags = &mut function_info.parameters_sampling[i as usize];
                 *flags |= sampling_bit;
 
                 arguments[i as usize].ty
@@ -469,8 +468,7 @@ impl<I: Iterator<Item = u32>> super::Parser<I> {
                 *self.handle_sampling.get_mut(&handle).unwrap() |= sampling_bit
             }
             crate::Expression::FunctionArgument(i) => {
-                let flags = function_info.parameters_sampling[i as usize]
-                    .get_or_insert(SamplingFlags::empty());
+                let flags = &mut function_info.parameters_sampling[i as usize];
                 *flags |= sampling_bit;
             }
             ref other => return Err(Error::InvalidGlobalVar(other.clone())),

--- a/src/front/spv/image.rs
+++ b/src/front/spv/image.rs
@@ -31,7 +31,7 @@ impl Arena<crate::Expression> {
         match self[handle] {
             crate::Expression::GlobalVariable(handle) => Ok(global_vars[handle].ty),
             crate::Expression::FunctionArgument(i) => Ok(arguments[i as usize].ty),
-            ref other => Err(Error::InvalidGlobalVar(other.clone())),
+            ref other => Err(Error::InvalidImageExpression(other.clone())),
         }
     }
 }

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -409,7 +409,7 @@ pub struct Parser<I> {
     options: Options,
     index_constants: Vec<Handle<crate::Constant>>,
     index_constant_expressions: Vec<Handle<crate::Expression>>,
-    function_info: FastHashMap<Handle<crate::Function>, FunctionInfo>,
+    function_info: Vec<FunctionInfo>,
 }
 
 impl<I: Iterator<Item = u32>> Parser<I> {
@@ -441,7 +441,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
             options: options.clone(),
             index_constants: Vec::new(),
             index_constant_expressions: Vec::new(),
-            function_info: FastHashMap::default(),
+            function_info: Vec::new(),
         }
     }
 
@@ -2312,7 +2312,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
 
                     // Patch sampling flags
                     for (i, arg) in arguments.iter().enumerate() {
-                        let callee_info = &self.function_info[&handle];
+                        let callee_info = &self.function_info[handle.index()];
 
                         if let Some(flags) = callee_info.parameters_sampling.get(i).and_then(|e| *e)
                         {
@@ -2323,7 +2323,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                                 crate::Expression::FunctionArgument(i) => {
                                     if let Some(handle) = function {
                                         let function_info =
-                                            self.function_info.get_mut(&handle).unwrap();
+                                            self.function_info.get_mut(handle.index()).unwrap();
                                         let caller_flags = function_info.parameters_sampling
                                             [i as usize]
                                             .get_or_insert(image::SamplingFlags::empty());

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1673,8 +1673,9 @@ impl Parser {
         allow_deref: bool,
     ) -> Result<Handle<crate::Expression>, Error<'a>> {
         let mut needs_deref = match ctx.expressions[handle] {
-            crate::Expression::LocalVariable(_) | crate::Expression::GlobalVariable(_) => {
-                allow_deref
+            crate::Expression::LocalVariable(_) => allow_deref,
+            crate::Expression::GlobalVariable(var) => {
+                ctx.global_vars[var].class != crate::StorageClass::Handle && allow_deref
             }
             _ => false,
         };

--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -159,6 +159,24 @@ impl ExpressionInfo {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+enum GlobalOrArgument {
+    Global(Handle<crate::GlobalVariable>),
+    Argument(u32),
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+struct ArgumentSampling {
+    /// Whether this argument is used as an image or a sampler
+    image: bool,
+    /// The other global or argument used in the sampling
+    uses: Vec<GlobalOrArgument>,
+}
+
 #[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
@@ -181,6 +199,10 @@ pub struct FunctionInfo {
     ///
     /// Each item corresponds to an expression in the function.
     expressions: Box<[ExpressionInfo]>,
+    /// Vector with information of wether or not a functin argument is used for sampling
+    ///
+    /// Each item corresponds to a function argument
+    argument_sampling: Box<[Option<ArgumentSampling>]>,
 }
 
 impl FunctionInfo {
@@ -273,21 +295,101 @@ impl FunctionInfo {
     }
 
     /// Inherit information from a called function.
-    fn process_call(&mut self, info: &Self) -> FunctionUniformity {
+    fn process_call(
+        &mut self,
+        info: &Self,
+        arguments: &[Handle<crate::Expression>],
+        expression_arena: &Arena<crate::Expression>,
+    ) -> Result<FunctionUniformity, FunctionError> {
         for key in info.sampling_set.iter() {
             self.sampling_set.insert(key.clone());
+        }
+        for (i, arg_sampling) in info
+            .argument_sampling
+            .iter()
+            .enumerate()
+            .filter_map(|(i, s)| Some((i, s.as_ref()?)))
+        {
+            let handle = arguments[i];
+            let arg_storage = match expression_arena[handle] {
+                crate::Expression::GlobalVariable(var) => GlobalOrArgument::Global(var),
+                crate::Expression::FunctionArgument(i) => GlobalOrArgument::Argument(i),
+                _ => {
+                    return Err(FunctionError::Expression {
+                        handle,
+                        error: ExpressionError::ExpectedGlobalVariable,
+                    })
+                }
+            };
+
+            for other in arg_sampling.uses.iter() {
+                let other_storage = match *other {
+                    GlobalOrArgument::Global(var) => GlobalOrArgument::Global(var),
+                    GlobalOrArgument::Argument(i) => {
+                        let other_handle = arguments[i as usize];
+                        match expression_arena[other_handle] {
+                            crate::Expression::GlobalVariable(var) => GlobalOrArgument::Global(var),
+                            crate::Expression::FunctionArgument(i) => GlobalOrArgument::Argument(i),
+                            _ => {
+                                return Err(FunctionError::Expression {
+                                    handle,
+                                    error: ExpressionError::ExpectedGlobalVariable,
+                                })
+                            }
+                        }
+                    }
+                };
+
+                match (arg_storage, other_storage) {
+                    (GlobalOrArgument::Global(arg), GlobalOrArgument::Global(other)) => {
+                        if arg_sampling.image {
+                            self.sampling_set.insert(SamplingKey {
+                                image: arg,
+                                sampler: other,
+                            });
+                        } else {
+                            self.sampling_set.insert(SamplingKey {
+                                image: other,
+                                sampler: arg,
+                            });
+                        }
+                    }
+                    (GlobalOrArgument::Argument(i), _) => {
+                        let sampling =
+                            self.argument_sampling[i as usize].get_or_insert_with(|| {
+                                ArgumentSampling {
+                                    image: arg_sampling.image,
+                                    uses: Vec::with_capacity(1),
+                                }
+                            });
+
+                        sampling.uses.push(other_storage)
+                    }
+                    (_, GlobalOrArgument::Argument(i)) => {
+                        let sampling =
+                            self.argument_sampling[i as usize].get_or_insert_with(|| {
+                                ArgumentSampling {
+                                    image: !arg_sampling.image,
+                                    uses: Vec::with_capacity(1),
+                                }
+                            });
+
+                        sampling.uses.push(arg_storage)
+                    }
+                }
+            }
         }
         for (mine, other) in self.global_uses.iter_mut().zip(info.global_uses.iter()) {
             *mine |= *other;
         }
-        FunctionUniformity {
+        Ok(FunctionUniformity {
             result: info.uniformity.clone(),
             exit: if info.may_kill {
                 ExitFlags::MAY_KILL
             } else {
                 ExitFlags::empty()
             },
-        }
+        })
     }
 
     /// Computes the expression info and stores it in `self.expressions`.
@@ -397,16 +499,45 @@ impl FunctionInfo {
                 level,
                 depth_ref,
             } => {
-                self.sampling_set.insert(SamplingKey {
-                    image: match expression_arena[image] {
-                        crate::Expression::GlobalVariable(var) => var,
-                        _ => return Err(ExpressionError::ExpectedGlobalVariable),
-                    },
-                    sampler: match expression_arena[sampler] {
-                        crate::Expression::GlobalVariable(var) => var,
-                        _ => return Err(ExpressionError::ExpectedGlobalVariable),
-                    },
-                });
+                let image_storage = match expression_arena[image] {
+                    crate::Expression::GlobalVariable(var) => GlobalOrArgument::Global(var),
+                    crate::Expression::FunctionArgument(i) => GlobalOrArgument::Argument(i),
+                    _ => return Err(ExpressionError::ExpectedGlobalVariable),
+                };
+                let sampler_storage = match expression_arena[sampler] {
+                    crate::Expression::GlobalVariable(var) => GlobalOrArgument::Global(var),
+                    crate::Expression::FunctionArgument(i) => GlobalOrArgument::Argument(i),
+                    _ => return Err(ExpressionError::ExpectedGlobalVariable),
+                };
+
+                match (image_storage, sampler_storage) {
+                    (GlobalOrArgument::Global(image), GlobalOrArgument::Global(sampler)) => {
+                        self.sampling_set.insert(SamplingKey { image, sampler });
+                    }
+                    (GlobalOrArgument::Argument(i), _) => {
+                        let sampling =
+                            self.argument_sampling[i as usize].get_or_insert_with(|| {
+                                ArgumentSampling {
+                                    image: true,
+                                    uses: Vec::with_capacity(1),
+                                }
+                            });
+
+                        sampling.uses.push(sampler_storage)
+                    }
+                    (_, GlobalOrArgument::Argument(i)) => {
+                        let sampling =
+                            self.argument_sampling[i as usize].get_or_insert_with(|| {
+                                ArgumentSampling {
+                                    image: false,
+                                    uses: Vec::with_capacity(1),
+                                }
+                            });
+
+                        sampling.uses.push(image_storage)
+                    }
+                }
+
                 // "nur" == "Non-Uniform Result"
                 let array_nur = array_index.and_then(|h| self.add_ref(h));
                 let level_nur = match level {
@@ -501,10 +632,11 @@ impl FunctionInfo {
                 requirements: UniformityRequirements::empty(),
             },
             E::Call(function) => {
-                let fun = other_functions
+                let info = other_functions
                     .get(function.index())
                     .ok_or(ExpressionError::CallToUndeclaredFunction(function))?;
-                self.process_call(fun).result
+
+                info.uniformity.clone()
             }
             E::ArrayLength(expr) => Uniformity {
                 non_uniform_result: self.add_ref_impl(expr, GlobalUse::QUERY),
@@ -537,6 +669,7 @@ impl FunctionInfo {
         statements: &[crate::Statement],
         other_functions: &[FunctionInfo],
         mut disruptor: Option<UniformityDisruptor>,
+        expression_arena: &Arena<crate::Expression>,
     ) -> Result<FunctionUniformity, FunctionError> {
         use crate::Statement as S;
 
@@ -582,7 +715,9 @@ impl FunctionInfo {
                     },
                     exit: ExitFlags::empty(),
                 },
-                S::Block(ref b) => self.process_block(b, other_functions, disruptor)?,
+                S::Block(ref b) => {
+                    self.process_block(b, other_functions, disruptor, expression_arena)?
+                }
                 S::If {
                     condition,
                     ref accept,
@@ -591,10 +726,18 @@ impl FunctionInfo {
                     let condition_nur = self.add_ref(condition);
                     let branch_disruptor =
                         disruptor.or(condition_nur.map(UniformityDisruptor::Expression));
-                    let accept_uniformity =
-                        self.process_block(accept, other_functions, branch_disruptor)?;
-                    let reject_uniformity =
-                        self.process_block(reject, other_functions, branch_disruptor)?;
+                    let accept_uniformity = self.process_block(
+                        accept,
+                        other_functions,
+                        branch_disruptor,
+                        expression_arena,
+                    )?;
+                    let reject_uniformity = self.process_block(
+                        reject,
+                        other_functions,
+                        branch_disruptor,
+                        expression_arena,
+                    )?;
                     accept_uniformity | reject_uniformity
                 }
                 S::Switch {
@@ -608,8 +751,12 @@ impl FunctionInfo {
                     let mut uniformity = FunctionUniformity::new();
                     let mut case_disruptor = branch_disruptor;
                     for case in cases.iter() {
-                        let case_uniformity =
-                            self.process_block(&case.body, other_functions, case_disruptor)?;
+                        let case_uniformity = self.process_block(
+                            &case.body,
+                            other_functions,
+                            case_disruptor,
+                            expression_arena,
+                        )?;
                         case_disruptor = if case.fall_through {
                             case_disruptor.or(case_uniformity.exit_disruptor())
                         } else {
@@ -618,18 +765,27 @@ impl FunctionInfo {
                         uniformity = uniformity | case_uniformity;
                     }
                     // using the disruptor inherited from the last fall-through chain
-                    let default_exit =
-                        self.process_block(default, other_functions, case_disruptor)?;
+                    let default_exit = self.process_block(
+                        default,
+                        other_functions,
+                        case_disruptor,
+                        expression_arena,
+                    )?;
                     uniformity | default_exit
                 }
                 S::Loop {
                     ref body,
                     ref continuing,
                 } => {
-                    let body_uniformity = self.process_block(body, other_functions, disruptor)?;
+                    let body_uniformity =
+                        self.process_block(body, other_functions, disruptor, expression_arena)?;
                     let continuing_disruptor = disruptor.or(body_uniformity.exit_disruptor());
-                    let continuing_uniformity =
-                        self.process_block(continuing, other_functions, continuing_disruptor)?;
+                    let continuing_uniformity = self.process_block(
+                        continuing,
+                        other_functions,
+                        continuing_disruptor,
+                        expression_arena,
+                    )?;
                     body_uniformity | continuing_uniformity
                 }
                 S::Return { value } => FunctionUniformity {
@@ -680,7 +836,7 @@ impl FunctionInfo {
                         },
                     )?;
                     //Note: the result is validated by the Validator, not here
-                    self.process_call(info)
+                    self.process_call(info, arguments, expression_arena)?
                 }
             };
 
@@ -708,6 +864,7 @@ impl ModuleInfo {
             sampling_set: crate::FastHashSet::default(),
             global_uses: vec![GlobalUse::empty(); module.global_variables.len()].into_boxed_slice(),
             expressions: vec![ExpressionInfo::new(); fun.expressions.len()].into_boxed_slice(),
+            argument_sampling: vec![None; fun.arguments.len()].into_boxed_slice(),
         };
         let resolve_context = ResolveContext {
             constants: &module.constants,
@@ -730,7 +887,7 @@ impl ModuleInfo {
             }
         }
 
-        let uniformity = info.process_block(&fun.body, &self.functions, None)?;
+        let uniformity = info.process_block(&fun.body, &self.functions, None, &fun.expressions)?;
         info.uniformity = uniformity.result;
         info.may_kill = uniformity.exit.contains(ExitFlags::MAY_KILL);
 
@@ -812,6 +969,7 @@ fn uniform_control_flow() {
         sampling_set: crate::FastHashSet::default(),
         global_uses: vec![GlobalUse::empty(); global_var_arena.len()].into_boxed_slice(),
         expressions: vec![ExpressionInfo::new(); expressions.len()].into_boxed_slice(),
+        argument_sampling: vec![None; 0].into_boxed_slice(),
     };
     let resolve_context = ResolveContext {
         constants: &constant_arena,
@@ -845,7 +1003,7 @@ fn uniform_control_flow() {
         ],
     };
     assert_eq!(
-        info.process_block(&[stmt_emit1, stmt_if_uniform], &[], None),
+        info.process_block(&[stmt_emit1, stmt_if_uniform], &[], None, &expressions),
         Ok(FunctionUniformity {
             result: Uniformity {
                 non_uniform_result: None,
@@ -870,7 +1028,7 @@ fn uniform_control_flow() {
         reject: Vec::new(),
     };
     assert_eq!(
-        info.process_block(&[stmt_emit2, stmt_if_non_uniform], &[], None),
+        info.process_block(&[stmt_emit2, stmt_if_non_uniform], &[], None, &expressions),
         Err(FunctionError::NonUniformControlFlow(
             UniformityRequirements::DERIVATIVE,
             derivative_expr,
@@ -888,7 +1046,8 @@ fn uniform_control_flow() {
         info.process_block(
             &[stmt_emit3, stmt_return_non_uniform],
             &[],
-            Some(UniformityDisruptor::Return)
+            Some(UniformityDisruptor::Return),
+            &expressions
         ),
         Ok(FunctionUniformity {
             result: Uniformity {
@@ -914,7 +1073,8 @@ fn uniform_control_flow() {
         info.process_block(
             &[stmt_emit4, stmt_assign, stmt_kill, stmt_return_pointer],
             &[],
-            Some(UniformityDisruptor::Discard)
+            Some(UniformityDisruptor::Discard),
+            &expressions
         ),
         Ok(FunctionUniformity {
             result: Uniformity {

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -61,6 +61,8 @@ pub enum ExpressionError {
     Type(#[from] ResolveError),
     #[error("Not a global variable")]
     ExpectedGlobalVariable,
+    #[error("Not a global variable or a function argument")]
+    ExpectedGlobalOrArgument,
     #[error("Calling an undeclared function {0:?}")]
     CallToUndeclaredFunction(Handle<crate::Function>),
     #[error("Needs to be an image instead of {0:?}")]

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -339,24 +339,26 @@ impl super::Validator {
                 depth_ref,
             } => {
                 // check the validity of expressions
-                let image_var = match function.expressions[image] {
+                let image_ty = match function.expressions[image] {
                     crate::Expression::GlobalVariable(var_handle) => {
-                        &module.global_variables[var_handle]
+                        module.global_variables[var_handle].ty
                     }
+                    crate::Expression::FunctionArgument(i) => function.arguments[i as usize].ty,
                     _ => return Err(ExpressionError::ExpectedGlobalVariable),
                 };
-                let sampler_var = match function.expressions[sampler] {
+                let sampler_ty = match function.expressions[sampler] {
                     crate::Expression::GlobalVariable(var_handle) => {
-                        &module.global_variables[var_handle]
+                        module.global_variables[var_handle].ty
                     }
+                    crate::Expression::FunctionArgument(i) => function.arguments[i as usize].ty,
                     _ => return Err(ExpressionError::ExpectedGlobalVariable),
                 };
-                let comparison = match module.types[sampler_var.ty].inner {
+                let comparison = match module.types[sampler_ty].inner {
                     Ti::Sampler { comparison } => comparison,
-                    _ => return Err(ExpressionError::ExpectedSamplerType(sampler_var.ty)),
+                    _ => return Err(ExpressionError::ExpectedSamplerType(sampler_ty)),
                 };
 
-                let (class, dim) = match module.types[image_var.ty].inner {
+                let (class, dim) = match module.types[image_ty].inner {
                     Ti::Image {
                         class,
                         arrayed,
@@ -377,7 +379,7 @@ impl super::Validator {
                         }
                         (class, dim)
                     }
-                    _ => return Err(ExpressionError::ExpectedImageType(image_var.ty)),
+                    _ => return Err(ExpressionError::ExpectedImageType(image_ty)),
                 };
 
                 // check sampling and comparison properties
@@ -515,13 +517,14 @@ impl super::Validator {
                 array_index,
                 index,
             } => {
-                let var = match function.expressions[image] {
+                let ty = match function.expressions[image] {
                     crate::Expression::GlobalVariable(var_handle) => {
-                        &module.global_variables[var_handle]
+                        module.global_variables[var_handle].ty
                     }
+                    crate::Expression::FunctionArgument(i) => function.arguments[i as usize].ty,
                     _ => return Err(ExpressionError::ExpectedGlobalVariable),
                 };
-                match module.types[var.ty].inner {
+                match module.types[ty].inner {
                     Ti::Image {
                         class,
                         arrayed,
@@ -564,18 +567,19 @@ impl super::Validator {
                             }
                         }
                     }
-                    _ => return Err(ExpressionError::ExpectedImageType(var.ty)),
+                    _ => return Err(ExpressionError::ExpectedImageType(ty)),
                 }
                 ShaderStages::all()
             }
             E::ImageQuery { image, query } => {
-                let var = match function.expressions[image] {
+                let ty = match function.expressions[image] {
                     crate::Expression::GlobalVariable(var_handle) => {
-                        &module.global_variables[var_handle]
+                        module.global_variables[var_handle].ty
                     }
+                    crate::Expression::FunctionArgument(i) => function.arguments[i as usize].ty,
                     _ => return Err(ExpressionError::ExpectedGlobalVariable),
                 };
-                match module.types[var.ty].inner {
+                match module.types[ty].inner {
                     Ti::Image { class, arrayed, .. } => {
                         let can_level = match class {
                             crate::ImageClass::Sampled { multi, .. } => !multi,
@@ -593,7 +597,7 @@ impl super::Validator {
                             return Err(ExpressionError::InvalidImageClass(class));
                         }
                     }
-                    _ => return Err(ExpressionError::ExpectedImageType(var.ty)),
+                    _ => return Err(ExpressionError::ExpectedImageType(ty)),
                 }
                 ShaderStages::all()
             }

--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -578,7 +578,7 @@ impl super::Validator {
         for (index, argument) in fun.arguments.iter().enumerate() {
             if !self.types[argument.ty.index()]
                 .flags
-                .contains(TypeFlags::DATA | TypeFlags::SIZED)
+                .contains(TypeFlags::ARGUMENT)
             {
                 return Err(FunctionError::InvalidArgumentType {
                     index,

--- a/src/valid/type.rs
+++ b/src/valid/type.rs
@@ -46,6 +46,9 @@ bitflags::bitflags! {
 
         /// This is a top-level host-shareable type.
         const TOP_LEVEL = 0x10;
+
+        /// This type can be passed as a function argument.
+        const ARGUMENT = 0x20;
     }
 }
 
@@ -192,7 +195,8 @@ impl super::Validator {
                     TypeFlags::DATA
                         | TypeFlags::SIZED
                         | TypeFlags::INTERFACE
-                        | TypeFlags::HOST_SHARED,
+                        | TypeFlags::HOST_SHARED
+                        | TypeFlags::ARGUMENT,
                     width as u32,
                 )
             }
@@ -205,7 +209,8 @@ impl super::Validator {
                     TypeFlags::DATA
                         | TypeFlags::SIZED
                         | TypeFlags::INTERFACE
-                        | TypeFlags::HOST_SHARED,
+                        | TypeFlags::HOST_SHARED
+                        | TypeFlags::ARGUMENT,
                     count * (width as u32),
                 )
             }
@@ -222,7 +227,8 @@ impl super::Validator {
                     TypeFlags::DATA
                         | TypeFlags::SIZED
                         | TypeFlags::INTERFACE
-                        | TypeFlags::HOST_SHARED,
+                        | TypeFlags::HOST_SHARED
+                        | TypeFlags::ARGUMENT,
                     count * (width as u32),
                 )
             }
@@ -239,9 +245,9 @@ impl super::Validator {
                 // `DATA`.
                 let base_info = &self.types[base.index()];
                 let data_flag = if base_info.flags.contains(TypeFlags::SIZED) {
-                    TypeFlags::DATA
+                    TypeFlags::DATA | TypeFlags::ARGUMENT
                 } else if let crate::TypeInner::Struct { .. } = types[base].inner {
-                    TypeFlags::DATA
+                    TypeFlags::DATA | TypeFlags::ARGUMENT
                 } else {
                     TypeFlags::empty()
                 };
@@ -350,7 +356,7 @@ impl super::Validator {
                             return Err(TypeError::NonPositiveArrayLength(const_handle));
                         }
 
-                        TypeFlags::SIZED
+                        TypeFlags::SIZED | TypeFlags::ARGUMENT
                     }
                     crate::ArraySize::Dynamic => {
                         // Non-SIZED types may only appear as the last element of a structure.
@@ -376,7 +382,8 @@ impl super::Validator {
                     TypeFlags::DATA
                         | TypeFlags::SIZED
                         | TypeFlags::HOST_SHARED
-                        | TypeFlags::INTERFACE,
+                        | TypeFlags::INTERFACE
+                        | TypeFlags::ARGUMENT,
                     1,
                 );
                 let mut min_offset = 0;
@@ -460,7 +467,7 @@ impl super::Validator {
 
                 ti
             }
-            Ti::Image { .. } | Ti::Sampler { .. } => TypeInfo::new(TypeFlags::empty(), 0),
+            Ti::Image { .. } | Ti::Sampler { .. } => TypeInfo::new(TypeFlags::ARGUMENT, 0),
         })
     }
 }

--- a/tests/in/texture-arg.wgsl
+++ b/tests/in/texture-arg.wgsl
@@ -1,0 +1,13 @@
+[[group(0), binding(0)]]
+var Texture: texture_2d<f32>;
+[[group(0), binding(1)]]
+var Sampler: sampler;
+
+fn test(Passed_Texture: texture_2d<f32>, Passed_Sampler: sampler) -> vec4<f32> {
+    return textureSample(Passed_Texture, Passed_Sampler, vec2<f32>(0.0, 0.0));
+}
+
+[[stage(fragment)]]
+fn main() -> [[location(0)]] vec4<f32> {
+    return test(Texture, Sampler);
+}

--- a/tests/out/analysis/collatz.info.ron
+++ b/tests/out/analysis/collatz.info.ron
@@ -336,6 +336,9 @@
                     ty: Handle(1),
                 ),
             ],
+            argument_sampling: [
+                None,
+            ],
         ),
     ],
     entry_points: [
@@ -491,6 +494,9 @@
                     assignable_global: None,
                     ty: Handle(1),
                 ),
+            ],
+            argument_sampling: [
+                None,
             ],
         ),
     ],

--- a/tests/out/analysis/collatz.info.ron
+++ b/tests/out/analysis/collatz.info.ron
@@ -336,9 +336,7 @@
                     ty: Handle(1),
                 ),
             ],
-            argument_sampling: [
-                None,
-            ],
+            sampling: [],
         ),
     ],
     entry_points: [
@@ -495,9 +493,7 @@
                     ty: Handle(1),
                 ),
             ],
-            argument_sampling: [
-                None,
-            ],
+            sampling: [],
         ),
     ],
 )

--- a/tests/out/analysis/shadow.info.ron
+++ b/tests/out/analysis/shadow.info.ron
@@ -1060,10 +1060,7 @@
                     )),
                 ),
             ],
-            argument_sampling: [
-                None,
-                None,
-            ],
+            sampling: [],
         ),
         (
             flags: (
@@ -2752,7 +2749,7 @@
                     ty: Handle(4),
                 ),
             ],
-            argument_sampling: [],
+            sampling: [],
         ),
     ],
     entry_points: [
@@ -2876,10 +2873,7 @@
                     ty: Handle(4),
                 ),
             ],
-            argument_sampling: [
-                None,
-                None,
-            ],
+            sampling: [],
         ),
     ],
 )

--- a/tests/out/analysis/shadow.info.ron
+++ b/tests/out/analysis/shadow.info.ron
@@ -1060,6 +1060,10 @@
                     )),
                 ),
             ],
+            argument_sampling: [
+                None,
+                None,
+            ],
         ),
         (
             flags: (
@@ -2748,6 +2752,7 @@
                     ty: Handle(4),
                 ),
             ],
+            argument_sampling: [],
         ),
     ],
     entry_points: [
@@ -2870,6 +2875,10 @@
                     assignable_global: None,
                     ty: Handle(4),
                 ),
+            ],
+            argument_sampling: [
+                None,
+                None,
             ],
         ),
     ],

--- a/tests/out/glsl/texture-arg.main.Fragment.glsl
+++ b/tests/out/glsl/texture-arg.main.Fragment.glsl
@@ -1,0 +1,19 @@
+#version 310 es
+
+precision highp float;
+
+uniform highp sampler2D _group_0_binding_0;
+
+layout(location = 0) out vec4 _fs2p_location0;
+
+vec4 test(highp sampler2D Passed_Texture, ) {
+    vec4 _expr7 = texture(Passed_Texture, vec2(vec2(0.0, 0.0)));
+    return _expr7;
+}
+
+void main() {
+    vec4 _expr2 = test(_group_0_binding_0, );
+    _fs2p_location0 = _expr2;
+    return;
+}
+

--- a/tests/out/glsl/texture-arg.main.Fragment.glsl
+++ b/tests/out/glsl/texture-arg.main.Fragment.glsl
@@ -6,13 +6,13 @@ uniform highp sampler2D _group_0_binding_0;
 
 layout(location = 0) out vec4 _fs2p_location0;
 
-vec4 test(highp sampler2D Passed_Texture, ) {
+vec4 test(highp sampler2D Passed_Texture) {
     vec4 _expr7 = texture(Passed_Texture, vec2(vec2(0.0, 0.0)));
     return _expr7;
 }
 
 void main() {
-    vec4 _expr2 = test(_group_0_binding_0, );
+    vec4 _expr2 = test(_group_0_binding_0);
     _fs2p_location0 = _expr2;
     return;
 }

--- a/tests/out/msl/texture-arg.msl
+++ b/tests/out/msl/texture-arg.msl
@@ -1,0 +1,22 @@
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+
+metal::float4 test(
+    metal::texture2d<float, metal::access::sample> Passed_Texture,
+    metal::sampler Passed_Sampler
+) {
+    metal::float4 _e7 = Passed_Texture.sample(Passed_Sampler, metal::float2(0.0, 0.0));
+    return _e7;
+}
+
+struct main1Output {
+    metal::float4 member [[color(0)]];
+};
+fragment main1Output main1(
+  metal::texture2d<float, metal::access::sample> Texture [[user(fake0)]]
+, metal::sampler Sampler [[user(fake0)]]
+) {
+    metal::float4 _e2 = test(Texture, Sampler);
+    return main1Output { _e2 };
+}

--- a/tests/out/wgsl/texture-arg.wgsl
+++ b/tests/out/wgsl/texture-arg.wgsl
@@ -1,0 +1,15 @@
+[[group(0), binding(0)]]
+var Texture: texture_2d<f32>;
+[[group(0), binding(1)]]
+var Sampler: sampler;
+
+fn test(Passed_Texture: texture_2d<f32>, Passed_Sampler: sampler) -> vec4<f32> {
+    let _e7: vec4<f32> = textureSample(Passed_Texture, Passed_Sampler, vec2<f32>(0.0, 0.0));
+    return _e7;
+}
+
+[[stage(fragment)]]
+fn main() -> [[location(0)]] vec4<f32> {
+    let _e2: vec4<f32> = test(Texture, Sampler);
+    return _e2;
+}

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -372,6 +372,10 @@ fn convert_wgsl() {
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::WGSL,
         ),
         ("bounds-check-zero", Targets::SPIRV),
+        (
+            "texture-arg",
+            Targets::METAL | Targets::GLSL | Targets::WGSL,
+        ),
     ];
 
     for &(name, targets) in inputs.iter() {


### PR DESCRIPTION
WIP.

spv-in accepts shaders with sampling using a function argument and the validator partially supports it, the `sampling_set` of `FunctionInfo` only supports globals still so it can't validate shaders with this yet.