### PR TITLE
Create Processor for Detecting Unused Module Items

### DIFF
--- a/src/back/glsl/features.rs
+++ b/src/back/glsl/features.rs
@@ -224,7 +224,12 @@ impl<'a, W> Writer<'a, W> {
             self.features.request(Features::COMPUTE_SHADER)
         }
 
-        for (_, ty) in self.module.types.iter() {
+        for (handle, ty) in self.module.types.iter() {
+            // Skip unused types
+            if self.unused_items.types.contains(&handle) {
+                continue;
+            }
+
             match ty.inner {
                 TypeInner::Scalar { kind, width } => self.scalar_required_features(kind, width),
                 TypeInner::Vector { kind, width, .. } => self.scalar_required_features(kind, width),
@@ -289,7 +294,12 @@ impl<'a, W> Writer<'a, W> {
             }
         }
 
-        for (_, global) in self.module.global_variables.iter() {
+        for (handle, global) in self.module.global_variables.iter() {
+            // Skip unused globals
+            if self.unused_items.global_variables.contains(&handle) {
+                continue;
+            }
+
             match global.class {
                 StorageClass::WorkGroup => self.features.request(Features::COMPUTE_SHADER),
                 StorageClass::Storage => self.features.request(Features::BUFFER_STORAGE),

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -6,12 +6,14 @@ mod layouter;
 mod namer;
 mod terminator;
 mod typifier;
+mod unused;
 
 pub use index::IndexableLength;
 pub use layouter::{Alignment, InvalidBaseType, Layouter, TypeLayout};
 pub use namer::{EntryPointIndex, NameKey, Namer};
 pub use terminator::ensure_block_returns;
 pub use typifier::{ResolveContext, ResolveError, TypeResolution};
+pub use unused::{get_unused_items, UnusedItems};
 
 #[derive(Clone, Debug, thiserror::Error, PartialEq)]
 pub enum ProcError {

--- a/src/proc/unused.rs
+++ b/src/proc/unused.rs
@@ -1,0 +1,415 @@
+use std::collections::HashSet;
+
+use crate::Handle;
+
+/// Collection of handles for unused items in a module
+#[derive(Default, Clone, Debug)]
+pub struct UnusedItems {
+    pub types: HashSet<Handle<crate::Type>>,
+    pub global_variables: HashSet<Handle<crate::GlobalVariable>>,
+    pub constants: HashSet<Handle<crate::Constant>>,
+    pub functions: HashSet<Handle<crate::Function>>,
+}
+
+/// Gets the list of unused items for a given module
+///
+/// You may optionally specify an entry point and this will detect all items not used by that
+/// entrypoint
+pub fn get_unused_items<'a>(
+    module: &'a crate::Module,
+    entry_point: Option<&'a crate::EntryPoint>,
+) -> UnusedItems {
+    // Lists of used items
+    let mut used_global_variables = HashSet::with_capacity(module.global_variables.len());
+    let mut used_types = HashSet::with_capacity(module.types.len());
+    let mut used_constants = HashSet::with_capacity(module.constants.len());
+    let mut used_functions = HashSet::with_capacity(module.functions.len());
+
+    // Lists of unused items
+    let mut unused = UnusedItems::default();
+
+    // Get the entry point to use as a usage reference, or else just look through all entrypoints
+    let entry_points = if let Some(entry_point) = entry_point {
+        vec![entry_point]
+    } else {
+        module.entry_points.iter().collect::<Vec<_>>()
+    };
+
+    // For every entrypoint
+    for entry_point in entry_points {
+        let ctx = &mut CrawlContext {
+            module,
+            function: &entry_point.function,
+            used_global_variables: &mut used_global_variables,
+            used_types: &mut used_types,
+            used_constants: &mut used_constants,
+            used_functions: &mut used_functions,
+        };
+
+        // Add all argument types to the used types list
+        for arg in &entry_point.function.arguments {
+            crawl_type(arg.ty, &ctx.module.types, ctx.used_types);
+        }
+
+        // Crawl the function body and add any global variables and typesthat are used to the used list
+        crawl_block(&entry_point.function.body, ctx);
+    }
+
+    // For every used global variable
+    for global_variable in &used_global_variables {
+        // Add it's type to the list of used types
+        let var = &module.global_variables[*global_variable];
+        crawl_type(var.ty, &module.types, &mut used_types);
+    }
+
+    // Any items that are not in the used list, add to the unused list
+    for (handle, _) in module.types.iter() {
+        if !used_types.contains(&handle) {
+            unused.types.insert(handle);
+        }
+    }
+    for (handle, _) in module.global_variables.iter() {
+        if !used_global_variables.contains(&handle) {
+            unused.global_variables.insert(handle);
+        }
+    }
+    for (handle, _) in module.constants.iter() {
+        if !used_constants.contains(&handle) {
+            unused.constants.insert(handle);
+        }
+    }
+    for (handle, _) in module.functions.iter() {
+        if !used_functions.contains(&handle) {
+            unused.functions.insert(handle);
+        }
+    }
+
+    // Return the unused items
+    unused
+}
+
+/// Context for module crawling functions
+struct CrawlContext<'a> {
+    module: &'a crate::Module,
+    function: &'a crate::Function,
+    used_global_variables: &'a mut HashSet<Handle<crate::GlobalVariable>>,
+    used_types: &'a mut HashSet<Handle<crate::Type>>,
+    used_constants: &'a mut HashSet<Handle<crate::Constant>>,
+    used_functions: &'a mut HashSet<Handle<crate::Function>>,
+}
+
+/// Crawl a constant and register used items
+fn crawl_constant(constant: Handle<crate::Constant>, ctx: &mut CrawlContext) {
+    ctx.used_constants.insert(constant);
+    if let crate::ConstantInner::Composite { ty, ref components } =
+        ctx.module.constants[constant].inner
+    {
+        crawl_type(ty, &ctx.module.types, ctx.used_types);
+
+        for component in components {
+            crawl_constant(*component, ctx);
+        }
+    }
+}
+
+/// Crawl a type and register sub-types
+fn crawl_type(
+    ty: Handle<crate::Type>,
+    types: &crate::Arena<crate::Type>,
+    used_types: &mut HashSet<Handle<crate::Type>>,
+) {
+    if !used_types.insert(ty) {
+        // Skip if we've already visited this type
+        return;
+    }
+
+    // Crawl any sub-types
+    match types[ty].inner {
+        crate::TypeInner::Scalar { kind: _, width: _ } => (),
+        crate::TypeInner::Vector {
+            size: _,
+            kind: _,
+            width: _,
+        } => (),
+        crate::TypeInner::Matrix {
+            columns: _,
+            rows: _,
+            width: _,
+        } => (),
+        crate::TypeInner::Pointer { base, class: _ } => {
+            crawl_type(base, types, used_types);
+        }
+        crate::TypeInner::ValuePointer {
+            size: _,
+            kind: _,
+            width: _,
+            class: _,
+        } => (),
+        crate::TypeInner::Array {
+            base,
+            size: _,
+            stride: _,
+        } => {
+            crawl_type(base, types, used_types);
+        }
+        crate::TypeInner::Struct {
+            top_level: _,
+            ref members,
+            span: _,
+        } => {
+            for member in members {
+                crawl_type(member.ty, types, used_types);
+            }
+        }
+        crate::TypeInner::Image {
+            dim: _,
+            arrayed: _,
+            class: _,
+        } => (),
+        crate::TypeInner::Sampler { comparison: _ } => (),
+    }
+}
+
+/// Crawl an expression and register used items
+fn crawl_expr(expression: Handle<crate::Expression>, ctx: &mut CrawlContext) {
+    match ctx.function.expressions[expression] {
+        crate::Expression::GlobalVariable(handle) => {
+            ctx.used_global_variables.insert(handle);
+        }
+        crate::Expression::Access { base, index } => {
+            crawl_expr(base, ctx);
+            crawl_expr(index, ctx);
+        }
+        crate::Expression::AccessIndex { base, index: _ } => {
+            crawl_expr(base, ctx);
+        }
+        crate::Expression::Constant(constant) => {
+            crawl_constant(constant, ctx);
+        }
+        crate::Expression::Splat { size: _, value } => {
+            crawl_expr(value, ctx);
+        }
+        crate::Expression::Swizzle {
+            size: _,
+            vector,
+            pattern: _,
+        } => {
+            crawl_expr(vector, ctx);
+        }
+        crate::Expression::Compose { ty, ref components } => {
+            crawl_type(ty, &ctx.module.types, ctx.used_types);
+            for component in components {
+                crawl_expr(*component, ctx);
+            }
+        }
+        crate::Expression::FunctionArgument(_) => (),
+        crate::Expression::LocalVariable(local) => {
+            crawl_type(
+                ctx.function.local_variables[local].ty,
+                &ctx.module.types,
+                ctx.used_types,
+            );
+        }
+        crate::Expression::Load { pointer } => {
+            crawl_expr(pointer, ctx);
+        }
+        crate::Expression::ImageSample {
+            image,
+            sampler,
+            coordinate,
+            array_index,
+            offset: _,
+            level: _,
+            depth_ref,
+        } => {
+            for expr in [
+                Some(image),
+                Some(sampler),
+                Some(coordinate),
+                array_index,
+                depth_ref,
+            ]
+            .iter()
+            .flatten()
+            .copied()
+            {
+                crawl_expr(expr, ctx);
+            }
+        }
+        crate::Expression::ImageLoad {
+            image,
+            coordinate,
+            array_index,
+            index,
+        } => {
+            for expr in &[Some(image), Some(coordinate), array_index, index] {
+                if let Some(expr) = *expr {
+                    crawl_expr(expr, ctx);
+                }
+            }
+        }
+        crate::Expression::ImageQuery { image, query } => {
+            crawl_expr(image, ctx);
+            if let crate::ImageQuery::Size { level: Some(level) } = query {
+                crawl_expr(level, ctx);
+            }
+        }
+        crate::Expression::Unary { op: _, expr } => {
+            crawl_expr(expr, ctx);
+        }
+        crate::Expression::Binary { op: _, left, right } => {
+            crawl_expr(left, ctx);
+            crawl_expr(right, ctx);
+        }
+        crate::Expression::Select {
+            condition,
+            accept,
+            reject,
+        } => {
+            crawl_expr(condition, ctx);
+            crawl_expr(accept, ctx);
+            crawl_expr(reject, ctx);
+        }
+        crate::Expression::Derivative { axis: _, expr } => {
+            crawl_expr(expr, ctx);
+        }
+        crate::Expression::Relational { fun: _, argument } => {
+            crawl_expr(argument, ctx);
+        }
+        crate::Expression::Math {
+            fun: _,
+            arg,
+            arg1,
+            arg2,
+        } => {
+            crawl_expr(arg, ctx);
+            if let Some(arg1) = arg1 {
+                crawl_expr(arg1, ctx);
+            }
+            if let Some(arg2) = arg2 {
+                crawl_expr(arg2, ctx);
+            }
+        }
+        crate::Expression::As {
+            expr,
+            kind: _,
+            convert: _,
+        } => {
+            crawl_expr(expr, ctx);
+        }
+        crate::Expression::Call(function) => {
+            if ctx.used_functions.insert(function) {
+                let function = &ctx.module.functions[function];
+
+                crawl_block(
+                    &function.body,
+                    &mut CrawlContext {
+                        module: ctx.module,
+                        function,
+                        used_global_variables: ctx.used_global_variables,
+                        used_types: ctx.used_types,
+                        used_constants: ctx.used_constants,
+                        used_functions: ctx.used_functions,
+                    },
+                );
+            }
+        }
+        crate::Expression::ArrayLength(expr) => {
+            crawl_expr(expr, ctx);
+        }
+    }
+}
+
+/// Crawl a block and register used items
+fn crawl_block(#[allow(clippy::ptr_arg)] block: &crate::Block, ctx: &mut CrawlContext) {
+    for statement in block {
+        match *statement {
+            crate::Statement::Emit(ref range) => {
+                for expr in range.clone() {
+                    crawl_expr(expr, ctx)
+                }
+            }
+            crate::Statement::Block(ref block) => crawl_block(block, ctx),
+            crate::Statement::If {
+                condition: _,
+                ref accept,
+                ref reject,
+            } => {
+                crawl_block(accept, ctx);
+                crawl_block(reject, ctx);
+            }
+            crate::Statement::Switch {
+                selector,
+                ref cases,
+                ref default,
+            } => {
+                crawl_expr(selector, ctx);
+                for case in cases {
+                    crawl_block(&case.body, ctx);
+                }
+                crawl_block(default, ctx);
+            }
+            crate::Statement::Loop {
+                ref body,
+                ref continuing,
+            } => {
+                crawl_block(body, ctx);
+                crawl_block(continuing, ctx);
+            }
+            crate::Statement::Break => (),
+            crate::Statement::Continue => (),
+            crate::Statement::Return { value } => {
+                if let Some(expression_handle) = value {
+                    crawl_expr(expression_handle, ctx);
+                }
+            }
+            crate::Statement::Kill => (),
+            crate::Statement::Barrier(_) => (),
+            crate::Statement::Store { pointer, value } => {
+                crawl_expr(pointer, ctx);
+                crawl_expr(value, ctx);
+            }
+            crate::Statement::ImageStore {
+                image,
+                coordinate,
+                array_index,
+                value,
+            } => {
+                crawl_expr(image, ctx);
+                crawl_expr(coordinate, ctx);
+                if let Some(index) = array_index {
+                    crawl_expr(index, ctx);
+                }
+                crawl_expr(value, ctx);
+            }
+            crate::Statement::Call {
+                function,
+                ref arguments,
+                result,
+            } => {
+                if ctx.used_functions.insert(function) {
+                    let function = &ctx.module.functions[function];
+                    crawl_block(
+                        &function.body,
+                        &mut CrawlContext {
+                            module: ctx.module,
+                            function,
+                            used_global_variables: ctx.used_global_variables,
+                            used_types: ctx.used_types,
+                            used_constants: ctx.used_constants,
+                            used_functions: ctx.used_functions,
+                        },
+                    );
+                }
+
+                for arg in arguments {
+                    crawl_expr(*arg, ctx);
+                }
+
+                if let Some(result) = result {
+                    crawl_expr(result, ctx);
+                }
+            }
+        }
+    }
+}

--- a/tests/out/glsl/quad.fs_extra.Fragment.glsl
+++ b/tests/out/glsl/quad.fs_extra.Fragment.glsl
@@ -3,11 +3,6 @@
 precision highp float;
 precision highp int;
 
-struct VertexOutput {
-    vec2 uv;
-    vec4 position;
-};
-
 layout(location = 0) out vec4 _fs2p_location0;
 
 void main() {

--- a/tests/out/glsl/quad.main.Fragment.glsl
+++ b/tests/out/glsl/quad.main.Fragment.glsl
@@ -3,11 +3,6 @@
 precision highp float;
 precision highp int;
 
-struct VertexOutput {
-    vec2 uv;
-    vec4 position;
-};
-
 uniform highp sampler2D _group_0_binding_0;
 
 smooth in vec2 _vs2fs_location0;


### PR DESCRIPTION
Creates a module processor that returns the list of items in the module
that are not used for a particular entrypoint. Also integrated with the
GLSL backend to prune unused items from generated shaders.

---

Not super tested yet, but I think it's working! I'll mark it not a draft after more testing.