### PR TITLE
Fix WGSL vector splat constructor's type handling

### DIFF
--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1746,12 +1746,19 @@ impl Parser {
                 ty_resolution.inner_with(ctx.types),
                 ctx.typifier.get(last_component, ctx.types),
             ) {
-                (&crate::TypeInner::Vector { size, .. }, &crate::TypeInner::Scalar { .. }) => {
-                    crate::Expression::Splat {
-                        size,
-                        value: last_component,
-                    }
-                }
+                (
+                    &crate::TypeInner::Vector {
+                        size, kind, width, ..
+                    },
+                    &crate::TypeInner::Scalar {
+                        kind: arg_kind,
+                        width: arg_width,
+                        ..
+                    },
+                ) if arg_kind == kind && arg_width == width => crate::Expression::Splat {
+                    size,
+                    value: last_component,
+                },
                 (
                     &crate::TypeInner::Scalar { kind, width, .. },
                     &crate::TypeInner::Scalar { .. },

--- a/src/front/wgsl/tests.rs
+++ b/src/front/wgsl/tests.rs
@@ -65,6 +65,22 @@ fn parse_type_cast() {
     ",
     )
     .unwrap();
+    parse_str(
+        "
+        fn main() {
+            let x: vec2<f32> = vec2<f32>(0.0);
+        }
+    ",
+    )
+    .unwrap();
+    assert!(parse_str(
+        "
+        fn main() {
+            let x: vec2<f32> = vec2<f32>(0);
+        }
+    ",
+    )
+    .is_err());
 }
 
 #[test]


### PR DESCRIPTION
Previously the constructor just used the type of the scalar argument
regardless of whether or not it actually matched the vector splat
constructors target type. This resulted in e.g. `vec2<f32>(0)`
erroneously getting the type of a bi-vector of Sints with width 4.

Now the splat constructor checks that the kind and width of the scalar
argument is the same as that of the target specified in the
constructor's type parameter.

For example, this code
```wgsl
fn main() {
    let z = vec2<f32>(0);
    let z_norm_sq = dot(z, z);
}
```
now results in the following error:
```
error: cannot cast a i32 to a vec2<f32>
  ┌─ wgsl:2:22
  │
2 │     let z = vec2<f32>(0);
  │                      ^^^ cannot cast a i32 to a vec2<f32>

Could not parse WGSL
```

Fixes #1222.