### PR TITLE
Fixes for zero init variables and variables with array type for hlsl and glsl backends

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -613,7 +613,7 @@ impl<'a, W: Write> Writer<'a, W> {
 
         // Write the array size
         // Writes nothing if `ArraySize::Dynamic`
-        // Panics if `ArraySize::Constant` has a constant that isn't an uint
+        // Panics if `ArraySize::Constant` has a constant that isn't an sint or uint
         match size {
             crate::ArraySize::Constant(const_handle) => {
                 match self.module.constants[const_handle].inner {

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -507,6 +507,10 @@ impl<'a, W: Write> Writer<'a, W> {
                         width: _,
                         value: crate::ScalarValue::Uint(size),
                     } => write!(self.out, "{}", size)?,
+                    crate::ConstantInner::Scalar {
+                        width: _,
+                        value: crate::ScalarValue::Sint(size),
+                    } => write!(self.out, "{}", size)?,
                     _ => unreachable!(),
                 }
             }

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -499,7 +499,7 @@ impl<'a, W: Write> Writer<'a, W> {
 
         // Write the array size
         // Writes nothing if `ArraySize::Dynamic`
-        // Panics if `ArraySize::Constant` has a constant that isn't an uint
+        // Panics if `ArraySize::Constant` has a constant that isn't an sint or uint
         match size {
             crate::ArraySize::Constant(const_handle) => {
                 match module.constants[const_handle].inner {

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -1142,20 +1142,7 @@ impl super::Validator {
                 }
                 ShaderStages::all()
             }
-            E::As {
-                expr,
-                kind,
-                convert,
-            } => {
-                let prev_kind = resolver
-                    .resolve(expr)?
-                    .scalar_kind()
-                    .ok_or(ExpressionError::InvalidCastArgument)?;
-
-                if prev_kind == Sk::Bool || kind == Sk::Bool {
-                    return Err(ExpressionError::InvalidCastArgument);
-                }
-
+            E::As { kind, convert, .. } => {
                 match convert {
                     Some(width) if !self.check_width(kind, width) => {
                         return Err(ExpressionError::InvalidCastArgument)

--- a/tests/out/glsl/boids.main.Compute.glsl
+++ b/tests/out/glsl/boids.main.Compute.glsl
@@ -31,15 +31,15 @@ buffer Particles_block_2Cs {
 
 void main() {
     uvec3 global_invocation_id = gl_GlobalInvocationID;
-    vec2 vPos;
-    vec2 vVel;
-    vec2 cMass;
-    vec2 cVel;
-    vec2 colVel;
+    vec2 vPos = vec2(0.0, 0.0);
+    vec2 vVel = vec2(0.0, 0.0);
+    vec2 cMass = vec2(0.0, 0.0);
+    vec2 cVel = vec2(0.0, 0.0);
+    vec2 colVel = vec2(0.0, 0.0);
     int cMassCount = 0;
     int cVelCount = 0;
-    vec2 pos;
-    vec2 vel;
+    vec2 pos = vec2(0.0, 0.0);
+    vec2 vel = vec2(0.0, 0.0);
     uint i = 0u;
     uint index = global_invocation_id.x;
     if ((index >= 1500u)) {

--- a/tests/out/glsl/quad-vert.main.Vertex.glsl
+++ b/tests/out/glsl/quad-vert.main.Vertex.glsl
@@ -45,8 +45,8 @@ void main() {
     vec2 _expr10 = v_uv;
     vec4 _expr11 = perVertexStruct.gen_gl_Position;
     float _expr12 = perVertexStruct.gen_gl_PointSize;
-    float _expr13[] = perVertexStruct.gen_gl_ClipDistance;
-    float _expr14[] = perVertexStruct.gen_gl_CullDistance;
+    float _expr13[1] = perVertexStruct.gen_gl_ClipDistance;
+    float _expr14[1] = perVertexStruct.gen_gl_CullDistance;
     type10 _tmp_return = type10(_expr10, _expr11, _expr12, _expr13, _expr14);
     _vs2fs_location0 = _tmp_return.member;
     gl_Position = _tmp_return.gen_gl_Position;

--- a/tests/out/glsl/skybox.vs_main.Vertex.glsl
+++ b/tests/out/glsl/skybox.vs_main.Vertex.glsl
@@ -17,8 +17,8 @@ layout(location = 0) smooth out vec3 _vs2fs_location0;
 
 void main() {
     uint vertex_index = uint(gl_VertexID);
-    int tmp1_;
-    int tmp2_;
+    int tmp1_ = 0;
+    int tmp2_ = 0;
     tmp1_ = (int(vertex_index) / 2);
     tmp2_ = (int(vertex_index) & 1);
     int _expr10 = tmp1_;


### PR DESCRIPTION
This PR contains:

1. Allow to translate from bool to another type in validator
1. [hlsl-out] Allow sint array size
1. [hlsl-out] Fix local variable writing with array type
1. [glsl-out] Fix array type writing
1. [glsl-out] Fix zero initialization for local variables