### PR TITLE
[hlsl-out] More improvements 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ validate-hlsl: $(SNAPSHOTS_BASE_OUT)/hlsl/*.hlsl
 		fragment="" \
 		compute="" \
 		. $${config}; \
-		DXC_PARAMS="-Wno-parentheses-equality -Zi -Qembed_debug;" \
+		DXC_PARAMS="-Wno-parentheses-equality -Zi -Qembed_debug"; \
 		[ ! -z "$${vertex}" ] && echo "Vertex Stage:" && dxc $${file} -T $${vertex} -E $${vertex_name} $${DXC_PARAMS} > /dev/null; \
 		[ ! -z "$${fragment}" ] && echo "Fragment Stage:" && dxc $${file} -T $${fragment} -E $${fragment_name} $${DXC_PARAMS} > /dev/null; \
 		[ ! -z "$${compute}" ] && echo "Compute Stage:" && dxc $${file} -T $${compute} -E $${compute_name} $${DXC_PARAMS} > /dev/null; \

--- a/src/back/hlsl/mod.rs
+++ b/src/back/hlsl/mod.rs
@@ -50,11 +50,10 @@ impl Default for Options {
 
 /// Structure that contains a reflection info
 pub struct ReflectionInfo {
-    /// Information about all entry points (stage, name).
-    /// HLSL backend returns information about all entry points in shaders that will be allowed by the `hlsl` compiler.
+    /// Real name of entry point allowed by the `hlsl` compiler.
     /// For example:
     /// the entry point with the name `line` is valid for `wgsl`, but not valid for `hlsl`, because `line` is a reserved keyword.
-    pub entry_points: Vec<(crate::ShaderStage, String)>,
+    pub entry_points: Vec<String>,
     // TODO: locations
 }
 

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -188,7 +188,7 @@ impl<'a, W: Write> Writer<'a, W> {
                 writeln!(self.out)?;
             }
 
-            entry_points_info.push((ep.stage, name))
+            entry_points_info.push(name);
         }
 
         Ok(super::ReflectionInfo {

--- a/tests/out/hlsl/interface.hlsl
+++ b/tests/out/hlsl/interface.hlsl
@@ -1,0 +1,51 @@
+struct VertexOutput {
+    float4 position : SV_Position;
+    float varying : LOC1;
+};
+
+struct FragmentOutput {
+    float depth : SV_Depth;
+    uint sample_mask : SV_Coverage;
+    float color : SV_Target0;
+};
+
+struct VertexInput_vertex {
+    uint vertex_index1 : SV_VertexID;
+    uint instance_index1 : SV_InstanceID;
+    uint color1 : LOC10;
+};
+
+struct FragmentInput_fragment {
+    VertexOutput in2;
+    bool front_facing1 : SV_IsFrontFace;
+    uint sample_index1 : SV_SampleIndex;
+    uint sample_mask1 : SV_Coverage;
+};
+
+struct ComputeInput_compute {
+    uint3 global_id1 : SV_DispatchThreadID;
+    uint3 local_id1 : SV_GroupThreadID;
+    uint local_index1 : SV_GroupIndex;
+    uint3 wg_id1 : SV_GroupID;
+};
+
+VertexOutput vertex(VertexInput_vertex vertexinput_vertex)
+{
+    uint tmp = ((vertexinput_vertex.vertex_index1 + vertexinput_vertex.instance_index1) + vertexinput_vertex.color1);
+    const VertexOutput vertexoutput1 = { float4(1.0.xxxx), float(tmp) };
+    return vertexoutput1;
+}
+
+FragmentOutput fragment(FragmentInput_fragment fragmentinput_fragment)
+{
+    uint mask = (fragmentinput_fragment.sample_mask1 & (1u << fragmentinput_fragment.sample_index1));
+    float color2 = (fragmentinput_fragment.front_facing1 ? 0.0 : 1.0);
+    const FragmentOutput fragmentoutput1 = { fragmentinput_fragment.in2.varying, mask, color2 };
+    return fragmentoutput1;
+}
+
+[numthreads(1, 1, 1)]
+void compute(ComputeInput_compute computeinput_compute)
+{
+    return;
+}

--- a/tests/out/hlsl/interface.hlsl.config
+++ b/tests/out/hlsl/interface.hlsl.config
@@ -1,0 +1,6 @@
+vertex=vs_5_0
+vertex_name=vertex
+fragment=ps_5_0
+fragment_name=fragment
+compute=cs_5_0
+compute_name=compute

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -374,7 +374,10 @@ fn convert_wgsl() {
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,
         ),
         //TODO: GLSL https://github.com/gfx-rs/naga/issues/874
-        ("interface", Targets::SPIRV | Targets::METAL | Targets::WGSL),
+        (
+            "interface",
+            Targets::SPIRV | Targets::METAL | Targets::HLSL | Targets::WGSL,
+        ),
         (
             "globals",
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::WGSL,

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -284,8 +284,8 @@ fn write_output_hlsl(
     // This file contains an info about profiles (shader stages) contains inside generated shader
     // This info will be passed to dxc
     let mut config_str = String::from("");
-    for (stage, name) in reflection_info.entry_points.iter() {
-        let stage_str = match stage {
+    for (index, ep) in module.entry_points.iter().enumerate() {
+        let stage_str = match ep.stage {
             naga::ShaderStage::Vertex => "vertex",
             naga::ShaderStage::Fragment => "fragment",
             naga::ShaderStage::Compute => "compute",
@@ -294,9 +294,9 @@ fn write_output_hlsl(
             "{}{}={}\n{}_name={}\n",
             config_str,
             stage_str,
-            options.shader_model.to_profile_string(*stage),
+            options.shader_model.to_profile_string(ep.stage),
             stage_str,
-            name
+            &reflection_info.entry_points[index]
         );
     }
     fs::write(


### PR DESCRIPTION
1. Implement `Select` expression.
2. Enable `interface` snapshot
3. Return only real names for entry point in ReflectionInfo, instead of tuple (stage, name).
4. Properly write locations for fragment output (`SV_TargetN`, instead of `LOCN`)