### PR TITLE
[spv-in] allow float16 and float64

### DIFF
--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -69,6 +69,8 @@ pub const SUPPORTED_CAPABILITIES: &[spirv::Capability] = &[
     spirv::Capability::Int8,
     spirv::Capability::Int16,
     spirv::Capability::Int64,
+    spirv::Capability::Float16,
+    spirv::Capability::Float64,
     spirv::Capability::Geometry,
     // tricky ones
     spirv::Capability::UniformBufferArrayDynamicIndexing,


### PR DESCRIPTION
The availability is checked at run-time by the validator.