### PR TITLE
Update GLSL snapshots for quad, after e76824a.

### DIFF
--- a/tests/out/glsl/quad.fs_extra.Fragment.glsl
+++ b/tests/out/glsl/quad.fs_extra.Fragment.glsl
@@ -1,4 +1,4 @@
-#version 300 es
+#version 310 es
 
 precision highp float;
 

--- a/tests/out/glsl/quad.main.Fragment.glsl
+++ b/tests/out/glsl/quad.main.Fragment.glsl
@@ -1,4 +1,4 @@
-#version 300 es
+#version 310 es
 
 precision highp float;
 
@@ -9,7 +9,7 @@ struct VertexOutput {
 
 uniform highp sampler2D _group_0_binding_0;
 
-smooth in vec2 _vs2fs_location0;
+layout(location = 0) smooth in vec2 _vs2fs_location0;
 layout(location = 0) out vec4 _fs2p_location0;
 
 void main() {

--- a/tests/out/glsl/quad.main.Vertex.glsl
+++ b/tests/out/glsl/quad.main.Vertex.glsl
@@ -1,4 +1,4 @@
-#version 300 es
+#version 310 es
 
 precision highp float;
 
@@ -9,7 +9,7 @@ struct VertexOutput {
 
 layout(location = 0) in vec2 _p2vs_location0;
 layout(location = 1) in vec2 _p2vs_location1;
-smooth out vec2 _vs2fs_location0;
+layout(location = 0) smooth out vec2 _vs2fs_location0;
 
 void main() {
     vec2 pos = _p2vs_location0;
@@ -17,6 +17,7 @@ void main() {
     VertexOutput _tmp_return = VertexOutput(uv, vec4((1.2 * pos), 0.0, 1.0));
     _vs2fs_location0 = _tmp_return.uv;
     gl_Position = _tmp_return.position;
+    gl_Position.yz = vec2(-gl_Position.y, gl_Position.z * 2.0 - gl_Position.w);
     return;
 }
 


### PR DESCRIPTION
Unless I'm doing something wrong, we should find out why CI didn't warn us about these being out of date.