### PR TITLE
[glsl-in] more fixes

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -511,9 +511,19 @@ impl<'function> Context<'function> {
                 let (mut left, left_meta) = self.lower_expect(program, left, false, body)?;
                 let (mut right, right_meta) = self.lower_expect(program, right, false, body)?;
 
-                self.binary_implicit_conversion(
-                    program, &mut left, left_meta, &mut right, right_meta,
-                )?;
+                match op {
+                    BinaryOperator::ShiftLeft | BinaryOperator::ShiftRight => self
+                        .implicit_conversion(
+                            program,
+                            &mut right,
+                            right_meta,
+                            ScalarKind::Uint,
+                            4,
+                        )?,
+                    _ => self.binary_implicit_conversion(
+                        program, &mut left, left_meta, &mut right, right_meta,
+                    )?,
+                }
 
                 program.typifier_grow(self, left, left_meta)?;
                 program.typifier_grow(self, right, right_meta)?;

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -795,7 +795,7 @@ impl Program<'_> {
                                         Expression::Swizzle { .. }
                                     )
                                 {
-                                    let ty = self.module.types.append(Type {
+                                    let ty = self.module.types.fetch_or_append(Type {
                                         name: None,
                                         inner: TypeInner::Vector { size, kind, width },
                                     });

--- a/src/front/glsl/types.rs
+++ b/src/front/glsl/types.rs
@@ -133,12 +133,6 @@ pub fn parse_type(type_name: &str) -> Option<Type> {
                     "3D" => (ImageDimension::D3, false, sampled(false)),
                     "Cube" => (ImageDimension::Cube, false, sampled(false)),
                     "CubeArray" => (ImageDimension::D2, false, sampled(false)),
-                    "1DShadow" => (ImageDimension::D1, false, ImageClass::Depth),
-                    "1DArrayShadow" => (ImageDimension::D1, true, ImageClass::Depth),
-                    "2DShadow" => (ImageDimension::D2, false, ImageClass::Depth),
-                    "2DArrayShadow" => (ImageDimension::D2, true, ImageClass::Depth),
-                    "CubeShadow" => (ImageDimension::Cube, false, ImageClass::Depth),
-                    "CubeArrayShadow" => (ImageDimension::Cube, true, ImageClass::Depth),
                     _ => return None,
                 };
 

--- a/tests/in/glsl/900-implicit-conversions.vert
+++ b/tests/in/glsl/900-implicit-conversions.vert
@@ -9,7 +9,14 @@ void exact(int a) {}
 void implicit(float a) {}
 void implicit(int a) {}
 
+// All satisfy the kind condition but they have different dimensions
+void implicit_dims(float v) {  }
+void implicit_dims(vec2 v) {  }
+void implicit_dims(vec3 v) {  }
+void implicit_dims(vec4 v) {  }
+
 void main() {
   exact(1);
   implicit(1u);
+  implicit_dims(ivec3(1));
 }

--- a/tests/out/wgsl/900-implicit-conversions-vert.wgsl
+++ b/tests/out/wgsl/900-implicit-conversions-vert.wgsl
@@ -26,9 +26,38 @@ fn implicit1(a6: i32) {
     return;
 }
 
+fn implicit_dims(v: f32) {
+    var v1: f32;
+
+    v1 = v;
+    return;
+}
+
+fn implicit_dims1(v2: vec2<f32>) {
+    var v3: vec2<f32>;
+
+    v3 = v2;
+    return;
+}
+
+fn implicit_dims2(v4: vec3<f32>) {
+    var v5: vec3<f32>;
+
+    v5 = v4;
+    return;
+}
+
+fn implicit_dims3(v6: vec4<f32>) {
+    var v7: vec4<f32>;
+
+    v7 = v6;
+    return;
+}
+
 fn main1() {
     exact1(1);
     implicit(f32(1u));
+    implicit_dims2(vec3<f32>(vec3<i32>(1)));
     return;
 }
 


### PR DESCRIPTION
Things fixed:
- Type dimensions are now checked when implicit casting function calls (closes #1011)
- The right-side argument of a shifts are now implicitly casted to uint instead of the other argument's kind (closes #1062)
- Proxy writes now `fetch_or_append` the type (closes #1020)
- Adds supports for the `textureProj` call
- Removes the wrong textureShadow types that I incidentally introduced in #1074 (sorry)