### PR TITLE
glsl-out: adjust coordinate space

### DIFF
--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -797,10 +797,7 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
                             //TODO: declaration
                             // type_qualifier IDENTIFIER SEMICOLON
                             // type_qualifier IDENTIFIER identifier_list SEMICOLON
-                            Err(ErrorKind::NotImplemented(
-                                token.meta,
-                                "variable qualifier",
-                            ))
+                            Err(ErrorKind::NotImplemented(token.meta, "variable qualifier"))
                         }
                     }
                     TokenValue::Semicolon => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -942,7 +942,7 @@ pub enum Expression {
     },
     /// Constant value.
     ///
-    /// Every `Constant` expression 
+    /// Every `Constant` expression
     Constant(Handle<Constant>),
     /// Splat scalar into a vector.
     Splat {

--- a/tests/in/interpolate.param.ron
+++ b/tests/in/interpolate.param.ron
@@ -5,6 +5,7 @@
 	spv_adjust_coordinate_space: true,
 	glsl: (
 		version: Desktop(400),
+		writer_flags: (bits: 0),
 		binding_map: {},
 	),
 	glsl_custom: true,

--- a/tests/in/skybox.param.ron
+++ b/tests/in/skybox.param.ron
@@ -38,6 +38,7 @@
 	glsl_custom: true,
 	glsl: (
 		version: Embedded(320),
+		writer_flags: (bits: 0),
 		binding_map: {
 			(group: 0, binding: 0): 0,
 			(group: 0, binding: 1): 0,

--- a/tests/out/glsl/quad-vert.main.Vertex.glsl
+++ b/tests/out/glsl/quad-vert.main.Vertex.glsl
@@ -49,6 +49,7 @@ void main() {
     type10 _tmp_return = type10(_expr10, _expr11, _expr12, _expr13, _expr14);
     _vs2fs_location0 = _tmp_return.member;
     gl_Position = _tmp_return.gen_gl_Position;
+    gl_Position.z = gl_Position.z * 2.0 - gl_Position.w;
     return;
 }
 

--- a/tests/out/glsl/quad.main.Vertex.glsl
+++ b/tests/out/glsl/quad.main.Vertex.glsl
@@ -17,6 +17,7 @@ void main() {
     VertexOutput _tmp_return = VertexOutput(uv, vec4((1.2 * pos), 0.0, 1.0));
     _vs2fs_location0 = _tmp_return.uv;
     gl_Position = _tmp_return.position;
+    gl_Position.z = gl_Position.z * 2.0 - gl_Position.w;
     return;
 }
 

--- a/tests/out/glsl/shadow.fs_main.Fragment.glsl
+++ b/tests/out/glsl/shadow.fs_main.Fragment.glsl
@@ -28,7 +28,7 @@ float fetch_shadow(uint light_id, vec4 homogeneous_coords) {
     }
     vec2 flip_correction = vec2(0.5, -0.5);
     vec2 light_local = (((homogeneous_coords.xy * flip_correction) / vec2(homogeneous_coords.w)) + vec2(0.5, 0.5));
-    float _expr26 = textureGrad(_group_0_binding_2, vec4(light_local, int(light_id), (homogeneous_coords.z / homogeneous_coords.w)), vec2(0, 0), vec2(0,0));
+    float _expr26 = textureGrad(_group_0_binding_2, vec4(light_local, int(light_id), (homogeneous_coords.z / homogeneous_coords.w)), vec2(0,0), vec2(0,0));
     return _expr26;
 }
 


### PR DESCRIPTION
Similar to SPIR-V, by default we should assume the "native" coordinate space of the language. In case of OpenGL, this means depth from -1 to 1.
@JCapucho we'll need to do something opposite for glsl-in, unless we are already doing something :)

Draft because I'm still figuring out how to make `shadow` example working