### PR TITLE
Improve WGSL interpolation attributes

### DIFF
--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -324,30 +324,25 @@ impl<W: Write> Writer<W> {
                 Attribute::Binding(id) => format!("binding({})", id),
                 Attribute::Group(id) => format!("group({})", id),
                 Attribute::Interpolate(interpolation, sampling) => {
-                    let sampling_part = match sampling {
-                        Some(sampling) if sampling != crate::Sampling::default() => {
-                            Some(sampling_str(sampling))
-                        }
-                        _ => None,
-                    };
-                    let parts: Vec<_> = vec![
-                        if sampling_part.is_some()
-                            || (interpolation.is_some()
-                                && interpolation != Some(crate::Interpolation::default()))
-                        {
-                            Some(interpolation_str(interpolation.unwrap_or_default()))
-                        } else {
-                            None
-                        },
-                        sampling_part,
-                    ]
-                    .into_iter()
-                    .flatten()
-                    .collect();
-                    if parts.is_empty() {
-                        String::from("")
+                    if sampling.is_some() && sampling != Some(crate::Sampling::Center) {
+                        format!(
+                            "interpolate({}, {})",
+                            interpolation_str(
+                                interpolation.unwrap_or(crate::Interpolation::Perspective)
+                            ),
+                            sampling_str(sampling.unwrap_or(crate::Sampling::Center))
+                        )
+                    } else if interpolation.is_some()
+                        && interpolation != Some(crate::Interpolation::Perspective)
+                    {
+                        format!(
+                            "interpolate({})",
+                            interpolation_str(
+                                interpolation.unwrap_or(crate::Interpolation::Perspective)
+                            )
+                        )
                     } else {
-                        format!("interpolate({})", parts.join(", "))
+                        String::from("")
                     }
                 }
             };

--- a/src/front/wgsl/conv.rs
+++ b/src/front/wgsl/conv.rs
@@ -52,6 +52,7 @@ pub fn map_interpolation(word: &str, span: Span) -> Result<crate::Interpolation,
 
 pub fn map_sampling(word: &str, span: Span) -> Result<crate::Sampling, Error<'_>> {
     match word {
+        "center" => Ok(crate::Sampling::Center),
         "centroid" => Ok(crate::Sampling::Centroid),
         "sample" => Ok(crate::Sampling::Sample),
         _ => Err(Error::UnknownAttribute(span)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,6 +340,12 @@ pub enum Interpolation {
     Flat,
 }
 
+impl Default for Interpolation {
+    fn default() -> Self {
+        Self::Perspective
+    }
+}
+
 /// The sampling qualifiers of a binding or struct field.
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
@@ -356,6 +362,12 @@ pub enum Sampling {
     /// Interpolate the value at each sample location. In multisampling, invoke
     /// the fragment shader once per sample.
     Sample,
+}
+
+impl Default for Sampling {
+    fn default() -> Self {
+        Self::Center
+    }
 }
 
 /// Member of a user-defined structure.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,12 +340,6 @@ pub enum Interpolation {
     Flat,
 }
 
-impl Default for Interpolation {
-    fn default() -> Self {
-        Self::Perspective
-    }
-}
-
 /// The sampling qualifiers of a binding or struct field.
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
@@ -362,12 +356,6 @@ pub enum Sampling {
     /// Interpolate the value at each sample location. In multisampling, invoke
     /// the fragment shader once per sample.
     Sample,
-}
-
-impl Default for Sampling {
-    fn default() -> Self {
-        Self::Center
-    }
 }
 
 /// Member of a user-defined structure.

--- a/tests/in/interpolate.wgsl
+++ b/tests/in/interpolate.wgsl
@@ -1,14 +1,14 @@
-//TODO: mere with "interface"?
+//TODO: merge with "interface"?
 
 struct FragmentInput {
   [[builtin(position)]] position: vec4<f32>;
   [[location(0), interpolate(flat)]] flat : u32;
   [[location(1), interpolate(linear)]] linear : f32;
-  [[location(2), interpolate(linear,centroid)]] linear_centroid : vec2<f32>;
-  [[location(3), interpolate(linear,sample)]] linear_sample : vec3<f32>;
+  [[location(2), interpolate(linear, centroid)]] linear_centroid : vec2<f32>;
+  [[location(3), interpolate(linear, sample)]] linear_sample : vec3<f32>;
   [[location(4), interpolate(perspective)]] perspective : vec4<f32>;
-  [[location(5), interpolate(perspective,centroid)]] perspective_centroid : f32;
-  [[location(6), interpolate(perspective,sample)]] perspective_sample : f32;
+  [[location(5), interpolate(perspective, centroid)]] perspective_centroid : f32;
+  [[location(6), interpolate(perspective, sample)]] perspective_sample : f32;
 };
 
 [[stage(vertex)]]

--- a/tests/out/wgsl/210-bevy-2d-shader-frag.wgsl
+++ b/tests/out/wgsl/210-bevy-2d-shader-frag.wgsl
@@ -4,7 +4,7 @@ struct ColorMaterial_color {
 };
 
 struct FragmentOutput {
-    [[location(0), interpolate(perspective)]] o_Target: vec4<f32>;
+    [[location(0)]] o_Target: vec4<f32>;
 };
 
 var<private> v_Uv: vec2<f32>;

--- a/tests/out/wgsl/210-bevy-2d-shader-vert.wgsl
+++ b/tests/out/wgsl/210-bevy-2d-shader-vert.wgsl
@@ -14,7 +14,7 @@ struct Sprite_size {
 };
 
 struct VertexOutput {
-    [[location(0), interpolate(perspective)]] v_Uv: vec2<f32>;
+    [[location(0)]] v_Uv: vec2<f32>;
     [[builtin(position)]] member: vec4<f32>;
 };
 
@@ -46,7 +46,7 @@ fn main1() {
 }
 
 [[stage(vertex)]]
-fn main([[location(0), interpolate(perspective)]] Vertex_Position: vec3<f32>, [[location(2), interpolate(perspective)]] Vertex_Uv: vec2<f32>) -> VertexOutput {
+fn main([[location(0)]] Vertex_Position: vec3<f32>, [[location(2)]] Vertex_Uv: vec2<f32>) -> VertexOutput {
     Vertex_Position1 = Vertex_Position;
     Vertex_Uv1 = Vertex_Uv;
     main1();

--- a/tests/out/wgsl/210-bevy-shader-vert.wgsl
+++ b/tests/out/wgsl/210-bevy-shader-vert.wgsl
@@ -9,9 +9,9 @@ struct Transform {
 };
 
 struct VertexOutput {
-    [[location(0), interpolate(perspective)]] v_Position: vec3<f32>;
-    [[location(1), interpolate(perspective)]] v_Normal: vec3<f32>;
-    [[location(2), interpolate(perspective)]] v_Uv: vec2<f32>;
+    [[location(0)]] v_Position: vec3<f32>;
+    [[location(1)]] v_Normal: vec3<f32>;
+    [[location(2)]] v_Uv: vec2<f32>;
     [[builtin(position)]] member: vec4<f32>;
 };
 
@@ -46,7 +46,7 @@ fn main1() {
 }
 
 [[stage(vertex)]]
-fn main([[location(0), interpolate(perspective)]] Vertex_Position: vec3<f32>, [[location(1), interpolate(perspective)]] Vertex_Normal: vec3<f32>, [[location(2), interpolate(perspective)]] Vertex_Uv: vec2<f32>) -> VertexOutput {
+fn main([[location(0)]] Vertex_Position: vec3<f32>, [[location(1)]] Vertex_Normal: vec3<f32>, [[location(2)]] Vertex_Uv: vec2<f32>) -> VertexOutput {
     Vertex_Position1 = Vertex_Position;
     Vertex_Normal1 = Vertex_Normal;
     Vertex_Uv1 = Vertex_Uv;

--- a/tests/out/wgsl/800-out-of-bounds-panic-vert.wgsl
+++ b/tests/out/wgsl/800-out-of-bounds-panic-vert.wgsl
@@ -9,7 +9,7 @@ struct VertexPushConstants {
 };
 
 struct VertexOutput {
-    [[location(0), interpolate(perspective)]] frag_color: vec4<f32>;
+    [[location(0)]] frag_color: vec4<f32>;
     [[builtin(position)]] member: vec4<f32>;
 };
 
@@ -32,7 +32,7 @@ fn main1() {
 }
 
 [[stage(vertex)]]
-fn main([[location(0), interpolate(perspective)]] position: vec2<f32>, [[location(1), interpolate(perspective)]] color: vec4<f32>) -> VertexOutput {
+fn main([[location(0)]] position: vec2<f32>, [[location(1)]] color: vec4<f32>) -> VertexOutput {
     position1 = position;
     color1 = color;
     main1();

--- a/tests/out/wgsl/bevy-pbr-frag.wgsl
+++ b/tests/out/wgsl/bevy-pbr-frag.wgsl
@@ -53,7 +53,7 @@ struct StandardMaterial_emissive {
 };
 
 struct FragmentOutput {
-    [[location(0), interpolate(perspective)]] o_Target: vec4<f32>;
+    [[location(0)]] o_Target: vec4<f32>;
 };
 
 var<private> v_WorldPosition1: vec3<f32>;
@@ -842,7 +842,7 @@ fn main1() {
 }
 
 [[stage(fragment)]]
-fn main([[location(0), interpolate(perspective)]] v_WorldPosition: vec3<f32>, [[location(1), interpolate(perspective)]] v_WorldNormal: vec3<f32>, [[location(2), interpolate(perspective)]] v_Uv: vec2<f32>, [[location(3), interpolate(perspective)]] v_WorldTangent: vec4<f32>, [[builtin(front_facing)]] param: bool) -> FragmentOutput {
+fn main([[location(0)]] v_WorldPosition: vec3<f32>, [[location(1)]] v_WorldNormal: vec3<f32>, [[location(2)]] v_Uv: vec2<f32>, [[location(3)]] v_WorldTangent: vec4<f32>, [[builtin(front_facing)]] param: bool) -> FragmentOutput {
     v_WorldPosition1 = v_WorldPosition;
     v_WorldNormal1 = v_WorldNormal;
     v_Uv1 = v_Uv;

--- a/tests/out/wgsl/bevy-pbr-vert.wgsl
+++ b/tests/out/wgsl/bevy-pbr-vert.wgsl
@@ -9,10 +9,10 @@ struct Transform {
 };
 
 struct VertexOutput {
-    [[location(0), interpolate(perspective)]] v_WorldPosition: vec3<f32>;
-    [[location(1), interpolate(perspective)]] v_WorldNormal: vec3<f32>;
-    [[location(2), interpolate(perspective)]] v_Uv: vec2<f32>;
-    [[location(3), interpolate(perspective)]] v_WorldTangent: vec4<f32>;
+    [[location(0)]] v_WorldPosition: vec3<f32>;
+    [[location(1)]] v_WorldNormal: vec3<f32>;
+    [[location(2)]] v_Uv: vec2<f32>;
+    [[location(3)]] v_WorldTangent: vec4<f32>;
     [[builtin(position)]] member: vec4<f32>;
 };
 
@@ -54,7 +54,7 @@ fn main1() {
 }
 
 [[stage(vertex)]]
-fn main([[location(0), interpolate(perspective)]] Vertex_Position: vec3<f32>, [[location(1), interpolate(perspective)]] Vertex_Normal: vec3<f32>, [[location(2), interpolate(perspective)]] Vertex_Uv: vec2<f32>, [[location(3), interpolate(perspective)]] Vertex_Tangent: vec4<f32>) -> VertexOutput {
+fn main([[location(0)]] Vertex_Position: vec3<f32>, [[location(1)]] Vertex_Normal: vec3<f32>, [[location(2)]] Vertex_Uv: vec2<f32>, [[location(3)]] Vertex_Tangent: vec4<f32>) -> VertexOutput {
     Vertex_Position1 = Vertex_Position;
     Vertex_Normal1 = Vertex_Normal;
     Vertex_Uv1 = Vertex_Uv;

--- a/tests/out/wgsl/bool-select-frag.wgsl
+++ b/tests/out/wgsl/bool-select-frag.wgsl
@@ -1,5 +1,5 @@
 struct FragmentOutput {
-    [[location(0), interpolate(perspective)]] o_color: vec4<f32>;
+    [[location(0)]] o_color: vec4<f32>;
 };
 
 var<private> o_color: vec4<f32>;

--- a/tests/out/wgsl/clamp-splat-vert.wgsl
+++ b/tests/out/wgsl/clamp-splat-vert.wgsl
@@ -12,7 +12,7 @@ fn main1() {
 }
 
 [[stage(vertex)]]
-fn main([[location(0), interpolate(perspective)]] a_pos: vec2<f32>) -> VertexOutput {
+fn main([[location(0)]] a_pos: vec2<f32>) -> VertexOutput {
     a_pos1 = a_pos;
     main1();
     let _e3: vec4<f32> = gl_Position;

--- a/tests/out/wgsl/extra.wgsl
+++ b/tests/out/wgsl/extra.wgsl
@@ -7,6 +7,6 @@ struct PushConstants {
 var<push_constant> pc: PushConstants;
 
 [[stage(fragment)]]
-fn main([[location(0), interpolate(perspective)]] color: vec4<f32>) -> [[location(0)]] vec4<f32> {
+fn main([[location(0)]] color: vec4<f32>) -> [[location(0)]] vec4<f32> {
     return color;
 }

--- a/tests/out/wgsl/interface.wgsl
+++ b/tests/out/wgsl/interface.wgsl
@@ -1,6 +1,6 @@
 struct VertexOutput {
     [[builtin(position)]] position: vec4<f32>;
-    [[location(1), interpolate(perspective)]] varying: f32;
+    [[location(1)]] varying: f32;
 };
 
 struct FragmentOutput {

--- a/tests/out/wgsl/interpolate.wgsl
+++ b/tests/out/wgsl/interpolate.wgsl
@@ -2,11 +2,11 @@ struct FragmentInput {
     [[builtin(position)]] position: vec4<f32>;
     [[location(0), interpolate(flat)]] flat: u32;
     [[location(1), interpolate(linear)]] linear: f32;
-    [[location(2), interpolate(linear,centroid)]] linear_centroid: vec2<f32>;
-    [[location(3), interpolate(linear,sample)]] linear_sample: vec3<f32>;
-    [[location(4), interpolate(perspective)]] perspective: vec4<f32>;
-    [[location(5), interpolate(perspective,centroid)]] perspective_centroid: f32;
-    [[location(6), interpolate(perspective,sample)]] perspective_sample: f32;
+    [[location(2), interpolate(linear, centroid)]] linear_centroid: vec2<f32>;
+    [[location(3), interpolate(linear, sample)]] linear_sample: vec3<f32>;
+    [[location(4)]] perspective: vec4<f32>;
+    [[location(5), interpolate(perspective, centroid)]] perspective_centroid: f32;
+    [[location(6), interpolate(perspective, sample)]] perspective_sample: f32;
 };
 
 [[stage(vertex)]]

--- a/tests/out/wgsl/multiple_entry_points-glsl.wgsl
+++ b/tests/out/wgsl/multiple_entry_points-glsl.wgsl
@@ -3,7 +3,7 @@ struct VertexOutput {
 };
 
 struct FragmentOutput {
-    [[location(0), interpolate(perspective)]] o_color: vec4<f32>;
+    [[location(0)]] o_color: vec4<f32>;
 };
 
 var<private> gl_Position: vec4<f32>;

--- a/tests/out/wgsl/quad-vert.wgsl
+++ b/tests/out/wgsl/quad-vert.wgsl
@@ -4,7 +4,7 @@ struct gl_PerVertex {
 };
 
 struct VertexOutput {
-    [[location(0), interpolate(perspective)]] member: vec2<f32>;
+    [[location(0)]] member: vec2<f32>;
     [[builtin(position)]] gl_Position: vec4<f32>;
 };
 

--- a/tests/out/wgsl/quad.wgsl
+++ b/tests/out/wgsl/quad.wgsl
@@ -1,5 +1,5 @@
 struct VertexOutput {
-    [[location(0), interpolate(perspective)]] uv: vec2<f32>;
+    [[location(0)]] uv: vec2<f32>;
     [[builtin(position)]] position: vec4<f32>;
 };
 
@@ -16,7 +16,7 @@ fn main([[location(0)]] pos: vec2<f32>, [[location(1)]] uv: vec2<f32>) -> Vertex
 }
 
 [[stage(fragment)]]
-fn main1([[location(0), interpolate(perspective)]] uv1: vec2<f32>) -> [[location(0)]] vec4<f32> {
+fn main1([[location(0)]] uv1: vec2<f32>) -> [[location(0)]] vec4<f32> {
     let color: vec4<f32> = textureSample(u_texture, u_sampler, uv1);
     if ((color.w == 0.0)) {
         discard;

--- a/tests/out/wgsl/quad_glsl-frag.wgsl
+++ b/tests/out/wgsl/quad_glsl-frag.wgsl
@@ -1,5 +1,5 @@
 struct FragmentOutput {
-    [[location(0), interpolate(perspective)]] o_color: vec4<f32>;
+    [[location(0)]] o_color: vec4<f32>;
 };
 
 var<private> v_uv: vec2<f32>;

--- a/tests/out/wgsl/quad_glsl-vert.wgsl
+++ b/tests/out/wgsl/quad_glsl-vert.wgsl
@@ -1,5 +1,5 @@
 struct VertexOutput {
-    [[location(0), interpolate(perspective)]] v_uv: vec2<f32>;
+    [[location(0)]] v_uv: vec2<f32>;
     [[builtin(position)]] member: vec4<f32>;
 };
 
@@ -17,7 +17,7 @@ fn main1() {
 }
 
 [[stage(vertex)]]
-fn main([[location(0), interpolate(perspective)]] a_pos: vec2<f32>, [[location(1), interpolate(perspective)]] a_uv: vec2<f32>) -> VertexOutput {
+fn main([[location(0)]] a_pos: vec2<f32>, [[location(1)]] a_uv: vec2<f32>) -> VertexOutput {
     a_pos1 = a_pos;
     a_uv1 = a_uv;
     main1();

--- a/tests/out/wgsl/shadow.wgsl
+++ b/tests/out/wgsl/shadow.wgsl
@@ -37,7 +37,7 @@ fn fetch_shadow(light_id: u32, homogeneous_coords: vec4<f32>) -> f32 {
 }
 
 [[stage(fragment)]]
-fn fs_main([[location(0), interpolate(perspective)]] raw_normal: vec3<f32>, [[location(1), interpolate(perspective)]] position: vec4<f32>) -> [[location(0)]] vec4<f32> {
+fn fs_main([[location(0)]] raw_normal: vec3<f32>, [[location(1)]] position: vec4<f32>) -> [[location(0)]] vec4<f32> {
     var color: vec3<f32> = vec3<f32>(0.05, 0.05, 0.05);
     var i: u32 = 0u;
 

--- a/tests/out/wgsl/skybox.wgsl
+++ b/tests/out/wgsl/skybox.wgsl
@@ -1,6 +1,6 @@
 struct VertexOutput {
     [[builtin(position)]] position: vec4<f32>;
-    [[location(0), interpolate(perspective)]] uv: vec3<f32>;
+    [[location(0)]] uv: vec3<f32>;
 };
 
 [[block]]


### PR DESCRIPTION
This PR improves Naga's WGSL output by omitting parts of interpolation attributes which match default values.

 It also enables the parsing of [`center` interpolation sampling](https://gpuweb.github.io/gpuweb/wgsl/#interpolation).