### PR TITLE
[spv-out] Track block termination statically.

### DIFF
--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -528,7 +528,7 @@ impl<W: Write> Writer<W> {
                 if let Some(storage_class) = storage_class_str(class) {
                     write!(self.out, "<{}>", storage_class)?;
                 }
-            },
+            }
             _ => {
                 return Err(Error::Unimplemented(format!(
                     "write_value_type {:?}",


### PR DESCRIPTION
Rather than giving `Block` an optional `terminator` field in addition to its
`body`, track block termination statically, with two types:

- `Block` is a block without a termination instruction. This is what most code
  generation functions operate on.

- `TerminatedBlock` is a block with a termination instruction. This is what
  `Function::blocks` holds.

The `Function::consume` method takes a `Block` by value, together with a
termination instruction, and turns it into a `TerminatedBlock`.

This lets us remove some unwraps and awkward conditions.

As part of this change, `Writer::write_block` no longer hits an `unimplemented!`
for Naga statements following `Break`, `Return`, and so on. Instead, it simply
doesn't emit code for them, which is a correct translation. If we want to forbid
these, we should handle that in validation instead.