### PR TITLE
wgsl-in: add more error tests

### DIFF
--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -197,7 +197,7 @@ impl<'a> Lexer<'a> {
         (token, rest)
     }
 
-    fn current_byte_offset(&self) -> usize {
+    pub(super) fn current_byte_offset(&self) -> usize {
         self.source.len() - self.input.len()
     }
 

--- a/src/valid/type.rs
+++ b/src/valid/type.rs
@@ -241,7 +241,7 @@ impl super::Validator {
                 // the type of an `AccessIndex` expression referring to a
                 // dynamically sized array appearing as the final member of a
                 // top-level `Struct`. But such pointers cannot be passed to
-                // functions, stored in varibles, etc. So, we mark them as not
+                // functions, stored in variables, etc. So, we mark them as not
                 // `DATA`.
                 let base_info = &self.types[base.index()];
                 let data_flag = if base_info.flags.contains(TypeFlags::SIZED) {


### PR DESCRIPTION
Most errors still need improvements (using debug output for type handles, better descriptions, etc.), but just trying to capture most of the existing behavior for now, and switch to spans wherever it's easily possible.

We cover most of `wgsl::Error` with snapshots now, but still missing a few places (e.g. `ResolveError` variants or all of the possible cases for `Unexpected` tokens).