### PR TITLE
Implement lexing and parsing for all WGSL number literal types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 petgraph = { version ="0.5", optional = true }
 rose_tree = { version ="0.2", optional = true }
 pp-rs = { version = "0.2.1", optional = true }
+hexf-parse = { version = "0.2.1", optional = true }
 
 [features]
 default = []
@@ -40,7 +41,7 @@ serialize = ["serde"]
 deserialize = ["serde"]
 spv-in = ["petgraph", "spirv", "rose_tree"]
 spv-out = ["spirv"]
-wgsl-in = ["codespan-reporting"]
+wgsl-in = ["codespan-reporting", "hexf-parse"]
 wgsl-out = []
 hlsl-out = []
 span = ["codespan-reporting"]

--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -681,7 +681,12 @@ fn test_tokens() {
             Token::Number {
                 value: "2",
                 ty: 'u',
-                width: "3",
+                width: "",
+            },
+            Token::Number {
+                value: "3",
+                ty: 'i',
+                width: "",
             },
             Token::Word("o"),
         ],
@@ -692,9 +697,9 @@ fn test_tokens() {
             Token::Number {
                 value: "2.4",
                 ty: 'f',
-                width: "44",
+                width: "",
             },
-            Token::Word("po"),
+            Token::Word("f44po"),
         ],
     );
     sub_test(

--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -1,4 +1,4 @@
-use super::{conv, Error, ExpectedToken, Span, Token, TokenSpan};
+use super::{conv, Error, ExpectedToken, NumberType, Span, Token, TokenSpan};
 
 fn _consume_str<'a>(input: &'a str, what: &str) -> Option<&'a str> {
     if input.starts_with(what) {
@@ -303,13 +303,13 @@ fn consume_number(input: &str) -> (Token, &str) {
                 value
             },
             ty: if state.uint_suffix {
-                'u'
+                NumberType::Uint
             } else if state.is_float() {
-                'f'
+                NumberType::Float
             } else {
-                'i'
+                NumberType::Sint
             },
-            width: "",
+            width: None,
         },
         rest,
     )
@@ -639,8 +639,8 @@ fn test_tokens() {
         &[
             Token::Number {
                 value: "92",
-                ty: 'i',
-                width: "",
+                ty: NumberType::Sint,
+                width: None,
             },
             Token::Word("No"),
         ],
@@ -650,13 +650,13 @@ fn test_tokens() {
         &[
             Token::Number {
                 value: "2",
-                ty: 'u',
-                width: "",
+                ty: NumberType::Uint,
+                width: None,
             },
             Token::Number {
                 value: "3",
-                ty: 'i',
-                width: "",
+                ty: NumberType::Sint,
+                width: None,
             },
             Token::Word("o"),
         ],
@@ -666,8 +666,8 @@ fn test_tokens() {
         &[
             Token::Number {
                 value: "2.4",
-                ty: 'f',
-                width: "",
+                ty: NumberType::Float,
+                width: None,
             },
             Token::Word("f44po"),
         ],
@@ -691,8 +691,8 @@ fn test_variable_decl() {
             Token::Paren('('),
             Token::Number {
                 value: "0",
-                ty: 'i',
-                width: "",
+                ty: NumberType::Sint,
+                width: None,
             },
             Token::Paren(')'),
             Token::DoubleParen(']'),

--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -105,21 +105,17 @@ fn consume_number(input: &str) -> (Token, &str) {
                 '0' => {
                     state.digit_state = NLDigitState::LeadingZero;
                     state.leading_zeros += 1;
-                    true
                 }
                 '1'..='9' => {
                     state.digit_state = NLDigitState::DigitBeforeDot;
-                    true
                 }
                 'a'..='f' | 'A'..='F' if hex => {
                     state.digit_state = NLDigitState::DigitBeforeDot;
-                    true
                 }
                 '.' => {
                     state.digit_state = NLDigitState::OnlyDot;
-                    true
                 }
-                _ => false,
+                _ => return false,
             },
 
             NumberLexerState {
@@ -129,36 +125,29 @@ fn consume_number(input: &str) -> (Token, &str) {
                 ..
             } => match c {
                 '0' => {
-                    state.digit_state = NLDigitState::LeadingZero;
+                    // We stay in NLDigitState::LeadingZero.
                     state.leading_zeros += 1;
-                    true
                 }
                 '1'..='9' => {
                     state.digit_state = NLDigitState::DigitBeforeDot;
-                    true
                 }
                 'a'..='f' | 'A'..='F' if hex => {
                     state.digit_state = NLDigitState::DigitBeforeDot;
-                    true
                 }
                 '.' => {
                     state.digit_state = NLDigitState::DigitsThenDot;
-                    true
                 }
                 'e' | 'E' if !hex => {
                     state.digit_state = NLDigitState::Exponent;
-                    true
                 }
                 'p' | 'P' if hex => {
                     state.digit_state = NLDigitState::Exponent;
-                    true
                 }
                 'u' => {
                     // We stay in NLDigitState::LeadingZero.
                     state.uint_suffix = true;
-                    true
                 }
-                _ => false,
+                _ => return false,
             },
 
             NumberLexerState {
@@ -168,31 +157,25 @@ fn consume_number(input: &str) -> (Token, &str) {
                 ..
             } => match c {
                 '0'..='9' => {
-                    state.digit_state = NLDigitState::DigitBeforeDot;
-                    true
+                    // We stay in NLDigitState::DigitBeforeDot.
                 }
                 'a'..='f' | 'A'..='F' if hex => {
-                    state.digit_state = NLDigitState::DigitBeforeDot;
-                    true
+                    // We stay in NLDigitState::DigitBeforeDot.
                 }
                 '.' => {
                     state.digit_state = NLDigitState::DigitsThenDot;
-                    true
                 }
                 'e' | 'E' if !hex => {
                     state.digit_state = NLDigitState::Exponent;
-                    true
                 }
                 'p' | 'P' if hex => {
                     state.digit_state = NLDigitState::Exponent;
-                    true
                 }
                 'u' => {
-                    // We stay in NLDigitState::LeadingZero.
+                    // We stay in NLDigitState::DigitBeforeDot.
                     state.uint_suffix = true;
-                    true
                 }
-                _ => false,
+                _ => return false,
             },
 
             NumberLexerState {
@@ -203,13 +186,11 @@ fn consume_number(input: &str) -> (Token, &str) {
             } => match c {
                 '0'..='9' => {
                     state.digit_state = NLDigitState::DigitAfterDot;
-                    true
                 }
                 'a'..='f' | 'A'..='F' if hex => {
                     state.digit_state = NLDigitState::DigitAfterDot;
-                    true
                 }
-                _ => false,
+                _ => return false,
             },
 
             NumberLexerState {
@@ -226,21 +207,17 @@ fn consume_number(input: &str) -> (Token, &str) {
             } => match c {
                 '0'..='9' => {
                     state.digit_state = NLDigitState::DigitAfterDot;
-                    true
                 }
                 'a'..='f' | 'A'..='F' if hex => {
                     state.digit_state = NLDigitState::DigitAfterDot;
-                    true
                 }
                 'e' | 'E' if !hex => {
                     state.digit_state = NLDigitState::Exponent;
-                    true
                 }
                 'p' | 'P' if hex => {
                     state.digit_state = NLDigitState::Exponent;
-                    true
                 }
-                _ => false,
+                _ => return false,
             },
 
             NumberLexerState {
@@ -250,13 +227,11 @@ fn consume_number(input: &str) -> (Token, &str) {
             } => match c {
                 '0'..='9' => {
                     state.digit_state = NLDigitState::DigitAfterExponent;
-                    true
                 }
                 '-' | '+' => {
                     state.digit_state = NLDigitState::SignAfterExponent;
-                    true
                 }
-                _ => false,
+                _ => return false,
             },
 
             NumberLexerState {
@@ -271,15 +246,17 @@ fn consume_number(input: &str) -> (Token, &str) {
             } => match c {
                 '0'..='9' => {
                     state.digit_state = NLDigitState::DigitAfterExponent;
-                    true
                 }
-                _ => false,
+                _ => return false,
             },
 
             NumberLexerState {
                 uint_suffix: true, ..
-            } => false, // Scanning is done once we've reached a type suffix.
+            } => return false, // Scanning is done once we've reached a type suffix.
         }
+
+        // No match branch has rejected this yet, so we are still in a number literal
+        true
     };
 
     let pos = working_substr

--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -16,7 +16,7 @@ fn consume_any(input: &str, what: impl Fn(char) -> bool) -> (&str, &str) {
 /// Tries to skip a given prefix in the input string.
 /// Returns whether the prefix was present and could therefore be skipped,
 /// the remaining str and the number of *bytes* skipped.
-fn try_skip_prefix<'a, 'b>(input: &'a str, prefix: &'b str) -> (bool, &'a str, usize) {
+pub fn try_skip_prefix<'a, 'b>(input: &'a str, prefix: &'b str) -> (bool, &'a str, usize) {
     if input.starts_with(prefix) {
         (true, &input[prefix.len()..], prefix.len())
     } else {
@@ -546,34 +546,6 @@ impl<'a> Lexer<'a> {
         match self.next() {
             (Token::Word(word), _) => Ok(word),
             other => Err(Error::Unexpected(other, ExpectedToken::Identifier)),
-        }
-    }
-
-    fn _next_float_literal(&mut self) -> Result<f32, Error<'a>> {
-        match self.next() {
-            (Token::Number { value, .. }, span) => {
-                value.parse().map_err(|e| Error::BadFloat(span, e))
-            }
-            other => Err(Error::Unexpected(other, ExpectedToken::Float)),
-        }
-    }
-
-    pub(super) fn next_uint_literal(&mut self) -> Result<u32, Error<'a>> {
-        match self.next() {
-            (Token::Number { value, .. }, span) => {
-                let v = value.parse();
-                v.map_err(|e| Error::BadU32(span, e))
-            }
-            other => Err(Error::Unexpected(other, ExpectedToken::Uint)),
-        }
-    }
-
-    pub(super) fn next_sint_literal(&mut self) -> Result<i32, Error<'a>> {
-        match self.next() {
-            (Token::Number { value, .. }, span) => {
-                value.parse().map_err(|e| Error::BadI32(span, e))
-            }
-            other => Err(Error::Unexpected(other, ExpectedToken::Sint)),
         }
     }
 

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -4,6 +4,7 @@
 
 mod conv;
 mod lexer;
+mod number_literals;
 #[cfg(test)]
 mod tests;
 
@@ -16,7 +17,13 @@ use crate::{
     Bytes, ConstantInner, FastHashMap, ScalarValue,
 };
 
-use self::lexer::{try_skip_prefix, Lexer};
+use self::{
+    lexer::Lexer,
+    number_literals::{
+        get_f32_literal, get_i32_literal, get_u32_literal, parse_generic_non_negative_int_literal,
+        parse_non_negative_sint_literal, parse_sint_literal,
+    },
+};
 use codespan_reporting::{
     diagnostic::{Diagnostic, Label},
     files::{Files, SimpleFile},
@@ -25,7 +32,7 @@ use codespan_reporting::{
         termcolor::{ColorChoice, ColorSpec, StandardStream, WriteColor},
     },
 };
-use hexf_parse::{parse_hexf32, ParseHexfError};
+use hexf_parse::ParseHexfError;
 use std::{
     borrow::Cow,
     convert::TryFrom,
@@ -977,226 +984,6 @@ pub enum Scope {
 }
 
 type LocalFunctionCall = (Handle<crate::Function>, Vec<Handle<crate::Expression>>);
-
-fn check_int_literal(word_without_minus: &str, minus: bool, hex: bool) -> Result<(), BadIntError> {
-    let leading_zeros = word_without_minus
-        .bytes()
-        .take_while(|&b| b == b'0')
-        .count();
-
-    if word_without_minus == "0" && minus {
-        Err(BadIntError::NegativeZero)
-    } else if word_without_minus != "0" && !hex && leading_zeros != 0 {
-        Err(BadIntError::LeadingZeros)
-    } else {
-        Ok(())
-    }
-}
-
-fn get_i32_literal(word: &str, span: Span) -> Result<i32, Error<'_>> {
-    let (minus, word_without_minus, _) = try_skip_prefix(word, "-");
-    let (hex, word_without_minus_and_0x, _) = try_skip_prefix(word_without_minus, "0x");
-
-    check_int_literal(word_without_minus, minus, hex)
-        .map_err(|e| Error::BadI32(span.clone(), e))?;
-
-    let parsed_val = match (hex, minus) {
-        (true, true) => i32::from_str_radix(&format!("-{}", word_without_minus_and_0x), 16),
-        (true, false) => i32::from_str_radix(word_without_minus_and_0x, 16),
-        (false, _) => word.parse(),
-    };
-
-    parsed_val.map_err(|e| Error::BadI32(span, e.into()))
-}
-
-fn get_u32_literal(word: &str, span: Span) -> Result<u32, Error<'_>> {
-    let (minus, word_without_minus, _) = try_skip_prefix(word, "-");
-    let (hex, word_without_minus_and_0x, _) = try_skip_prefix(word_without_minus, "0x");
-
-    check_int_literal(word_without_minus, minus, hex)
-        .map_err(|e| Error::BadU32(span.clone(), e))?;
-
-    // We need to add a minus here as well, since the lexer also accepts syntactically incorrect negative uints
-    let parsed_val = match (hex, minus) {
-        (true, true) => u32::from_str_radix(&format!("-{}", word_without_minus_and_0x), 16),
-        (true, false) => u32::from_str_radix(word_without_minus_and_0x, 16),
-        (false, _) => word.parse(),
-    };
-
-    parsed_val.map_err(|e| Error::BadU32(span, e.into()))
-}
-
-fn get_f32_literal(word: &str, span: Span) -> Result<f32, Error<'_>> {
-    let hex = word.starts_with("0x") || word.starts_with("-0x");
-
-    let parsed_val = if hex {
-        parse_hexf32(word, false).map_err(BadFloatError::ParseHexfError)
-    } else {
-        word.parse::<f32>().map_err(BadFloatError::ParseFloatError)
-    };
-
-    parsed_val.map_err(|e| Error::BadFloat(span, e))
-}
-
-fn parse_sint_literal<'a>(lexer: &mut Lexer<'a>, width: Bytes) -> Result<i32, Error<'a>> {
-    let token_span = lexer.next();
-
-    if width != 4 {
-        // Only 32-bit literals supported by the spec and naga for now!
-        return Err(Error::BadScalarWidth(token_span.1, width));
-    }
-
-    match token_span {
-        (
-            Token::Number {
-                value,
-                ty: NumberType::Sint,
-                width: token_width,
-            },
-            span,
-        ) if token_width.unwrap_or(4) == width => get_i32_literal(value, span),
-        other => Err(Error::Unexpected(
-            other,
-            ExpectedToken::Number {
-                ty: Some(NumberType::Sint),
-                width: Some(width),
-            },
-        )),
-    }
-}
-
-fn _parse_uint_literal<'a>(lexer: &mut Lexer<'a>, width: Bytes) -> Result<u32, Error<'a>> {
-    let token_span = lexer.next();
-
-    if width != 4 {
-        // Only 32-bit literals supported by the spec and naga for now!
-        return Err(Error::BadScalarWidth(token_span.1, width));
-    }
-
-    match token_span {
-        (
-            Token::Number {
-                value,
-                ty: NumberType::Uint,
-                width: token_width,
-            },
-            span,
-        ) if token_width.unwrap_or(4) == width => get_u32_literal(value, span),
-        other => Err(Error::Unexpected(
-            other,
-            ExpectedToken::Number {
-                ty: Some(NumberType::Uint),
-                width: Some(width),
-            },
-        )),
-    }
-}
-
-/// Parse a non-negative signed integer literal.
-/// This is for attributes like `size`, `location` and others.
-fn parse_non_negative_sint_literal<'a>(
-    lexer: &mut Lexer<'a>,
-    width: Bytes,
-) -> Result<u32, Error<'a>> {
-    let token_span = lexer.next();
-
-    if width != 4 {
-        // Only 32-bit literals supported by the spec and naga for now!
-        return Err(Error::BadScalarWidth(token_span.1, width));
-    }
-
-    match token_span {
-        (
-            Token::Number {
-                value,
-                ty: NumberType::Sint,
-                width: token_width,
-            },
-            span,
-        ) if token_width.unwrap_or(4) == width => {
-            let i32_val = get_i32_literal(value, span.clone())?;
-            u32::try_from(i32_val).map_err(|_| Error::NegativeInt(span))
-        }
-        other => Err(Error::Unexpected(
-            other,
-            ExpectedToken::Number {
-                ty: Some(NumberType::Sint),
-                width: Some(width),
-            },
-        )),
-    }
-}
-
-/// Parse a non-negative integer literal that may be either signed or unsigned.
-/// This is for the `workgroup_size` attribute and array lengths.
-/// Note: these values should be no larger than [`i32::MAX`], but this is not checked here.
-fn parse_generic_non_negative_int_literal<'a>(
-    lexer: &mut Lexer<'a>,
-    width: Bytes,
-) -> Result<u32, Error<'a>> {
-    let token_span = lexer.next();
-
-    if width != 4 {
-        // Only 32-bit literals supported by the spec and naga for now!
-        return Err(Error::BadScalarWidth(token_span.1, width));
-    }
-
-    match token_span {
-        (
-            Token::Number {
-                value,
-                ty: NumberType::Sint,
-                width: token_width,
-            },
-            span,
-        ) if token_width.unwrap_or(4) == width => {
-            let i32_val = get_i32_literal(value, span.clone())?;
-            u32::try_from(i32_val).map_err(|_| Error::NegativeInt(span))
-        }
-        (
-            Token::Number {
-                value,
-                ty: NumberType::Uint,
-                width: token_width,
-            },
-            span,
-        ) if token_width.unwrap_or(4) == width => get_u32_literal(value, span),
-        other => Err(Error::Unexpected(
-            other,
-            ExpectedToken::Number {
-                ty: Some(NumberType::Sint),
-                width: Some(width),
-            },
-        )),
-    }
-}
-
-fn _parse_float_literal<'a>(lexer: &mut Lexer<'a>, width: Bytes) -> Result<f32, Error<'a>> {
-    let token_span = lexer.next();
-
-    if width != 4 {
-        // Only 32-bit literals supported by the spec and naga for now!
-        return Err(Error::BadScalarWidth(token_span.1, width));
-    }
-
-    match token_span {
-        (
-            Token::Number {
-                value,
-                ty: NumberType::Float,
-                width: token_width,
-            },
-            span,
-        ) if token_width.unwrap_or(4) == width => get_f32_literal(value, span),
-        other => Err(Error::Unexpected(
-            other,
-            ExpectedToken::Number {
-                ty: Some(NumberType::Float),
-                width: Some(width),
-            },
-        )),
-    }
-}
 
 #[derive(Default)]
 struct BindingParser {

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -97,6 +97,16 @@ pub enum ExpectedToken<'a> {
 }
 
 #[derive(Clone, Debug, Error)]
+pub enum BadIntError {
+    #[error(transparent)]
+    ParseIntError(#[from] ParseIntError),
+    #[error("non-hex negative zero integer literals are not allowed")]
+    NegativeZero,
+    #[error("leading zeros for non-hex integer literals are not allowed")]
+    LeadingZeros,
+}
+
+#[derive(Clone, Debug, Error)]
 pub enum BadFloatError {
     #[error(transparent)]
     ParseFloatError(#[from] ParseFloatError),
@@ -107,8 +117,8 @@ pub enum BadFloatError {
 #[derive(Clone, Debug)]
 pub enum Error<'a> {
     Unexpected(TokenSpan<'a>, ExpectedToken<'a>),
-    BadU32(Span, ParseIntError),
-    BadI32(Span, ParseIntError),
+    BadU32(Span, BadIntError),
+    BadI32(Span, BadIntError),
     /// A negative signed integer literal where both signed and unsigned,
     /// but only non-negative literals are allowed.
     NegativeInt(Span),
@@ -966,23 +976,43 @@ pub enum Scope {
 
 type LocalFunctionCall = (Handle<crate::Function>, Vec<Handle<crate::Expression>>);
 
+fn check_int_literal(word_without_minus: &str, minus: bool, hex: bool) -> Result<(), BadIntError> {
+    let leading_zeros = word_without_minus
+        .bytes()
+        .take_while(|&b| b == b'0')
+        .count();
+
+    if word_without_minus == "0" && minus {
+        Err(BadIntError::NegativeZero)
+    } else if word_without_minus != "0" && !hex && leading_zeros != 0 {
+        Err(BadIntError::LeadingZeros)
+    } else {
+        Ok(())
+    }
+}
+
 fn get_i32_literal(word: &str, span: Span) -> Result<i32, Error<'_>> {
     let (minus, word_without_minus, _) = try_skip_prefix(word, "-");
     let (hex, word_without_minus_and_0x, _) = try_skip_prefix(word_without_minus, "0x");
 
-    // TODO: fail for non-hex negative zero or remove test for it
+    check_int_literal(word_without_minus, minus, hex)
+        .map_err(|e| Error::BadI32(span.clone(), e))?;
+
     let parsed_val = match (hex, minus) {
         (true, true) => i32::from_str_radix(&format!("-{}", word_without_minus_and_0x), 16),
         (true, false) => i32::from_str_radix(word_without_minus_and_0x, 16),
         (false, _) => word.parse(),
     };
 
-    parsed_val.map_err(|e| Error::BadI32(span, e))
+    parsed_val.map_err(|e| Error::BadI32(span, e.into()))
 }
 
 fn get_u32_literal(word: &str, span: Span) -> Result<u32, Error<'_>> {
     let (minus, word_without_minus, _) = try_skip_prefix(word, "-");
     let (hex, word_without_minus_and_0x, _) = try_skip_prefix(word_without_minus, "0x");
+
+    check_int_literal(word_without_minus, minus, hex)
+        .map_err(|e| Error::BadU32(span.clone(), e))?;
 
     // We need to add a minus here as well, since the lexer also accepts syntactically incorrect negative uints
     let parsed_val = match (hex, minus) {
@@ -991,7 +1021,7 @@ fn get_u32_literal(word: &str, span: Span) -> Result<u32, Error<'_>> {
         (false, _) => word.parse(),
     };
 
-    parsed_val.map_err(|e| Error::BadU32(span, e))
+    parsed_val.map_err(|e| Error::BadU32(span, e.into()))
 }
 
 fn get_f32_literal(word: &str, span: Span) -> Result<f32, Error<'_>> {

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -25,6 +25,7 @@ use codespan_reporting::{
         termcolor::{ColorChoice, ColorSpec, StandardStream, WriteColor},
     },
 };
+use hexf_parse::{parse_hexf32, ParseHexfError};
 use std::{
     borrow::Cow,
     convert::TryFrom,
@@ -110,8 +111,8 @@ pub enum BadIntError {
 pub enum BadFloatError {
     #[error(transparent)]
     ParseFloatError(#[from] ParseFloatError),
-    #[error("hex float literals are not yet implemented")]
-    HexFloat,
+    #[error(transparent)]
+    ParseHexfError(#[from] ParseHexfError),
 }
 
 #[derive(Clone, Debug)]
@@ -1028,7 +1029,7 @@ fn get_f32_literal(word: &str, span: Span) -> Result<f32, Error<'_>> {
     let hex = word.starts_with("0x") || word.starts_with("-0x");
 
     let parsed_val = if hex {
-        Err(BadFloatError::HexFloat)
+        parse_hexf32(word, false).map_err(BadFloatError::ParseHexfError)
     } else {
         word.parse::<f32>().map_err(BadFloatError::ParseFloatError)
     };

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -189,11 +189,12 @@ impl<'a> Error<'a> {
                         }
                         ExpectedToken::Identifier => "identifier".to_string(),
                         ExpectedToken::Number { ty, width } => {
-                            let literal_ty_str = ty.map(|ty| match ty {
-                                    NumberType::Float => "floating-point",
-                                    NumberType::Uint => "unsigned integer",
-                                    NumberType::Sint => "signed integer",
-                                }).unwrap_or("arbitrary number");
+                            let literal_ty_str = match ty {
+                                Some(NumberType::Float) => "floating-point",
+                                Some(NumberType::Uint) => "unsigned integer",
+                                Some(NumberType::Sint) => "signed integer",
+                                None => "arbitrary number",
+                            };
                             if let Some(width) = width {
                                 format!(
                                     "{} literal of {}-bit width",

--- a/src/front/wgsl/number_literals.rs
+++ b/src/front/wgsl/number_literals.rs
@@ -1,0 +1,239 @@
+use std::convert::TryFrom;
+
+use hexf_parse::parse_hexf32;
+
+use crate::Bytes;
+
+use super::{
+    lexer::{try_skip_prefix, Lexer},
+    BadFloatError, BadIntError, Error, ExpectedToken, NumberType, Span, Token,
+};
+
+fn check_int_literal(word_without_minus: &str, minus: bool, hex: bool) -> Result<(), BadIntError> {
+    let leading_zeros = word_without_minus
+        .bytes()
+        .take_while(|&b| b == b'0')
+        .count();
+
+    if word_without_minus == "0" && minus {
+        Err(BadIntError::NegativeZero)
+    } else if word_without_minus != "0" && !hex && leading_zeros != 0 {
+        Err(BadIntError::LeadingZeros)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn get_i32_literal(word: &str, span: Span) -> Result<i32, Error<'_>> {
+    let (minus, word_without_minus, _) = try_skip_prefix(word, "-");
+    let (hex, word_without_minus_and_0x, _) = try_skip_prefix(word_without_minus, "0x");
+
+    check_int_literal(word_without_minus, minus, hex)
+        .map_err(|e| Error::BadI32(span.clone(), e))?;
+
+    let parsed_val = match (hex, minus) {
+        (true, true) => i32::from_str_radix(&format!("-{}", word_without_minus_and_0x), 16),
+        (true, false) => i32::from_str_radix(word_without_minus_and_0x, 16),
+        (false, _) => word.parse(),
+    };
+
+    parsed_val.map_err(|e| Error::BadI32(span, e.into()))
+}
+
+pub fn get_u32_literal(word: &str, span: Span) -> Result<u32, Error<'_>> {
+    let (minus, word_without_minus, _) = try_skip_prefix(word, "-");
+    let (hex, word_without_minus_and_0x, _) = try_skip_prefix(word_without_minus, "0x");
+
+    check_int_literal(word_without_minus, minus, hex)
+        .map_err(|e| Error::BadU32(span.clone(), e))?;
+
+    // We need to add a minus here as well, since the lexer also accepts syntactically incorrect negative uints
+    let parsed_val = match (hex, minus) {
+        (true, true) => u32::from_str_radix(&format!("-{}", word_without_minus_and_0x), 16),
+        (true, false) => u32::from_str_radix(word_without_minus_and_0x, 16),
+        (false, _) => word.parse(),
+    };
+
+    parsed_val.map_err(|e| Error::BadU32(span, e.into()))
+}
+
+pub fn get_f32_literal(word: &str, span: Span) -> Result<f32, Error<'_>> {
+    let hex = word.starts_with("0x") || word.starts_with("-0x");
+
+    let parsed_val = if hex {
+        parse_hexf32(word, false).map_err(BadFloatError::ParseHexfError)
+    } else {
+        word.parse::<f32>().map_err(BadFloatError::ParseFloatError)
+    };
+
+    parsed_val.map_err(|e| Error::BadFloat(span, e))
+}
+
+pub(super) fn parse_sint_literal<'a>(
+    lexer: &mut Lexer<'a>,
+    width: Bytes,
+) -> Result<i32, Error<'a>> {
+    let token_span = lexer.next();
+
+    if width != 4 {
+        // Only 32-bit literals supported by the spec and naga for now!
+        return Err(Error::BadScalarWidth(token_span.1, width));
+    }
+
+    match token_span {
+        (
+            Token::Number {
+                value,
+                ty: NumberType::Sint,
+                width: token_width,
+            },
+            span,
+        ) if token_width.unwrap_or(4) == width => get_i32_literal(value, span),
+        other => Err(Error::Unexpected(
+            other,
+            ExpectedToken::Number {
+                ty: Some(NumberType::Sint),
+                width: Some(width),
+            },
+        )),
+    }
+}
+
+pub(super) fn _parse_uint_literal<'a>(
+    lexer: &mut Lexer<'a>,
+    width: Bytes,
+) -> Result<u32, Error<'a>> {
+    let token_span = lexer.next();
+
+    if width != 4 {
+        // Only 32-bit literals supported by the spec and naga for now!
+        return Err(Error::BadScalarWidth(token_span.1, width));
+    }
+
+    match token_span {
+        (
+            Token::Number {
+                value,
+                ty: NumberType::Uint,
+                width: token_width,
+            },
+            span,
+        ) if token_width.unwrap_or(4) == width => get_u32_literal(value, span),
+        other => Err(Error::Unexpected(
+            other,
+            ExpectedToken::Number {
+                ty: Some(NumberType::Uint),
+                width: Some(width),
+            },
+        )),
+    }
+}
+
+/// Parse a non-negative signed integer literal.
+/// This is for attributes like `size`, `location` and others.
+pub(super) fn parse_non_negative_sint_literal<'a>(
+    lexer: &mut Lexer<'a>,
+    width: Bytes,
+) -> Result<u32, Error<'a>> {
+    let token_span = lexer.next();
+
+    if width != 4 {
+        // Only 32-bit literals supported by the spec and naga for now!
+        return Err(Error::BadScalarWidth(token_span.1, width));
+    }
+
+    match token_span {
+        (
+            Token::Number {
+                value,
+                ty: NumberType::Sint,
+                width: token_width,
+            },
+            span,
+        ) if token_width.unwrap_or(4) == width => {
+            let i32_val = get_i32_literal(value, span.clone())?;
+            u32::try_from(i32_val).map_err(|_| Error::NegativeInt(span))
+        }
+        other => Err(Error::Unexpected(
+            other,
+            ExpectedToken::Number {
+                ty: Some(NumberType::Sint),
+                width: Some(width),
+            },
+        )),
+    }
+}
+
+/// Parse a non-negative integer literal that may be either signed or unsigned.
+/// This is for the `workgroup_size` attribute and array lengths.
+/// Note: these values should be no larger than [`i32::MAX`], but this is not checked here.
+pub(super) fn parse_generic_non_negative_int_literal<'a>(
+    lexer: &mut Lexer<'a>,
+    width: Bytes,
+) -> Result<u32, Error<'a>> {
+    let token_span = lexer.next();
+
+    if width != 4 {
+        // Only 32-bit literals supported by the spec and naga for now!
+        return Err(Error::BadScalarWidth(token_span.1, width));
+    }
+
+    match token_span {
+        (
+            Token::Number {
+                value,
+                ty: NumberType::Sint,
+                width: token_width,
+            },
+            span,
+        ) if token_width.unwrap_or(4) == width => {
+            let i32_val = get_i32_literal(value, span.clone())?;
+            u32::try_from(i32_val).map_err(|_| Error::NegativeInt(span))
+        }
+        (
+            Token::Number {
+                value,
+                ty: NumberType::Uint,
+                width: token_width,
+            },
+            span,
+        ) if token_width.unwrap_or(4) == width => get_u32_literal(value, span),
+        other => Err(Error::Unexpected(
+            other,
+            ExpectedToken::Number {
+                ty: Some(NumberType::Sint),
+                width: Some(width),
+            },
+        )),
+    }
+}
+
+pub(super) fn _parse_float_literal<'a>(
+    lexer: &mut Lexer<'a>,
+    width: Bytes,
+) -> Result<f32, Error<'a>> {
+    let token_span = lexer.next();
+
+    if width != 4 {
+        // Only 32-bit literals supported by the spec and naga for now!
+        return Err(Error::BadScalarWidth(token_span.1, width));
+    }
+
+    match token_span {
+        (
+            Token::Number {
+                value,
+                ty: NumberType::Float,
+                width: token_width,
+            },
+            span,
+        ) if token_width.unwrap_or(4) == width => get_f32_literal(value, span),
+        other => Err(Error::Unexpected(
+            other,
+            ExpectedToken::Number {
+                ty: Some(NumberType::Float),
+                width: Some(width),
+            },
+        )),
+    }
+}

--- a/src/front/wgsl/tests.rs
+++ b/src/front/wgsl/tests.rs
@@ -28,6 +28,7 @@ fn parse_decimal_floats() {
     parse_str("let a : f32 = 2.3e+55;").unwrap();
 
     assert!(parse_str("let a : f32 = 42.1234f;").is_err());
+    assert!(parse_str("let a : f32 = 42.1234f32;").is_err());
 }
 
 #[test]
@@ -39,6 +40,9 @@ fn parse_hex_floats() {
     parse_str("let a : f32 = -0x.1p-5;").unwrap();
     parse_str("let a : f32 = 0xC.8p+55;").unwrap();
     parse_str("let a : f32 = 0x1p1;").unwrap();
+
+    assert!(parse_str("let a : f32 = 0x1p1f;").is_err());
+    assert!(parse_str("let a : f32 = 0x1p1f32;").is_err());
 }
 
 #[test]
@@ -50,6 +54,8 @@ fn parse_decimal_ints() {
 
     assert!(parse_str("let a : i32 = -0;").is_err());
     assert!(parse_str("let a : i32 = 1.0;").is_err());
+    assert!(parse_str("let a : i32 = 1i;").is_err());
+    assert!(parse_str("let a : i32 = 1i32;").is_err());
 
     // u32 /^0x[0-9a-fA-F]+u|0u|[1-9][0-9]*u$/
     parse_str("let a : u32 = 0u;").unwrap();
@@ -57,6 +63,7 @@ fn parse_decimal_ints() {
 
     assert!(parse_str("let a : u32 = -0u;").is_err());
     assert!(parse_str("let a : u32 = 1.0u;").is_err());
+    assert!(parse_str("let a : u32 = 1u32;").is_err());
 }
 
 #[test]
@@ -65,9 +72,14 @@ fn parse_hex_ints() {
     parse_str("let a : i32 = -0x0;").unwrap();
     parse_str("let a : i32 = 0x2a4D2;").unwrap();
 
+    assert!(parse_str("let a : i32 = 0x2a4D2i;").is_err());
+    assert!(parse_str("let a : i32 = 0x2a4D2i32;").is_err());
+
     // u32 /^0x[0-9a-fA-F]+u|0u|[1-9][0-9]*u$/
     parse_str("let a : u32 = 0x0u;").unwrap();
     parse_str("let a : u32 = 0x2a4D2u;").unwrap();
+
+    assert!(parse_str("let a : u32 = 0x2a4D2u32;").is_err());
 }
 
 #[test]

--- a/src/front/wgsl/tests.rs
+++ b/src/front/wgsl/tests.rs
@@ -14,6 +14,62 @@ fn parse_comment() {
     .unwrap();
 }
 
+// Regexes for the literals are taken from the working draft at
+// https://www.w3.org/TR/2021/WD-WGSL-20210806/#literals
+
+#[test]
+fn parse_decimal_floats() {
+    // /^(-?[0-9]*\.[0-9]+|-?[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?$/
+    parse_str("let a : f32 = -1.;").unwrap();
+    parse_str("let a : f32 = -.1;").unwrap();
+    parse_str("let a : f32 = 42.1234;").unwrap();
+    parse_str("let a : f32 = -1.E3;").unwrap();
+    parse_str("let a : f32 = -.1e-5;").unwrap();
+    parse_str("let a : f32 = 2.3e+55;").unwrap();
+
+    assert!(parse_str("let a : f32 = 42.1234f;").is_err());
+}
+
+#[test]
+fn parse_hex_floats() {
+    // /^-?0x([0-9a-fA-F]*\.?[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)(p|P)(\+|-)?[0-9]+$/
+    parse_str("let a : f32 = -0xa.p1;").unwrap();
+    parse_str("let a : f32 = -0x.fp9;").unwrap();
+    parse_str("let a : f32 = 0x2a.4D2P4;").unwrap();
+    parse_str("let a : f32 = -0x.1p-5;").unwrap();
+    parse_str("let a : f32 = 0xC.8p+55;").unwrap();
+    parse_str("let a : f32 = 0x1p1;").unwrap();
+}
+
+#[test]
+fn parse_decimal_ints() {
+    // i32 /^-?0x[0-9a-fA-F]+|0|-?[1-9][0-9]*$/
+    parse_str("let a : i32 = 0;").unwrap();
+    parse_str("let a : i32 = 1092;").unwrap();
+    parse_str("let a : i32 = -9923;").unwrap();
+
+    assert!(parse_str("let a : i32 = -0;").is_err());
+    assert!(parse_str("let a : i32 = 1.0;").is_err());
+
+    // u32 /^0x[0-9a-fA-F]+u|0u|[1-9][0-9]*u$/
+    parse_str("let a : u32 = 0u;").unwrap();
+    parse_str("let a : u32 = 1092u;").unwrap();
+
+    assert!(parse_str("let a : u32 = -0u;").is_err());
+    assert!(parse_str("let a : u32 = 1.0u;").is_err());
+}
+
+#[test]
+fn parse_hex_ints() {
+    // i32 /^-?0x[0-9a-fA-F]+|0|-?[1-9][0-9]*$/
+    parse_str("let a : i32 = -0x0;").unwrap();
+    parse_str("let a : i32 = 0x2a4D2;").unwrap();
+
+    // u32 /^0x[0-9a-fA-F]+u|0u|[1-9][0-9]*u$/
+    parse_str("let a : u32 = 0x0u;").unwrap();
+    parse_str("let a : u32 = 0x2a4D2u;").unwrap();
+}
+
 #[test]
 fn parse_types() {
     parse_str("let a : i32 = 2;").unwrap();

--- a/src/front/wgsl/tests.rs
+++ b/src/front/wgsl/tests.rs
@@ -88,7 +88,7 @@ fn parse_type_inference() {
         fn foo() {
             let a = 2u;
             let b: u32 = a;
-            var x = 3f32;
+            var x = 3.;
             var y = vec2<f32>(1, 2);
         }",
     )

--- a/src/front/wgsl/tests.rs
+++ b/src/front/wgsl/tests.rs
@@ -53,6 +53,7 @@ fn parse_decimal_ints() {
     parse_str("let a : i32 = -9923;").unwrap();
 
     assert!(parse_str("let a : i32 = -0;").is_err());
+    assert!(parse_str("let a : i32 = 01;").is_err());
     assert!(parse_str("let a : i32 = 1.0;").is_err());
     assert!(parse_str("let a : i32 = 1i;").is_err());
     assert!(parse_str("let a : i32 = 1i32;").is_err());
@@ -62,6 +63,7 @@ fn parse_decimal_ints() {
     parse_str("let a : u32 = 1092u;").unwrap();
 
     assert!(parse_str("let a : u32 = -0u;").is_err());
+    assert!(parse_str("let a : u32 = 01u;").is_err());
     assert!(parse_str("let a : u32 = 1.0u;").is_err());
     assert!(parse_str("let a : u32 = 1u32;").is_err());
 }

--- a/tests/in/interpolate.wgsl
+++ b/tests/in/interpolate.wgsl
@@ -16,7 +16,7 @@ fn main() -> FragmentInput {
    var out: FragmentInput;
 
    out.position = vec4<f32>(2.0, 4.0, 5.0, 6.0);
-   out.flat = 8u32;
+   out.flat = 8u;
    out.linear = 27.0;
    out.linear_centroid = vec2<f32>(64.0, 125.0);
    out.linear_sample = vec3<f32>(216.0, 343.0, 512.0);

--- a/tests/in/operators.wgsl
+++ b/tests/in/operators.wgsl
@@ -1,35 +1,3 @@
-// Regexes for the literals are taken from the working draft at
-// https://www.w3.org/TR/2021/WD-WGSL-20210806/#literals
-
-// matches for /^(-?[0-9]*\.[0-9]+|-?[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?$/
-let dec_float_lit_0 : f32 = -1.;
-let dec_float_lit_1 : f32 = -.1;
-let dec_float_lit_2 : f32 = 42.1234;
-let dec_float_lit_3 : f32 = -1.E3;
-let dec_float_lit_4 : f32 = -.1e-5;
-let dec_float_lit_5 : f32 = 2.3e+55;
-
-// matches for /^-?0x([0-9a-fA-F]*\.?[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)(p|P)(\+|-)?[0-9]+$/
-let hex_float_lit_0 : f32 = -0xa.p1;
-let hex_float_lit_1 : f32 = -0x.fp9;
-let hex_float_lit_2 : f32 = 0x2a.4D2P4;
-let hex_float_lit_3 : f32 = -0x.1p-5;
-let hex_float_lit_4 : f32 = 0xC.8p+55;
-let hex_float_lit_5 : f32 = 0x1p1;
-
-// matches for /^-?0x[0-9a-fA-F]+|0|-?[1-9][0-9]*$/
-let int_lit_0 : i32 = -0x0;
-let int_lit_1 : i32 = 0;
-let int_lit_2 : i32 = 0x2a4D2;
-let int_lit_3 : i32 = 1092;
-let int_lit_4 : i32 = -9923;
-
-// matches for /^0x[0-9a-fA-F]+u|0u|[1-9][0-9]*u$/
-let uint_lit_0 : u32 = 0x0u;
-let uint_lit_1 : u32 = 0u;
-let uint_lit_2 : u32 = 0x2a4D2u;
-let uint_lit_3 : u32 = 1092u;
-
 //TODO: support splatting constructors for globals?
 let v_f32_one: vec4<f32> = vec4<f32>(1.0, 1.0, 1.0, 1.0);
 let v_f32_zero: vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);

--- a/tests/in/operators.wgsl
+++ b/tests/in/operators.wgsl
@@ -1,3 +1,35 @@
+// Regexes for the literals are taken from the working draft at
+// https://www.w3.org/TR/2021/WD-WGSL-20210806/#literals
+
+// matches for /^(-?[0-9]*\.[0-9]+|-?[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?$/
+let dec_float_lit_0 : f32 = -1.;
+let dec_float_lit_1 : f32 = -.1;
+let dec_float_lit_2 : f32 = 42.1234;
+let dec_float_lit_3 : f32 = -1.E3;
+let dec_float_lit_4 : f32 = -.1e-5;
+let dec_float_lit_5 : f32 = 2.3e+55;
+
+// matches for /^-?0x([0-9a-fA-F]*\.?[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)(p|P)(\+|-)?[0-9]+$/
+let hex_float_lit_0 : f32 = -0xa.p1;
+let hex_float_lit_1 : f32 = -0x.fp9;
+let hex_float_lit_2 : f32 = 0x2a.4D2P4;
+let hex_float_lit_3 : f32 = -0x.1p-5;
+let hex_float_lit_4 : f32 = 0xC.8p+55;
+let hex_float_lit_5 : f32 = 0x1p1;
+
+// matches for /^-?0x[0-9a-fA-F]+|0|-?[1-9][0-9]*$/
+let int_lit_0 : i32 = -0x0;
+let int_lit_1 : i32 = 0;
+let int_lit_2 : i32 = 0x2a4D2;
+let int_lit_3 : i32 = 1092;
+let int_lit_4 : i32 = -9923;
+
+// matches for /^0x[0-9a-fA-F]+u|0u|[1-9][0-9]*u$/
+let uint_lit_0 : u32 = 0x0u;
+let uint_lit_1 : u32 = 0u;
+let uint_lit_2 : u32 = 0x2a4D2u;
+let uint_lit_3 : u32 = 1092u;
+
 //TODO: support splatting constructors for globals?
 let v_f32_one: vec4<f32> = vec4<f32>(1.0, 1.0, 1.0, 1.0);
 let v_f32_zero: vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);

--- a/tests/out/glsl/boids.main.Compute.glsl
+++ b/tests/out/glsl/boids.main.Compute.glsl
@@ -126,7 +126,7 @@ void main() {
     vVel = (((_e107 + (_e108 * _e110)) + (_e113 * _e115)) + (_e118 * _e120));
     vec2 _e123 = vVel;
     vec2 _e125 = vVel;
-    vVel = (normalize(_e123) * clamp(length(_e125), 0.0, 0.1));
+    vVel = (normalize(_e123) * clamp(length(_e125), 0.0, 0.10000000149011612));
     vec2 _e131 = vPos;
     vec2 _e132 = vVel;
     float _e134 = _group_0_binding_0.deltaT;

--- a/tests/out/glsl/operators.main.Compute.glsl
+++ b/tests/out/glsl/operators.main.Compute.glsl
@@ -11,7 +11,7 @@ vec4 builtins() {
     vec4 s2_ = (true ? vec4(1.0, 1.0, 1.0, 1.0) : vec4(0.0, 0.0, 0.0, 0.0));
     vec4 s3_ = mix(vec4(0.0, 0.0, 0.0, 0.0), vec4(1.0, 1.0, 1.0, 1.0), bvec4(false, false, false, false));
     vec4 m1_ = mix(vec4(0.0, 0.0, 0.0, 0.0), vec4(1.0, 1.0, 1.0, 1.0), vec4(0.5, 0.5, 0.5, 0.5));
-    vec4 m2_ = mix(vec4(0.0, 0.0, 0.0, 0.0), vec4(1.0, 1.0, 1.0, 1.0), 0.1);
+    vec4 m2_ = mix(vec4(0.0, 0.0, 0.0, 0.0), vec4(1.0, 1.0, 1.0, 1.0), 0.10000000149011612);
     float b1_ = intBitsToFloat(ivec4(1, 1, 1, 1).x);
     vec4 b2_ = intBitsToFloat(ivec4(1, 1, 1, 1));
     return (((((vec4(ivec4(s1_)) + s2_) + m1_) + m2_) + vec4(b1_)) + b2_);

--- a/tests/out/glsl/quad.main.Vertex.glsl
+++ b/tests/out/glsl/quad.main.Vertex.glsl
@@ -15,7 +15,7 @@ smooth out vec2 _vs2fs_location0;
 void main() {
     vec2 pos = _p2vs_location0;
     vec2 uv = _p2vs_location1;
-    VertexOutput _tmp_return = VertexOutput(uv, vec4((1.2 * pos), 0.0, 1.0));
+    VertexOutput _tmp_return = VertexOutput(uv, vec4((1.2000000476837158 * pos), 0.0, 1.0));
     _vs2fs_location0 = _tmp_return.uv;
     gl_Position = _tmp_return.position;
     return;

--- a/tests/out/glsl/shadow.fs_main.Fragment.glsl
+++ b/tests/out/glsl/shadow.fs_main.Fragment.glsl
@@ -36,7 +36,7 @@ float fetch_shadow(uint light_id, vec4 homogeneous_coords) {
 void main() {
     vec3 raw_normal = _vs2fs_location0;
     vec4 position = _vs2fs_location1;
-    vec3 color = vec3(0.05, 0.05, 0.05);
+    vec3 color = vec3(0.05000000074505806, 0.05000000074505806, 0.05000000074505806);
     uint i = 0u;
     vec3 normal = normalize(raw_normal);
     bool loop_init = true;

--- a/tests/out/hlsl/boids.hlsl
+++ b/tests/out/hlsl/boids.hlsl
@@ -118,7 +118,7 @@ void main(uint3 global_invocation_id : SV_DispatchThreadID)
     vVel = (((_expr107 + (_expr108 * _expr110)) + (_expr113 * _expr115)) + (_expr118 * _expr120));
     float2 _expr123 = vVel;
     float2 _expr125 = vVel;
-    vVel = (normalize(_expr123) * clamp(length(_expr125), 0.0, 0.1));
+    vVel = (normalize(_expr123) * clamp(length(_expr125), 0.0, 0.10000000149011612));
     float2 _expr131 = vPos;
     float2 _expr132 = vVel;
     float _expr134 = params.deltaT;

--- a/tests/out/hlsl/image.hlsl
+++ b/tests/out/hlsl/image.hlsl
@@ -200,8 +200,8 @@ float4 sample1() : SV_Target0
     float2 tc = float2(0.5.xx);
     float4 s2d = image_2d.Sample(sampler_reg, tc);
     float4 s2d_offset = image_2d.Sample(sampler_reg, tc, int2(3, 1));
-    float4 s2d_level = image_2d.SampleLevel(sampler_reg, tc, 2.3);
-    float4 s2d_level_offset = image_2d.SampleLevel(sampler_reg, tc, 2.3, int2(3, 1));
+    float4 s2d_level = image_2d.SampleLevel(sampler_reg, tc, 2.299999952316284);
+    float4 s2d_level_offset = image_2d.SampleLevel(sampler_reg, tc, 2.299999952316284, int2(3, 1));
     return (((s2d + s2d_offset) + s2d_level) + s2d_level_offset);
 }
 

--- a/tests/out/hlsl/operators.hlsl
+++ b/tests/out/hlsl/operators.hlsl
@@ -9,7 +9,7 @@ float4 builtins()
     float4 s2_ = (true ? float4(1.0, 1.0, 1.0, 1.0) : float4(0.0, 0.0, 0.0, 0.0));
     float4 s3_ = (bool4(false, false, false, false) ? float4(0.0, 0.0, 0.0, 0.0) : float4(1.0, 1.0, 1.0, 1.0));
     float4 m1_ = lerp(float4(0.0, 0.0, 0.0, 0.0), float4(1.0, 1.0, 1.0, 1.0), float4(0.5, 0.5, 0.5, 0.5));
-    float4 m2_ = lerp(float4(0.0, 0.0, 0.0, 0.0), float4(1.0, 1.0, 1.0, 1.0), 0.1);
+    float4 m2_ = lerp(float4(0.0, 0.0, 0.0, 0.0), float4(1.0, 1.0, 1.0, 1.0), 0.10000000149011612);
     float b1_ = float(int4(1, 1, 1, 1).x);
     float4 b2_ = float4(int4(1, 1, 1, 1));
     return (((((float4(int4(s1_.xxxx)) + s2_) + m1_) + m2_) + float4(b1_.xxxx)) + b2_);

--- a/tests/out/hlsl/quad.hlsl
+++ b/tests/out/hlsl/quad.hlsl
@@ -1,4 +1,4 @@
-static const float c_scale = 1.2;
+static const float c_scale = 1.2000000476837158;
 
 struct VertexOutput {
     linear float2 uv : LOC0;

--- a/tests/out/hlsl/shadow.hlsl
+++ b/tests/out/hlsl/shadow.hlsl
@@ -1,4 +1,4 @@
-static const float3 c_ambient = float3(0.05, 0.05, 0.05);
+static const float3 c_ambient = float3(0.05000000074505806, 0.05000000074505806, 0.05000000074505806);
 static const uint c_max_lights = 10;
 
 struct Globals {
@@ -36,7 +36,7 @@ float4 fs_main(FragmentInput_fs_main fragmentinput_fs_main) : SV_Target0
 {
     float3 raw_normal = fragmentinput_fs_main.raw_normal1;
     float4 position = fragmentinput_fs_main.position1;
-    float3 color = float3(0.05, 0.05, 0.05);
+    float3 color = float3(0.05000000074505806, 0.05000000074505806, 0.05000000074505806);
     uint i = 0u;
 
     float3 normal = normalize(raw_normal);

--- a/tests/out/msl/boids.msl
+++ b/tests/out/msl/boids.msl
@@ -130,7 +130,7 @@ kernel void main1(
     vVel = ((_e107 + (_e108 * _e110)) + (_e113 * _e115)) + (_e118 * _e120);
     metal::float2 _e123 = vVel;
     metal::float2 _e125 = vVel;
-    vVel = metal::normalize(_e123) * metal::clamp(metal::length(_e125), 0.0, 0.1);
+    vVel = metal::normalize(_e123) * metal::clamp(metal::length(_e125), 0.0, 0.10000000149011612);
     metal::float2 _e131 = vPos;
     metal::float2 _e132 = vVel;
     float _e134 = params.deltaT;

--- a/tests/out/msl/image.msl
+++ b/tests/out/msl/image.msl
@@ -73,8 +73,8 @@ fragment sampleOutput sample(
     metal::float2 tc = metal::float2(0.5);
     metal::float4 s2d = image_2d.sample(sampler_reg, tc);
     metal::float4 s2d_offset = image_2d.sample(sampler_reg, tc, const_type7_);
-    metal::float4 s2d_level = image_2d.sample(sampler_reg, tc, metal::level(2.3));
-    metal::float4 s2d_level_offset = image_2d.sample(sampler_reg, tc, metal::level(2.3), const_type7_);
+    metal::float4 s2d_level = image_2d.sample(sampler_reg, tc, metal::level(2.299999952316284));
+    metal::float4 s2d_level_offset = image_2d.sample(sampler_reg, tc, metal::level(2.299999952316284), const_type7_);
     return sampleOutput { ((s2d + s2d_offset) + s2d_level) + s2d_level_offset };
 }
 

--- a/tests/out/msl/operators.msl
+++ b/tests/out/msl/operators.msl
@@ -13,7 +13,7 @@ metal::float4 builtins(
     metal::float4 s2_ = true ? v_f32_one : v_f32_zero;
     metal::float4 s3_ = metal::select(v_f32_one, v_f32_zero, metal::bool4(false, false, false, false));
     metal::float4 m1_ = metal::mix(v_f32_zero, v_f32_one, v_f32_half);
-    metal::float4 m2_ = metal::mix(v_f32_zero, v_f32_one, 0.1);
+    metal::float4 m2_ = metal::mix(v_f32_zero, v_f32_one, 0.10000000149011612);
     float b1_ = as_type<float>(v_i32_one.x);
     metal::float4 b2_ = as_type<float4>(v_i32_one);
     return ((((static_cast<float4>(metal::int4(s1_)) + s2_) + m1_) + m2_) + metal::float4(b1_)) + b2_;

--- a/tests/out/msl/quad.msl
+++ b/tests/out/msl/quad.msl
@@ -2,7 +2,7 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-constexpr constant float c_scale = 1.2;
+constexpr constant float c_scale = 1.2000000476837158;
 struct VertexOutput {
     metal::float2 uv;
     metal::float4 position;

--- a/tests/out/msl/shadow.msl
+++ b/tests/out/msl/shadow.msl
@@ -19,7 +19,7 @@ typedef Light type3[1];
 struct Lights {
     type3 data;
 };
-constant metal::float3 c_ambient = {0.05, 0.05, 0.05};
+constant metal::float3 c_ambient = {0.05000000074505806, 0.05000000074505806, 0.05000000074505806};
 
 float fetch_shadow(
     metal::uint light_id,

--- a/tests/out/wgsl/boids.wgsl
+++ b/tests/out/wgsl/boids.wgsl
@@ -124,7 +124,7 @@ fn main([[builtin(global_invocation_id)]] global_invocation_id: vec3<u32>) {
     vVel = (((_e107 + (_e108 * _e110)) + (_e113 * _e115)) + (_e118 * _e120));
     let _e123: vec2<f32> = vVel;
     let _e125: vec2<f32> = vVel;
-    vVel = (normalize(_e123) * clamp(length(_e125), 0.0, 0.1));
+    vVel = (normalize(_e123) * clamp(length(_e125), 0.0, 0.10000000149011612));
     let _e131: vec2<f32> = vPos;
     let _e132: vec2<f32> = vVel;
     let _e134: f32 = params.deltaT;

--- a/tests/out/wgsl/image.wgsl
+++ b/tests/out/wgsl/image.wgsl
@@ -74,8 +74,8 @@ fn sample() -> [[location(0)]] vec4<f32> {
     let tc: vec2<f32> = vec2<f32>(0.5);
     let s2d: vec4<f32> = textureSample(image_2d, sampler_reg, tc);
     let s2d_offset: vec4<f32> = textureSample(image_2d, sampler_reg, tc, vec2<i32>(3, 1));
-    let s2d_level: vec4<f32> = textureSampleLevel(image_2d, sampler_reg, tc, 2.3);
-    let s2d_level_offset: vec4<f32> = textureSampleLevel(image_2d, sampler_reg, tc, 2.3, vec2<i32>(3, 1));
+    let s2d_level: vec4<f32> = textureSampleLevel(image_2d, sampler_reg, tc, 2.299999952316284);
+    let s2d_level_offset: vec4<f32> = textureSampleLevel(image_2d, sampler_reg, tc, 2.299999952316284, vec2<i32>(3, 1));
     return (((s2d + s2d_offset) + s2d_level) + s2d_level_offset);
 }
 

--- a/tests/out/wgsl/operators.wgsl
+++ b/tests/out/wgsl/operators.wgsl
@@ -7,7 +7,7 @@ fn builtins() -> vec4<f32> {
     let s2_: vec4<f32> = select(vec4<f32>(0.0, 0.0, 0.0, 0.0), vec4<f32>(1.0, 1.0, 1.0, 1.0), true);
     let s3_: vec4<f32> = select(vec4<f32>(1.0, 1.0, 1.0, 1.0), vec4<f32>(0.0, 0.0, 0.0, 0.0), vec4<bool>(false, false, false, false));
     let m1_: vec4<f32> = mix(vec4<f32>(0.0, 0.0, 0.0, 0.0), vec4<f32>(1.0, 1.0, 1.0, 1.0), vec4<f32>(0.5, 0.5, 0.5, 0.5));
-    let m2_: vec4<f32> = mix(vec4<f32>(0.0, 0.0, 0.0, 0.0), vec4<f32>(1.0, 1.0, 1.0, 1.0), 0.1);
+    let m2_: vec4<f32> = mix(vec4<f32>(0.0, 0.0, 0.0, 0.0), vec4<f32>(1.0, 1.0, 1.0, 1.0), 0.10000000149011612);
     let b1_: f32 = bitcast<f32>(vec4<i32>(1, 1, 1, 1).x);
     let b2_: vec4<f32> = vec4<f32>(vec4<i32>(1, 1, 1, 1));
     return (((((vec4<f32>(vec4<i32>(s1_)) + s2_) + m1_) + m2_) + vec4<f32>(b1_)) + b2_);

--- a/tests/out/wgsl/quad.wgsl
+++ b/tests/out/wgsl/quad.wgsl
@@ -3,7 +3,7 @@ struct VertexOutput {
     [[builtin(position)]] position: vec4<f32>;
 };
 
-let c_scale: f32 = 1.2;
+let c_scale: f32 = 1.2000000476837158;
 
 [[group(0), binding(0)]]
 var u_texture: texture_2d<f32>;

--- a/tests/out/wgsl/shadow.wgsl
+++ b/tests/out/wgsl/shadow.wgsl
@@ -14,7 +14,7 @@ struct Lights {
     data: [[stride(96)]] array<Light>;
 };
 
-let c_ambient: vec3<f32> = vec3<f32>(0.05, 0.05, 0.05);
+let c_ambient: vec3<f32> = vec3<f32>(0.05000000074505806, 0.05000000074505806, 0.05000000074505806);
 let c_max_lights: u32 = 10u;
 
 [[group(0), binding(0)]]
@@ -38,7 +38,7 @@ fn fetch_shadow(light_id: u32, homogeneous_coords: vec4<f32>) -> f32 {
 
 [[stage(fragment)]]
 fn fs_main([[location(0)]] raw_normal: vec3<f32>, [[location(1)]] position: vec4<f32>) -> [[location(0)]] vec4<f32> {
-    var color: vec3<f32> = vec3<f32>(0.05, 0.05, 0.05);
+    var color: vec3<f32> = vec3<f32>(0.05000000074505806, 0.05000000074505806, 0.05000000074505806);
     var i: u32 = 0u;
 
     let normal: vec3<f32> = normalize(raw_normal);

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -49,13 +49,11 @@ fn invalid_integer() {
 fn invalid_float() {
     check(
         "let scale: f32 = 1.1.;",
-        r###"error: expected floating-point literal, found `1.1.`
-  ┌─ wgsl:1:18
+        r###"error: expected ';', found '.'
+  ┌─ wgsl:1:21
   │
 1 │ let scale: f32 = 1.1.;
-  │                  ^^^^ expected floating-point literal
-  │
-  = note: invalid float literal
+  │                     ^ expected ';'
 
 "###,
     );
@@ -102,11 +100,11 @@ fn negative_index() {
                 return a[-1];
             }
         "#,
-        r#"error: expected non-negative integer constant expression, found `-1`
+        r#"error: expected unsigned integer constant expression, found `-1`
   ┌─ wgsl:4:26
   │
 4 │                 return a[-1];
-  │                          ^^ expected non-negative integer
+  │                          ^^ expected unsigned integer
 
 "#,
     );

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -62,22 +62,6 @@ fn invalid_float() {
 }
 
 #[test]
-fn invalid_scalar_width() {
-    check(
-        "let scale: f32 = 1.1f1000;",
-        r###"error: invalid width of `1000` for literal
-  ┌─ wgsl:1:18
-  │
-1 │ let scale: f32 = 1.1f1000;
-  │                  ^^^^^^^^ invalid width
-  │
-  = note: valid widths are 8, 16, 32, 64
-
-"###,
-    );
-}
-
-#[test]
 fn invalid_texture_sample_type() {
     check(
         "let x: texture_2d<f16>;",


### PR DESCRIPTION
I tried to implement lexing for all different types of number literals
as described by the current working draft and editor's draft
(they are the same for the literal definitions at the time of writing).
This should bring naga closer to being able to parse all kinds of number literals,
partially resolving #866 for example.

The next step would be to also allow for parsing of these new kinds of number literals,
as the currently used `FromStr::parse` won't work for hexadecimal literals (float or integer), see rust-lang/rfcs#1098.
The relevant code for this seems to be here:
https://github.com/gfx-rs/naga/blob/e384bce771db1d7dd156e9e29afe9d9235984924/src/front/wgsl/mod.rs#L1027-L1060

I have added the test cases I had written up for #866 to `tests/in/operators.wgsl` since they seem to fit in there
(though the file name might need some bikeshedding, should they stay there).
I have not yet adjusted any of the output files for the test, as I'm somewhat unsure about what they'd look like.

While I have tried my best to make the code easy to understand, it has become somewhat unwieldy due to the state machinery required to (hopefully) correctly lex the literals.
This state machine code also still needs to see some testing / fuzzing, which I haven't done myself so far.
I have tested how naga fails for `operators.wgsl` and my small tests seem to indicate that the literals are lexed correctly.

For example, with the following WGSL code:
```wgsl
let hex_float_lit_0 : f32 = -0xa.p1;
```
the modified code reports the following error:
```
expected floating-point literal, found `-0xa.p1`
```
wheras the old code reports the following:
```
the type of `hex_float_lit_0` is expected to be [1]
```

An alternative to lexing the literals this way, with a manually written state machine, would be to use the regexes given in the WGSL spec directly (after correcting them, since they use `+` ambiguously for example) with some existing regex engine like https://github.com/rust-lang/regex, this would pull in additional dependencies, but might be worth it, to reduce maintenance efforts, should the spec change it's definitions.