### PR TITLE
[wgsl-out] Write pointers types and loads

### DIFF
--- a/src/front/wgsl/conv.rs
+++ b/src/front/wgsl/conv.rs
@@ -9,6 +9,7 @@ pub fn map_storage_class(word: &str, span: Span) -> Result<crate::StorageClass, 
             access: crate::StorageAccess::default(),
         }),
         "push_constant" => Ok(crate::StorageClass::PushConstant),
+        "function" => Ok(crate::StorageClass::Function),
         _ => Err(Error::UnknownStorageClass(span)),
     }
 }

--- a/tests/out/wgsl/246-collatz-comp.wgsl
+++ b/tests/out/wgsl/246-collatz-comp.wgsl
@@ -4,7 +4,7 @@ struct PrimeIndices {
 };
 
 [[group(0), binding(0)]]
-var<storage,read_write> global: PrimeIndices;
+var<storage, read_write> global: PrimeIndices;
 var<private> gl_GlobalInvocationID: vec3<u32>;
 
 fn collatz_iterations(n: u32) -> u32 {

--- a/tests/out/wgsl/access.wgsl
+++ b/tests/out/wgsl/access.wgsl
@@ -7,7 +7,7 @@ struct Bar {
 };
 
 [[group(0), binding(0)]]
-var<storage,read_write> bar: Bar;
+var<storage, read_write> bar: Bar;
 
 [[stage(vertex)]]
 fn foo([[builtin(vertex_index)]] vi: u32) -> [[builtin(position)]] vec4<f32> {

--- a/tests/out/wgsl/boids.wgsl
+++ b/tests/out/wgsl/boids.wgsl
@@ -26,7 +26,7 @@ var<uniform> params: SimParams;
 [[group(0), binding(1)]]
 var<storage> particlesSrc: Particles;
 [[group(0), binding(2)]]
-var<storage,read_write> particlesDst: Particles;
+var<storage, read_write> particlesDst: Particles;
 
 [[stage(compute), workgroup_size(64, 1, 1)]]
 fn main([[builtin(global_invocation_id)]] global_invocation_id: vec3<u32>) {

--- a/tests/out/wgsl/collatz.wgsl
+++ b/tests/out/wgsl/collatz.wgsl
@@ -4,7 +4,7 @@ struct PrimeIndices {
 };
 
 [[group(0), binding(0)]]
-var<storage,read_write> v_indices: PrimeIndices;
+var<storage, read_write> v_indices: PrimeIndices;
 
 fn collatz_iterations(n_base: u32) -> u32 {
     var n: u32;


### PR DESCRIPTION
Closes #1211 

Writes pointer types with the new syntax, adds support for the function storage class and writes dereferences where needed.

(Will follow up with dereference support for wgsl-in)