### PR TITLE
[spv-out] Move cached expression table to BlockContext.

### DIFF
--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -197,7 +197,7 @@ impl<'w> BlockContext<'w> {
 
             // The chain rule: if this `Access...`'s `base` operand was
             // previously omitted, then omit this one, too.
-            _ => self.writer.cached.ids[expr_handle.index()] == 0,
+            _ => self.cached.ids[expr_handle.index()] == 0,
         }
     }
 
@@ -1150,7 +1150,7 @@ impl<'w> BlockContext<'w> {
             crate::Expression::ArrayLength(expr) => self.write_runtime_array_length(expr, block)?,
         };
 
-        self.writer.cached[expr_handle] = id;
+        self.cached[expr_handle] = id;
         Ok(())
     }
 
@@ -1578,7 +1578,7 @@ impl<'w> BlockContext<'w> {
 
                     let type_id = match result {
                         Some(expr) => {
-                            self.writer.cached[expr] = id;
+                            self.cached[expr] = id;
                             self.writer.lookup_function_call.insert(expr, id);
                             let ty_handle = self.ir_module.functions[local_function]
                                 .result

--- a/src/back/spv/index.rs
+++ b/src/back/spv/index.rs
@@ -177,7 +177,7 @@ impl<'w> BlockContext<'w> {
         index: Handle<crate::Expression>,
         block: &mut Block,
     ) -> Result<BoundsCheckResult, Error> {
-        let index_id = self.cached(index);
+        let index_id = self.cached[index];
 
         // Get the sequence's maximum valid index. Return early if we've already
         // done the bounds check.
@@ -237,7 +237,7 @@ impl<'w> BlockContext<'w> {
         index: Handle<crate::Expression>,
         block: &mut Block,
     ) -> Result<BoundsCheckResult, Error> {
-        let index_id = self.cached(index);
+        let index_id = self.cached[index];
 
         // Get the sequence's length. Return early if we've already done the
         // bounds check.
@@ -367,7 +367,7 @@ impl<'w> BlockContext<'w> {
                 self.write_index_comparison(base, index, block)?
             }
             IndexBoundsCheckPolicy::UndefinedBehavior => {
-                BoundsCheckResult::Computed(self.cached(index))
+                BoundsCheckResult::Computed(self.cached[index])
             }
         })
     }
@@ -384,8 +384,8 @@ impl<'w> BlockContext<'w> {
     ) -> Result<Word, Error> {
         let result_type_id = self.get_expression_type_id(&self.fun_info[expr_handle].ty)?;
 
-        let base_id = self.cached(base);
-        let index_id = self.cached(index);
+        let base_id = self.cached[base];
+        let index_id = self.cached[index];
 
         let result_id = match self.write_bounds_check(base, index, block)? {
             BoundsCheckResult::KnownInBounds(known_index) => {

--- a/src/back/spv/mod.rs
+++ b/src/back/spv/mod.rs
@@ -366,10 +366,6 @@ impl BlockContext<'_> {
         self.writer
             .get_constant_scalar(crate::ScalarValue::Uint(index as _), 4)
     }
-
-    fn cached(&self, expression: Handle<crate::Expression>) -> Word {
-        self.cached[expression]
-    }
 }
 
 #[derive(Clone, Copy, Default)]


### PR DESCRIPTION
Since the table of cached expressions is only meaningful within a single
function, it's really something that should only be accessed from
`BlockContext`.

However, to save heap allocations, it makes sense to retain it in the `Writer`
between functions. But the `Writer` field should have a different name, to
ensure people don't use it by accident.
