### PR TITLE
[glsl-in] Add support for shadow sampling

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -163,6 +163,30 @@ impl<'a> Program<'a> {
         Ok(context.typifier.get(handle, &self.module.types))
     }
 
+    /// Invalidates the cached type resolution for `handle` forcing a recomputation
+    pub fn invalidate_expression<'b>(
+        &'b self,
+        context: &'b mut Context,
+        handle: Handle<Expression>,
+        meta: SourceMetadata,
+    ) -> Result<(), ErrorKind> {
+        let resolve_ctx = ResolveContext {
+            constants: &self.module.constants,
+            types: &self.module.types,
+            global_vars: &self.module.global_variables,
+            local_vars: context.locals,
+            functions: &self.module.functions,
+            arguments: context.arguments,
+        };
+
+        context
+            .typifier
+            .invalidate(handle, context.expressions, &resolve_ctx)
+            .map_err(|error| {
+                ErrorKind::SemanticError(meta, format!("Can't resolve type: {:?}", error).into())
+            })
+    }
+
     pub fn solve_constant(
         &mut self,
         ctx: &Context,

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -737,7 +737,9 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
                                     // parse the body
                                     self.parse_compound_statement(&mut context, &mut body)?;
 
-                                    let Context { arg_use, .. } = context;
+                                    let Context {
+                                        arg_use, depth_set, ..
+                                    } = context;
                                     let handle = self.program.add_function(
                                         Function {
                                             name: Some(name.clone()),
@@ -750,6 +752,7 @@ impl<'source, 'program, 'options> Parser<'source, 'program, 'options> {
                                         },
                                         name,
                                         parameters,
+                                        depth_set,
                                         qualifiers,
                                         meta,
                                     )?;

--- a/src/front/mod.rs
+++ b/src/front/mod.rs
@@ -85,6 +85,26 @@ impl Typifier {
         }
         Ok(())
     }
+
+    /// Invalidates the cached type resolution for `epxr_handle` forcing a recomputation
+    ///
+    /// If the type of the expression hasn't yet been calculated a
+    /// [`grow`](Self::grow) is performed instead
+    pub fn invalidate(
+        &mut self,
+        expr_handle: Handle<crate::Expression>,
+        expressions: &Arena<crate::Expression>,
+        ctx: &ResolveContext,
+    ) -> Result<(), ResolveError> {
+        if self.resolutions.len() <= expr_handle.index() {
+            self.grow(expr_handle, expressions, ctx)
+        } else {
+            let expr = &expressions[expr_handle];
+            let resolution = ctx.resolve(expr, |h| &self.resolutions[h.index()])?;
+            self.resolutions[expr_handle.index()] = resolution;
+            Ok(())
+        }
+    }
 }
 
 impl ops::Index<Handle<crate::Expression>> for Typifier {


### PR DESCRIPTION
glsl has no concept of depth images, so the frontend when parsing a constructor for shadow combined samplers will convert the image from sampled to depth, further more to support this when using textures passed trough function arguments a bitset is used that upon function call will be checked and will also convert the image type if needed.