### PR TITLE
Improve CLI Argument Doc and Error Handling

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,3 +18,4 @@ naga = { path = "../", features = ["wgsl-in", "wgsl-out", "glsl-in", "glsl-out",
 log = "0.4"
 codespan-reporting = "0.11"
 env_logger = "0.8"
+argh = "0.1.5"


### PR DESCRIPTION
- Use argh for parsing commandline arguments and generating help message
- Remove almost all panics and handle errors by printing them and
exiting 1

Resolves #1107 

---

This adds the `argh` dependency for argument parsing which adds a measurable amount of compile time:

**Before:**

Targets: | naga-cli 0.4.0 (bin "naga")
-- | --
Total time: | 23.6s

**After:**

Targets: | naga-cli 0.4.0 (bin "naga")
-- | --
Total time: | 25.3s

That's a 1.7s ( 7.2% ) increase in build time on a clean release build.

If this is undesired I can switch it back to using the old parser, update the help message for the old parser to include available options, and keep the improved error handling introduced in this PR.