### PR TITLE
[glsl-in] Implicitly splat the results of clamp()

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -883,6 +883,25 @@ impl<'function> Context<'function> {
 
         Ok(())
     }
+
+    pub fn implicit_splat(
+        &mut self,
+        program: &mut Program,
+        expr: &mut Handle<Expression>,
+        meta: SourceMetadata,
+        vector_size: Option<VectorSize>,
+    ) -> Result<(), ErrorKind> {
+        let expr_type = program.resolve_type(self, *expr, meta)?;
+
+        if let (&TypeInner::Scalar { .. }, Some(size)) = (expr_type, vector_size) {
+            *expr = self.expressions.append(Expression::Splat {
+                size,
+                value: *expr,
+            })
+        }
+
+        Ok(())
+    }
 }
 
 pub fn type_power(kind: ScalarKind) -> Option<u32> {

--- a/tests/in/glsl/clamp-splat.vert
+++ b/tests/in/glsl/clamp-splat.vert
@@ -1,0 +1,6 @@
+#version 450
+layout(location = 0) in vec2 a_pos;
+
+void main() {
+  gl_Position = vec4(clamp(a_pos, 0.0, 1.0), 0.0, 1.0);
+}

--- a/tests/out/wgsl/clamp-splat-vert.wgsl
+++ b/tests/out/wgsl/clamp-splat-vert.wgsl
@@ -1,0 +1,20 @@
+struct VertexOutput {
+    [[builtin(position)]] member: vec4<f32>;
+};
+
+var<private> a_pos1: vec2<f32>;
+var<private> gl_Position: vec4<f32>;
+
+fn main1() {
+    let _e2: vec2<f32> = a_pos1;
+    gl_Position = vec4<f32>(clamp(_e2, vec2<f32>(0.0), vec2<f32>(1.0)), 0.0, 1.0);
+    return;
+}
+
+[[stage(vertex)]]
+fn main([[location(0), interpolate(perspective)]] a_pos: vec2<f32>) -> VertexOutput {
+    a_pos1 = a_pos;
+    main1();
+    let _e3: vec4<f32> = gl_Position;
+    return VertexOutput(_e3);
+}


### PR DESCRIPTION
Fixes #1049.