### PR TITLE
Allow mixing on a scalar selector

### DIFF
--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -1077,7 +1077,7 @@ impl super::Validator {
                             _ => return Err(ExpressionError::InvalidArgumentType(fun, 0, arg)),
                         }
                     }
-                    Mf::FaceForward | Mf::Fma | Mf::Mix | Mf::SmoothStep => {
+                    Mf::FaceForward | Mf::Fma | Mf::SmoothStep => {
                         let (arg1_ty, arg2_ty) = match (arg1_ty, arg2_ty) {
                             (Some(ty1), Some(ty2)) => (ty1, ty2),
                             _ => return Err(ExpressionError::WrongArgumentCount(fun)),
@@ -1104,6 +1104,46 @@ impl super::Validator {
                                 2,
                                 arg2.unwrap(),
                             ));
+                        }
+                    }
+                    Mf::Mix => {
+                        let (arg1_ty, arg2_ty) = match (arg1_ty, arg2_ty) {
+                            (Some(ty1), Some(ty2)) => (ty1, ty2),
+                            _ => return Err(ExpressionError::WrongArgumentCount(fun)),
+                        };
+                        let arg_width = match *arg_ty {
+                            Ti::Scalar {
+                                kind: Sk::Float,
+                                width,
+                            }
+                            | Ti::Vector {
+                                kind: Sk::Float,
+                                width,
+                                ..
+                            } => width,
+                            _ => return Err(ExpressionError::InvalidArgumentType(fun, 0, arg)),
+                        };
+                        if arg1_ty != arg_ty {
+                            return Err(ExpressionError::InvalidArgumentType(
+                                fun,
+                                1,
+                                arg1.unwrap(),
+                            ));
+                        }
+                        // the last argument can always be a scalar
+                        match *arg2_ty {
+                            Ti::Scalar {
+                                kind: Sk::Float,
+                                width,
+                            } if width == arg_width => {}
+                            _ if arg2_ty == arg_ty => {}
+                            _ => {
+                                return Err(ExpressionError::InvalidArgumentType(
+                                    fun,
+                                    2,
+                                    arg2.unwrap(),
+                                ));
+                            }
                         }
                     }
                     Mf::Inverse | Mf::Determinant => {

--- a/tests/in/operators.wgsl
+++ b/tests/in/operators.wgsl
@@ -1,3 +1,20 @@
+//TODO: support splatting constructors for globals?
+let v_f32_one: vec4<f32> = vec4<f32>(1.0, 1.0, 1.0, 1.0);
+let v_f32_zero: vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+let v_f32_half: vec4<f32> = vec4<f32>(0.5, 0.5, 0.5, 0.5);
+
+fn builtins() -> vec4<f32> {
+    // select()
+    let condition = true;
+    let s1 = select(0, 1, condition);
+    let s2 = select(v_f32_zero, v_f32_one, condition);
+    // mix()
+    let m1 = mix(v_f32_zero, v_f32_one, v_f32_half);
+    let m2 = mix(v_f32_zero, v_f32_one, 0.1);
+    // done
+    return vec4<f32>(vec4<i32>(s1)) + s2 + m1 + m2;
+}
+
 fn splat() -> vec4<f32> {
     let a = (1.0 + vec2<f32>(2.0) - 3.0) / 4.0;
     let b = vec4<i32>(5) % 2;
@@ -9,17 +26,9 @@ fn unary() -> i32 {
     if (!true) { return a; } else { return ~a; };
 }
 
-fn selection() -> vec4<f32> {
-    let vector1 = vec4<f32>(1.0);
-    let vector2 = vec4<f32>(1.0);
-    let condition = true;
-    let a = select(0, 1, condition);
-    return select(vector1, vector2, condition);
-}
-
 [[stage(compute), workgroup_size(1)]]
 fn main() {
-    let a = splat();
-    let b = unary();
-    let c = selection();
+    let a = builtins();
+    let b = splat();
+    let c = unary();
 }

--- a/tests/out/glsl/operators.main.Compute.glsl
+++ b/tests/out/glsl/operators.main.Compute.glsl
@@ -6,6 +6,14 @@ precision highp int;
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 
+vec4 builtins() {
+    int s1_ = (true ? 1 : 0);
+    vec4 s2_ = (true ? vec4(1.0, 1.0, 1.0, 1.0) : vec4(0.0, 0.0, 0.0, 0.0));
+    vec4 m1_ = mix(vec4(0.0, 0.0, 0.0, 0.0), vec4(1.0, 1.0, 1.0, 1.0), vec4(0.5, 0.5, 0.5, 0.5));
+    vec4 m2_ = mix(vec4(0.0, 0.0, 0.0, 0.0), vec4(1.0, 1.0, 1.0, 1.0), 0.1);
+    return (((vec4(ivec4(s1_)) + s2_) + m1_) + m2_);
+}
+
 vec4 splat() {
     vec2 a = (((vec2(1.0) + vec2(2.0)) - vec2(3.0)) / vec2(4.0));
     ivec4 b = (ivec4(5) % ivec4(2));
@@ -20,17 +28,10 @@ int unary() {
     }
 }
 
-vec4 selection() {
-    vec4 vector1_ = vec4(1.0);
-    vec4 vector2_ = vec4(1.0);
-    int a = (true ? 1 : 0);
-    return (true ? vector2_ : vector1_);
-}
-
 void main() {
-    vec4 _expr0 = splat();
-    int _expr1 = unary();
-    vec4 _expr2 = selection();
+    vec4 _expr3 = builtins();
+    vec4 _expr4 = splat();
+    int _expr5 = unary();
     return;
 }
 

--- a/tests/out/hlsl/operators.hlsl
+++ b/tests/out/hlsl/operators.hlsl
@@ -1,3 +1,15 @@
+static const float4 v_f32_one = float4(1.0, 1.0, 1.0, 1.0);
+static const float4 v_f32_zero = float4(0.0, 0.0, 0.0, 0.0);
+static const float4 v_f32_half = float4(0.5, 0.5, 0.5, 0.5);
+
+float4 builtins()
+{
+    int s1_ = (true ? 1 : 0);
+    float4 s2_ = (true ? float4(1.0, 1.0, 1.0, 1.0) : float4(0.0, 0.0, 0.0, 0.0));
+    float4 m1_ = lerp(float4(0.0, 0.0, 0.0, 0.0), float4(1.0, 1.0, 1.0, 1.0), float4(0.5, 0.5, 0.5, 0.5));
+    float4 m2_ = lerp(float4(0.0, 0.0, 0.0, 0.0), float4(1.0, 1.0, 1.0, 1.0), 0.1);
+    return (((float4(int4(s1_.xxxx)) + s2_) + m1_) + m2_);
+}
 
 float4 splat()
 {
@@ -15,19 +27,11 @@ int unary()
     }
 }
 
-float4 selection()
-{
-    float4 vector1_ = float4(1.0.xxxx);
-    float4 vector2_ = float4(1.0.xxxx);
-    int a = (true ? 1 : 0);
-    return (true ? vector2_ : vector1_);
-}
-
 [numthreads(1, 1, 1)]
 void main()
 {
-    const float4 _e0 = splat();
-    const int _e1 = unary();
-    const float4 _e2 = selection();
+    const float4 _e3 = builtins();
+    const float4 _e4 = splat();
+    const int _e5 = unary();
     return;
 }

--- a/tests/out/msl/operators.msl
+++ b/tests/out/msl/operators.msl
@@ -2,6 +2,18 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
+constant metal::float4 v_f32_one = {1.0, 1.0, 1.0, 1.0};
+constant metal::float4 v_f32_zero = {0.0, 0.0, 0.0, 0.0};
+constant metal::float4 v_f32_half = {0.5, 0.5, 0.5, 0.5};
+
+metal::float4 builtins(
+) {
+    int s1_ = true ? 1 : 0;
+    metal::float4 s2_ = true ? v_f32_one : v_f32_zero;
+    metal::float4 m1_ = metal::mix(v_f32_zero, v_f32_one, v_f32_half);
+    metal::float4 m2_ = metal::mix(v_f32_zero, v_f32_one, 0.1);
+    return ((static_cast<float4>(metal::int4(s1_)) + s2_) + m1_) + m2_;
+}
 
 metal::float4 splat(
 ) {
@@ -19,18 +31,10 @@ int unary(
     }
 }
 
-metal::float4 selection(
-) {
-    metal::float4 vector1_ = metal::float4(1.0);
-    metal::float4 vector2_ = metal::float4(1.0);
-    int a = true ? 1 : 0;
-    return true ? vector2_ : vector1_;
-}
-
 kernel void main1(
 ) {
-    metal::float4 _e0 = splat();
-    int _e1 = unary();
-    metal::float4 _e2 = selection();
+    metal::float4 _e3 = builtins();
+    metal::float4 _e4 = splat();
+    int _e5 = unary();
     return;
 }

--- a/tests/out/spv/operators.spvasm
+++ b/tests/out/spv/operators.spvasm
@@ -1,84 +1,96 @@
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 61
+; Bound: 73
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %55 "main"
-OpExecutionMode %55 LocalSize 1 1 1
+OpEntryPoint GLCompute %67 "main"
+OpExecutionMode %67 LocalSize 1 1 1
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpConstant  %4  1.0
-%5 = OpConstant  %4  2.0
-%6 = OpConstant  %4  3.0
-%7 = OpConstant  %4  4.0
-%9 = OpTypeInt 32 1
-%8 = OpConstant  %9  5
-%10 = OpConstant  %9  2
-%11 = OpConstant  %9  1
-%13 = OpTypeBool
-%12 = OpConstantTrue  %13
-%14 = OpConstant  %9  0
-%15 = OpTypeVector %4 4
-%18 = OpTypeFunction %15
-%20 = OpTypeVector %4 2
-%28 = OpTypeVector %9 4
-%37 = OpTypeFunction %9
-%44 = OpConstantNull  %9
-%52 = OpTypeVector %13 4
-%56 = OpTypeFunction %2
-%17 = OpFunction  %15  None %18
-%16 = OpLabel
-OpBranch %19
-%19 = OpLabel
-%21 = OpCompositeConstruct  %20  %5 %5
-%22 = OpCompositeConstruct  %20  %3 %3
-%23 = OpFAdd  %20  %22 %21
-%24 = OpCompositeConstruct  %20  %6 %6
-%25 = OpFSub  %20  %23 %24
-%26 = OpCompositeConstruct  %20  %7 %7
-%27 = OpFDiv  %20  %25 %26
-%29 = OpCompositeConstruct  %28  %8 %8 %8 %8
-%30 = OpCompositeConstruct  %28  %10 %10 %10 %10
-%31 = OpSMod  %28  %29 %30
-%32 = OpVectorShuffle  %15  %27 %27 0 1 0 1
-%33 = OpConvertSToF  %15  %31
-%34 = OpFAdd  %15  %32 %33
-OpReturnValue %34
+%5 = OpConstant  %4  0.0
+%6 = OpConstant  %4  0.5
+%8 = OpTypeBool
+%7 = OpConstantTrue  %8
+%10 = OpTypeInt 32 1
+%9 = OpConstant  %10  0
+%11 = OpConstant  %10  1
+%12 = OpConstant  %4  0.1
+%13 = OpConstant  %4  2.0
+%14 = OpConstant  %4  3.0
+%15 = OpConstant  %4  4.0
+%16 = OpConstant  %10  5
+%17 = OpConstant  %10  2
+%18 = OpTypeVector %4 4
+%19 = OpConstantComposite  %18  %3 %3 %3 %3
+%20 = OpConstantComposite  %18  %5 %5 %5 %5
+%21 = OpConstantComposite  %18  %6 %6 %6 %6
+%24 = OpTypeFunction %18
+%28 = OpTypeVector %8 4
+%33 = OpTypeVector %10 4
+%42 = OpTypeVector %4 2
+%58 = OpTypeFunction %10
+%65 = OpConstantNull  %10
+%68 = OpTypeFunction %2
+%23 = OpFunction  %18  None %24
+%22 = OpLabel
+OpBranch %25
+%25 = OpLabel
+%26 = OpSelect  %10  %7 %11 %9
+%29 = OpCompositeConstruct  %28  %7 %7 %7 %7
+%27 = OpSelect  %18  %29 %19 %20
+%30 = OpExtInst  %18  %1 FMix %20 %19 %21
+%32 = OpCompositeConstruct  %18  %12 %12 %12 %12
+%31 = OpExtInst  %18  %1 FMix %20 %19 %32
+%34 = OpCompositeConstruct  %33  %26 %26 %26 %26
+%35 = OpConvertSToF  %18  %34
+%36 = OpFAdd  %18  %35 %27
+%37 = OpFAdd  %18  %36 %30
+%38 = OpFAdd  %18  %37 %31
+OpReturnValue %38
 OpFunctionEnd
-%36 = OpFunction  %9  None %37
-%35 = OpLabel
-OpBranch %38
-%38 = OpLabel
-%39 = OpLogicalNot  %13  %12
-OpSelectionMerge %40 None
-OpBranchConditional %39 %41 %42
+%40 = OpFunction  %18  None %24
+%39 = OpLabel
+OpBranch %41
 %41 = OpLabel
+%43 = OpCompositeConstruct  %42  %13 %13
+%44 = OpCompositeConstruct  %42  %3 %3
+%45 = OpFAdd  %42  %44 %43
+%46 = OpCompositeConstruct  %42  %14 %14
+%47 = OpFSub  %42  %45 %46
+%48 = OpCompositeConstruct  %42  %15 %15
+%49 = OpFDiv  %42  %47 %48
+%50 = OpCompositeConstruct  %33  %16 %16 %16 %16
+%51 = OpCompositeConstruct  %33  %17 %17 %17 %17
+%52 = OpSMod  %33  %50 %51
+%53 = OpVectorShuffle  %18  %49 %49 0 1 0 1
+%54 = OpConvertSToF  %18  %52
+%55 = OpFAdd  %18  %53 %54
+OpReturnValue %55
+OpFunctionEnd
+%57 = OpFunction  %10  None %58
+%56 = OpLabel
+OpBranch %59
+%59 = OpLabel
+%60 = OpLogicalNot  %8  %7
+OpSelectionMerge %61 None
+OpBranchConditional %60 %62 %63
+%62 = OpLabel
 OpReturnValue %11
-%42 = OpLabel
-%43 = OpNot  %9  %11
-OpReturnValue %43
-%40 = OpLabel
-OpReturnValue %44
+%63 = OpLabel
+%64 = OpNot  %10  %11
+OpReturnValue %64
+%61 = OpLabel
+OpReturnValue %65
 OpFunctionEnd
-%46 = OpFunction  %15  None %18
-%45 = OpLabel
-OpBranch %47
-%47 = OpLabel
-%48 = OpCompositeConstruct  %15  %3 %3 %3 %3
-%49 = OpCompositeConstruct  %15  %3 %3 %3 %3
-%50 = OpSelect  %9  %12 %11 %14
-%53 = OpCompositeConstruct  %52  %12 %12 %12 %12
-%51 = OpSelect  %15  %53 %49 %48
-OpReturnValue %51
-OpFunctionEnd
-%55 = OpFunction  %2  None %56
-%54 = OpLabel
-OpBranch %57
-%57 = OpLabel
-%58 = OpFunctionCall  %15  %17
-%59 = OpFunctionCall  %9  %36
-%60 = OpFunctionCall  %15  %46
+%67 = OpFunction  %2  None %68
+%66 = OpLabel
+OpBranch %69
+%69 = OpLabel
+%70 = OpFunctionCall  %18  %23
+%71 = OpFunctionCall  %18  %40
+%72 = OpFunctionCall  %10  %57
 OpReturn
 OpFunctionEnd

--- a/tests/out/wgsl/operators.wgsl
+++ b/tests/out/wgsl/operators.wgsl
@@ -1,3 +1,14 @@
+let v_f32_one: vec4<f32> = vec4<f32>(1.0, 1.0, 1.0, 1.0);
+let v_f32_zero: vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+let v_f32_half: vec4<f32> = vec4<f32>(0.5, 0.5, 0.5, 0.5);
+fn builtins() -> vec4<f32> {
+    let s1_: i32 = select(0, 1, true);
+    let s2_: vec4<f32> = select(vec4<f32>(0.0, 0.0, 0.0, 0.0), vec4<f32>(1.0, 1.0, 1.0, 1.0), true);
+    let m1_: vec4<f32> = mix(vec4<f32>(0.0, 0.0, 0.0, 0.0), vec4<f32>(1.0, 1.0, 1.0, 1.0), vec4<f32>(0.5, 0.5, 0.5, 0.5));
+    let m2_: vec4<f32> = mix(vec4<f32>(0.0, 0.0, 0.0, 0.0), vec4<f32>(1.0, 1.0, 1.0, 1.0), 0.1);
+    return (((vec4<f32>(vec4<i32>(s1_)) + s2_) + m1_) + m2_);
+}
+
 fn splat() -> vec4<f32> {
     let a: vec2<f32> = (((vec2<f32>(1.0) + vec2<f32>(2.0)) - vec2<f32>(3.0)) / vec2<f32>(4.0));
     let b: vec4<i32> = (vec4<i32>(5) % vec4<i32>(2));
@@ -12,17 +23,10 @@ fn unary() -> i32 {
     }
 }
 
-fn selection() -> vec4<f32> {
-    let vector1_: vec4<f32> = vec4<f32>(1.0);
-    let vector2_: vec4<f32> = vec4<f32>(1.0);
-    let a: i32 = select(0, 1, true);
-    return select(vector1_, vector2_, true);
-}
-
 [[stage(compute), workgroup_size(1, 1, 1)]]
 fn main() {
-    let _e0: vec4<f32> = splat();
-    let _e1: i32 = unary();
-    let _e2: vec4<f32> = selection();
+    let _e3: vec4<f32> = builtins();
+    let _e4: vec4<f32> = splat();
+    let _e5: i32 = unary();
     return;
 }


### PR DESCRIPTION
See https://github.com/gpuweb/gpuweb/pull/1974

I'm not totally sure if it's worth getting this into IR, or just resolve at the WGSL frontend side.
Pros:
  - more compact backend output, since there are no splats introduced if not needed (WGSL, GLSL, HLSL)
  - supporting the idea of "WGSL is text form of our IR", which is the basis for #752 
  - less logic in GLSL-in and WGSL-in
Cons:
  - more logic in SPV-out and the validator
  - less restricted IR - more difficult to fuzz, etc