### PR TITLE
[wgsl-out] Move case-closing-brace writer inside cases loop

### DIFF
--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -804,9 +804,9 @@ impl<W: Write> Writer<W> {
                         if case.fall_through {
                             writeln!(self.out, "{}fallthrough;", INDENT.repeat(indent + 2))?;
                         }
-                    }
 
-                    writeln!(self.out, "{}}}", INDENT.repeat(indent + 1))?;
+                        writeln!(self.out, "{}}}", INDENT.repeat(indent + 1))?;
+                    }
                 }
 
                 if !default.is_empty() {


### PR DESCRIPTION
## This PR
This PR fixes #1191 by moving the `writeln!` statement responsible for printing the ending brace for case statements from just after the cases loop to being the last statement of the cases loop. This means that a closing brace is printed for each case statement instead of just the cases section as a whole.

## Notes
All existing unit tests have passed after this change, and so has the `make validate-wgsl` command. However, this PR does not currently add any unit tests for switch cases. While making this edit, I was unable to find the unit tests for `back::wgsl::Writer`. Do these tests exist? And if so, where should I integrate the tests for switch case writing?
