### PR TITLE
glsl-out: fix emission of location/binding attributes

### DIFF
--- a/tests/in/quad.param.ron
+++ b/tests/in/quad.param.ron
@@ -2,4 +2,9 @@
 	spv_version: (1, 0),
 	spv_debug: true,
 	spv_adjust_coordinate_space: true,
+	glsl: (
+		version: Embedded(300),
+		writer_flags: (bits: 0),
+		binding_map: {},
+	),
 )

--- a/tests/out/glsl/quad-vert.main.Vertex.glsl
+++ b/tests/out/glsl/quad-vert.main.Vertex.glsl
@@ -25,7 +25,7 @@ vec2 a_pos1 = vec2(0, 0);
 
 layout(location = 1) in vec2 _p2vs_location1;
 layout(location = 0) in vec2 _p2vs_location0;
-smooth out vec2 _vs2fs_location0;
+layout(location = 0) smooth out vec2 _vs2fs_location0;
 
 void main2() {
     vec2 _expr12 = a_uv1;

--- a/tests/out/glsl/quad.fs_extra.Fragment.glsl
+++ b/tests/out/glsl/quad.fs_extra.Fragment.glsl
@@ -1,4 +1,4 @@
-#version 310 es
+#version 300 es
 
 precision highp float;
 

--- a/tests/out/glsl/quad.main.Fragment.glsl
+++ b/tests/out/glsl/quad.main.Fragment.glsl
@@ -1,4 +1,4 @@
-#version 310 es
+#version 300 es
 
 precision highp float;
 

--- a/tests/out/glsl/quad.main.Vertex.glsl
+++ b/tests/out/glsl/quad.main.Vertex.glsl
@@ -1,4 +1,4 @@
-#version 310 es
+#version 300 es
 
 precision highp float;
 
@@ -17,7 +17,6 @@ void main() {
     VertexOutput _tmp_return = VertexOutput(uv, vec4((1.2 * pos), 0.0, 1.0));
     _vs2fs_location0 = _tmp_return.uv;
     gl_Position = _tmp_return.position;
-    gl_Position.yz = vec2(-gl_Position.y, gl_Position.z * 2.0 - gl_Position.w);
     return;
 }
 

--- a/tests/out/glsl/shadow.fs_main.Fragment.glsl
+++ b/tests/out/glsl/shadow.fs_main.Fragment.glsl
@@ -18,8 +18,8 @@ readonly buffer Lights_block_1 {
 
 uniform highp sampler2DArrayShadow _group_0_binding_2;
 
-smooth in vec3 _vs2fs_location0;
-smooth in vec4 _vs2fs_location1;
+layout(location = 0) smooth in vec3 _vs2fs_location0;
+layout(location = 1) smooth in vec4 _vs2fs_location1;
 layout(location = 0) out vec4 _fs2p_location0;
 
 float fetch_shadow(uint light_id, vec4 homogeneous_coords) {

--- a/tests/out/glsl/skybox.fs_main.Fragment.glsl
+++ b/tests/out/glsl/skybox.fs_main.Fragment.glsl
@@ -9,7 +9,7 @@ struct VertexOutput {
 
 layout(binding = 0) uniform highp samplerCube _group_0_binding_1;
 
-smooth in vec3 _vs2fs_location0;
+layout(location = 0) smooth in vec3 _vs2fs_location0;
 layout(location = 0) out vec4 _fs2p_location0;
 
 void main() {

--- a/tests/out/glsl/skybox.vs_main.Vertex.glsl
+++ b/tests/out/glsl/skybox.vs_main.Vertex.glsl
@@ -12,7 +12,7 @@ layout(binding = 0) uniform Data_block_0 {
     mat4x4 view;
 } _group_0_binding_0;
 
-smooth out vec3 _vs2fs_location0;
+layout(location = 0) smooth out vec3 _vs2fs_location0;
 
 void main() {
     uint vertex_index = uint(gl_VertexID);


### PR DESCRIPTION
Should help https://github.com/gfx-rs/wgpu/issues/1617
Here is the breakdown:
  - "location" is supported unconditionally for VS inputs and FS outputs
  - "location" requires GLSL ES 310 for varyings (VS outputs and FS inputs)
  - "binding" requires GLSL ES 310