### PR TITLE
Add Explicit Int Precision for GLSL ES Backend

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -409,11 +409,12 @@ impl<'a, W: Write> Writer<'a, W> {
             writeln!(self.out, "#extension GL_EXT_texture_shadow_lod : require")?;
         }
 
-        // glsl es requires a precision to be specified for floats
+        // glsl es requires a precision to be specified for floats and ints
         // TODO: Should this be user configurable?
         if es {
             writeln!(self.out)?;
             writeln!(self.out, "precision highp float;")?;
+            writeln!(self.out, "precision highp int;")?;
             writeln!(self.out)?;
         }
 

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -203,7 +203,10 @@ impl<W: Write> Writer<W> {
         for (index, arg) in func.arguments.iter().enumerate() {
             // Write argument attribute if a binding is present
             if let Some(ref binding) = arg.binding {
-                self.write_attributes(&map_binding_to_attribute(binding, module.types[arg.ty].inner.scalar_kind()), false)?;
+                self.write_attributes(
+                    &map_binding_to_attribute(binding, module.types[arg.ty].inner.scalar_kind()),
+                    false,
+                )?;
                 write!(self.out, " ")?;
             }
             // Write argument name
@@ -231,7 +234,10 @@ impl<W: Write> Writer<W> {
         if let Some(ref result) = func.result {
             write!(self.out, " -> ")?;
             if let Some(ref binding) = result.binding {
-                self.write_attributes(&map_binding_to_attribute(binding, module.types[result.ty].inner.scalar_kind()), true)?;
+                self.write_attributes(
+                    &map_binding_to_attribute(binding, module.types[result.ty].inner.scalar_kind()),
+                    true,
+                )?;
             }
             self.write_type(module, result.ty)?;
         }
@@ -400,7 +406,10 @@ impl<W: Write> Writer<W> {
             // The indentation is only for readability
             write!(self.out, "{}", back::INDENT)?;
             if let Some(ref binding) = member.binding {
-                self.write_attributes(&map_binding_to_attribute(binding, module.types[member.ty].inner.scalar_kind()), true)?;
+                self.write_attributes(
+                    &map_binding_to_attribute(binding, module.types[member.ty].inner.scalar_kind()),
+                    true,
+                )?;
             }
             // Write struct member name and type
             let member_name = &self.names[&NameKey::StructMember(handle, index as u32)];
@@ -1580,7 +1589,10 @@ fn storage_class_str(storage_class: crate::StorageClass) -> Option<&'static str>
     }
 }
 
-fn map_binding_to_attribute(binding: &crate::Binding, scalar_kind: Option<crate::ScalarKind>) -> Vec<Attribute> {
+fn map_binding_to_attribute(
+    binding: &crate::Binding,
+    scalar_kind: Option<crate::ScalarKind>,
+) -> Vec<Attribute> {
     match *binding {
         crate::Binding::BuiltIn(built_in) => vec![Attribute::BuiltIn(built_in)],
         crate::Binding::Location {
@@ -1592,9 +1604,7 @@ fn map_binding_to_attribute(binding: &crate::Binding, scalar_kind: Option<crate:
                 Attribute::Location(location),
                 Attribute::Interpolate(interpolation, sampling),
             ],
-            _ => vec![
-                Attribute::Location(location),
-            ],
+            _ => vec![Attribute::Location(location)],
         },
     }
 }

--- a/tests/out/glsl/boids.main.Compute.glsl
+++ b/tests/out/glsl/boids.main.Compute.glsl
@@ -1,6 +1,7 @@
 #version 310 es
 
 precision highp float;
+precision highp int;
 
 layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 

--- a/tests/out/glsl/control-flow.main.Compute.glsl
+++ b/tests/out/glsl/control-flow.main.Compute.glsl
@@ -1,6 +1,7 @@
 #version 310 es
 
 precision highp float;
+precision highp int;
 
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 

--- a/tests/out/glsl/empty.main.Compute.glsl
+++ b/tests/out/glsl/empty.main.Compute.glsl
@@ -1,6 +1,7 @@
 #version 310 es
 
 precision highp float;
+precision highp int;
 
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 

--- a/tests/out/glsl/globals.main.Compute.glsl
+++ b/tests/out/glsl/globals.main.Compute.glsl
@@ -1,6 +1,7 @@
 #version 310 es
 
 precision highp float;
+precision highp int;
 
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 

--- a/tests/out/glsl/operators.main.Compute.glsl
+++ b/tests/out/glsl/operators.main.Compute.glsl
@@ -1,6 +1,7 @@
 #version 310 es
 
 precision highp float;
+precision highp int;
 
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 

--- a/tests/out/glsl/quad-vert.main.Vertex.glsl
+++ b/tests/out/glsl/quad-vert.main.Vertex.glsl
@@ -1,6 +1,7 @@
 #version 310 es
 
 precision highp float;
+precision highp int;
 
 struct type10 {
     vec2 member;

--- a/tests/out/glsl/quad.fs_extra.Fragment.glsl
+++ b/tests/out/glsl/quad.fs_extra.Fragment.glsl
@@ -1,6 +1,7 @@
 #version 300 es
 
 precision highp float;
+precision highp int;
 
 struct VertexOutput {
     vec2 uv;

--- a/tests/out/glsl/quad.main.Fragment.glsl
+++ b/tests/out/glsl/quad.main.Fragment.glsl
@@ -1,6 +1,7 @@
 #version 300 es
 
 precision highp float;
+precision highp int;
 
 struct VertexOutput {
     vec2 uv;

--- a/tests/out/glsl/quad.main.Vertex.glsl
+++ b/tests/out/glsl/quad.main.Vertex.glsl
@@ -1,6 +1,7 @@
 #version 300 es
 
 precision highp float;
+precision highp int;
 
 struct VertexOutput {
     vec2 uv;

--- a/tests/out/glsl/shadow.fs_main.Fragment.glsl
+++ b/tests/out/glsl/shadow.fs_main.Fragment.glsl
@@ -1,6 +1,7 @@
 #version 310 es
 
 precision highp float;
+precision highp int;
 
 struct Light {
     mat4x4 proj;

--- a/tests/out/glsl/skybox.fs_main.Fragment.glsl
+++ b/tests/out/glsl/skybox.fs_main.Fragment.glsl
@@ -1,6 +1,7 @@
 #version 320 es
 
 precision highp float;
+precision highp int;
 
 struct VertexOutput {
     vec4 position;

--- a/tests/out/glsl/skybox.vs_main.Vertex.glsl
+++ b/tests/out/glsl/skybox.vs_main.Vertex.glsl
@@ -1,6 +1,7 @@
 #version 320 es
 
 precision highp float;
+precision highp int;
 
 struct VertexOutput {
     vec4 position;

--- a/tests/out/glsl/standard.derivatives.Fragment.glsl
+++ b/tests/out/glsl/standard.derivatives.Fragment.glsl
@@ -1,6 +1,7 @@
 #version 310 es
 
 precision highp float;
+precision highp int;
 
 layout(location = 0) out vec4 _fs2p_location0;
 

--- a/tests/out/glsl/texture-arg.main.Fragment.glsl
+++ b/tests/out/glsl/texture-arg.main.Fragment.glsl
@@ -1,6 +1,7 @@
 #version 310 es
 
 precision highp float;
+precision highp int;
 
 uniform highp sampler2D _group_0_binding_0;
 


### PR DESCRIPTION
I ran into an [error](https://matrix.to/#/!FZyQrssSlHEZqrYcOb:matrix.org/$XhLgbZcu0uCYJjUm07uVTNUjwCxjOXv8etwaOt7_y8E?via=matrix.org&via=mozilla.org&via=kyju.org) while targeting WebGL where the shaders failed to link because of differing precision between vertex and fragment shaders in a uniform with an integer field. This explicitly sets the integer precision to `highp` so that they match across vertex and fragment shaders.