### PR TITLE
[hlsl-out] Validate all entry points in Makefile

### DIFF
--- a/tests/out/hlsl/control-flow.hlsl.config
+++ b/tests/out/hlsl/control-flow.hlsl.config
@@ -1,2 +1,3 @@
-compute=cs_5_0
-compute_name=main
+vertex=()
+fragment=()
+compute=(main:cs_5_0 )

--- a/tests/out/hlsl/empty.hlsl.config
+++ b/tests/out/hlsl/empty.hlsl.config
@@ -1,2 +1,3 @@
-compute=cs_5_0
-compute_name=main
+vertex=()
+fragment=()
+compute=(main:cs_5_0 )

--- a/tests/out/hlsl/globals.hlsl.config
+++ b/tests/out/hlsl/globals.hlsl.config
@@ -1,2 +1,3 @@
-compute=cs_5_0
-compute_name=main
+vertex=()
+fragment=()
+compute=(main:cs_5_0 )

--- a/tests/out/hlsl/image.hlsl.config
+++ b/tests/out/hlsl/image.hlsl.config
@@ -1,8 +1,3 @@
-compute=cs_5_0
-compute_name=main
-vertex=vs_5_0
-vertex_name=queries
-fragment=ps_5_0
-fragment_name=sample1
-fragment=ps_5_0
-fragment_name=sample_comparison
+vertex=(queries:vs_5_0 )
+fragment=(sample1:ps_5_0 sample_comparison:ps_5_0 )
+compute=(main:cs_5_0 )

--- a/tests/out/hlsl/interface.hlsl.config
+++ b/tests/out/hlsl/interface.hlsl.config
@@ -1,6 +1,3 @@
-vertex=vs_5_0
-vertex_name=vertex
-fragment=ps_5_0
-fragment_name=fragment
-compute=cs_5_0
-compute_name=compute
+vertex=(vertex:vs_5_0 )
+fragment=(fragment:ps_5_0 )
+compute=(compute:cs_5_0 )

--- a/tests/out/hlsl/interpolate.hlsl.config
+++ b/tests/out/hlsl/interpolate.hlsl.config
@@ -1,4 +1,3 @@
-vertex=vs_5_0
-vertex_name=main
-fragment=ps_5_0
-fragment_name=main1
+vertex=(main:vs_5_0 )
+fragment=(main1:ps_5_0 )
+compute=()

--- a/tests/out/hlsl/operators.hlsl.config
+++ b/tests/out/hlsl/operators.hlsl.config
@@ -1,2 +1,3 @@
-compute=cs_5_0
-compute_name=main
+vertex=()
+fragment=()
+compute=(main:cs_5_0 )

--- a/tests/out/hlsl/quad-vert.hlsl.config
+++ b/tests/out/hlsl/quad-vert.hlsl.config
@@ -1,2 +1,3 @@
-vertex=vs_5_0
-vertex_name=main
+vertex=(main:vs_5_0 )
+fragment=()
+compute=()

--- a/tests/out/hlsl/quad.hlsl.config
+++ b/tests/out/hlsl/quad.hlsl.config
@@ -1,6 +1,3 @@
-vertex=vs_5_0
-vertex_name=main
-fragment=ps_5_0
-fragment_name=main1
-fragment=ps_5_0
-fragment_name=fs_extra
+vertex=(main:vs_5_0 )
+fragment=(main1:ps_5_0 fs_extra:ps_5_0 )
+compute=()

--- a/tests/out/hlsl/shadow.hlsl.config
+++ b/tests/out/hlsl/shadow.hlsl.config
@@ -1,2 +1,3 @@
-fragment=ps_5_0
-fragment_name=fs_main
+vertex=()
+fragment=(fs_main:ps_5_0 )
+compute=()

--- a/tests/out/hlsl/skybox.hlsl.config
+++ b/tests/out/hlsl/skybox.hlsl.config
@@ -1,4 +1,3 @@
-vertex=vs_5_1
-vertex_name=vs_main
-fragment=ps_5_1
-fragment_name=fs_main
+vertex=(vs_main:vs_5_1 )
+fragment=(fs_main:ps_5_1 )
+compute=()

--- a/tests/out/hlsl/standard.hlsl.config
+++ b/tests/out/hlsl/standard.hlsl.config
@@ -1,2 +1,3 @@
-fragment=ps_5_0
-fragment_name=derivatives
+vertex=()
+fragment=(derivatives:ps_5_0 )
+compute=()

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -304,27 +304,55 @@ fn write_output_hlsl(
     // This file contains an info about profiles (shader stages) contains inside generated shader
     // This info will be passed to dxc
     let mut config_str = String::new();
+    let mut vertex_str = String::from("vertex=(");
+    let mut fragment_str = String::from("fragment=(");
+    let mut compute_str = String::from("compute=(");
     for (index, ep) in module.entry_points.iter().enumerate() {
         let name = match reflection_info.entry_point_names[index] {
             Ok(ref name) => name,
             Err(_) => continue,
         };
-        let stage_str = match ep.stage {
-            naga::ShaderStage::Vertex => "vertex",
-            naga::ShaderStage::Fragment => "fragment",
-            naga::ShaderStage::Compute => "compute",
-        };
-        writeln!(
-            config_str,
-            "{}={}_{}\n{}_name={}",
-            stage_str,
-            ep.stage.to_hlsl_str(),
-            options.shader_model.to_str(),
-            stage_str,
-            name,
-        )
-        .unwrap();
+        match ep.stage {
+            naga::ShaderStage::Vertex => {
+                write!(
+                    vertex_str,
+                    "{}:{}_{} ",
+                    name,
+                    ep.stage.to_hlsl_str(),
+                    options.shader_model.to_str(),
+                )
+                .unwrap();
+            }
+            naga::ShaderStage::Fragment => {
+                write!(
+                    fragment_str,
+                    "{}:{}_{} ",
+                    name,
+                    ep.stage.to_hlsl_str(),
+                    options.shader_model.to_str(),
+                )
+                .unwrap();
+            }
+            naga::ShaderStage::Compute => {
+                write!(
+                    compute_str,
+                    "{}:{}_{} ",
+                    name,
+                    ep.stage.to_hlsl_str(),
+                    options.shader_model.to_str(),
+                )
+                .unwrap();
+            }
+        }
     }
+
+    writeln!(
+        config_str,
+        "{})\n{})\n{})",
+        vertex_str, fragment_str, compute_str
+    )
+    .unwrap();
+
     fs::write(
         destination.join(format!("hlsl/{}.hlsl.config", file_name)),
         config_str,


### PR DESCRIPTION
All entry points validations passed 🚀.

Still uses config files, but with a more readable `Makefile`. My attempt to implement validation with comments inside hlsl shaders makes `Makefile` unreadable at all and full of dark magic.