### PR TITLE
[spv-out]: Use OpCompositeConstruct's schmear behavior.

### DIFF
--- a/tests/out/spv/shadow.spvasm
+++ b/tests/out/spv/shadow.spvasm
@@ -1,13 +1,13 @@
 ; SPIR-V
 ; Version: 1.2
 ; Generator: rspirv
-; Bound: 124
+; Bound: 122
 OpCapability Shader
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %79 "fs_main" %71 %74 %77
-OpExecutionMode %79 OriginUpperLeft
+OpEntryPoint Fragment %77 "fs_main" %69 %72 %75
+OpExecutionMode %77 OriginUpperLeft
 OpSource GLSL 450
 OpName %9 "c_max_lights"
 OpName %14 "Globals"
@@ -24,11 +24,11 @@ OpName %27 "s_lights"
 OpName %29 "t_shadow"
 OpName %31 "sampler_shadow"
 OpName %36 "fetch_shadow"
-OpName %66 "color"
-OpName %68 "i"
-OpName %71 "raw_normal"
-OpName %74 "position"
-OpName %79 "fs_main"
+OpName %64 "color"
+OpName %66 "i"
+OpName %69 "raw_normal"
+OpName %72 "position"
+OpName %77 "fs_main"
 OpDecorate %14 Block
 OpMemberDecorate %14 0 Offset 0
 OpMemberDecorate %17 0 Offset 0
@@ -48,9 +48,9 @@ OpDecorate %29 DescriptorSet 0
 OpDecorate %29 Binding 2
 OpDecorate %31 DescriptorSet 0
 OpDecorate %31 Binding 3
-OpDecorate %71 Location 0
-OpDecorate %74 Location 1
-OpDecorate %77 Location 0
+OpDecorate %69 Location 0
+OpDecorate %72 Location 1
+OpDecorate %75 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpConstant  %4  0.0
@@ -86,18 +86,18 @@ OpDecorate %77 Location 0
 %42 = OpTypeBool
 %54 = OpTypeInt 32 1
 %59 = OpTypeSampledImage %20
-%67 = OpTypePointer Function %23
-%69 = OpTypePointer Function %10
-%72 = OpTypePointer Input %23
-%71 = OpVariable  %72  Input
-%75 = OpTypePointer Input %16
-%74 = OpVariable  %75  Input
-%78 = OpTypePointer Output %16
-%77 = OpVariable  %78  Output
-%80 = OpTypeFunction %2
-%90 = OpTypePointer Uniform %13
-%98 = OpTypePointer StorageBuffer %18
-%100 = OpTypePointer StorageBuffer %17
+%65 = OpTypePointer Function %23
+%67 = OpTypePointer Function %10
+%70 = OpTypePointer Input %23
+%69 = OpVariable  %70  Input
+%73 = OpTypePointer Input %16
+%72 = OpVariable  %73  Input
+%76 = OpTypePointer Output %16
+%75 = OpVariable  %76  Output
+%78 = OpTypeFunction %2
+%88 = OpTypePointer Uniform %13
+%96 = OpTypePointer StorageBuffer %18
+%98 = OpTypePointer StorageBuffer %17
 %36 = OpFunction  %4  None %37
 %34 = OpFunctionParameter  %10
 %35 = OpFunctionParameter  %16
@@ -125,71 +125,69 @@ OpReturnValue %5
 %56 = OpCompositeExtract  %4  %35 2
 %57 = OpCompositeExtract  %4  %35 3
 %58 = OpFDiv  %4  %56 %57
-%60 = OpCompositeExtract  %4  %53 0
-%61 = OpCompositeExtract  %4  %53 1
-%62 = OpConvertUToF  %4  %55
-%63 = OpCompositeConstruct  %23  %60 %61 %62
-%64 = OpSampledImage  %59  %38 %39
-%65 = OpImageSampleDrefExplicitLod  %4  %64 %63 %58 Lod %3
-OpReturnValue %65
+%60 = OpConvertUToF  %4  %55
+%61 = OpCompositeConstruct  %23  %53 %60
+%62 = OpSampledImage  %59  %38 %39
+%63 = OpImageSampleDrefExplicitLod  %4  %62 %61 %58 Lod %3
+OpReturnValue %63
 OpFunctionEnd
-%79 = OpFunction  %2  None %80
-%70 = OpLabel
-%66 = OpVariable  %67  Function %24
-%68 = OpVariable  %69  Function %11
-%73 = OpLoad  %23  %71
-%76 = OpLoad  %16  %74
-%81 = OpLoad  %20  %29
-%82 = OpLoad  %21  %31
+%77 = OpFunction  %2  None %78
+%68 = OpLabel
+%64 = OpVariable  %65  Function %24
+%66 = OpVariable  %67  Function %11
+%71 = OpLoad  %23  %69
+%74 = OpLoad  %16  %72
+%79 = OpLoad  %20  %29
+%80 = OpLoad  %21  %31
+OpBranch %81
+%81 = OpLabel
+%82 = OpExtInst  %23  %1 Normalize %71
 OpBranch %83
 %83 = OpLabel
-%84 = OpExtInst  %23  %1 Normalize %73
+OpLoopMerge %84 %86 None
 OpBranch %85
 %85 = OpLabel
-OpLoopMerge %86 %88 None
-OpBranch %87
-%87 = OpLabel
-%89 = OpLoad  %10  %68
-%91 = OpAccessChain  %90  %25 %11
-%92 = OpLoad  %13  %91
-%93 = OpCompositeExtract  %10  %92 0
-%94 = OpExtInst  %10  %1 UMin %93 %9
-%95 = OpUGreaterThanEqual  %42  %89 %94
-OpSelectionMerge %96 None
-OpBranchConditional %95 %97 %96
-%97 = OpLabel
+%87 = OpLoad  %10  %66
+%89 = OpAccessChain  %88  %25 %11
+%90 = OpLoad  %13  %89
+%91 = OpCompositeExtract  %10  %90 0
+%92 = OpExtInst  %10  %1 UMin %91 %9
+%93 = OpUGreaterThanEqual  %42  %87 %92
+OpSelectionMerge %94 None
+OpBranchConditional %93 %95 %94
+%95 = OpLabel
+OpBranch %84
+%94 = OpLabel
+%97 = OpLoad  %10  %66
+%99 = OpAccessChain  %98  %27 %11 %97
+%100 = OpLoad  %17  %99
+%101 = OpLoad  %10  %66
+%102 = OpCompositeExtract  %15  %100 0
+%103 = OpMatrixTimesVector  %16  %102 %74
+%104 = OpFunctionCall  %4  %36 %101 %103
+%105 = OpCompositeExtract  %16  %100 1
+%106 = OpVectorShuffle  %23  %105 %105 0 1 2
+%107 = OpVectorShuffle  %23  %74 %74 0 1 2
+%108 = OpFSub  %23  %106 %107
+%109 = OpExtInst  %23  %1 Normalize %108
+%110 = OpDot  %4  %82 %109
+%111 = OpExtInst  %4  %1 FMax %3 %110
+%112 = OpLoad  %23  %64
+%113 = OpFMul  %4  %104 %111
+%114 = OpCompositeExtract  %16  %100 2
+%115 = OpVectorShuffle  %23  %114 %114 0 1 2
+%116 = OpVectorTimesScalar  %23  %115 %113
+%117 = OpFAdd  %23  %112 %116
+OpStore %64 %117
 OpBranch %86
-%96 = OpLabel
-%99 = OpLoad  %10  %68
-%101 = OpAccessChain  %100  %27 %11 %99
-%102 = OpLoad  %17  %101
-%103 = OpLoad  %10  %68
-%104 = OpCompositeExtract  %15  %102 0
-%105 = OpMatrixTimesVector  %16  %104 %76
-%106 = OpFunctionCall  %4  %36 %103 %105
-%107 = OpCompositeExtract  %16  %102 1
-%108 = OpVectorShuffle  %23  %107 %107 0 1 2
-%109 = OpVectorShuffle  %23  %76 %76 0 1 2
-%110 = OpFSub  %23  %108 %109
-%111 = OpExtInst  %23  %1 Normalize %110
-%112 = OpDot  %4  %84 %111
-%113 = OpExtInst  %4  %1 FMax %3 %112
-%114 = OpLoad  %23  %66
-%115 = OpFMul  %4  %106 %113
-%116 = OpCompositeExtract  %16  %102 2
-%117 = OpVectorShuffle  %23  %116 %116 0 1 2
-%118 = OpVectorTimesScalar  %23  %117 %115
-%119 = OpFAdd  %23  %114 %118
-OpStore %66 %119
-OpBranch %88
-%88 = OpLabel
-%120 = OpLoad  %10  %68
-%121 = OpIAdd  %10  %120 %12
-OpStore %68 %121
-OpBranch %85
 %86 = OpLabel
-%122 = OpLoad  %23  %66
-%123 = OpCompositeConstruct  %16  %122 %5
-OpStore %77 %123
+%118 = OpLoad  %10  %66
+%119 = OpIAdd  %10  %118 %12
+OpStore %66 %119
+OpBranch %83
+%84 = OpLabel
+%120 = OpLoad  %23  %64
+%121 = OpCompositeConstruct  %16  %120 %5
+OpStore %75 %121
 OpReturn
 OpFunctionEnd


### PR DESCRIPTION
In `back::spv::Writer::write_texture_coordinates`, `OpCompositeConstruct` can concatenate scalars and vectors, so when combining coordinates with an array index, there is no need to extract the coordinate vector's components individually: once the index has been converted to the appropriate component type, it can be combined with the coordinates in a single instruction.