### PR TITLE
[glsl-in] Don't clone HirExpr when lowering

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -240,6 +240,11 @@ impl<T> Arena<T> {
             marker: PhantomData,
         }
     }
+
+    /// Clears the arena keeping all allocations
+    pub fn clear(&mut self) {
+        self.data.clear()
+    }
 }
 
 impl<T> ops::Index<Handle<T>> for Arena<T> {

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -192,8 +192,9 @@ impl<'source> ParsingContext<'source> {
 
         let mut ctx = Context::new(parser, &mut block);
 
-        let expr = self.parse_conditional(parser, &mut ctx, &mut block, None)?;
-        let (root, meta) = ctx.lower_expect(parser, expr, false, &mut block)?;
+        let mut stmt_ctx = ctx.stmt_ctx();
+        let expr = self.parse_conditional(parser, &mut ctx, &mut stmt_ctx, &mut block, None)?;
+        let (root, meta) = ctx.lower_expect(stmt_ctx, parser, expr, false, &mut block)?;
 
         Ok((parser.solve_constant(&ctx, root, meta)?, meta))
     }

--- a/src/front/glsl/parser/declarations.rs
+++ b/src/front/glsl/parser/declarations.rs
@@ -98,8 +98,9 @@ impl<'source> ParsingContext<'source> {
                 meta,
             ))
         } else {
-            let expr = self.parse_assignment(parser, ctx, body)?;
-            let (mut init, init_meta) = ctx.lower_expect(parser, expr, false, body)?;
+            let mut stmt = ctx.stmt_ctx();
+            let expr = self.parse_assignment(parser, ctx, &mut stmt, body)?;
+            let (mut init, init_meta) = ctx.lower_expect(stmt, parser, expr, false, body)?;
 
             let scalar_components = scalar_components(&parser.module.types[ty].inner);
             if let Some((kind, width)) = scalar_components {


### PR DESCRIPTION
Introduces a new type `StmtContext` which now holds the `Arena<HirExpr>`, this type is needed because lowering requires a disjoint borrow otherwise a clone is needed.

This type is reused in between lowers, this needed a new method on the `Arena` equal to it's `Vec` counterpart `clear`.