### PR TITLE
[glsl-in] Fixes and improvements #2

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -925,6 +925,22 @@ impl<'function> Context<'function> {
 
         Ok(())
     }
+
+    pub fn vector_resize(
+        &mut self,
+        size: VectorSize,
+        vector: Handle<Expression>,
+        body: &mut Block,
+    ) -> Handle<Expression> {
+        self.add_expression(
+            Expression::Swizzle {
+                size,
+                vector,
+                pattern: crate::SwizzleComponent::XYZW,
+            },
+            body,
+        )
+    }
 }
 
 impl<'function> Index<Handle<Expression>> for Context<'function> {

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -730,10 +730,19 @@ impl Program {
                     .resolve_type(ctx, selector, selector_meta)?
                     .scalar_kind()
                 {
+                    // When the selector is a boolean vector the result is
+                    // calculated per component, for each component of the
+                    // selector if it's false the respective component from the
+                    // first argument is selected, if it's true the respective
+                    // component from the second argument is selected
+                    //
+                    // Note(jcapucho): yes, it's inverted in comparison with the
+                    // IR and SPIR-V and yes I spent a full debugging a shader
+                    // because of this weird behavior
                     Some(ScalarKind::Bool) => Expression::Select {
                         condition: selector,
-                        accept: arg,
-                        reject: arg1,
+                        accept: arg1,
+                        reject: arg,
                     },
                     _ => Expression::Math {
                         fun: MathFunction::Mix,

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -1763,13 +1763,11 @@ impl<'source, 'program> Parser<'source, 'program> {
                     if self.peek_type_name() || self.peek_type_qualifier() {
                         self.parse_declaration(ctx, body, false)?;
                     } else {
-                        self.parse_expression(ctx, body)?;
+                        let expr = self.parse_expression(ctx, body)?;
+                        ctx.lower(self.program, expr, false, body)?;
                         self.expect(TokenValue::Semicolon)?;
                     }
                 }
-
-                ctx.emit_flush(body);
-                ctx.emit_start();
 
                 let (mut block, mut continuing) = (Block::new(), Block::new());
 

--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -419,12 +419,12 @@ impl Program {
 
         if let Some(location) = location {
             let input = storage == StorageQualifier::Input;
-            let interpolation = self.module.types[ty].inner.scalar_kind().map(|kind| {
-                if let ScalarKind::Float = kind {
-                    Interpolation::Perspective
-                } else {
-                    Interpolation::Flat
-                }
+            let interpolation = interpolation.or_else(|| {
+                let kind = self.module.types[ty].inner.scalar_kind()?;
+                Some(match kind {
+                    ScalarKind::Float => Interpolation::Perspective,
+                    _ => Interpolation::Flat,
+                })
             });
 
             let handle = self.module.global_variables.append(GlobalVariable {

--- a/tests/out/wgsl/246-collatz-comp.wgsl
+++ b/tests/out/wgsl/246-collatz-comp.wgsl
@@ -1,6 +1,6 @@
 [[block]]
 struct PrimeIndices {
-    indices: [[stride(16)]] array<u32>;
+    indices: [[stride(4)]] array<u32>;
 };
 
 [[group(0), binding(0)]]

--- a/tests/out/wgsl/280-matrix-cast-vert.wgsl
+++ b/tests/out/wgsl/280-matrix-cast-vert.wgsl
@@ -1,9 +1,7 @@
 fn main1() {
-    var a: mat4x4<f32>;
+    var a: mat4x4<f32> = mat4x4<f32>(vec4<f32>(1.0, 0.0, 0.0, 0.0), vec4<f32>(0.0, 1.0, 0.0, 0.0), vec4<f32>(0.0, 0.0, 1.0, 0.0), vec4<f32>(0.0, 0.0, 0.0, 1.0));
 
-    let _e2: vec4<f32> = vec4<f32>(f32(1));
-    a = mat4x4<f32>(_e2, _e2, _e2, _e2);
-    return;
+    let _e1: f32 = f32(1);
 }
 
 [[stage(vertex)]]

--- a/tests/out/wgsl/long-form-matrix-vert.wgsl
+++ b/tests/out/wgsl/long-form-matrix-vert.wgsl
@@ -1,5 +1,5 @@
 fn main1() {
-    var splat: mat2x2<f32>;
+    var splat: mat2x2<f32> = mat2x2<f32>(vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0));
     var normal: mat2x2<f32> = mat2x2<f32>(vec2<f32>(1.0, 1.0), vec2<f32>(2.0, 2.0));
     var a: mat2x2<f32> = mat2x2<f32>(vec2<f32>(1.0, 2.0), vec2<f32>(3.0, 4.0));
     var b: mat2x2<f32> = mat2x2<f32>(vec2<f32>(1.0, 2.0), vec2<f32>(3.0, 4.0));
@@ -7,21 +7,20 @@ fn main1() {
     var d: mat3x3<f32> = mat3x3<f32>(vec3<f32>(2.0, 2.0, 1.0), vec3<f32>(1.0, 1.0, 1.0), vec3<f32>(1.0, 1.0, 1.0));
     var e: mat4x4<f32> = mat4x4<f32>(vec4<f32>(2.0, 2.0, 1.0, 1.0), vec4<f32>(1.0, 1.0, 2.0, 2.0), vec4<f32>(1.0, 1.0, 1.0, 1.0), vec4<f32>(1.0, 1.0, 1.0, 1.0));
 
-    let _e2: vec2<f32> = vec2<f32>(f32(1));
-    splat = mat2x2<f32>(_e2, _e2);
-    let _e7: vec2<f32> = vec2<f32>(f32(1));
-    let _e10: vec2<f32> = vec2<f32>(f32(2));
-    let _e36: vec2<f32> = vec2<f32>(f32(2), f32(3));
-    let _e51: vec3<f32> = vec3<f32>(f32(1));
-    let _e54: vec3<f32> = vec3<f32>(f32(1));
-    let _e71: vec2<f32> = vec2<f32>(f32(2));
-    let _e75: vec3<f32> = vec3<f32>(f32(1));
-    let _e78: vec3<f32> = vec3<f32>(f32(1));
-    let _e95: vec2<f32> = vec2<f32>(f32(2));
-    let _e98: vec4<f32> = vec4<f32>(f32(1));
-    let _e101: vec2<f32> = vec2<f32>(f32(2));
-    let _e104: vec4<f32> = vec4<f32>(f32(1));
-    let _e107: vec4<f32> = vec4<f32>(f32(1));
+    let _e1: f32 = f32(1);
+    let _e9: vec2<f32> = vec2<f32>(f32(1));
+    let _e12: vec2<f32> = vec2<f32>(f32(2));
+    let _e38: vec2<f32> = vec2<f32>(f32(2), f32(3));
+    let _e53: vec3<f32> = vec3<f32>(f32(1));
+    let _e56: vec3<f32> = vec3<f32>(f32(1));
+    let _e73: vec2<f32> = vec2<f32>(f32(2));
+    let _e77: vec3<f32> = vec3<f32>(f32(1));
+    let _e80: vec3<f32> = vec3<f32>(f32(1));
+    let _e97: vec2<f32> = vec2<f32>(f32(2));
+    let _e100: vec4<f32> = vec4<f32>(f32(1));
+    let _e103: vec2<f32> = vec2<f32>(f32(2));
+    let _e106: vec4<f32> = vec4<f32>(f32(1));
+    let _e109: vec4<f32> = vec4<f32>(f32(1));
 }
 
 [[stage(vertex)]]


### PR DESCRIPTION
All the fixes are contained in their own commits and can be reviewed individually

- Respect user defined interpolation
- Lower the init expression in for loops
- Use std430 for `buffer` objects (as defined in the spec)
- Reduce number of produced vector resizes (makes the output more readable)
- Matrix initializers with only one scalar produce diagonal matrices
- `mix` when using a boolean selector has inverted argument order (compared to the IR and SPV)