### PR TITLE
[glsl-in] Improvements and fixes

### DIFF
--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -189,7 +189,21 @@ impl Program<'_> {
             }
             FunctionCallKind::Function(name) => {
                 match name.as_str() {
-                    "sampler2D" => {
+                    "sampler1D"
+                    | "sampler1DArray"
+                    | "sampler2D"
+                    | "sampler2DArray"
+                    | "sampler2DMS"
+                    | "sampler2DMSArray"
+                    | "sampler3D"
+                    | "samplerCube"
+                    | "samplerCubeArray"
+                    | "sampler1DShadow"
+                    | "sampler1DArrayShadow"
+                    | "sampler2DShadow"
+                    | "sampler2DArrayShadow"
+                    | "samplerCubeShadow"
+                    | "samplerCubeArrayShadow" => {
                         if args.len() != 2 {
                             return Err(ErrorKind::wrong_function_args(name, 2, args.len(), meta));
                         }

--- a/tests/out/wgsl/246-collatz-comp.wgsl
+++ b/tests/out/wgsl/246-collatz-comp.wgsl
@@ -9,11 +9,10 @@ var<private> gl_GlobalInvocationID: vec3<u32>;
 
 fn collatz_iterations(n: u32) -> u32 {
     var n1: u32;
-    var i: u32;
+    var i: u32 = 0u;
     var local: u32;
 
     n1 = n;
-    i = u32(0);
     loop {
         let _e7: u32 = n1;
         if (!((_e7 != u32(1)))) {

--- a/tests/out/wgsl/constant-array-size-vert.wgsl
+++ b/tests/out/wgsl/constant-array-size-vert.wgsl
@@ -7,11 +7,10 @@ struct Data {
 var<uniform> global: Data;
 
 fn function() -> vec4<f32> {
-    var sum: vec4<f32>;
+    var sum: vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);
     var i: i32 = 0;
     var local: i32;
 
-    sum = vec4<f32>(f32(0));
     loop {
         let _e9: i32 = i;
         if (!((_e9 < 42))) {


### PR DESCRIPTION
yet another one of these types of PR, this time we have
- Support for parsing all texture types and for shadow samplers
- Implicit splatting of arguments for the `max` builtin
- A fix for implicit conversions using bitcast instead of a regular cast
- Support for parsing array initializers of the form `type[maybe_size](components)`, glsl has this quirk that initializers for arrays without a size aren't actually dynamic but the size comes from the argument count, so things like `float[](1,2,3,4)` is of type `float[4]`