### PR TITLE
[glsl-in] Fixes and improvements

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -8,7 +8,7 @@ use crate::{
     proc::ResolveContext, Arena, BinaryOperator, Binding, Block, Constant, Expression, FastHashMap,
     Function, FunctionArgument, GlobalVariable, Handle, Interpolation, LocalVariable, Module,
     RelationalFunction, ResourceBinding, Sampling, ScalarKind, ScalarValue, ShaderStage, Statement,
-    StorageClass, Type, TypeInner, UnaryOperator, VectorSize,
+    StorageAccess, StorageClass, Type, TypeInner, UnaryOperator, VectorSize,
 };
 use core::convert::TryFrom;
 use std::ops::Index;
@@ -1054,6 +1054,7 @@ pub enum TypeQualifier {
     Layout(StructLayout),
     Precision(Precision),
     EarlyFragmentTests,
+    StorageAccess(StorageAccess),
 }
 
 #[derive(Debug, Clone)]

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -598,7 +598,7 @@ impl Program<'_> {
                     body,
                 )))
             }
-            "max" => {
+            "min" | "max" => {
                 if args.len() != 2 {
                     return Err(ErrorKind::wrong_function_args(name, 2, args.len(), meta));
                 }
@@ -606,23 +606,22 @@ impl Program<'_> {
                 let (mut arg0, arg0_meta) = args[0];
                 let (mut arg1, arg1_meta) = args[1];
 
-                let arg0_size = match *self.resolve_type(ctx, arg0, arg0_meta)? {
-                    TypeInner::Vector { size, .. } => Some(size),
-                    _ => None,
-                };
-                let arg1_size = match *self.resolve_type(ctx, arg1, arg1_meta)? {
-                    TypeInner::Vector { size, .. } => Some(size),
-                    _ => None,
-                };
-
                 ctx.binary_implicit_conversion(self, &mut arg0, arg0_meta, &mut arg1, arg1_meta)?;
 
-                ctx.implicit_splat(self, &mut arg0, arg0_meta, arg1_size)?;
-                ctx.implicit_splat(self, &mut arg1, arg1_meta, arg0_size)?;
+                if let TypeInner::Vector { size, .. } = *self.resolve_type(ctx, arg0, arg0_meta)? {
+                    ctx.implicit_splat(self, &mut arg1, arg1_meta, Some(size))?;
+                }
+                if let TypeInner::Vector { size, .. } = *self.resolve_type(ctx, arg1, arg1_meta)? {
+                    ctx.implicit_splat(self, &mut arg0, arg0_meta, Some(size))?;
+                }
 
                 Ok(Some(ctx.add_expression(
                     Expression::Math {
-                        fun: MathFunction::Max,
+                        fun: match name.as_str() {
+                            "min" => MathFunction::Min,
+                            "max" => MathFunction::Max,
+                            _ => unreachable!(),
+                        },
                         arg: arg0,
                         arg1: Some(arg1),
                         arg2: None,
@@ -630,8 +629,8 @@ impl Program<'_> {
                     body,
                 )))
             }
-            "pow" | "dot" | "min" | "reflect" | "cross" | "outerProduct" | "distance" | "step"
-            | "modf" | "frexp" | "ldexp" => {
+            "pow" | "dot" | "reflect" | "cross" | "outerProduct" | "distance" | "step" | "modf"
+            | "frexp" | "ldexp" => {
                 if args.len() != 2 {
                     return Err(ErrorKind::wrong_function_args(name, 2, args.len(), meta));
                 }
@@ -646,7 +645,6 @@ impl Program<'_> {
                         fun: match name.as_str() {
                             "pow" => MathFunction::Pow,
                             "dot" => MathFunction::Dot,
-                            "min" => MathFunction::Min,
                             "reflect" => MathFunction::Reflect,
                             "cross" => MathFunction::Cross,
                             "outerProduct" => MathFunction::Outer,

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -679,6 +679,13 @@ impl Program<'_> {
                     &mut selector,
                     selector_meta,
                 )?;
+                ctx.binary_implicit_conversion(
+                    self,
+                    &mut arg1,
+                    arg1_meta,
+                    &mut selector,
+                    selector_meta,
+                )?;
 
                 let is_vector = match *self.resolve_type(ctx, selector, selector_meta)? {
                     TypeInner::Vector { .. } => true,

--- a/src/front/glsl/lex.rs
+++ b/src/front/glsl/lex.rs
@@ -3,7 +3,7 @@ use super::{
     token::{SourceMetadata, Token, TokenValue},
     types::parse_type,
 };
-use crate::FastHashMap;
+use crate::{FastHashMap, StorageAccess};
 use pp_rs::{
     pp::Preprocessor,
     token::{Punct, Token as PPToken, TokenValue as PPTokenValue},
@@ -76,6 +76,9 @@ impl<'a> Iterator for Lexer<'a> {
                     "highp" => TokenValue::PrecisionQualifier(Precision::High),
                     "mediump" => TokenValue::PrecisionQualifier(Precision::Medium),
                     "lowp" => TokenValue::PrecisionQualifier(Precision::Low),
+                    "restrict" => TokenValue::Restrict,
+                    "readonly" => TokenValue::StorageAccess(StorageAccess::LOAD),
+                    "writeonly" => TokenValue::StorageAccess(StorageAccess::STORE),
                     // values
                     "true" => TokenValue::BoolConstant(true),
                     "false" => TokenValue::BoolConstant(false),

--- a/src/front/glsl/offset.rs
+++ b/src/front/glsl/offset.rs
@@ -51,14 +51,10 @@ pub fn calculate_offset(
         // consuming N basic machine units, the base alignment is 2N or 4N, respectively.
         // 3. If the member is a three-component vector with components consuming N
         // basic machine units, the base alignment is 4N.
-        TypeInner::Vector { size, width, .. } => {
-            let val = match size {
-                crate::VectorSize::Tri => 4 * width as u32,
-                _ => size as u32 * width as u32,
-            };
-
-            (val, val)
-        }
+        TypeInner::Vector { size, width, .. } => match size {
+            crate::VectorSize::Tri => (4 * width as u32, 3 * width as u32),
+            _ => (size as u32 * width as u32, size as u32 * width as u32),
+        },
         // 4. If the member is an array of scalars or vectors, the base alignment and array
         // stride are set to match the base alignment of a single array element, according
         // to rules (1), (2), and (3), and rounded up to the base alignment of a vec4.

--- a/src/front/glsl/token.rs
+++ b/src/front/glsl/token.rs
@@ -56,6 +56,10 @@ pub enum TokenValue {
     Uniform,
     Buffer,
     Const,
+
+    Restrict,
+    StorageAccess(crate::StorageAccess),
+
     Interpolation(Interpolation),
     Sampling(Sampling),
     Precision,

--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -548,6 +548,7 @@ impl Program<'_> {
         }
 
         let mut mutable = true;
+        let mut precision = None;
 
         for &(ref qualifier, meta) in qualifiers {
             match *qualifier {
@@ -561,6 +562,12 @@ impl Program<'_> {
 
                     mutable = false;
                 }
+                TypeQualifier::Precision(ref p) => qualifier_arm!(
+                    p,
+                    precision,
+                    meta,
+                    "Cannot use more than one precision qualifier per declaration"
+                ),
                 _ => {
                     return Err(ErrorKind::SemanticError(
                         meta,


### PR DESCRIPTION
All the fixes are contained in their own commits and can be reviewed individually

- Use the same splatting logic of `max` for `min`
- Fix missing implicit conversion on `mix`
- Parse `restrict`, `readonly` and `writeonly` (no logic yet, only parsing)
- Accept precision qualifiers in locals
- Handle `pow` in constant evaluation
- Fix the span of a `gvec3`