### PR TITLE
[msl-out]: avoid inner structure for run-time array sizes

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -800,11 +800,14 @@ impl<W: Write> Writer<W> {
                     crate::TypeInner::ValuePointer { .. } | crate::TypeInner::Vector { .. } => {
                         write!(self.out, ".{}", back::COMPONENTS[index as usize])?;
                     }
-                    crate::TypeInner::Matrix { .. } => {
-                        write!(self.out, "[{}]", index)?;
-                    }
-                    crate::TypeInner::Array { .. } => {
+                    crate::TypeInner::Array {
+                        size: crate::ArraySize::Constant(_),
+                        ..
+                    } => {
                         write!(self.out, ".{}[{}]", WRAPPED_ARRAY_FIELD, index)?;
+                    }
+                    crate::TypeInner::Array { .. } | crate::TypeInner::Matrix { .. } => {
+                        write!(self.out, "[{}]", index)?;
                     }
                     _ => {
                         // unexpected indexing, should fail validation


### PR DESCRIPTION
Fixes #1202