### PR TITLE
[msl-out] Add 'this' as a reserved keyword

### DIFF
--- a/src/back/msl/keywords.rs
+++ b/src/back/msl/keywords.rs
@@ -55,6 +55,7 @@ pub const RESERVED: &[&str] = &[
     "vec_step",
     "visible",
     "as_type",
+    "this",
     // qualifiers
     "mutable",
     "static",


### PR DESCRIPTION
It seems that `this` is a reserved keyword in metal. Mark it as such.