### PR TITLE
hlsl: remove the boolean casts for unary operators

### DIFF
--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -100,6 +100,9 @@ impl<'a, W: Write> Writer<'a, W> {
             }
         }
 
+        // Extra newline for readability
+        writeln!(self.out)?;
+
         // Save all entry point output types
         let ep_results = module
             .entry_points
@@ -487,8 +490,6 @@ impl<'a, W: Write> Writer<'a, W> {
             }
         }
         writeln!(self.out, ";")?;
-        // End with extra newline for readability
-        writeln!(self.out)?;
         Ok(())
     }
 
@@ -1352,32 +1353,12 @@ impl<'a, W: Write> Writer<'a, W> {
             }
             Expression::Unary { op, expr } => {
                 // https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-operators#unary-operators
-                let convert_to_bool = if let TypeInner::Scalar {
-                    kind: crate::ScalarKind::Bool,
-                    ..
-                } = *func_ctx.info[expr].ty.inner_with(&module.types)
-                {
-                    false
-                } else {
-                    true
-                };
                 let op_str = match op {
                     crate::UnaryOperator::Negate => "-",
                     crate::UnaryOperator::Not => "!",
                 };
-                write!(self.out, "({}", op_str)?;
-
-                if convert_to_bool {
-                    write!(self.out, "bool(")?;
-                }
-
+                write!(self.out, "{}", op_str)?;
                 self.write_expr(module, expr, func_ctx)?;
-
-                if convert_to_bool {
-                    write!(self.out, ")")?;
-                }
-
-                write!(self.out, ")")?
             }
             Expression::As { expr, kind, .. } => {
                 let inner = func_ctx.info[expr].ty.inner_with(&module.types);

--- a/tests/out/hlsl/control-flow.hlsl
+++ b/tests/out/hlsl/control-flow.hlsl
@@ -1,3 +1,4 @@
+
 struct ComputeInput_main {
     uint3 global_id1 : SV_DispatchThreadID;
 };

--- a/tests/out/hlsl/empty.hlsl
+++ b/tests/out/hlsl/empty.hlsl
@@ -1,3 +1,4 @@
+
 [numthreads(1, 1, 1)]
 void main()
 {

--- a/tests/out/hlsl/image.hlsl
+++ b/tests/out/hlsl/image.hlsl
@@ -1,3 +1,4 @@
+
 Texture2D<uint4> image_mipmapped_src : register(t0);
 Texture2DMS<uint4> image_multisampled_src : register(t3);
 Texture2DMS<float> image_depth_multisampled_src : register(t4);

--- a/tests/out/hlsl/interface.hlsl
+++ b/tests/out/hlsl/interface.hlsl
@@ -1,3 +1,4 @@
+
 struct VertexOutput {
     float4 position : SV_Position;
     linear float varying : LOC1;

--- a/tests/out/hlsl/interpolate.hlsl
+++ b/tests/out/hlsl/interpolate.hlsl
@@ -1,3 +1,4 @@
+
 struct FragmentInput {
     float4 position : SV_Position;
     nointerpolation uint flat : LOC0;

--- a/tests/out/hlsl/operators.hlsl
+++ b/tests/out/hlsl/operators.hlsl
@@ -1,3 +1,4 @@
+
 float4 splat()
 {
     float2 a = (((float2(1.0.xx) + float2(2.0.xx)) - float2(3.0.xx)) / float2(4.0.xx));
@@ -7,10 +8,10 @@ float4 splat()
 
 int unary()
 {
-    if ((!true)) {
+    if (!true) {
         return 1;
     } else {
-        return (!bool(1));
+        return !1;
     }
 }
 

--- a/tests/out/hlsl/quad-vert.hlsl
+++ b/tests/out/hlsl/quad-vert.hlsl
@@ -1,3 +1,4 @@
+
 struct gl_PerVertex {
     float4 gl_Position : SV_Position;
     float gl_PointSize : PSIZE;

--- a/tests/out/hlsl/shadow.hlsl
+++ b/tests/out/hlsl/shadow.hlsl
@@ -1,5 +1,4 @@
 static const float3 c_ambient = float3(0.05, 0.05, 0.05);
-
 static const uint c_max_lights = 10;
 
 struct Globals {

--- a/tests/out/hlsl/skybox.hlsl
+++ b/tests/out/hlsl/skybox.hlsl
@@ -1,3 +1,4 @@
+
 struct VertexOutput {
     float4 position : SV_Position;
     linear float3 uv : LOC0;

--- a/tests/out/hlsl/standard.hlsl
+++ b/tests/out/hlsl/standard.hlsl
@@ -1,3 +1,4 @@
+
 struct FragmentInput_derivatives {
     float4 foo1 : SV_Position;
 };


### PR DESCRIPTION
Those bool casts on vectors were wrong. And on scalars I think they aren't necessary.