### PR TITLE
[wgsl] Implicitly readable global storage buffers

### DIFF
--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -3269,13 +3269,22 @@ impl Parser {
                         _ => crate::StorageClass::Private,
                     },
                 };
+                let storage_access = match class {
+                    crate::StorageClass::Storage => match module.types[pvar.ty].inner {
+                        crate::TypeInner::Struct { .. } | crate::TypeInner::Array { .. } => {
+                            pvar.access | crate::StorageAccess::LOAD
+                        }
+                        _ => pvar.access,
+                    },
+                    _ => pvar.access,
+                };
                 let var_handle = module.global_variables.append(crate::GlobalVariable {
                     name: Some(pvar.name.to_owned()),
                     class,
                     binding: binding.take(),
                     ty: pvar.ty,
                     init: pvar.init,
-                    storage_access: pvar.access,
+                    storage_access,
                 });
                 lookup_global_expression
                     .insert(pvar.name, crate::Expression::GlobalVariable(var_handle));

--- a/tests/in/access.wgsl
+++ b/tests/in/access.wgsl
@@ -9,15 +9,19 @@ struct Bar {
 [[group(0), binding(0)]]
 var<storage> bar: [[access(read_write)]] Bar;
 
+[[group(0), binding(1)]]
+var<storage> qux: Bar;
+
 [[stage(vertex)]]
 fn foo([[builtin(vertex_index)]] vi: u32) -> [[builtin(position)]] vec4<f32> {
-    var foo: f32 = 0.0;
-    // We should check that backed doesn't skip this expression
-    let baz: f32 = foo;
-    foo = 1.0;
+  var foo: f32 = 0.0;
+  // We should check that backend doesn't skip this expression
+  let baz: f32 = foo;
+  foo = 1.0;
 
 	let index = 3u;
 	let b = bar.matrix[index].x;
+	let q = qux.matrix[index].x;
 
 	let a = bar.data[arrayLength(&bar.data) - 2u];
 

--- a/tests/out/spv/access.spvasm
+++ b/tests/out/spv/access.spvasm
@@ -1,21 +1,22 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 58
+; Bound: 62
 OpCapability Shader
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Vertex %32 "foo" %27 %30
+OpEntryPoint Vertex %33 "foo" %28 %31
 OpSource GLSL 450
 OpName %18 "Bar"
 OpMemberName %18 0 "matrix"
 OpMemberName %18 1 "data"
 OpName %20 "bar"
-OpName %22 "foo"
-OpName %24 "c"
-OpName %27 "vi"
-OpName %32 "foo"
+OpName %22 "qux"
+OpName %23 "foo"
+OpName %25 "c"
+OpName %28 "vi"
+OpName %33 "foo"
 OpDecorate %17 ArrayStride 4
 OpDecorate %18 Block
 OpMemberDecorate %18 0 Offset 0
@@ -25,8 +26,11 @@ OpMemberDecorate %18 1 Offset 64
 OpDecorate %19 ArrayStride 4
 OpDecorate %20 DescriptorSet 0
 OpDecorate %20 Binding 0
-OpDecorate %27 BuiltIn VertexIndex
-OpDecorate %30 BuiltIn Position
+OpDecorate %22 NonWritable
+OpDecorate %22 DescriptorSet 0
+OpDecorate %22 Binding 1
+OpDecorate %28 BuiltIn VertexIndex
+OpDecorate %31 BuiltIn Position
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpConstant  %4  0.0
@@ -47,46 +51,50 @@ OpDecorate %30 BuiltIn Position
 %19 = OpTypeArray %10 %9
 %21 = OpTypePointer StorageBuffer %18
 %20 = OpVariable  %21  StorageBuffer
-%23 = OpTypePointer Function %4
-%25 = OpTypePointer Function %19
-%28 = OpTypePointer Input %7
-%27 = OpVariable  %28  Input
-%31 = OpTypePointer Output %16
-%30 = OpVariable  %31  Output
-%33 = OpTypeFunction %2
-%36 = OpTypePointer StorageBuffer %15
-%37 = OpTypePointer StorageBuffer %16
-%38 = OpConstant  %7  0
-%42 = OpTypePointer StorageBuffer %17
-%45 = OpTypePointer StorageBuffer %10
-%51 = OpTypePointer Function %10
-%55 = OpTypeVector %10 4
-%32 = OpFunction  %2  None %33
-%26 = OpLabel
-%22 = OpVariable  %23  Function %3
-%24 = OpVariable  %25  Function
-%29 = OpLoad  %7  %27
-OpBranch %34
-%34 = OpLabel
-%35 = OpLoad  %4  %22
-OpStore %22 %5
-%39 = OpAccessChain  %37  %20 %38 %6
-%40 = OpLoad  %16  %39
-%41 = OpCompositeExtract  %4  %40 0
-%43 = OpArrayLength  %7  %20 1
-%44 = OpISub  %7  %43 %8
-%46 = OpAccessChain  %45  %20 %13 %44
-%47 = OpLoad  %10  %46
-%48 = OpConvertFToS  %10  %41
-%49 = OpCompositeConstruct  %19  %47 %48 %11 %12 %9
-OpStore %24 %49
-%50 = OpIAdd  %7  %29 %13
-%52 = OpAccessChain  %51  %24 %50
-OpStore %52 %14
-%53 = OpAccessChain  %51  %24 %29
-%54 = OpLoad  %10  %53
-%56 = OpCompositeConstruct  %55  %54 %54 %54 %54
-%57 = OpConvertSToF  %16  %56
-OpStore %30 %57
+%22 = OpVariable  %21  StorageBuffer
+%24 = OpTypePointer Function %4
+%26 = OpTypePointer Function %19
+%29 = OpTypePointer Input %7
+%28 = OpVariable  %29  Input
+%32 = OpTypePointer Output %16
+%31 = OpVariable  %32  Output
+%34 = OpTypeFunction %2
+%37 = OpTypePointer StorageBuffer %15
+%38 = OpTypePointer StorageBuffer %16
+%39 = OpConstant  %7  0
+%46 = OpTypePointer StorageBuffer %17
+%49 = OpTypePointer StorageBuffer %10
+%55 = OpTypePointer Function %10
+%59 = OpTypeVector %10 4
+%33 = OpFunction  %2  None %34
+%27 = OpLabel
+%23 = OpVariable  %24  Function %3
+%25 = OpVariable  %26  Function
+%30 = OpLoad  %7  %28
+OpBranch %35
+%35 = OpLabel
+%36 = OpLoad  %4  %23
+OpStore %23 %5
+%40 = OpAccessChain  %38  %20 %39 %6
+%41 = OpLoad  %16  %40
+%42 = OpCompositeExtract  %4  %41 0
+%43 = OpAccessChain  %38  %22 %39 %6
+%44 = OpLoad  %16  %43
+%45 = OpCompositeExtract  %4  %44 0
+%47 = OpArrayLength  %7  %20 1
+%48 = OpISub  %7  %47 %8
+%50 = OpAccessChain  %49  %20 %13 %48
+%51 = OpLoad  %10  %50
+%52 = OpConvertFToS  %10  %42
+%53 = OpCompositeConstruct  %19  %51 %52 %11 %12 %9
+OpStore %25 %53
+%54 = OpIAdd  %7  %30 %13
+%56 = OpAccessChain  %55  %25 %54
+OpStore %56 %14
+%57 = OpAccessChain  %55  %25 %30
+%58 = OpLoad  %10  %57
+%60 = OpCompositeConstruct  %59  %58 %58 %58 %58
+%61 = OpConvertSToF  %16  %60
+OpStore %31 %61
 OpReturn
 OpFunctionEnd

--- a/tests/out/spv/bounds-check-zero.spvasm
+++ b/tests/out/spv/bounds-check-zero.spvasm
@@ -14,6 +14,7 @@ OpMemberDecorate %9 1 Offset 48
 OpMemberDecorate %9 2 Offset 64
 OpMemberDecorate %9 2 ColMajor
 OpMemberDecorate %9 2 MatrixStride 16
+OpDecorate %10 NonWritable
 OpDecorate %10 DescriptorSet 0
 OpDecorate %10 Binding 0
 %2 = OpTypeVoid

--- a/tests/out/wgsl/access.wgsl
+++ b/tests/out/wgsl/access.wgsl
@@ -6,6 +6,8 @@ struct Bar {
 
 [[group(0), binding(0)]]
 var<storage> bar: [[access(read_write)]] Bar;
+[[group(0), binding(1)]]
+var<storage> qux: [[access(read)]] Bar;
 
 [[stage(vertex)]]
 fn foo([[builtin(vertex_index)]] vi: u32) -> [[builtin(position)]] vec4<f32> {
@@ -14,8 +16,10 @@ fn foo([[builtin(vertex_index)]] vi: u32) -> [[builtin(position)]] vec4<f32> {
 
     let baz: f32 = foo1;
     foo1 = 1.0;
-    let _e9: vec4<f32> = bar.matrix[3];
-    let b: f32 = _e9.x;
+    let _e10: vec4<f32> = bar.matrix[3];
+    let b: f32 = _e10.x;
+    let _e14: vec4<f32> = qux.matrix[3];
+    let q: f32 = _e14.x;
     let a: i32 = bar.data[(arrayLength(&bar.data) - 2u)];
     c = array<i32,5>(a, i32(b), 3, 4, 5);
     c[(vi + 1u)] = 42;


### PR DESCRIPTION
This PR improves Naga's WGSL support by always allowing reads of global storage buffers; that is, globals of type `Array`/`Struct` that are declared in global scope via `var<storage>`.

These changes encompass the first set of changes that must be made for Naga's behaviour to reflect that of the WGSL specification as of 12 July 2021.