### PR TITLE
Validate the exact MSL version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ validate-spv: $(SNAPSHOTS_BASE_OUT)/spv/*.spvasm
 validate-msl: $(SNAPSHOTS_BASE_OUT)/msl/*.msl
 	@set -e && for file in $^ ; do \
 		echo "Validating" $${file#"$(SNAPSHOTS_BASE_OUT)/"};	\
-		cat $${file} | xcrun -sdk macosx metal -mmacosx-version-min=10.15 -x metal - -o /dev/null; \
+		header=$$(head -n1 $${file});	\
+		cat $${file} | xcrun -sdk macosx metal -mmacosx-version-min=10.11 -std=macos-$${header:13:8} -x metal - -o /dev/null; \
 	done
 
 validate-glsl: $(SNAPSHOTS_BASE_OUT)/glsl/*.glsl

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -189,7 +189,7 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Self {
         Options {
-            lang_version: (1, 0),
+            lang_version: (1, 1),
             per_stage_map: PerStageMap::default(),
             inline_samplers: Vec::new(),
             spirv_cross_compatibility: false,

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1573,6 +1573,11 @@ impl<W: Write> Writer<W> {
             .reset(module, super::keywords::RESERVED, &[], &mut self.names);
         self.runtime_sized_buffers.clear();
 
+        writeln!(
+            self.out,
+            "// language: metal{}.{}",
+            options.lang_version.0, options.lang_version.1
+        )?;
         writeln!(self.out, "#include <metal_stdlib>")?;
         writeln!(self.out, "#include <simd/simd.h>")?;
         writeln!(self.out)?;

--- a/tests/in/extra.param.ron
+++ b/tests/in/extra.param.ron
@@ -1,4 +1,12 @@
 (
 	god_mode: true,
 	spv_version: (1, 0),
+	msl_custom: true,
+	msl: (
+		lang_version: (2, 2),
+		per_stage_map: (),
+		inline_samplers: [],
+		spirv_cross_compatibility: false,
+		fake_missing_bindings: false,
+	),
 )

--- a/tests/out/msl/access.msl
+++ b/tests/out/msl/access.msl
@@ -1,3 +1,4 @@
+// language: metal2.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/boids.msl
+++ b/tests/out/msl/boids.msl
@@ -1,3 +1,4 @@
+// language: metal2.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/collatz.msl
+++ b/tests/out/msl/collatz.msl
@@ -1,3 +1,4 @@
+// language: metal1.1
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/control-flow.msl
+++ b/tests/out/msl/control-flow.msl
@@ -1,3 +1,4 @@
+// language: metal1.1
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/empty.msl
+++ b/tests/out/msl/empty.msl
@@ -1,3 +1,4 @@
+// language: metal1.1
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/extra.msl
+++ b/tests/out/msl/extra.msl
@@ -1,3 +1,4 @@
+// language: metal2.2
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/globals.msl
+++ b/tests/out/msl/globals.msl
@@ -1,3 +1,4 @@
+// language: metal1.1
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/image.msl
+++ b/tests/out/msl/image.msl
@@ -1,3 +1,4 @@
+// language: metal1.1
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/interface.msl
+++ b/tests/out/msl/interface.msl
@@ -1,3 +1,4 @@
+// language: metal1.1
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/interpolate.msl
+++ b/tests/out/msl/interpolate.msl
@@ -1,3 +1,4 @@
+// language: metal1.1
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/operators.msl
+++ b/tests/out/msl/operators.msl
@@ -1,3 +1,4 @@
+// language: metal1.1
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/quad-vert.msl
+++ b/tests/out/msl/quad-vert.msl
@@ -1,3 +1,4 @@
+// language: metal1.1
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/quad.msl
+++ b/tests/out/msl/quad.msl
@@ -1,3 +1,4 @@
+// language: metal1.1
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/shadow.msl
+++ b/tests/out/msl/shadow.msl
@@ -1,3 +1,4 @@
+// language: metal1.1
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/skybox.msl
+++ b/tests/out/msl/skybox.msl
@@ -1,3 +1,4 @@
+// language: metal2.1
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/standard.msl
+++ b/tests/out/msl/standard.msl
@@ -1,3 +1,4 @@
+// language: metal1.1
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/texture-arg.msl
+++ b/tests/out/msl/texture-arg.msl
@@ -1,3 +1,4 @@
+// language: metal1.1
 #include <metal_stdlib>
 #include <simd/simd.h>
 


### PR DESCRIPTION
Follow-up to #1097, which reverts the macos min version change, but instead allows each test to carry the version it was made with, and validate against this. So now we can make sure different MSL versions are tested.