### PR TITLE
[glsl-in] Add support for non constant global init

### DIFF
--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -314,6 +314,8 @@ impl Program {
 
     pub fn add_global_var(
         &mut self,
+        ctx: &mut Context,
+        body: &mut Block,
         VarDeclaration {
             qualifiers,
             ty,
@@ -446,14 +448,14 @@ impl Program {
             });
 
             if let Some(name) = name {
-                self.global_variables.push((
-                    name,
-                    GlobalLookup {
-                        kind: GlobalLookupKind::Variable(handle),
-                        entry_arg: Some(idx),
-                        mutable: !input,
-                    },
-                ));
+                let lookup = GlobalLookup {
+                    kind: GlobalLookupKind::Variable(handle),
+                    entry_arg: Some(idx),
+                    mutable: !input,
+                };
+                ctx.add_global(&name, lookup, self, body);
+
+                self.global_variables.push((name, lookup));
             }
 
             return Ok(GlobalOrConstant::Global(handle));
@@ -462,14 +464,14 @@ impl Program {
                 ErrorKind::SemanticError(meta, "const values must have an initializer".into())
             })?;
             if let Some(name) = name {
-                self.global_variables.push((
-                    name,
-                    GlobalLookup {
-                        kind: GlobalLookupKind::Constant(init),
-                        entry_arg: None,
-                        mutable: false,
-                    },
-                ));
+                let lookup = GlobalLookup {
+                    kind: GlobalLookupKind::Constant(init),
+                    entry_arg: None,
+                    mutable: false,
+                };
+                ctx.add_global(&name, lookup, self, body);
+
+                self.global_variables.push((name, lookup));
             }
             return Ok(GlobalOrConstant::Constant(init));
         }
@@ -498,14 +500,14 @@ impl Program {
         });
 
         if let Some(name) = name {
-            self.global_variables.push((
-                name,
-                GlobalLookup {
-                    kind: GlobalLookupKind::Variable(handle),
-                    entry_arg: None,
-                    mutable: true,
-                },
-            ));
+            let lookup = GlobalLookup {
+                kind: GlobalLookupKind::Variable(handle),
+                entry_arg: None,
+                mutable: true,
+            };
+            ctx.add_global(&name, lookup, self, body);
+
+            self.global_variables.push((name, lookup));
         }
 
         Ok(GlobalOrConstant::Global(handle))

--- a/tests/out/wgsl/210-bevy-2d-shader-frag.wgsl
+++ b/tests/out/wgsl/210-bevy-2d-shader-frag.wgsl
@@ -26,6 +26,6 @@ fn main1() {
 fn main([[location(0)]] v_Uv: vec2<f32>) -> FragmentOutput {
     v_Uv1 = v_Uv;
     main1();
-    let _e3: vec4<f32> = o_Target;
-    return FragmentOutput(_e3);
+    let _e9: vec4<f32> = o_Target;
+    return FragmentOutput(_e9);
 }

--- a/tests/out/wgsl/210-bevy-2d-shader-vert.wgsl
+++ b/tests/out/wgsl/210-bevy-2d-shader-vert.wgsl
@@ -51,7 +51,7 @@ fn main([[location(0)]] Vertex_Position: vec3<f32>, [[location(1)]] Vertex_Norma
     Vertex_Normal1 = Vertex_Normal;
     Vertex_Uv1 = Vertex_Uv;
     main1();
-    let _e7: vec2<f32> = v_Uv;
-    let _e9: vec4<f32> = gl_Position;
-    return VertexOutput(_e7, _e9);
+    let _e21: vec2<f32> = v_Uv;
+    let _e23: vec4<f32> = gl_Position;
+    return VertexOutput(_e21, _e23);
 }

--- a/tests/out/wgsl/210-bevy-shader-vert.wgsl
+++ b/tests/out/wgsl/210-bevy-shader-vert.wgsl
@@ -51,9 +51,9 @@ fn main([[location(0)]] Vertex_Position: vec3<f32>, [[location(1)]] Vertex_Norma
     Vertex_Normal1 = Vertex_Normal;
     Vertex_Uv1 = Vertex_Uv;
     main1();
-    let _e7: vec3<f32> = v_Position;
-    let _e9: vec3<f32> = v_Normal;
-    let _e11: vec2<f32> = v_Uv;
-    let _e13: vec4<f32> = gl_Position;
-    return VertexOutput(_e7, _e9, _e11, _e13);
+    let _e23: vec3<f32> = v_Position;
+    let _e25: vec3<f32> = v_Normal;
+    let _e27: vec2<f32> = v_Uv;
+    let _e29: vec4<f32> = gl_Position;
+    return VertexOutput(_e23, _e25, _e27, _e29);
 }

--- a/tests/out/wgsl/800-out-of-bounds-panic-vert.wgsl
+++ b/tests/out/wgsl/800-out-of-bounds-panic-vert.wgsl
@@ -36,7 +36,7 @@ fn main([[location(0)]] position: vec2<f32>, [[location(1)]] color: vec4<f32>) -
     position1 = position;
     color1 = color;
     main1();
-    let _e5: vec4<f32> = frag_color;
-    let _e7: vec4<f32> = gl_Position;
-    return VertexOutput(_e5, _e7);
+    let _e15: vec4<f32> = frag_color;
+    let _e17: vec4<f32> = gl_Position;
+    return VertexOutput(_e15, _e17);
 }

--- a/tests/out/wgsl/bevy-pbr-frag.wgsl
+++ b/tests/out/wgsl/bevy-pbr-frag.wgsl
@@ -849,6 +849,6 @@ fn main([[location(0)]] v_WorldPosition: vec3<f32>, [[location(1)]] v_WorldNorma
     v_WorldTangent1 = v_WorldTangent;
     gl_FrontFacing = param;
     main1();
-    let _e11: vec4<f32> = o_Target;
-    return FragmentOutput(_e11);
+    let _e72: vec4<f32> = o_Target;
+    return FragmentOutput(_e72);
 }

--- a/tests/out/wgsl/bevy-pbr-vert.wgsl
+++ b/tests/out/wgsl/bevy-pbr-vert.wgsl
@@ -60,10 +60,10 @@ fn main([[location(0)]] Vertex_Position: vec3<f32>, [[location(1)]] Vertex_Norma
     Vertex_Uv1 = Vertex_Uv;
     Vertex_Tangent1 = Vertex_Tangent;
     main1();
-    let _e9: vec3<f32> = v_WorldPosition;
-    let _e11: vec3<f32> = v_WorldNormal;
-    let _e13: vec2<f32> = v_Uv;
-    let _e15: vec4<f32> = v_WorldTangent;
-    let _e17: vec4<f32> = gl_Position;
-    return VertexOutput(_e9, _e11, _e13, _e15, _e17);
+    let _e29: vec3<f32> = v_WorldPosition;
+    let _e31: vec3<f32> = v_WorldNormal;
+    let _e33: vec2<f32> = v_Uv;
+    let _e35: vec4<f32> = v_WorldTangent;
+    let _e37: vec4<f32> = gl_Position;
+    return VertexOutput(_e29, _e31, _e33, _e35, _e37);
 }

--- a/tests/out/wgsl/bool-select-frag.wgsl
+++ b/tests/out/wgsl/bool-select-frag.wgsl
@@ -40,6 +40,6 @@ fn main1() {
 [[stage(fragment)]]
 fn main() -> FragmentOutput {
     main1();
-    let _e1: vec4<f32> = o_color;
-    return FragmentOutput(_e1);
+    let _e3: vec4<f32> = o_color;
+    return FragmentOutput(_e3);
 }

--- a/tests/out/wgsl/clamp-splat-vert.wgsl
+++ b/tests/out/wgsl/clamp-splat-vert.wgsl
@@ -15,6 +15,6 @@ fn main1() {
 fn main([[location(0)]] a_pos: vec2<f32>) -> VertexOutput {
     a_pos1 = a_pos;
     main1();
-    let _e3: vec4<f32> = gl_Position;
-    return VertexOutput(_e3);
+    let _e5: vec4<f32> = gl_Position;
+    return VertexOutput(_e5);
 }

--- a/tests/out/wgsl/multiple_entry_points-glsl.wgsl
+++ b/tests/out/wgsl/multiple_entry_points-glsl.wgsl
@@ -34,15 +34,15 @@ fn comp_main1() {
 [[stage(vertex)]]
 fn vert_main() -> VertexOutput {
     vert_main1();
-    let _e1: vec4<f32> = gl_Position;
-    return VertexOutput(_e1);
+    let _e3: vec4<f32> = gl_Position;
+    return VertexOutput(_e3);
 }
 
 [[stage(fragment)]]
 fn frag_main() -> FragmentOutput {
     frag_main1();
-    let _e1: vec4<f32> = o_color;
-    return FragmentOutput(_e1);
+    let _e3: vec4<f32> = o_color;
+    return FragmentOutput(_e3);
 }
 
 [[stage(compute), workgroup_size(1, 1, 1)]]

--- a/tests/out/wgsl/quad_glsl-frag.wgsl
+++ b/tests/out/wgsl/quad_glsl-frag.wgsl
@@ -14,6 +14,6 @@ fn main1() {
 fn main([[location(0)]] v_uv: vec2<f32>) -> FragmentOutput {
     v_uv1 = v_uv;
     main1();
-    let _e3: vec4<f32> = o_color;
-    return FragmentOutput(_e3);
+    let _e7: vec4<f32> = o_color;
+    return FragmentOutput(_e7);
 }

--- a/tests/out/wgsl/quad_glsl-vert.wgsl
+++ b/tests/out/wgsl/quad_glsl-vert.wgsl
@@ -21,7 +21,7 @@ fn main([[location(0)]] a_pos: vec2<f32>, [[location(1)]] a_uv: vec2<f32>) -> Ve
     a_pos1 = a_pos;
     a_uv1 = a_uv;
     main1();
-    let _e5: vec2<f32> = v_uv;
-    let _e7: vec4<f32> = gl_Position;
-    return VertexOutput(_e5, _e7);
+    let _e14: vec2<f32> = v_uv;
+    let _e16: vec4<f32> = gl_Position;
+    return VertexOutput(_e14, _e16);
 }


### PR DESCRIPTION
Glsl allows things such as

```glsl
layout (location = 0) in vec4 a;
vec4 b = a;
```

In this case `b` depends on `a` which can't be known at compile time, so it's necessary to add a small prologue to the entry point to initialize it.

The prologue for global initialization is added after the prologue that assigns from the entry point arguments to globals because the parser utilizes this globals as opposed to the arguments.