### PR TITLE
hlsl-out: use * for vector by vector multiplication

### DIFF
--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -1063,18 +1063,20 @@ impl<'a, W: Write> Writer<'a, W> {
                     write!(self.out, ")")?
                 }
             }
+            // Matrix * Vector has to be written as `mul(Matrix, Vector)`
             Expression::Binary {
                 op: crate::BinaryOperator::Multiply,
                 left,
                 right,
-            } => {
+            } if func_ctx.info[left].ty.inner_with(&module.types)
+                != func_ctx.info[right].ty.inner_with(&module.types) =>
+            {
                 write!(self.out, "mul(")?;
                 self.write_expr(module, left, func_ctx)?;
                 write!(self.out, ", ")?;
                 self.write_expr(module, right, func_ctx)?;
                 write!(self.out, ")")?;
             }
-            // TODO: copy-paste from wgsl-out
             Expression::Binary { op, left, right } => {
                 write!(self.out, "(")?;
                 self.write_expr(module, left, func_ctx)?;

--- a/tests/out/hlsl/image.hlsl
+++ b/tests/out/hlsl/image.hlsl
@@ -28,7 +28,7 @@ int2 NagaDimensions2D(Texture2D<uint4>)
 void main(ComputeInput_main computeinput_main)
 {
     int2 dim = NagaDimensions2D(image_storage_src);
-    int2 itc = (mul(dim, int2(computeinput_main.local_id1.xy)) % int2(10, 20));
+    int2 itc = ((dim * int2(computeinput_main.local_id1.xy)) % int2(10, 20));
     uint4 value1_ = image_mipmapped_src.Load(int3(itc, int(computeinput_main.local_id1.z)));
     uint4 value2_ = image_multisampled_src.Load(itc, int(computeinput_main.local_id1.z));
     uint4 value3_ = image_storage_src.Load(int3(itc, 0));

--- a/tests/out/hlsl/shadow.hlsl
+++ b/tests/out/hlsl/shadow.hlsl
@@ -32,7 +32,7 @@ float fetch_shadow(uint light_id, float4 homogeneous_coords)
         return 1.0;
     }
     float2 flip_correction = float2(0.5, -0.5);
-    float2 light_local = ((mul(homogeneous_coords.xy, flip_correction) / float2(homogeneous_coords.w.xx)) + float2(0.5, 0.5));
+    float2 light_local = (((homogeneous_coords.xy * flip_correction) / float2(homogeneous_coords.w.xx)) + float2(0.5, 0.5));
     float _expr26 = t_shadow.SampleCmpLevelZero(sampler_shadow, float3(light_local, int(light_id)), (homogeneous_coords.z / homogeneous_coords.w));
     return _expr26;
 }
@@ -56,7 +56,7 @@ float4 fs_main(FragmentInput_fs_main fragmentinput_fs_main) : SV_Target0
         float3 light_dir = normalize((light.pos.xyz - fragmentinput_fs_main.position1.xyz));
         float diffuse = max(0.0, dot(normal, light_dir));
         float3 _expr34 = color;
-        color = (_expr34 + mul(mul(_e25, diffuse), light.color.xyz));
+        color = (_expr34 + mul((_e25 * diffuse), light.color.xyz));
         uint _expr40 = i;
         i = (_expr40 + 1u);
     }

--- a/tests/out/hlsl/skybox.hlsl
+++ b/tests/out/hlsl/skybox.hlsl
@@ -29,7 +29,7 @@ VertexOutput vs_main(VertexInput_vs_main vertexinput_vs_main)
     tmp2_ = (int(vertexinput_vs_main.vertex_index1) & 1);
     int _expr10 = tmp1_;
     int _expr16 = tmp2_;
-    float4 pos = float4((mul(float(_expr10), 4.0) - 1.0), (mul(float(_expr16), 4.0) - 1.0), 0.0, 1.0);
+    float4 pos = float4(((float(_expr10) * 4.0) - 1.0), ((float(_expr16) * 4.0) - 1.0), 0.0, 1.0);
     float4 _expr27 = r_data.view[0];
     float4 _expr31 = r_data.view[1];
     float4 _expr35 = r_data.view[2];

--- a/tests/out/hlsl/standard.hlsl
+++ b/tests/out/hlsl/standard.hlsl
@@ -7,5 +7,5 @@ float4 derivatives(FragmentInput_derivatives fragmentinput_derivatives) : SV_Tar
     float4 x = ddx(fragmentinput_derivatives.foo1);
     float4 y = ddy(fragmentinput_derivatives.foo1);
     float4 z = fwidth(fragmentinput_derivatives.foo1);
-    return mul((x + y), z);
+    return ((x + y) * z);
 }


### PR DESCRIPTION
It turns out `mul` is strictly for dot product kinds of things