### PR TITLE
[spirv-in] Fix Storage Access for Storage Buffers

### DIFF
--- a/src/front/spv/convert.rs
+++ b/src/front/spv/convert.rs
@@ -155,7 +155,7 @@ pub(super) fn map_storage_class(word: spirv::Word) -> Result<super::ExtendedClas
         Some(Sc::Private) => Ec::Global(crate::StorageClass::Private),
         Some(Sc::UniformConstant) => Ec::Global(crate::StorageClass::Handle),
         Some(Sc::StorageBuffer) => Ec::Global(crate::StorageClass::Storage {
-            access: crate::StorageAccess::default(),
+            access: crate::StorageAccess::LOAD | crate::StorageAccess::STORE,
         }),
         // we expect the `Storage` case to be filtered out before calling this function.
         Some(Sc::Uniform) => Ec::Global(crate::StorageClass::Uniform),

--- a/tests/out/spv/pointer-access.spvasm
+++ b/tests/out/spv/pointer-access.spvasm
@@ -12,8 +12,6 @@ OpDecorate %12 ArrayStride 4
 OpDecorate %14 ArrayStride 4
 OpDecorate %15 Block
 OpMemberDecorate %15 0 Offset 0
-OpDecorate %17 NonReadable
-OpDecorate %17 NonWritable
 OpDecorate %17 DescriptorSet 0
 OpDecorate %17 Binding 0
 %2 = OpTypeVoid


### PR DESCRIPTION
I was getting a validation error when parsing a simple RustGPU-generated spirv file. I think, according to the spec, that the storage buffer storage class should have load and store access.

I know pretty much nothing about SPIRV, so I could be totally wrong, but this makes the SPIRV file in question validate and translate successfully with naga.