### PR TITLE
Texture bounds checks

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,11 +10,18 @@ struct Args {
     #[argh(switch)]
     validate: bool,
 
-    /// what policy to use for index bounds checking.
+    /// what policy to use for index bounds checking for arrays, vectors, and
+    /// matrices.
     ///
     /// May be `Restrict`, `ReadZeroSkipWrite`, or `UndefinedBehavior`
     #[argh(option)]
     index_bounds_check_policy: Option<BoundsCheckPolicyArg>,
+
+    /// what policy to use for texture bounds checking.
+    ///
+    /// May be `Restrict`, `ReadZeroSkipWrite`, or `UndefinedBehavior`
+    #[argh(option)]
+    image_bounds_check_policy: Option<BoundsCheckPolicyArg>,
 
     /// directory to dump the SPIR-V flow dump to
     #[argh(option)]
@@ -107,6 +114,7 @@ impl FromStr for GlslProfileArg {
 struct Parameters {
     validation_flags: naga::valid::ValidationFlags,
     index_bounds_check_policy: naga::back::BoundsCheckPolicy,
+    image_bounds_check_policy: naga::back::BoundsCheckPolicy,
     entry_point: Option<String>,
     spv_adjust_coordinate_space: bool,
     spv_flow_dump_prefix: Option<String>,
@@ -185,6 +193,9 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
     if let Some(policy) = args.index_bounds_check_policy {
         params.index_bounds_check_policy = policy.0;
+    }
+    if let Some(policy) = args.image_bounds_check_policy {
+        params.image_bounds_check_policy = policy.0;
     }
     params.spv_flow_dump_prefix = args.flow_dir;
     params.entry_point = args.entry_point;
@@ -307,6 +318,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 use naga::back::spv;
 
                 params.spv.index_bounds_check_policy = params.index_bounds_check_policy;
+                params.spv.image_bounds_check_policy = params.image_bounds_check_policy;
 
                 let spv = spv::write_vec(
                     &module,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,7 +14,7 @@ struct Args {
     ///
     /// May be `Restrict`, `ReadZeroSkipWrite`, or `UndefinedBehavior`
     #[argh(option)]
-    index_bounds_check_policy: Option<IndexBoundsCheckPolicyArg>,
+    index_bounds_check_policy: Option<BoundsCheckPolicyArg>,
 
     /// directory to dump the SPIR-V flow dump to
     #[argh(option)]
@@ -43,19 +43,19 @@ struct Args {
     output: Vec<String>,
 }
 
-/// Newtype so we can implement [`FromStr`] for `IndexBoundsCheckPolicy`.
+/// Newtype so we can implement [`FromStr`] for `BoundsCheckPolicy`.
 #[derive(Debug, Clone)]
-struct IndexBoundsCheckPolicyArg(naga::back::IndexBoundsCheckPolicy);
+struct BoundsCheckPolicyArg(naga::back::BoundsCheckPolicy);
 
-impl FromStr for IndexBoundsCheckPolicyArg {
+impl FromStr for BoundsCheckPolicyArg {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use naga::back::IndexBoundsCheckPolicy;
+        use naga::back::BoundsCheckPolicy;
         Ok(Self(match s.to_lowercase().as_str() {
-            "restrict" => IndexBoundsCheckPolicy::Restrict,
-            "readzeroskipwrite" => IndexBoundsCheckPolicy::ReadZeroSkipWrite,
-            "undefinedbehavior" => IndexBoundsCheckPolicy::UndefinedBehavior,
+            "restrict" => BoundsCheckPolicy::Restrict,
+            "readzeroskipwrite" => BoundsCheckPolicy::ReadZeroSkipWrite,
+            "undefinedbehavior" => BoundsCheckPolicy::UndefinedBehavior,
             _ => {
                 return Err(format!(
                     "Invalid value for --index-bounds-check-policy: {}",
@@ -106,7 +106,7 @@ impl FromStr for GlslProfileArg {
 #[derive(Default)]
 struct Parameters {
     validation_flags: naga::valid::ValidationFlags,
-    index_bounds_check_policy: naga::back::IndexBoundsCheckPolicy,
+    index_bounds_check_policy: naga::back::BoundsCheckPolicy,
     entry_point: Option<String>,
     spv_adjust_coordinate_space: bool,
     spv_flow_dump_prefix: Option<String>,

--- a/src/back/mod.rs
+++ b/src/back/mod.rs
@@ -123,7 +123,7 @@ impl<'a> FunctionCtx<'_> {
 /// -   Naga's own default is `UndefinedBehavior`, so that shader translations
 ///     are as faithful to the original as possible.
 #[derive(Clone, Copy, Debug)]
-pub enum IndexBoundsCheckPolicy {
+pub enum BoundsCheckPolicy {
     /// Replace out-of-bounds indexes with some arbitrary in-bounds index.
     ///
     /// (This does not necessarily mean clamping. For example, interpreting the
@@ -141,10 +141,10 @@ pub enum IndexBoundsCheckPolicy {
     UndefinedBehavior,
 }
 
-/// The default `IndexBoundsCheckPolicy` is `UndefinedBehavior`.
-impl Default for IndexBoundsCheckPolicy {
+/// The default `BoundsCheckPolicy` is `UndefinedBehavior`.
+impl Default for BoundsCheckPolicy {
     fn default() -> Self {
-        IndexBoundsCheckPolicy::UndefinedBehavior
+        BoundsCheckPolicy::UndefinedBehavior
     }
 }
 

--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -86,117 +86,6 @@ impl Writer {
 }
 
 impl<'w> BlockContext<'w> {
-    fn get_type_id(&mut self, lookup_type: LookupType) -> Word {
-        self.writer.get_type_id(lookup_type)
-    }
-
-    /// Extend image coordinates with an array index, if necessary.
-    ///
-    /// Whereas [`Expression::ImageLoad`] and [`ImageSample`] treat the array
-    /// index as a separate operand from the coordinates, SPIR-V image access
-    /// instructions include the array index in the `coordinates` operand. This
-    /// function builds a SPIR-V coordinate vector from a Naga coordinate vector
-    /// and array index.
-    ///
-    /// If `array_index` is `Some(expr)`, then this function constructs a new
-    /// vector that is `coordinates` with `array_index` concatenated onto the
-    /// end: a `vec2` becomes a `vec3`, a scalar becomes a `vec2`, and so on.
-    ///
-    /// Naga's `ImageLoad` and SPIR-V's `OpImageRead`, `OpImageFetch`, and
-    /// `OpImageWrite` all use integer coordinates, while Naga's `ImageSample`
-    /// and SPIR-V's `OpImageSample...` instructions all take floating-point
-    /// coordinate vectors. The array index, always an integer scalar, may need
-    /// to be converted to match the component type of `coordinates`.
-    ///
-    /// If `array_index` is `None`, this function simply returns the id for
-    /// `coordinates`.
-    ///
-    /// [`Expression::ImageLoad`]: crate::Expression::ImageLoad
-    /// [`ImageSample`]: crate::Expression::ImageSample
-    fn write_image_coordinates(
-        &mut self,
-        coordinates: Handle<crate::Expression>,
-        array_index: Option<Handle<crate::Expression>>,
-        block: &mut Block,
-    ) -> Result<Word, Error> {
-        use crate::TypeInner as Ti;
-        use crate::VectorSize as Vs;
-
-        let coordinate_id = self.cached[coordinates];
-
-        // If there's no array index, the image coordinates are exactly the
-        // `coordinate` field of the `Expression::ImageLoad`. No work is needed.
-        let array_index = match array_index {
-            None => return Ok(coordinate_id),
-            Some(ix) => ix,
-        };
-
-        // Find the component type of `coordinates`, and figure out the size the
-        // combined coordinate vector will have.
-        let (component_kind, result_size) = match *self.fun_info[coordinates]
-            .ty
-            .inner_with(&self.ir_module.types)
-        {
-            Ti::Scalar { kind, width: 4 } => (kind, Vs::Bi),
-            Ti::Vector {
-                kind,
-                width: 4,
-                size: Vs::Bi,
-            } => (kind, Vs::Tri),
-            Ti::Vector {
-                kind,
-                width: 4,
-                size: Vs::Tri,
-            } => (kind, Vs::Quad),
-            Ti::Vector { size: Vs::Quad, .. } => {
-                return Err(Error::Validation("extending vec4 coordinate"));
-            }
-            ref other => {
-                log::error!("wrong coordinate type {:?}", other);
-                return Err(Error::Validation("coordinate type"));
-            }
-        };
-
-        // Convert the index to the coordinate component type, if necessary.
-        let array_index_i32_id = self.cached[array_index];
-        let reconciled_array_index_id = if component_kind == crate::ScalarKind::Sint {
-            array_index_i32_id
-        } else {
-            let component_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
-                vector_size: None,
-                kind: component_kind,
-                width: 4,
-                pointer_class: None,
-            }));
-
-            let reconciled_id = self.gen_id();
-            block.body.push(Instruction::unary(
-                spirv::Op::ConvertUToF,
-                component_type_id,
-                reconciled_id,
-                array_index_i32_id,
-            ));
-            reconciled_id
-        };
-
-        // Find the SPIR-V type for the combined coordinates/index vector.
-        let combined_coordinate_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
-            vector_size: Some(result_size),
-            kind: component_kind,
-            width: 4,
-            pointer_class: None,
-        }));
-
-        // Schmear the coordinates and index together.
-        let id = self.gen_id();
-        block.body.push(Instruction::composite_construct(
-            combined_coordinate_type_id,
-            id,
-            &[coordinate_id, reconciled_array_index_id],
-        ));
-        Ok(id)
-    }
-
     /// Decide whether to put off emitting instructions for `expr_handle`.
     ///
     /// We would like to gather together chains of `Access` and `AccessIndex`
@@ -804,67 +693,7 @@ impl<'w> BlockContext<'w> {
                 array_index,
                 index,
             } => {
-                let image_id = self.get_image_id(image);
-                let coordinate_id = self.write_image_coordinates(coordinate, array_index, block)?;
-
-                let id = self.gen_id();
-
-                let image_ty = self.fun_info[image].ty.inner_with(&self.ir_module.types);
-                let mut instruction = match *image_ty {
-                    crate::TypeInner::Image {
-                        class: crate::ImageClass::Storage { .. },
-                        ..
-                    } => Instruction::image_read(result_type_id, id, image_id, coordinate_id),
-                    crate::TypeInner::Image {
-                        class: crate::ImageClass::Depth { multi: _ },
-                        ..
-                    } => {
-                        // Vulkan doesn't know about our `Depth` class, and it returns `vec4<f32>`,
-                        // so we need to grab the first component out of it.
-                        let load_result_type_id =
-                            self.get_type_id(LookupType::Local(LocalType::Value {
-                                vector_size: Some(crate::VectorSize::Quad),
-                                kind: crate::ScalarKind::Float,
-                                width: 4,
-                                pointer_class: None,
-                            }));
-                        Instruction::image_fetch(load_result_type_id, id, image_id, coordinate_id)
-                    }
-                    _ => Instruction::image_fetch(result_type_id, id, image_id, coordinate_id),
-                };
-
-                if let Some(index) = index {
-                    let index_id = self.cached[index];
-                    let image_ops = match *self.fun_info[image].ty.inner_with(&self.ir_module.types)
-                    {
-                        crate::TypeInner::Image {
-                            class: crate::ImageClass::Sampled { multi: true, .. },
-                            ..
-                        }
-                        | crate::TypeInner::Image {
-                            class: crate::ImageClass::Depth { multi: true },
-                            ..
-                        } => spirv::ImageOperands::SAMPLE,
-                        _ => spirv::ImageOperands::LOD,
-                    };
-                    instruction.add_operand(image_ops.bits());
-                    instruction.add_operand(index_id);
-                }
-
-                let inst_type_id = instruction.type_id;
-                block.body.push(instruction);
-                if inst_type_id != Some(result_type_id) {
-                    let sub_id = self.gen_id();
-                    block.body.push(Instruction::composite_extract(
-                        result_type_id,
-                        sub_id,
-                        id,
-                        &[0],
-                    ));
-                    sub_id
-                } else {
-                    id
-                }
+                self.write_image_load(result_type_id, image, coordinate, array_index, index, block)?
             }
             crate::Expression::ImageSample {
                 image,
@@ -874,162 +703,17 @@ impl<'w> BlockContext<'w> {
                 offset,
                 level,
                 depth_ref,
-            } => {
-                use super::instructions::SampleLod;
-                // image
-                let image_id = self.get_image_id(image);
-                let image_type = self.fun_info[image].ty.handle().unwrap();
-                // Vulkan doesn't know about our `Depth` class, and it returns `vec4<f32>`,
-                // so we need to grab the first component out of it.
-                let needs_sub_access = match self.ir_module.types[image_type].inner {
-                    crate::TypeInner::Image {
-                        class: crate::ImageClass::Depth { .. },
-                        ..
-                    } => depth_ref.is_none(),
-                    _ => false,
-                };
-                let sample_result_type_id = if needs_sub_access {
-                    self.get_type_id(LookupType::Local(LocalType::Value {
-                        vector_size: Some(crate::VectorSize::Quad),
-                        kind: crate::ScalarKind::Float,
-                        width: 4,
-                        pointer_class: None,
-                    }))
-                } else {
-                    result_type_id
-                };
-
-                // OpTypeSampledImage
-                let image_type_id = self.get_type_id(LookupType::Handle(image_type));
-                let sampled_image_type_id =
-                    self.get_type_id(LookupType::Local(LocalType::SampledImage { image_type_id }));
-
-                let sampler_id = self.get_image_id(sampler);
-                let coordinate_id = self.write_image_coordinates(coordinate, array_index, block)?;
-
-                let sampled_image_id = self.gen_id();
-                block.body.push(Instruction::sampled_image(
-                    sampled_image_type_id,
-                    sampled_image_id,
-                    image_id,
-                    sampler_id,
-                ));
-                let id = self.gen_id();
-
-                let depth_id = depth_ref.map(|handle| self.cached[handle]);
-                let mut mask = spirv::ImageOperands::empty();
-                mask.set(spirv::ImageOperands::CONST_OFFSET, offset.is_some());
-
-                let mut main_instruction = match level {
-                    crate::SampleLevel::Zero => {
-                        let mut inst = Instruction::image_sample(
-                            sample_result_type_id,
-                            id,
-                            SampleLod::Explicit,
-                            sampled_image_id,
-                            coordinate_id,
-                            depth_id,
-                        );
-
-                        let zero_id = self
-                            .writer
-                            .get_constant_scalar(crate::ScalarValue::Float(0.0), 4);
-
-                        mask |= spirv::ImageOperands::LOD;
-                        inst.add_operand(mask.bits());
-                        inst.add_operand(zero_id);
-
-                        inst
-                    }
-                    crate::SampleLevel::Auto => {
-                        let mut inst = Instruction::image_sample(
-                            sample_result_type_id,
-                            id,
-                            SampleLod::Implicit,
-                            sampled_image_id,
-                            coordinate_id,
-                            depth_id,
-                        );
-                        if !mask.is_empty() {
-                            inst.add_operand(mask.bits());
-                        }
-                        inst
-                    }
-                    crate::SampleLevel::Exact(lod_handle) => {
-                        let mut inst = Instruction::image_sample(
-                            sample_result_type_id,
-                            id,
-                            SampleLod::Explicit,
-                            sampled_image_id,
-                            coordinate_id,
-                            depth_id,
-                        );
-
-                        let lod_id = self.cached[lod_handle];
-                        mask |= spirv::ImageOperands::LOD;
-                        inst.add_operand(mask.bits());
-                        inst.add_operand(lod_id);
-
-                        inst
-                    }
-                    crate::SampleLevel::Bias(bias_handle) => {
-                        let mut inst = Instruction::image_sample(
-                            sample_result_type_id,
-                            id,
-                            SampleLod::Implicit,
-                            sampled_image_id,
-                            coordinate_id,
-                            depth_id,
-                        );
-
-                        let bias_id = self.cached[bias_handle];
-                        mask |= spirv::ImageOperands::BIAS;
-                        inst.add_operand(mask.bits());
-                        inst.add_operand(bias_id);
-
-                        inst
-                    }
-                    crate::SampleLevel::Gradient { x, y } => {
-                        let mut inst = Instruction::image_sample(
-                            sample_result_type_id,
-                            id,
-                            SampleLod::Explicit,
-                            sampled_image_id,
-                            coordinate_id,
-                            depth_id,
-                        );
-
-                        let x_id = self.cached[x];
-                        let y_id = self.cached[y];
-                        mask |= spirv::ImageOperands::GRAD;
-                        inst.add_operand(mask.bits());
-                        inst.add_operand(x_id);
-                        inst.add_operand(y_id);
-
-                        inst
-                    }
-                };
-
-                if let Some(offset_const) = offset {
-                    let offset_id = self.writer.constant_ids[offset_const.index()];
-                    main_instruction.add_operand(offset_id);
-                }
-
-                block.body.push(main_instruction);
-
-                if needs_sub_access {
-                    let sub_id = self.gen_id();
-                    block.body.push(Instruction::composite_extract(
-                        result_type_id,
-                        sub_id,
-                        id,
-                        &[0],
-                    ));
-                    sub_id
-                } else {
-                    id
-                }
-            }
+            } => self.write_image_sample(
+                result_type_id,
+                image,
+                sampler,
+                coordinate,
+                array_index,
+                offset,
+                level,
+                depth_ref,
+                block,
+            )?,
             crate::Expression::Select {
                 condition,
                 accept,
@@ -1094,143 +778,7 @@ impl<'w> BlockContext<'w> {
                 id
             }
             crate::Expression::ImageQuery { image, query } => {
-                use crate::{ImageClass as Ic, ImageDimension as Id, ImageQuery as Iq};
-
-                let image_id = self.get_image_id(image);
-                let image_type = self.fun_info[image].ty.handle().unwrap();
-                let (dim, arrayed, class) = match self.ir_module.types[image_type].inner {
-                    crate::TypeInner::Image {
-                        dim,
-                        arrayed,
-                        class,
-                    } => (dim, arrayed, class),
-                    _ => {
-                        return Err(Error::Validation("image type"));
-                    }
-                };
-
-                self.writer
-                    .require_any("image queries", &[spirv::Capability::ImageQuery])?;
-
-                match query {
-                    Iq::Size { level } => {
-                        let dim_coords = match dim {
-                            Id::D1 => 1,
-                            Id::D2 | Id::Cube => 2,
-                            Id::D3 => 3,
-                        };
-                        let extended_size_type_id = {
-                            let array_coords = if arrayed { 1 } else { 0 };
-                            let vector_size = match dim_coords + array_coords {
-                                2 => Some(crate::VectorSize::Bi),
-                                3 => Some(crate::VectorSize::Tri),
-                                4 => Some(crate::VectorSize::Quad),
-                                _ => None,
-                            };
-                            self.get_type_id(LookupType::Local(LocalType::Value {
-                                vector_size,
-                                kind: crate::ScalarKind::Sint,
-                                width: 4,
-                                pointer_class: None,
-                            }))
-                        };
-
-                        let (query_op, level_id) = match class {
-                            Ic::Storage { .. } => (spirv::Op::ImageQuerySize, None),
-                            _ => {
-                                let level_id = match level {
-                                    Some(expr) => self.cached[expr],
-                                    None => self.get_index_constant(0),
-                                };
-                                (spirv::Op::ImageQuerySizeLod, Some(level_id))
-                            }
-                        };
-
-                        // The ID of the vector returned by SPIR-V, which contains the dimensions
-                        // as well as the layer count.
-                        let id_extended = self.gen_id();
-                        let mut inst = Instruction::image_query(
-                            query_op,
-                            extended_size_type_id,
-                            id_extended,
-                            image_id,
-                        );
-                        if let Some(expr_id) = level_id {
-                            inst.add_operand(expr_id);
-                        }
-                        block.body.push(inst);
-
-                        if result_type_id != extended_size_type_id {
-                            let id = self.gen_id();
-                            let components = match dim {
-                                // always pick the first component, and duplicate it for all 3 dimensions
-                                Id::Cube => &[0u32, 0][..],
-                                _ => &[0u32, 1, 2, 3][..dim_coords],
-                            };
-                            block.body.push(Instruction::vector_shuffle(
-                                result_type_id,
-                                id,
-                                id_extended,
-                                id_extended,
-                                components,
-                            ));
-                            id
-                        } else {
-                            id_extended
-                        }
-                    }
-                    Iq::NumLevels => {
-                        let id = self.gen_id();
-                        block.body.push(Instruction::image_query(
-                            spirv::Op::ImageQueryLevels,
-                            result_type_id,
-                            id,
-                            image_id,
-                        ));
-                        id
-                    }
-                    Iq::NumLayers => {
-                        let vec_size = match dim {
-                            Id::D1 => crate::VectorSize::Bi,
-                            Id::D2 | Id::Cube => crate::VectorSize::Tri,
-                            Id::D3 => crate::VectorSize::Quad,
-                        };
-                        let extended_size_type_id =
-                            self.get_type_id(LookupType::Local(LocalType::Value {
-                                vector_size: Some(vec_size),
-                                kind: crate::ScalarKind::Sint,
-                                width: 4,
-                                pointer_class: None,
-                            }));
-                        let id_extended = self.gen_id();
-                        let mut inst = Instruction::image_query(
-                            spirv::Op::ImageQuerySizeLod,
-                            extended_size_type_id,
-                            id_extended,
-                            image_id,
-                        );
-                        inst.add_operand(self.get_index_constant(0));
-                        block.body.push(inst);
-                        let id = self.gen_id();
-                        block.body.push(Instruction::composite_extract(
-                            result_type_id,
-                            id,
-                            id_extended,
-                            &[vec_size as u32 - 1],
-                        ));
-                        id
-                    }
-                    Iq::NumSamples => {
-                        let id = self.gen_id();
-                        block.body.push(Instruction::image_query(
-                            spirv::Op::ImageQuerySamples,
-                            result_type_id,
-                            id,
-                            image_id,
-                        ));
-                        id
-                    }
-                }
+                self.write_image_query(result_type_id, image, query, block)?
             }
             crate::Expression::Relational { fun, argument } => {
                 use crate::RelationalFunction as Rf;
@@ -1367,27 +915,6 @@ impl<'w> BlockContext<'w> {
         };
 
         Ok(pointer)
-    }
-
-    fn get_image_id(&mut self, expr_handle: Handle<crate::Expression>) -> Word {
-        let id = match self.ir_function.expressions[expr_handle] {
-            crate::Expression::GlobalVariable(handle) => {
-                self.writer.global_variables[handle.index()].handle_id
-            }
-            crate::Expression::FunctionArgument(i) => {
-                self.function.parameters[i as usize].handle_id
-            }
-            ref other => unreachable!("Unexpected image expression {:?}", other),
-        };
-
-        if id == 0 {
-            unreachable!(
-                "Image expression {:?} doesn't have a handle ID",
-                expr_handle
-            );
-        }
-
-        id
     }
 
     pub(super) fn write_block(
@@ -1682,16 +1209,7 @@ impl<'w> BlockContext<'w> {
                     coordinate,
                     array_index,
                     value,
-                } => {
-                    let image_id = self.get_image_id(image);
-                    let coordinate_id =
-                        self.write_image_coordinates(coordinate, array_index, &mut block)?;
-                    let value_id = self.cached[value];
-
-                    block
-                        .body
-                        .push(Instruction::image_write(image_id, coordinate_id, value_id));
-                }
+                } => self.write_image_store(image, coordinate, array_index, value, &mut block)?,
                 crate::Statement::Call {
                     function: local_function,
                     ref arguments,

--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -90,7 +90,7 @@ impl<'w> BlockContext<'w> {
         self.writer.get_type_id(lookup_type)
     }
 
-    /// Extend texture coordinates with an array index, if necessary.
+    /// Extend image coordinates with an array index, if necessary.
     ///
     /// Whereas [`Expression::ImageLoad`] and [`ImageSample`] treat the array
     /// index as a separate operand from the coordinates, SPIR-V image access
@@ -113,7 +113,7 @@ impl<'w> BlockContext<'w> {
     ///
     /// [`Expression::ImageLoad`]: crate::Expression::ImageLoad
     /// [`ImageSample`]: crate::Expression::ImageSample
-    fn write_texture_coordinates(
+    fn write_image_coordinates(
         &mut self,
         coordinates: Handle<crate::Expression>,
         array_index: Option<Handle<crate::Expression>>,
@@ -124,7 +124,7 @@ impl<'w> BlockContext<'w> {
 
         let coordinate_id = self.cached[coordinates];
 
-        // If there's no array index, the texture coordinates are exactly the
+        // If there's no array index, the image coordinates are exactly the
         // `coordinate` field of the `Expression::ImageLoad`. No work is needed.
         let array_index = match array_index {
             None => return Ok(coordinate_id),
@@ -805,8 +805,7 @@ impl<'w> BlockContext<'w> {
                 index,
             } => {
                 let image_id = self.get_image_id(image);
-                let coordinate_id =
-                    self.write_texture_coordinates(coordinate, array_index, block)?;
+                let coordinate_id = self.write_image_coordinates(coordinate, array_index, block)?;
 
                 let id = self.gen_id();
 
@@ -906,8 +905,7 @@ impl<'w> BlockContext<'w> {
                     self.get_type_id(LookupType::Local(LocalType::SampledImage { image_type_id }));
 
                 let sampler_id = self.get_image_id(sampler);
-                let coordinate_id =
-                    self.write_texture_coordinates(coordinate, array_index, block)?;
+                let coordinate_id = self.write_image_coordinates(coordinate, array_index, block)?;
 
                 let sampled_image_id = self.gen_id();
                 block.body.push(Instruction::sampled_image(
@@ -1687,7 +1685,7 @@ impl<'w> BlockContext<'w> {
                 } => {
                     let image_id = self.get_image_id(image);
                     let coordinate_id =
-                        self.write_texture_coordinates(coordinate, array_index, &mut block)?;
+                        self.write_image_coordinates(coordinate, array_index, &mut block)?;
                     let value_id = self.cached[value];
 
                     block

--- a/src/back/spv/image.rs
+++ b/src/back/spv/image.rs
@@ -1,0 +1,553 @@
+//! Generating SPIR-V for image operations.
+
+use super::{Block, BlockContext, Error, Instruction, LocalType, LookupType};
+use crate::arena::Handle;
+use spirv::Word;
+
+impl<'w> BlockContext<'w> {
+    /// Extend image coordinates with an array index, if necessary.
+    ///
+    /// Whereas [`Expression::ImageLoad`] and [`ImageSample`] treat the array
+    /// index as a separate operand from the coordinates, SPIR-V image access
+    /// instructions include the array index in the `coordinates` operand. This
+    /// function builds a SPIR-V coordinate vector from a Naga coordinate vector
+    /// and array index.
+    ///
+    /// If `array_index` is `Some(expr)`, then this function constructs a new
+    /// vector that is `coordinates` with `array_index` concatenated onto the
+    /// end: a `vec2` becomes a `vec3`, a scalar becomes a `vec2`, and so on.
+    ///
+    /// Naga's `ImageLoad` and SPIR-V's `OpImageRead`, `OpImageFetch`, and
+    /// `OpImageWrite` all use integer coordinates, while Naga's `ImageSample`
+    /// and SPIR-V's `OpImageSample...` instructions all take floating-point
+    /// coordinate vectors. The array index, always an integer scalar, may need
+    /// to be converted to match the component type of `coordinates`.
+    ///
+    /// If `array_index` is `None`, this function simply returns the id for
+    /// `coordinates`.
+    ///
+    /// [`Expression::ImageLoad`]: crate::Expression::ImageLoad
+    /// [`ImageSample`]: crate::Expression::ImageSample
+    fn write_image_coordinates(
+        &mut self,
+        coordinates: Handle<crate::Expression>,
+        array_index: Option<Handle<crate::Expression>>,
+        block: &mut Block,
+    ) -> Result<Word, Error> {
+        use crate::TypeInner as Ti;
+        use crate::VectorSize as Vs;
+
+        let coordinate_id = self.cached[coordinates];
+
+        // If there's no array index, the image coordinates are exactly the
+        // `coordinate` field of the `Expression::ImageLoad`. No work is needed.
+        let array_index = match array_index {
+            None => return Ok(coordinate_id),
+            Some(ix) => ix,
+        };
+
+        // Find the component type of `coordinates`, and figure out the size the
+        // combined coordinate vector will have.
+        let (component_kind, result_size) = match *self.fun_info[coordinates]
+            .ty
+            .inner_with(&self.ir_module.types)
+        {
+            Ti::Scalar { kind, width: 4 } => (kind, Vs::Bi),
+            Ti::Vector {
+                kind,
+                width: 4,
+                size: Vs::Bi,
+            } => (kind, Vs::Tri),
+            Ti::Vector {
+                kind,
+                width: 4,
+                size: Vs::Tri,
+            } => (kind, Vs::Quad),
+            Ti::Vector { size: Vs::Quad, .. } => {
+                return Err(Error::Validation("extending vec4 coordinate"));
+            }
+            ref other => {
+                log::error!("wrong coordinate type {:?}", other);
+                return Err(Error::Validation("coordinate type"));
+            }
+        };
+
+        // Convert the index to the coordinate component type, if necessary.
+        let array_index_i32_id = self.cached[array_index];
+        let reconciled_array_index_id = if component_kind == crate::ScalarKind::Sint {
+            array_index_i32_id
+        } else {
+            let component_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
+                vector_size: None,
+                kind: component_kind,
+                width: 4,
+                pointer_class: None,
+            }));
+
+            let reconciled_id = self.gen_id();
+            block.body.push(Instruction::unary(
+                spirv::Op::ConvertUToF,
+                component_type_id,
+                reconciled_id,
+                array_index_i32_id,
+            ));
+            reconciled_id
+        };
+
+        // Find the SPIR-V type for the combined coordinates/index vector.
+        let combined_coordinate_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
+            vector_size: Some(result_size),
+            kind: component_kind,
+            width: 4,
+            pointer_class: None,
+        }));
+
+        // Schmear the coordinates and index together.
+        let id = self.gen_id();
+        block.body.push(Instruction::composite_construct(
+            combined_coordinate_type_id,
+            id,
+            &[coordinate_id, reconciled_array_index_id],
+        ));
+        Ok(id)
+    }
+
+    fn get_image_id(&mut self, expr_handle: Handle<crate::Expression>) -> Word {
+        let id = match self.ir_function.expressions[expr_handle] {
+            crate::Expression::GlobalVariable(handle) => {
+                self.writer.global_variables[handle.index()].handle_id
+            }
+            crate::Expression::FunctionArgument(i) => {
+                self.function.parameters[i as usize].handle_id
+            }
+            ref other => unreachable!("Unexpected image expression {:?}", other),
+        };
+
+        if id == 0 {
+            unreachable!(
+                "Image expression {:?} doesn't have a handle ID",
+                expr_handle
+            );
+        }
+
+        id
+    }
+
+    /// Generate code for an `ImageLoad` expression.
+    ///
+    /// The arguments are the components of an `Expression::ImageLoad` variant.
+    pub(super) fn write_image_load(
+        &mut self,
+        result_type_id: Word,
+        image: Handle<crate::Expression>,
+        coordinate: Handle<crate::Expression>,
+        array_index: Option<Handle<crate::Expression>>,
+        index: Option<Handle<crate::Expression>>,
+        block: &mut Block,
+    ) -> Result<Word, Error> {
+        let image_id = self.get_image_id(image);
+        let coordinate_id = self.write_image_coordinates(coordinate, array_index, block)?;
+
+        let id = self.gen_id();
+
+        let image_ty = self.fun_info[image].ty.inner_with(&self.ir_module.types);
+        let mut instruction = match *image_ty {
+            crate::TypeInner::Image {
+                class: crate::ImageClass::Storage { .. },
+                ..
+            } => Instruction::image_read(result_type_id, id, image_id, coordinate_id),
+            crate::TypeInner::Image {
+                class: crate::ImageClass::Depth { multi: _ },
+                ..
+            } => {
+                // Vulkan doesn't know about our `Depth` class, and it returns `vec4<f32>`,
+                // so we need to grab the first component out of it.
+                let load_result_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
+                    vector_size: Some(crate::VectorSize::Quad),
+                    kind: crate::ScalarKind::Float,
+                    width: 4,
+                    pointer_class: None,
+                }));
+                Instruction::image_fetch(load_result_type_id, id, image_id, coordinate_id)
+            }
+            _ => Instruction::image_fetch(result_type_id, id, image_id, coordinate_id),
+        };
+
+        if let Some(index) = index {
+            let index_id = self.cached[index];
+            let image_ops = match *self.fun_info[image].ty.inner_with(&self.ir_module.types) {
+                crate::TypeInner::Image {
+                    class: crate::ImageClass::Sampled { multi: true, .. },
+                    ..
+                }
+                | crate::TypeInner::Image {
+                    class: crate::ImageClass::Depth { multi: true },
+                    ..
+                } => spirv::ImageOperands::SAMPLE,
+                _ => spirv::ImageOperands::LOD,
+            };
+            instruction.add_operand(image_ops.bits());
+            instruction.add_operand(index_id);
+        }
+
+        let inst_type_id = instruction.type_id;
+        block.body.push(instruction);
+        let id = if inst_type_id != Some(result_type_id) {
+            let sub_id = self.gen_id();
+            block.body.push(Instruction::composite_extract(
+                result_type_id,
+                sub_id,
+                id,
+                &[0],
+            ));
+            sub_id
+        } else {
+            id
+        };
+
+        Ok(id)
+    }
+
+    /// Generate code for an `ImageSample` expression.
+    ///
+    /// The arguments are the components of an `Expression::ImageSample` variant.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn write_image_sample(
+        &mut self,
+        result_type_id: Word,
+        image: Handle<crate::Expression>,
+        sampler: Handle<crate::Expression>,
+        coordinate: Handle<crate::Expression>,
+        array_index: Option<Handle<crate::Expression>>,
+        offset: Option<Handle<crate::Constant>>,
+        level: crate::SampleLevel,
+        depth_ref: Option<Handle<crate::Expression>>,
+        block: &mut Block,
+    ) -> Result<Word, Error> {
+        use super::instructions::SampleLod;
+        // image
+        let image_id = self.get_image_id(image);
+        let image_type = self.fun_info[image].ty.handle().unwrap();
+        // Vulkan doesn't know about our `Depth` class, and it returns `vec4<f32>`,
+        // so we need to grab the first component out of it.
+        let needs_sub_access = match self.ir_module.types[image_type].inner {
+            crate::TypeInner::Image {
+                class: crate::ImageClass::Depth { .. },
+                ..
+            } => depth_ref.is_none(),
+            _ => false,
+        };
+        let sample_result_type_id = if needs_sub_access {
+            self.get_type_id(LookupType::Local(LocalType::Value {
+                vector_size: Some(crate::VectorSize::Quad),
+                kind: crate::ScalarKind::Float,
+                width: 4,
+                pointer_class: None,
+            }))
+        } else {
+            result_type_id
+        };
+
+        // OpTypeSampledImage
+        let image_type_id = self.get_type_id(LookupType::Handle(image_type));
+        let sampled_image_type_id =
+            self.get_type_id(LookupType::Local(LocalType::SampledImage { image_type_id }));
+
+        let sampler_id = self.get_image_id(sampler);
+        let coordinate_id = self.write_image_coordinates(coordinate, array_index, block)?;
+
+        let sampled_image_id = self.gen_id();
+        block.body.push(Instruction::sampled_image(
+            sampled_image_type_id,
+            sampled_image_id,
+            image_id,
+            sampler_id,
+        ));
+        let id = self.gen_id();
+
+        let depth_id = depth_ref.map(|handle| self.cached[handle]);
+        let mut mask = spirv::ImageOperands::empty();
+        mask.set(spirv::ImageOperands::CONST_OFFSET, offset.is_some());
+
+        let mut main_instruction = match level {
+            crate::SampleLevel::Zero => {
+                let mut inst = Instruction::image_sample(
+                    sample_result_type_id,
+                    id,
+                    SampleLod::Explicit,
+                    sampled_image_id,
+                    coordinate_id,
+                    depth_id,
+                );
+
+                let zero_id = self
+                    .writer
+                    .get_constant_scalar(crate::ScalarValue::Float(0.0), 4);
+
+                mask |= spirv::ImageOperands::LOD;
+                inst.add_operand(mask.bits());
+                inst.add_operand(zero_id);
+
+                inst
+            }
+            crate::SampleLevel::Auto => {
+                let mut inst = Instruction::image_sample(
+                    sample_result_type_id,
+                    id,
+                    SampleLod::Implicit,
+                    sampled_image_id,
+                    coordinate_id,
+                    depth_id,
+                );
+                if !mask.is_empty() {
+                    inst.add_operand(mask.bits());
+                }
+                inst
+            }
+            crate::SampleLevel::Exact(lod_handle) => {
+                let mut inst = Instruction::image_sample(
+                    sample_result_type_id,
+                    id,
+                    SampleLod::Explicit,
+                    sampled_image_id,
+                    coordinate_id,
+                    depth_id,
+                );
+
+                let lod_id = self.cached[lod_handle];
+                mask |= spirv::ImageOperands::LOD;
+                inst.add_operand(mask.bits());
+                inst.add_operand(lod_id);
+
+                inst
+            }
+            crate::SampleLevel::Bias(bias_handle) => {
+                let mut inst = Instruction::image_sample(
+                    sample_result_type_id,
+                    id,
+                    SampleLod::Implicit,
+                    sampled_image_id,
+                    coordinate_id,
+                    depth_id,
+                );
+
+                let bias_id = self.cached[bias_handle];
+                mask |= spirv::ImageOperands::BIAS;
+                inst.add_operand(mask.bits());
+                inst.add_operand(bias_id);
+
+                inst
+            }
+            crate::SampleLevel::Gradient { x, y } => {
+                let mut inst = Instruction::image_sample(
+                    sample_result_type_id,
+                    id,
+                    SampleLod::Explicit,
+                    sampled_image_id,
+                    coordinate_id,
+                    depth_id,
+                );
+
+                let x_id = self.cached[x];
+                let y_id = self.cached[y];
+                mask |= spirv::ImageOperands::GRAD;
+                inst.add_operand(mask.bits());
+                inst.add_operand(x_id);
+                inst.add_operand(y_id);
+
+                inst
+            }
+        };
+
+        if let Some(offset_const) = offset {
+            let offset_id = self.writer.constant_ids[offset_const.index()];
+            main_instruction.add_operand(offset_id);
+        }
+
+        block.body.push(main_instruction);
+
+        let id = if needs_sub_access {
+            let sub_id = self.gen_id();
+            block.body.push(Instruction::composite_extract(
+                result_type_id,
+                sub_id,
+                id,
+                &[0],
+            ));
+            sub_id
+        } else {
+            id
+        };
+
+        Ok(id)
+    }
+
+    /// Generate code for an `ImageQuery` expression.
+    ///
+    /// The arguments are the components of an `Expression::ImageQuery` variant.
+    pub(super) fn write_image_query(
+        &mut self,
+        result_type_id: Word,
+        image: Handle<crate::Expression>,
+        query: crate::ImageQuery,
+        block: &mut Block,
+    ) -> Result<Word, Error> {
+        use crate::{ImageClass as Ic, ImageDimension as Id, ImageQuery as Iq};
+
+        let image_id = self.get_image_id(image);
+        let image_type = self.fun_info[image].ty.handle().unwrap();
+        let (dim, arrayed, class) = match self.ir_module.types[image_type].inner {
+            crate::TypeInner::Image {
+                dim,
+                arrayed,
+                class,
+            } => (dim, arrayed, class),
+            _ => {
+                return Err(Error::Validation("image type"));
+            }
+        };
+
+        self.writer
+            .require_any("image queries", &[spirv::Capability::ImageQuery])?;
+
+        let id = match query {
+            Iq::Size { level } => {
+                let dim_coords = match dim {
+                    Id::D1 => 1,
+                    Id::D2 | Id::Cube => 2,
+                    Id::D3 => 3,
+                };
+                let extended_size_type_id = {
+                    let array_coords = if arrayed { 1 } else { 0 };
+                    let vector_size = match dim_coords + array_coords {
+                        2 => Some(crate::VectorSize::Bi),
+                        3 => Some(crate::VectorSize::Tri),
+                        4 => Some(crate::VectorSize::Quad),
+                        _ => None,
+                    };
+                    self.get_type_id(LookupType::Local(LocalType::Value {
+                        vector_size,
+                        kind: crate::ScalarKind::Sint,
+                        width: 4,
+                        pointer_class: None,
+                    }))
+                };
+
+                let (query_op, level_id) = match class {
+                    Ic::Storage { .. } => (spirv::Op::ImageQuerySize, None),
+                    _ => {
+                        let level_id = match level {
+                            Some(expr) => self.cached[expr],
+                            None => self.get_index_constant(0),
+                        };
+                        (spirv::Op::ImageQuerySizeLod, Some(level_id))
+                    }
+                };
+
+                // The ID of the vector returned by SPIR-V, which contains the dimensions
+                // as well as the layer count.
+                let id_extended = self.gen_id();
+                let mut inst = Instruction::image_query(
+                    query_op,
+                    extended_size_type_id,
+                    id_extended,
+                    image_id,
+                );
+                if let Some(expr_id) = level_id {
+                    inst.add_operand(expr_id);
+                }
+                block.body.push(inst);
+
+                if result_type_id != extended_size_type_id {
+                    let id = self.gen_id();
+                    let components = match dim {
+                        // always pick the first component, and duplicate it for all 3 dimensions
+                        Id::Cube => &[0u32, 0][..],
+                        _ => &[0u32, 1, 2, 3][..dim_coords],
+                    };
+                    block.body.push(Instruction::vector_shuffle(
+                        result_type_id,
+                        id,
+                        id_extended,
+                        id_extended,
+                        components,
+                    ));
+                    id
+                } else {
+                    id_extended
+                }
+            }
+            Iq::NumLevels => {
+                let id = self.gen_id();
+                block.body.push(Instruction::image_query(
+                    spirv::Op::ImageQueryLevels,
+                    result_type_id,
+                    id,
+                    image_id,
+                ));
+                id
+            }
+            Iq::NumLayers => {
+                let vec_size = match dim {
+                    Id::D1 => crate::VectorSize::Bi,
+                    Id::D2 | Id::Cube => crate::VectorSize::Tri,
+                    Id::D3 => crate::VectorSize::Quad,
+                };
+                let extended_size_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
+                    vector_size: Some(vec_size),
+                    kind: crate::ScalarKind::Sint,
+                    width: 4,
+                    pointer_class: None,
+                }));
+                let id_extended = self.gen_id();
+                let mut inst = Instruction::image_query(
+                    spirv::Op::ImageQuerySizeLod,
+                    extended_size_type_id,
+                    id_extended,
+                    image_id,
+                );
+                inst.add_operand(self.get_index_constant(0));
+                block.body.push(inst);
+                let id = self.gen_id();
+                block.body.push(Instruction::composite_extract(
+                    result_type_id,
+                    id,
+                    id_extended,
+                    &[vec_size as u32 - 1],
+                ));
+                id
+            }
+            Iq::NumSamples => {
+                let id = self.gen_id();
+                block.body.push(Instruction::image_query(
+                    spirv::Op::ImageQuerySamples,
+                    result_type_id,
+                    id,
+                    image_id,
+                ));
+                id
+            }
+        };
+
+        Ok(id)
+    }
+
+    pub(super) fn write_image_store(
+        &mut self,
+        image: Handle<crate::Expression>,
+        coordinate: Handle<crate::Expression>,
+        array_index: Option<Handle<crate::Expression>>,
+        value: Handle<crate::Expression>,
+        block: &mut Block,
+    ) -> Result<(), Error> {
+        let image_id = self.get_image_id(image);
+        let coordinate_id = self.write_image_coordinates(coordinate, array_index, block)?;
+        let value_id = self.cached[value];
+
+        block
+            .body
+            .push(Instruction::image_write(image_id, coordinate_id, value_id));
+
+        Ok(())
+    }
+}

--- a/src/back/spv/index.rs
+++ b/src/back/spv/index.rs
@@ -25,7 +25,7 @@ pub(super) enum ExpressionPointer {
 /// The results of performing a bounds check.
 ///
 /// On success, `write_bounds_check` returns a value of this type.
-pub enum BoundsCheckResult {
+pub(super) enum BoundsCheckResult {
     /// The index is statically known and in bounds, with the given value.
     KnownInBounds(u32),
 
@@ -38,7 +38,7 @@ pub enum BoundsCheckResult {
 }
 
 /// A value that we either know at translation time, or need to compute at runtime.
-pub enum MaybeKnown<T> {
+pub(super) enum MaybeKnown<T> {
     /// The value is known at shader translation time.
     Known(T),
 

--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -609,27 +609,14 @@ impl super::Instruction {
         instruction
     }
 
-    pub(super) fn image_fetch(
+    pub(super) fn image_fetch_or_read(
+        op: Op,
         result_type_id: Word,
         id: Word,
         image: Word,
         coordinates: Word,
     ) -> Self {
-        let mut instruction = Self::new(Op::ImageFetch);
-        instruction.set_type(result_type_id);
-        instruction.set_result(id);
-        instruction.add_operand(image);
-        instruction.add_operand(coordinates);
-        instruction
-    }
-
-    pub(super) fn image_read(
-        result_type_id: Word,
-        id: Word,
-        image: Word,
-        coordinates: Word,
-    ) -> Self {
-        let mut instruction = Self::new(Op::ImageRead);
+        let mut instruction = Self::new(op);
         instruction.set_type(result_type_id);
         instruction.set_result(id);
         instruction.add_operand(image);

--- a/src/back/spv/mod.rs
+++ b/src/back/spv/mod.rs
@@ -8,6 +8,7 @@ mod index;
 mod instructions;
 mod layout;
 mod recyclable;
+mod selection;
 mod writer;
 
 pub use spirv::Capability;

--- a/src/back/spv/mod.rs
+++ b/src/back/spv/mod.rs
@@ -3,6 +3,7 @@
 
 mod block;
 mod helpers;
+mod image;
 mod index;
 mod instructions;
 mod layout;
@@ -369,6 +370,10 @@ struct BlockContext<'w> {
 impl BlockContext<'_> {
     fn gen_id(&mut self) -> Word {
         self.writer.id_gen.next()
+    }
+
+    fn get_type_id(&mut self, lookup_type: LookupType) -> Word {
+        self.writer.get_type_id(lookup_type)
     }
 
     fn get_expression_type_id(&mut self, tr: &TypeResolution) -> Word {

--- a/src/back/spv/mod.rs
+++ b/src/back/spv/mod.rs
@@ -324,6 +324,17 @@ struct GlobalVariable {
     handle_id: Word,
 }
 
+impl GlobalVariable {
+    fn new(id: Word) -> GlobalVariable {
+        GlobalVariable { id, handle_id: 0 }
+    }
+
+    /// Prepare `self` for use within a single function.
+    fn reset_for_function(&mut self) {
+        self.handle_id = 0;
+    }
+}
+
 struct FunctionArgument {
     /// Actual instruction of the argument.
     instruction: Instruction,

--- a/src/back/spv/mod.rs
+++ b/src/back/spv/mod.rs
@@ -11,7 +11,7 @@ mod writer;
 
 pub use spirv::Capability;
 
-use crate::{arena::Handle, back::IndexBoundsCheckPolicy, proc::TypeResolution};
+use crate::{arena::Handle, back::BoundsCheckPolicy, proc::TypeResolution};
 
 use spirv::Word;
 use std::ops;
@@ -400,7 +400,7 @@ pub struct Writer {
     debugs: Vec<Instruction>,
     annotations: Vec<Instruction>,
     flags: WriterFlags,
-    index_bounds_check_policy: IndexBoundsCheckPolicy,
+    index_bounds_check_policy: BoundsCheckPolicy,
     void_type: Word,
     //TODO: convert most of these into vectors, addressable by handle indices
     lookup_type: crate::FastHashMap<LookupType, Word>,
@@ -444,7 +444,7 @@ pub struct Options {
 
     /// How should the generated code handle array, vector, or matrix indices
     /// that are out of range?
-    pub index_bounds_check_policy: IndexBoundsCheckPolicy,
+    pub index_bounds_check_policy: BoundsCheckPolicy,
 }
 
 impl Default for Options {
@@ -457,7 +457,7 @@ impl Default for Options {
             lang_version: (1, 0),
             flags,
             capabilities: None,
-            index_bounds_check_policy: super::IndexBoundsCheckPolicy::default(),
+            index_bounds_check_policy: super::BoundsCheckPolicy::default(),
         }
     }
 }

--- a/src/back/spv/mod.rs
+++ b/src/back/spv/mod.rs
@@ -418,6 +418,7 @@ pub struct Writer {
     annotations: Vec<Instruction>,
     flags: WriterFlags,
     index_bounds_check_policy: BoundsCheckPolicy,
+    image_bounds_check_policy: BoundsCheckPolicy,
     void_type: Word,
     //TODO: convert most of these into vectors, addressable by handle indices
     lookup_type: crate::FastHashMap<LookupType, Word>,
@@ -462,6 +463,9 @@ pub struct Options {
     /// How should the generated code handle array, vector, or matrix indices
     /// that are out of range?
     pub index_bounds_check_policy: BoundsCheckPolicy,
+    /// How should the generated code handle image references that are out of
+    /// range?
+    pub image_bounds_check_policy: BoundsCheckPolicy,
 }
 
 impl Default for Options {
@@ -475,6 +479,7 @@ impl Default for Options {
             flags,
             capabilities: None,
             index_bounds_check_policy: super::BoundsCheckPolicy::default(),
+            image_bounds_check_policy: super::BoundsCheckPolicy::default(),
         }
     }
 }

--- a/src/back/spv/selection.rs
+++ b/src/back/spv/selection.rs
@@ -55,8 +55,6 @@
 //! pointer for the duration of its lifetime. To obtain the block for generating
 //! code in the selection's body, call the `Selection::block` method.
 
-#![allow(dead_code)] // until texture bounds checks
-
 use super::{Block, BlockContext, Instruction};
 use spirv::Word;
 

--- a/src/back/spv/selection.rs
+++ b/src/back/spv/selection.rs
@@ -1,0 +1,257 @@
+//! Generate SPIR-V conditional structures.
+//!
+//! Builders for `if` structures with `and`s.
+//!
+//! The types in this module track the information needed to emit SPIR-V code
+//! for complex conditional structures, like those whose conditions involve
+//! short-circuiting 'and' and 'or' structures. These track labels and can emit
+//! `OpPhi` instructions to merge values produced along different paths.
+//!
+//! This currently only supports exactly the forms Naga uses, so it doesn't
+//! support `or` or `else`, and only supports zero or one merged values.
+//!
+//! Naga needs to emit code roughly like this:
+//!
+//! ```ignore
+//!
+//!     value = DEFAULT;
+//!     if COND1 && COND2 {
+//!         value = THEN_VALUE;
+//!     }
+//!     // use value
+//!
+//! ```
+//!
+//! Assuming `ctx` and `block` are a mutable references to a [`BlockContext`]
+//! and the current [`Block`], and `merge_type` is the SPIR-V type for the
+//! merged value `value`, we can build SPIR-V for the code above like so:
+//!
+//! ```ignore
+//!
+//!     let cond = Selection::start(block, merge_type);
+//!         // ... compute `cond1` ...
+//!     cond.if_true(ctx, cond1, DEFAULT);
+//!         // ... compute `cond2` ...
+//!     cond.if_true(ctx, cond2, DEFAULT);
+//!         // ... compute THEN_VALUE
+//!     let merged_value = cond.finish(ctx, THEN_VALUE);
+//!
+//! ```
+//!
+//! After this, `merged_value` is either `DEFAULT` or `THEN_VALUE`, depending on
+//! the path by which the merged block was reached.
+//!
+//! This takes care of writing all branch instructions, including an
+//! `OpSelectionMerge` annotation in the header block; starting new blocks and
+//! assigning them labels; and emitting the `OpPhi` that gathers together the
+//! right sources for the merged values, for every path through the selection
+//! construct.
+//!
+//! When there is no merged value to produce, you can pass `()` for `merge_type`
+//! and the merge values. In this case no `OpPhi` instructions are produced, and
+//! the `finish` method returns `()`.
+//!
+//! To enforce proper nesting, a `Selection` takes ownership of the `&mut Block`
+//! pointer for the duration of its lifetime. To obtain the block for generating
+//! code in the selection's body, call the `Selection::block` method.
+
+#![allow(dead_code)] // until texture bounds checks
+
+use super::{Block, BlockContext, Instruction};
+use spirv::Word;
+
+/// A private struct recording what we know about the selection construct so far.
+pub(super) struct Selection<'b, M: MergeTuple> {
+    /// The block pointer we're emitting code into.
+    block: &'b mut Block,
+
+    /// The label of the selection construct's merge block, or `None` if we
+    /// haven't yet written the `OpSelectionMerge` merge instruction.
+    merge_label: Option<Word>,
+
+    /// A set of `(VALUES, PARENT)` pairs, used to build `OpPhi` instructions in
+    /// the merge block. Each `PARENT` is the label of a predecessor block of
+    /// the merge block. The corresponding `VALUES` holds the ids of the values
+    /// that `PARENT` contributes to the merged values.
+    ///
+    /// We emit all branches to the merge block, so we know all its
+    /// predecessors. And we refuse to emit a branch unless we're given the
+    /// values the branching block contributes to the merge, so we always have
+    /// everything we need to emit the correct phis, by construction.
+    values: Vec<(M, Word)>,
+
+    /// The types of the values in each element of `values`.
+    merge_types: M,
+}
+
+impl<'b, M: MergeTuple> Selection<'b, M> {
+    /// Start a new selection construct.
+    ///
+    /// The `block` argument indicates the selection's header block.
+    ///
+    /// The `merge_types` argument should be a `Word` or tuple of `Word`s, each
+    /// value being the SPIR-V result type id of an `OpPhi` instruction that
+    /// will be written to the selection's merge block when this selection's
+    /// [`finish`] method is called. This argument may also be `()`, for
+    /// selections that produce no values.
+    ///
+    /// (This function writes no code to `block` itself; it simply constructs a
+    /// fresh `Selection`.)
+    ///
+    /// [`finish`]: Selection::finish
+    pub(super) fn start(block: &'b mut Block, merge_types: M) -> Self {
+        Selection {
+            block,
+            merge_label: None,
+            values: vec![],
+            merge_types,
+        }
+    }
+
+    pub(super) fn block(&mut self) -> &mut Block {
+        self.block
+    }
+
+    /// Branch to a successor block if `cond` is true, otherwise merge.
+    ///
+    /// If `cond` is false, branch to the merge block, using `values` as the
+    /// merged values. Otherwise, proceed to a new block.
+    ///
+    /// The `values` argument must be the same shape as the `merge_types`
+    /// argument passed to `Selection::start`.
+    pub(super) fn if_true(&mut self, ctx: &mut BlockContext, cond: Word, values: M) {
+        self.values.push((values, self.block.label_id));
+
+        let merge_label = self.make_merge_label(ctx);
+        let next_label = ctx.gen_id();
+        ctx.function.consume(
+            std::mem::replace(self.block, Block::new(next_label)),
+            Instruction::branch_conditional(cond, next_label, merge_label),
+        );
+    }
+
+    /// Emit an unconditional branch to the merge block, and compute merged
+    /// values.
+    ///
+    /// Use `final_values` as the merged values contributed by the current
+    /// block, and transition to the merge block, emitting `OpPhi` instructions
+    /// to produce the merged values. This must be the same shape as the
+    /// `merge_types` argument passed to [`Selection::start`].
+    ///
+    /// Return the SPIR-V ids of the merged values. This value has the same
+    /// shape as the `merge_types` argument passed to `Selection::start`.
+    pub(super) fn finish(self, ctx: &mut BlockContext, final_values: M) -> M {
+        match self {
+            Selection {
+                merge_label: None, ..
+            } => {
+                // We didn't actually emit any branches, so `self.values` must
+                // be empty, and `final_values` are the only sources we have for
+                // the merged values. Easy peasy.
+                final_values
+            }
+
+            Selection {
+                block,
+                merge_label: Some(merge_label),
+                mut values,
+                merge_types,
+            } => {
+                // Emit the final branch and transition to the merge block.
+                values.push((final_values, block.label_id));
+                ctx.function.consume(
+                    std::mem::replace(block, Block::new(merge_label)),
+                    Instruction::branch(merge_label),
+                );
+
+                // Now that we're in the merge block, build the phi instructions.
+                merge_types.write_phis(ctx, block, &values)
+            }
+        }
+    }
+
+    /// Return the id of the merge block, writing a merge instruction if needed.
+    fn make_merge_label(&mut self, ctx: &mut BlockContext) -> Word {
+        match self.merge_label {
+            None => {
+                let merge_label = ctx.gen_id();
+                self.block.body.push(Instruction::selection_merge(
+                    merge_label,
+                    spirv::SelectionControl::NONE,
+                ));
+                self.merge_label = Some(merge_label);
+                merge_label
+            }
+            Some(merge_label) => merge_label,
+        }
+    }
+}
+
+/// A trait to help `Selection` manage any number of merged values.
+///
+/// Some selection constructs, like a `ReadZeroSkipWrite` bounds check on a
+/// [`Load`] expression, produce a single merged value. Others produce no merged
+/// value, like a bounds check on a [`Store`] statement.
+///
+/// To let `Selection` work nicely with both cases, we let the merge type
+/// argument passed to [`Selection::start`] be any type that implements this
+/// `MergeTuple` trait. `MergeTuple` is then implemented for `()`, `Word`,
+/// `(Word, Word)`, and so on.
+///
+/// A `MergeTuple` type can represent either a bunch of SPIR-V types or values;
+/// the `merge_types` argument to `Selection::start` are type ids, whereas the
+/// `values` arguments to the [`if_true`] and [`finish`] methods are value ids.
+/// The set of merged value returned by `finish` is a tuple of value ids.
+///
+/// In fact, since Naga only uses zero- and single-valued selection constructs
+/// at present, we only implement `MergeTuple` for `()` and `Word`. But if you
+/// add more cases, feel free to add more implementations. Once const generics
+/// are available, we could have a single implementation of `MergeTuple` for all
+/// lengths of arrays, and be done with it.
+///
+/// [`Load`]: crate::Expression::Load
+/// [`Store`]: crate::Statement::Store
+/// [`if_true`]: Selection::if_true
+/// [`finish`]: Selection::finish
+pub(super) trait MergeTuple: Sized {
+    /// Write OpPhi instructions for the given set of predecessors.
+    ///
+    /// The `predecessors` vector should be a vector of `(LABEL, VALUES)` pairs,
+    /// where each `VALUES` holds the values contributed by the branch from
+    /// `LABEL`, which should be one of the current block's predecessors.
+    fn write_phis(
+        self,
+        ctx: &mut BlockContext,
+        block: &mut Block,
+        predecessors: &[(Self, Word)],
+    ) -> Self;
+}
+
+/// Selections that produce a single merged value.
+///
+/// For example, `ImageLoad` with `BoundsCheckPolicy::ReadZeroSkipWrite` either
+/// returns a texel value or zeros.
+impl MergeTuple for Word {
+    fn write_phis(
+        self,
+        ctx: &mut BlockContext,
+        block: &mut Block,
+        predecessors: &[(Word, Word)],
+    ) -> Word {
+        let merged_value = ctx.gen_id();
+        block
+            .body
+            .push(Instruction::phi(self, merged_value, predecessors));
+        merged_value
+    }
+}
+
+/// Selections that produce no merged values.
+///
+/// For example, `ImageStore` under `BoundsCheckPolicy::ReadZeroSkipWrite`
+/// either does the store or skips it, but in neither case does it produce a
+/// value.
+impl MergeTuple for () {
+    /// No phis need to be generated.
+    fn write_phis(self, _: &mut BlockContext, _: &mut Block, _: &[((), Word)]) {}
+}

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -422,7 +422,7 @@ impl Writer {
 
         // fill up the `GlobalVariable::handle_id`
         for gv in self.global_variables.iter_mut() {
-            gv.handle_id = 0;
+            gv.reset_for_function();
         }
         for (handle, var) in ir_module.global_variables.iter() {
             // Handle globals are pre-emitted and should be loaded automatically.
@@ -1248,8 +1248,7 @@ impl Writer {
         for (_, var) in ir_module.global_variables.iter() {
             let (instruction, id) = self.write_global_variable(ir_module, var)?;
             instruction.to_words(&mut self.logical_layout.declarations);
-            self.global_variables
-                .push(GlobalVariable { id, handle_id: 0 });
+            self.global_variables.push(GlobalVariable::new(id));
         }
 
         // all functions

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -67,6 +67,7 @@ impl Writer {
             annotations: vec![],
             flags: options.flags,
             index_bounds_check_policy: options.index_bounds_check_policy,
+            image_bounds_check_policy: options.image_bounds_check_policy,
             void_type,
             lookup_type: crate::FastHashMap::default(),
             lookup_function: crate::FastHashMap::default(),
@@ -103,6 +104,7 @@ impl Writer {
             // Copied from the old Writer:
             flags: self.flags,
             index_bounds_check_policy: self.index_bounds_check_policy,
+            image_bounds_check_policy: self.image_bounds_check_policy,
             capabilities_available: take(&mut self.capabilities_available),
 
             // Initialized afresh:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1044,7 +1044,22 @@ pub enum Expression {
         level: SampleLevel,
         depth_ref: Option<Handle<Expression>>,
     },
+
     /// Load a texel from an image.
+    ///
+    /// For most images, this returns a four-element vector of the same
+    /// [`ScalarKind`] as the image. If the format of the image does not have
+    /// four components, default values are provided: the first three components
+    /// (typically R, G, and B) default to zero, and the final component
+    /// (typically alpha) defaults to one.
+    ///
+    /// However, if the image's [`class`] is [`Depth`], then this returns a
+    /// [`Float`] scalar value.
+    ///
+    /// [`ScalarKind`]: ScalarKind
+    /// [`class`]: TypeInner::Image::class
+    /// [`Depth`]: ImageClass::Depth
+    /// [`Float`]: ScalarKind::Float
     ImageLoad {
         /// The image to load a texel from. This must have type [`Image`]. (This
         /// will necessarily be a [`GlobalVariable`] or [`FunctionArgument`]
@@ -1110,6 +1125,7 @@ pub enum Expression {
         /// [`multi`]: ImageClass::Sampled::multi
         index: Option<Handle<Expression>>,
     },
+
     /// Query information from an image.
     ImageQuery {
         image: Handle<Expression>,

--- a/tests/in/bounds-check-image-restrict.param.ron
+++ b/tests/in/bounds-check-image-restrict.param.ron
@@ -1,0 +1,5 @@
+(
+	image_bounds_check_restrict: true,
+	spv_version: (1, 1),
+	spv_debug: true,
+)

--- a/tests/in/bounds-check-image-restrict.wgsl
+++ b/tests/in/bounds-check-image-restrict.wgsl
@@ -1,0 +1,83 @@
+[[group(0), binding(0)]]
+var image_1d: texture_1d<f32>;
+
+fn test_textureLoad_1d(coords: i32, level: i32) -> vec4<f32> {
+   return textureLoad(image_1d, coords, level);
+}
+
+[[group(0), binding(0)]]
+var image_2d: texture_2d<f32>;
+
+fn test_textureLoad_2d(coords: vec2<i32>, level: i32) -> vec4<f32> {
+   return textureLoad(image_2d, coords, level);
+}
+
+[[group(0), binding(0)]]
+var image_2d_array: texture_2d_array<f32>;
+
+fn test_textureLoad_2d_array(coords: vec2<i32>, index: i32, level: i32) -> vec4<f32> {
+   return textureLoad(image_2d_array, coords, index, level);
+}
+
+[[group(0), binding(0)]]
+var image_3d: texture_3d<f32>;
+
+fn test_textureLoad_3d(coords: vec3<i32>, level: i32) -> vec4<f32> {
+   return textureLoad(image_3d, coords, level);
+}
+
+[[group(0), binding(0)]]
+var image_multisampled_2d: texture_multisampled_2d<f32>;
+
+fn test_textureLoad_multisampled_2d(coords: vec2<i32>, sample: i32) -> vec4<f32> {
+   return textureLoad(image_multisampled_2d, coords, sample);
+}
+
+[[group(0), binding(0)]]
+var image_depth_2d: texture_depth_2d;
+
+fn test_textureLoad_depth_2d(coords: vec2<i32>, level: i32) -> f32 {
+   return textureLoad(image_depth_2d, coords, level);
+}
+
+[[group(0), binding(0)]]
+var image_depth_2d_array: texture_depth_2d_array;
+
+fn test_textureLoad_depth_2d_array(coords: vec2<i32>, index: i32, level: i32) -> f32 {
+   return textureLoad(image_depth_2d_array, coords, index, level);
+}
+
+[[group(0), binding(0)]]
+var image_depth_multisampled_2d: texture_depth_multisampled_2d;
+
+fn test_textureLoad_depth_multisampled_2d(coords: vec2<i32>, sample: i32) -> f32 {
+   return textureLoad(image_depth_multisampled_2d, coords, sample);
+}
+
+[[group(0), binding(0)]]
+var image_storage_1d: texture_storage_1d<rgba8unorm, write>;
+
+fn test_textureStore_1d(coords: i32, value: vec4<f32>) {
+    textureStore(image_storage_1d, coords, value);
+}
+
+[[group(0), binding(0)]]
+var image_storage_2d: texture_storage_2d<rgba8unorm, write>;
+
+fn test_textureStore_2d(coords: vec2<i32>, value: vec4<f32>) {
+    textureStore(image_storage_2d, coords, value);
+}
+
+[[group(0), binding(0)]]
+var image_storage_2d_array: texture_storage_2d_array<rgba8unorm, write>;
+
+fn test_textureStore_2d_array(coords: vec2<i32>, array_index: i32, value: vec4<f32>) {
+ textureStore(image_storage_2d_array, coords, array_index, value);
+}
+
+[[group(0), binding(0)]]
+var image_storage_3d: texture_storage_3d<rgba8unorm, write>;
+
+fn test_textureStore_3d(coords: vec3<i32>, value: vec4<f32>) {
+    textureStore(image_storage_3d, coords, value);
+}

--- a/tests/in/bounds-check-image-rzsw.param.ron
+++ b/tests/in/bounds-check-image-rzsw.param.ron
@@ -1,0 +1,5 @@
+(
+        image_bounds_check_read_zero_skip_write: true,
+	spv_version: (1, 1),
+	spv_debug: true,
+)

--- a/tests/in/bounds-check-image-rzsw.wgsl
+++ b/tests/in/bounds-check-image-rzsw.wgsl
@@ -1,0 +1,83 @@
+[[group(0), binding(0)]]
+var image_1d: texture_1d<f32>;
+
+fn test_textureLoad_1d(coords: i32, level: i32) -> vec4<f32> {
+   return textureLoad(image_1d, coords, level);
+}
+
+[[group(0), binding(0)]]
+var image_2d: texture_2d<f32>;
+
+fn test_textureLoad_2d(coords: vec2<i32>, level: i32) -> vec4<f32> {
+   return textureLoad(image_2d, coords, level);
+}
+
+[[group(0), binding(0)]]
+var image_2d_array: texture_2d_array<f32>;
+
+fn test_textureLoad_2d_array(coords: vec2<i32>, index: i32, level: i32) -> vec4<f32> {
+   return textureLoad(image_2d_array, coords, index, level);
+}
+
+[[group(0), binding(0)]]
+var image_3d: texture_3d<f32>;
+
+fn test_textureLoad_3d(coords: vec3<i32>, level: i32) -> vec4<f32> {
+   return textureLoad(image_3d, coords, level);
+}
+
+[[group(0), binding(0)]]
+var image_multisampled_2d: texture_multisampled_2d<f32>;
+
+fn test_textureLoad_multisampled_2d(coords: vec2<i32>, sample: i32) -> vec4<f32> {
+   return textureLoad(image_multisampled_2d, coords, sample);
+}
+
+[[group(0), binding(0)]]
+var image_depth_2d: texture_depth_2d;
+
+fn test_textureLoad_depth_2d(coords: vec2<i32>, level: i32) -> f32 {
+   return textureLoad(image_depth_2d, coords, level);
+}
+
+[[group(0), binding(0)]]
+var image_depth_2d_array: texture_depth_2d_array;
+
+fn test_textureLoad_depth_2d_array(coords: vec2<i32>, index: i32, level: i32) -> f32 {
+   return textureLoad(image_depth_2d_array, coords, index, level);
+}
+
+[[group(0), binding(0)]]
+var image_depth_multisampled_2d: texture_depth_multisampled_2d;
+
+fn test_textureLoad_depth_multisampled_2d(coords: vec2<i32>, sample: i32) -> f32 {
+   return textureLoad(image_depth_multisampled_2d, coords, sample);
+}
+
+[[group(0), binding(0)]]
+var image_storage_1d: texture_storage_1d<rgba8unorm, write>;
+
+fn test_textureStore_1d(coords: i32, value: vec4<f32>) {
+    textureStore(image_storage_1d, coords, value);
+}
+
+[[group(0), binding(0)]]
+var image_storage_2d: texture_storage_2d<rgba8unorm, write>;
+
+fn test_textureStore_2d(coords: vec2<i32>, value: vec4<f32>) {
+    textureStore(image_storage_2d, coords, value);
+}
+
+[[group(0), binding(0)]]
+var image_storage_2d_array: texture_storage_2d_array<rgba8unorm, write>;
+
+fn test_textureStore_2d_array(coords: vec2<i32>, array_index: i32, value: vec4<f32>) {
+ textureStore(image_storage_2d_array, coords, array_index, value);
+}
+
+[[group(0), binding(0)]]
+var image_storage_3d: texture_storage_3d<rgba8unorm, write>;
+
+fn test_textureStore_3d(coords: vec3<i32>, value: vec4<f32>) {
+    textureStore(image_storage_3d, coords, value);
+}

--- a/tests/in/bounds-check-zero.wgsl
+++ b/tests/in/bounds-check-zero.wgsl
@@ -1,4 +1,4 @@
-// Tests for `naga::back::IndexBoundsCheckPolicy::ReadZeroSkipWrite`.
+// Tests for `naga::back::BoundsCheckPolicy::ReadZeroSkipWrite`.
 
 [[block]]
 struct Globals {

--- a/tests/out/spv/bounds-check-image-restrict.spvasm
+++ b/tests/out/spv/bounds-check-image-restrict.spvasm
@@ -1,0 +1,316 @@
+; SPIR-V
+; Version: 1.1
+; Generator: rspirv
+; Bound: 214
+OpCapability ImageQuery
+OpCapability Image1D
+OpCapability Shader
+OpCapability Sampled1D
+OpCapability Linkage
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpSource GLSL 450
+OpName %20 "image_1d"
+OpName %22 "image_2d"
+OpName %24 "image_2d_array"
+OpName %26 "image_3d"
+OpName %28 "image_multisampled_2d"
+OpName %30 "image_depth_2d"
+OpName %32 "image_depth_2d_array"
+OpName %34 "image_depth_multisampled_2d"
+OpName %36 "image_storage_1d"
+OpName %38 "image_storage_2d"
+OpName %40 "image_storage_2d_array"
+OpName %42 "image_storage_3d"
+OpName %47 "test_textureLoad_1d"
+OpName %62 "test_textureLoad_2d"
+OpName %78 "test_textureLoad_2d_array"
+OpName %94 "test_textureLoad_3d"
+OpName %109 "test_textureLoad_multisampled_2d"
+OpName %123 "test_textureLoad_depth_2d"
+OpName %140 "test_textureLoad_depth_2d_array"
+OpName %157 "test_textureLoad_depth_multisampled_2d"
+OpName %172 "test_textureStore_1d"
+OpName %182 "test_textureStore_2d"
+OpName %194 "test_textureStore_2d_array"
+OpName %206 "test_textureStore_3d"
+OpDecorate %20 DescriptorSet 0
+OpDecorate %20 Binding 0
+OpDecorate %22 DescriptorSet 0
+OpDecorate %22 Binding 0
+OpDecorate %24 DescriptorSet 0
+OpDecorate %24 Binding 0
+OpDecorate %26 DescriptorSet 0
+OpDecorate %26 Binding 0
+OpDecorate %28 DescriptorSet 0
+OpDecorate %28 Binding 0
+OpDecorate %30 DescriptorSet 0
+OpDecorate %30 Binding 0
+OpDecorate %32 DescriptorSet 0
+OpDecorate %32 Binding 0
+OpDecorate %34 DescriptorSet 0
+OpDecorate %34 Binding 0
+OpDecorate %36 NonReadable
+OpDecorate %36 DescriptorSet 0
+OpDecorate %36 Binding 0
+OpDecorate %38 NonReadable
+OpDecorate %38 DescriptorSet 0
+OpDecorate %38 Binding 0
+OpDecorate %40 NonReadable
+OpDecorate %40 DescriptorSet 0
+OpDecorate %40 Binding 0
+OpDecorate %42 NonReadable
+OpDecorate %42 DescriptorSet 0
+OpDecorate %42 Binding 0
+%2 = OpTypeVoid
+%4 = OpTypeFloat 32
+%3 = OpTypeImage %4 1D 0 0 0 1 Unknown
+%5 = OpTypeInt 32 1
+%6 = OpTypeVector %4 4
+%7 = OpTypeImage %4 2D 0 0 0 1 Unknown
+%8 = OpTypeVector %5 2
+%9 = OpTypeImage %4 2D 0 1 0 1 Unknown
+%10 = OpTypeImage %4 3D 0 0 0 1 Unknown
+%11 = OpTypeVector %5 3
+%12 = OpTypeImage %4 2D 0 0 1 1 Unknown
+%13 = OpTypeImage %4 2D 1 0 0 1 Unknown
+%14 = OpTypeImage %4 2D 1 1 0 1 Unknown
+%15 = OpTypeImage %4 2D 1 0 1 1 Unknown
+%16 = OpTypeImage %4 1D 0 0 0 2 Rgba8
+%17 = OpTypeImage %4 2D 0 0 0 2 Rgba8
+%18 = OpTypeImage %4 2D 0 1 0 2 Rgba8
+%19 = OpTypeImage %4 3D 0 0 0 2 Rgba8
+%21 = OpTypePointer UniformConstant %3
+%20 = OpVariable  %21  UniformConstant
+%23 = OpTypePointer UniformConstant %7
+%22 = OpVariable  %23  UniformConstant
+%25 = OpTypePointer UniformConstant %9
+%24 = OpVariable  %25  UniformConstant
+%27 = OpTypePointer UniformConstant %10
+%26 = OpVariable  %27  UniformConstant
+%29 = OpTypePointer UniformConstant %12
+%28 = OpVariable  %29  UniformConstant
+%31 = OpTypePointer UniformConstant %13
+%30 = OpVariable  %31  UniformConstant
+%33 = OpTypePointer UniformConstant %14
+%32 = OpVariable  %33  UniformConstant
+%35 = OpTypePointer UniformConstant %15
+%34 = OpVariable  %35  UniformConstant
+%37 = OpTypePointer UniformConstant %16
+%36 = OpVariable  %37  UniformConstant
+%39 = OpTypePointer UniformConstant %17
+%38 = OpVariable  %39  UniformConstant
+%41 = OpTypePointer UniformConstant %18
+%40 = OpVariable  %41  UniformConstant
+%43 = OpTypePointer UniformConstant %19
+%42 = OpVariable  %43  UniformConstant
+%48 = OpTypeFunction %6 %5 %5
+%52 = OpConstant  %5  1
+%63 = OpTypeFunction %6 %8 %5
+%70 = OpConstantComposite  %8  %52 %52
+%79 = OpTypeFunction %6 %8 %5 %5
+%87 = OpConstantComposite  %11  %52 %52 %52
+%95 = OpTypeFunction %6 %11 %5
+%102 = OpConstantComposite  %11  %52 %52 %52
+%116 = OpConstantComposite  %8  %52 %52
+%124 = OpTypeFunction %4 %8 %5
+%131 = OpConstantComposite  %8  %52 %52
+%141 = OpTypeFunction %4 %8 %5 %5
+%149 = OpConstantComposite  %11  %52 %52 %52
+%164 = OpConstantComposite  %8  %52 %52
+%173 = OpTypeFunction %2 %5 %6
+%183 = OpTypeFunction %2 %8 %6
+%187 = OpConstantComposite  %8  %52 %52
+%195 = OpTypeFunction %2 %8 %5 %6
+%200 = OpConstantComposite  %11  %52 %52 %52
+%207 = OpTypeFunction %2 %11 %6
+%211 = OpConstantComposite  %11  %52 %52 %52
+%47 = OpFunction  %6  None %48
+%45 = OpFunctionParameter  %5
+%46 = OpFunctionParameter  %5
+%44 = OpLabel
+%49 = OpLoad  %3  %20
+OpBranch %50
+%50 = OpLabel
+%51 = OpImageQueryLevels  %5  %49
+%53 = OpISub  %5  %51 %52
+%54 = OpExtInst  %5  %1 UMin %46 %53
+%55 = OpImageQuerySizeLod  %5  %49 %54
+%56 = OpISub  %5  %55 %52
+%57 = OpExtInst  %5  %1 UMin %45 %56
+%58 = OpImageFetch  %6  %49 %57 Lod %54
+OpReturnValue %58
+OpFunctionEnd
+%62 = OpFunction  %6  None %63
+%60 = OpFunctionParameter  %8
+%61 = OpFunctionParameter  %5
+%59 = OpLabel
+%64 = OpLoad  %7  %22
+OpBranch %65
+%65 = OpLabel
+%66 = OpImageQueryLevels  %5  %64
+%67 = OpISub  %5  %66 %52
+%68 = OpExtInst  %5  %1 UMin %61 %67
+%69 = OpImageQuerySizeLod  %8  %64 %68
+%71 = OpISub  %8  %69 %70
+%72 = OpExtInst  %8  %1 UMin %60 %71
+%73 = OpImageFetch  %6  %64 %72 Lod %68
+OpReturnValue %73
+OpFunctionEnd
+%78 = OpFunction  %6  None %79
+%75 = OpFunctionParameter  %8
+%76 = OpFunctionParameter  %5
+%77 = OpFunctionParameter  %5
+%74 = OpLabel
+%80 = OpLoad  %9  %24
+OpBranch %81
+%81 = OpLabel
+%82 = OpCompositeConstruct  %11  %75 %76
+%83 = OpImageQueryLevels  %5  %80
+%84 = OpISub  %5  %83 %52
+%85 = OpExtInst  %5  %1 UMin %77 %84
+%86 = OpImageQuerySizeLod  %11  %80 %85
+%88 = OpISub  %11  %86 %87
+%89 = OpExtInst  %11  %1 UMin %82 %88
+%90 = OpImageFetch  %6  %80 %89 Lod %85
+OpReturnValue %90
+OpFunctionEnd
+%94 = OpFunction  %6  None %95
+%92 = OpFunctionParameter  %11
+%93 = OpFunctionParameter  %5
+%91 = OpLabel
+%96 = OpLoad  %10  %26
+OpBranch %97
+%97 = OpLabel
+%98 = OpImageQueryLevels  %5  %96
+%99 = OpISub  %5  %98 %52
+%100 = OpExtInst  %5  %1 UMin %93 %99
+%101 = OpImageQuerySizeLod  %11  %96 %100
+%103 = OpISub  %11  %101 %102
+%104 = OpExtInst  %11  %1 UMin %92 %103
+%105 = OpImageFetch  %6  %96 %104 Lod %100
+OpReturnValue %105
+OpFunctionEnd
+%109 = OpFunction  %6  None %63
+%107 = OpFunctionParameter  %8
+%108 = OpFunctionParameter  %5
+%106 = OpLabel
+%110 = OpLoad  %12  %28
+OpBranch %111
+%111 = OpLabel
+%112 = OpImageQuerySamples  %5  %110
+%113 = OpISub  %5  %112 %52
+%114 = OpExtInst  %5  %1 UMin %108 %113
+%115 = OpImageQuerySize  %8  %110
+%117 = OpISub  %8  %115 %116
+%118 = OpExtInst  %8  %1 UMin %107 %117
+%119 = OpImageFetch  %6  %110 %118 Sample %114
+OpReturnValue %119
+OpFunctionEnd
+%123 = OpFunction  %4  None %124
+%121 = OpFunctionParameter  %8
+%122 = OpFunctionParameter  %5
+%120 = OpLabel
+%125 = OpLoad  %13  %30
+OpBranch %126
+%126 = OpLabel
+%127 = OpImageQueryLevels  %5  %125
+%128 = OpISub  %5  %127 %52
+%129 = OpExtInst  %5  %1 UMin %122 %128
+%130 = OpImageQuerySizeLod  %8  %125 %129
+%132 = OpISub  %8  %130 %131
+%133 = OpExtInst  %8  %1 UMin %121 %132
+%134 = OpImageFetch  %6  %125 %133 Lod %129
+%135 = OpCompositeExtract  %4  %134 0
+OpReturnValue %135
+OpFunctionEnd
+%140 = OpFunction  %4  None %141
+%137 = OpFunctionParameter  %8
+%138 = OpFunctionParameter  %5
+%139 = OpFunctionParameter  %5
+%136 = OpLabel
+%142 = OpLoad  %14  %32
+OpBranch %143
+%143 = OpLabel
+%144 = OpCompositeConstruct  %11  %137 %138
+%145 = OpImageQueryLevels  %5  %142
+%146 = OpISub  %5  %145 %52
+%147 = OpExtInst  %5  %1 UMin %139 %146
+%148 = OpImageQuerySizeLod  %11  %142 %147
+%150 = OpISub  %11  %148 %149
+%151 = OpExtInst  %11  %1 UMin %144 %150
+%152 = OpImageFetch  %6  %142 %151 Lod %147
+%153 = OpCompositeExtract  %4  %152 0
+OpReturnValue %153
+OpFunctionEnd
+%157 = OpFunction  %4  None %124
+%155 = OpFunctionParameter  %8
+%156 = OpFunctionParameter  %5
+%154 = OpLabel
+%158 = OpLoad  %15  %34
+OpBranch %159
+%159 = OpLabel
+%160 = OpImageQuerySamples  %5  %158
+%161 = OpISub  %5  %160 %52
+%162 = OpExtInst  %5  %1 UMin %156 %161
+%163 = OpImageQuerySize  %8  %158
+%165 = OpISub  %8  %163 %164
+%166 = OpExtInst  %8  %1 UMin %155 %165
+%167 = OpImageFetch  %6  %158 %166 Sample %162
+%168 = OpCompositeExtract  %4  %167 0
+OpReturnValue %168
+OpFunctionEnd
+%172 = OpFunction  %2  None %173
+%170 = OpFunctionParameter  %5
+%171 = OpFunctionParameter  %6
+%169 = OpLabel
+%174 = OpLoad  %16  %36
+OpBranch %175
+%175 = OpLabel
+%176 = OpImageQuerySize  %5  %174
+%177 = OpISub  %5  %176 %52
+%178 = OpExtInst  %5  %1 UMin %170 %177
+OpImageWrite %174 %178 %171
+OpReturn
+OpFunctionEnd
+%182 = OpFunction  %2  None %183
+%180 = OpFunctionParameter  %8
+%181 = OpFunctionParameter  %6
+%179 = OpLabel
+%184 = OpLoad  %17  %38
+OpBranch %185
+%185 = OpLabel
+%186 = OpImageQuerySize  %8  %184
+%188 = OpISub  %8  %186 %187
+%189 = OpExtInst  %8  %1 UMin %180 %188
+OpImageWrite %184 %189 %181
+OpReturn
+OpFunctionEnd
+%194 = OpFunction  %2  None %195
+%191 = OpFunctionParameter  %8
+%192 = OpFunctionParameter  %5
+%193 = OpFunctionParameter  %6
+%190 = OpLabel
+%196 = OpLoad  %18  %40
+OpBranch %197
+%197 = OpLabel
+%198 = OpCompositeConstruct  %11  %191 %192
+%199 = OpImageQuerySize  %11  %196
+%201 = OpISub  %11  %199 %200
+%202 = OpExtInst  %11  %1 UMin %198 %201
+OpImageWrite %196 %202 %193
+OpReturn
+OpFunctionEnd
+%206 = OpFunction  %2  None %207
+%204 = OpFunctionParameter  %11
+%205 = OpFunctionParameter  %6
+%203 = OpLabel
+%208 = OpLoad  %19  %42
+OpBranch %209
+%209 = OpLabel
+%210 = OpImageQuerySize  %11  %208
+%212 = OpISub  %11  %210 %211
+%213 = OpExtInst  %11  %1 UMin %204 %212
+OpImageWrite %208 %213 %205
+OpReturn
+OpFunctionEnd

--- a/tests/out/spv/bounds-check-image-rzsw.spvasm
+++ b/tests/out/spv/bounds-check-image-rzsw.spvasm
@@ -1,0 +1,390 @@
+; SPIR-V
+; Version: 1.1
+; Generator: rspirv
+; Bound: 244
+OpCapability ImageQuery
+OpCapability Image1D
+OpCapability Shader
+OpCapability Sampled1D
+OpCapability Linkage
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpSource GLSL 450
+OpName %20 "image_1d"
+OpName %22 "image_2d"
+OpName %24 "image_2d_array"
+OpName %26 "image_3d"
+OpName %28 "image_multisampled_2d"
+OpName %30 "image_depth_2d"
+OpName %32 "image_depth_2d_array"
+OpName %34 "image_depth_multisampled_2d"
+OpName %36 "image_storage_1d"
+OpName %38 "image_storage_2d"
+OpName %40 "image_storage_2d_array"
+OpName %42 "image_storage_3d"
+OpName %47 "test_textureLoad_1d"
+OpName %65 "test_textureLoad_2d"
+OpName %85 "test_textureLoad_2d_array"
+OpName %105 "test_textureLoad_3d"
+OpName %123 "test_textureLoad_multisampled_2d"
+OpName %140 "test_textureLoad_depth_2d"
+OpName %160 "test_textureLoad_depth_2d_array"
+OpName %180 "test_textureLoad_depth_multisampled_2d"
+OpName %198 "test_textureStore_1d"
+OpName %209 "test_textureStore_2d"
+OpName %222 "test_textureStore_2d_array"
+OpName %235 "test_textureStore_3d"
+OpDecorate %20 DescriptorSet 0
+OpDecorate %20 Binding 0
+OpDecorate %22 DescriptorSet 0
+OpDecorate %22 Binding 0
+OpDecorate %24 DescriptorSet 0
+OpDecorate %24 Binding 0
+OpDecorate %26 DescriptorSet 0
+OpDecorate %26 Binding 0
+OpDecorate %28 DescriptorSet 0
+OpDecorate %28 Binding 0
+OpDecorate %30 DescriptorSet 0
+OpDecorate %30 Binding 0
+OpDecorate %32 DescriptorSet 0
+OpDecorate %32 Binding 0
+OpDecorate %34 DescriptorSet 0
+OpDecorate %34 Binding 0
+OpDecorate %36 NonReadable
+OpDecorate %36 DescriptorSet 0
+OpDecorate %36 Binding 0
+OpDecorate %38 NonReadable
+OpDecorate %38 DescriptorSet 0
+OpDecorate %38 Binding 0
+OpDecorate %40 NonReadable
+OpDecorate %40 DescriptorSet 0
+OpDecorate %40 Binding 0
+OpDecorate %42 NonReadable
+OpDecorate %42 DescriptorSet 0
+OpDecorate %42 Binding 0
+%2 = OpTypeVoid
+%4 = OpTypeFloat 32
+%3 = OpTypeImage %4 1D 0 0 0 1 Unknown
+%5 = OpTypeInt 32 1
+%6 = OpTypeVector %4 4
+%7 = OpTypeImage %4 2D 0 0 0 1 Unknown
+%8 = OpTypeVector %5 2
+%9 = OpTypeImage %4 2D 0 1 0 1 Unknown
+%10 = OpTypeImage %4 3D 0 0 0 1 Unknown
+%11 = OpTypeVector %5 3
+%12 = OpTypeImage %4 2D 0 0 1 1 Unknown
+%13 = OpTypeImage %4 2D 1 0 0 1 Unknown
+%14 = OpTypeImage %4 2D 1 1 0 1 Unknown
+%15 = OpTypeImage %4 2D 1 0 1 1 Unknown
+%16 = OpTypeImage %4 1D 0 0 0 2 Rgba8
+%17 = OpTypeImage %4 2D 0 0 0 2 Rgba8
+%18 = OpTypeImage %4 2D 0 1 0 2 Rgba8
+%19 = OpTypeImage %4 3D 0 0 0 2 Rgba8
+%21 = OpTypePointer UniformConstant %3
+%20 = OpVariable  %21  UniformConstant
+%23 = OpTypePointer UniformConstant %7
+%22 = OpVariable  %23  UniformConstant
+%25 = OpTypePointer UniformConstant %9
+%24 = OpVariable  %25  UniformConstant
+%27 = OpTypePointer UniformConstant %10
+%26 = OpVariable  %27  UniformConstant
+%29 = OpTypePointer UniformConstant %12
+%28 = OpVariable  %29  UniformConstant
+%31 = OpTypePointer UniformConstant %13
+%30 = OpVariable  %31  UniformConstant
+%33 = OpTypePointer UniformConstant %14
+%32 = OpVariable  %33  UniformConstant
+%35 = OpTypePointer UniformConstant %15
+%34 = OpVariable  %35  UniformConstant
+%37 = OpTypePointer UniformConstant %16
+%36 = OpVariable  %37  UniformConstant
+%39 = OpTypePointer UniformConstant %17
+%38 = OpVariable  %39  UniformConstant
+%41 = OpTypePointer UniformConstant %18
+%40 = OpVariable  %41  UniformConstant
+%43 = OpTypePointer UniformConstant %19
+%42 = OpVariable  %43  UniformConstant
+%48 = OpTypeFunction %6 %5 %5
+%51 = OpTypeBool
+%52 = OpConstantNull  %6
+%66 = OpTypeFunction %6 %8 %5
+%69 = OpConstantNull  %6
+%75 = OpTypeVector %51 2
+%86 = OpTypeFunction %6 %8 %5 %5
+%90 = OpConstantNull  %6
+%96 = OpTypeVector %51 3
+%106 = OpTypeFunction %6 %11 %5
+%109 = OpConstantNull  %6
+%126 = OpConstantNull  %6
+%141 = OpTypeFunction %4 %8 %5
+%144 = OpConstantNull  %6
+%161 = OpTypeFunction %4 %8 %5 %5
+%165 = OpConstantNull  %6
+%183 = OpConstantNull  %6
+%199 = OpTypeFunction %2 %5 %6
+%210 = OpTypeFunction %2 %8 %6
+%223 = OpTypeFunction %2 %8 %5 %6
+%236 = OpTypeFunction %2 %11 %6
+%47 = OpFunction  %6  None %48
+%45 = OpFunctionParameter  %5
+%46 = OpFunctionParameter  %5
+%44 = OpLabel
+%49 = OpLoad  %3  %20
+OpBranch %50
+%50 = OpLabel
+%53 = OpImageQueryLevels  %5  %49
+%54 = OpULessThan  %51  %46 %53
+OpSelectionMerge %55 None
+OpBranchConditional %54 %56 %55
+%56 = OpLabel
+%57 = OpImageQuerySizeLod  %5  %49 %46
+%58 = OpULessThan  %51  %45 %57
+OpBranchConditional %58 %59 %55
+%59 = OpLabel
+%60 = OpImageFetch  %6  %49 %45 Lod %46
+OpBranch %55
+%55 = OpLabel
+%61 = OpPhi  %6  %52 %50 %52 %56 %60 %59
+OpReturnValue %61
+OpFunctionEnd
+%65 = OpFunction  %6  None %66
+%63 = OpFunctionParameter  %8
+%64 = OpFunctionParameter  %5
+%62 = OpLabel
+%67 = OpLoad  %7  %22
+OpBranch %68
+%68 = OpLabel
+%70 = OpImageQueryLevels  %5  %67
+%71 = OpULessThan  %51  %64 %70
+OpSelectionMerge %72 None
+OpBranchConditional %71 %73 %72
+%73 = OpLabel
+%74 = OpImageQuerySizeLod  %8  %67 %64
+%76 = OpULessThan  %75  %63 %74
+%77 = OpAll  %51  %76
+OpBranchConditional %77 %78 %72
+%78 = OpLabel
+%79 = OpImageFetch  %6  %67 %63 Lod %64
+OpBranch %72
+%72 = OpLabel
+%80 = OpPhi  %6  %69 %68 %69 %73 %79 %78
+OpReturnValue %80
+OpFunctionEnd
+%85 = OpFunction  %6  None %86
+%82 = OpFunctionParameter  %8
+%83 = OpFunctionParameter  %5
+%84 = OpFunctionParameter  %5
+%81 = OpLabel
+%87 = OpLoad  %9  %24
+OpBranch %88
+%88 = OpLabel
+%89 = OpCompositeConstruct  %11  %82 %83
+%91 = OpImageQueryLevels  %5  %87
+%92 = OpULessThan  %51  %84 %91
+OpSelectionMerge %93 None
+OpBranchConditional %92 %94 %93
+%94 = OpLabel
+%95 = OpImageQuerySizeLod  %11  %87 %84
+%97 = OpULessThan  %96  %89 %95
+%98 = OpAll  %51  %97
+OpBranchConditional %98 %99 %93
+%99 = OpLabel
+%100 = OpImageFetch  %6  %87 %89 Lod %84
+OpBranch %93
+%93 = OpLabel
+%101 = OpPhi  %6  %90 %88 %90 %94 %100 %99
+OpReturnValue %101
+OpFunctionEnd
+%105 = OpFunction  %6  None %106
+%103 = OpFunctionParameter  %11
+%104 = OpFunctionParameter  %5
+%102 = OpLabel
+%107 = OpLoad  %10  %26
+OpBranch %108
+%108 = OpLabel
+%110 = OpImageQueryLevels  %5  %107
+%111 = OpULessThan  %51  %104 %110
+OpSelectionMerge %112 None
+OpBranchConditional %111 %113 %112
+%113 = OpLabel
+%114 = OpImageQuerySizeLod  %11  %107 %104
+%115 = OpULessThan  %96  %103 %114
+%116 = OpAll  %51  %115
+OpBranchConditional %116 %117 %112
+%117 = OpLabel
+%118 = OpImageFetch  %6  %107 %103 Lod %104
+OpBranch %112
+%112 = OpLabel
+%119 = OpPhi  %6  %109 %108 %109 %113 %118 %117
+OpReturnValue %119
+OpFunctionEnd
+%123 = OpFunction  %6  None %66
+%121 = OpFunctionParameter  %8
+%122 = OpFunctionParameter  %5
+%120 = OpLabel
+%124 = OpLoad  %12  %28
+OpBranch %125
+%125 = OpLabel
+%127 = OpImageQuerySamples  %5  %124
+%128 = OpULessThan  %51  %122 %127
+OpSelectionMerge %129 None
+OpBranchConditional %128 %130 %129
+%130 = OpLabel
+%131 = OpImageQuerySize  %8  %124
+%132 = OpULessThan  %75  %121 %131
+%133 = OpAll  %51  %132
+OpBranchConditional %133 %134 %129
+%134 = OpLabel
+%135 = OpImageFetch  %6  %124 %121 Sample %122
+OpBranch %129
+%129 = OpLabel
+%136 = OpPhi  %6  %126 %125 %126 %130 %135 %134
+OpReturnValue %136
+OpFunctionEnd
+%140 = OpFunction  %4  None %141
+%138 = OpFunctionParameter  %8
+%139 = OpFunctionParameter  %5
+%137 = OpLabel
+%142 = OpLoad  %13  %30
+OpBranch %143
+%143 = OpLabel
+%145 = OpImageQueryLevels  %5  %142
+%146 = OpULessThan  %51  %139 %145
+OpSelectionMerge %147 None
+OpBranchConditional %146 %148 %147
+%148 = OpLabel
+%149 = OpImageQuerySizeLod  %8  %142 %139
+%150 = OpULessThan  %75  %138 %149
+%151 = OpAll  %51  %150
+OpBranchConditional %151 %152 %147
+%152 = OpLabel
+%153 = OpImageFetch  %6  %142 %138 Lod %139
+OpBranch %147
+%147 = OpLabel
+%154 = OpPhi  %6  %144 %143 %144 %148 %153 %152
+%155 = OpCompositeExtract  %4  %154 0
+OpReturnValue %155
+OpFunctionEnd
+%160 = OpFunction  %4  None %161
+%157 = OpFunctionParameter  %8
+%158 = OpFunctionParameter  %5
+%159 = OpFunctionParameter  %5
+%156 = OpLabel
+%162 = OpLoad  %14  %32
+OpBranch %163
+%163 = OpLabel
+%164 = OpCompositeConstruct  %11  %157 %158
+%166 = OpImageQueryLevels  %5  %162
+%167 = OpULessThan  %51  %159 %166
+OpSelectionMerge %168 None
+OpBranchConditional %167 %169 %168
+%169 = OpLabel
+%170 = OpImageQuerySizeLod  %11  %162 %159
+%171 = OpULessThan  %96  %164 %170
+%172 = OpAll  %51  %171
+OpBranchConditional %172 %173 %168
+%173 = OpLabel
+%174 = OpImageFetch  %6  %162 %164 Lod %159
+OpBranch %168
+%168 = OpLabel
+%175 = OpPhi  %6  %165 %163 %165 %169 %174 %173
+%176 = OpCompositeExtract  %4  %175 0
+OpReturnValue %176
+OpFunctionEnd
+%180 = OpFunction  %4  None %141
+%178 = OpFunctionParameter  %8
+%179 = OpFunctionParameter  %5
+%177 = OpLabel
+%181 = OpLoad  %15  %34
+OpBranch %182
+%182 = OpLabel
+%184 = OpImageQuerySamples  %5  %181
+%185 = OpULessThan  %51  %179 %184
+OpSelectionMerge %186 None
+OpBranchConditional %185 %187 %186
+%187 = OpLabel
+%188 = OpImageQuerySize  %8  %181
+%189 = OpULessThan  %75  %178 %188
+%190 = OpAll  %51  %189
+OpBranchConditional %190 %191 %186
+%191 = OpLabel
+%192 = OpImageFetch  %6  %181 %178 Sample %179
+OpBranch %186
+%186 = OpLabel
+%193 = OpPhi  %6  %183 %182 %183 %187 %192 %191
+%194 = OpCompositeExtract  %4  %193 0
+OpReturnValue %194
+OpFunctionEnd
+%198 = OpFunction  %2  None %199
+%196 = OpFunctionParameter  %5
+%197 = OpFunctionParameter  %6
+%195 = OpLabel
+%200 = OpLoad  %16  %36
+OpBranch %201
+%201 = OpLabel
+%202 = OpImageQuerySize  %5  %200
+%203 = OpULessThan  %51  %196 %202
+OpSelectionMerge %204 None
+OpBranchConditional %203 %205 %204
+%205 = OpLabel
+OpImageWrite %200 %196 %197
+OpBranch %204
+%204 = OpLabel
+OpReturn
+OpFunctionEnd
+%209 = OpFunction  %2  None %210
+%207 = OpFunctionParameter  %8
+%208 = OpFunctionParameter  %6
+%206 = OpLabel
+%211 = OpLoad  %17  %38
+OpBranch %212
+%212 = OpLabel
+%213 = OpImageQuerySize  %8  %211
+%214 = OpULessThan  %75  %207 %213
+%215 = OpAll  %51  %214
+OpSelectionMerge %216 None
+OpBranchConditional %215 %217 %216
+%217 = OpLabel
+OpImageWrite %211 %207 %208
+OpBranch %216
+%216 = OpLabel
+OpReturn
+OpFunctionEnd
+%222 = OpFunction  %2  None %223
+%219 = OpFunctionParameter  %8
+%220 = OpFunctionParameter  %5
+%221 = OpFunctionParameter  %6
+%218 = OpLabel
+%224 = OpLoad  %18  %40
+OpBranch %225
+%225 = OpLabel
+%226 = OpCompositeConstruct  %11  %219 %220
+%227 = OpImageQuerySize  %11  %224
+%228 = OpULessThan  %96  %226 %227
+%229 = OpAll  %51  %228
+OpSelectionMerge %230 None
+OpBranchConditional %229 %231 %230
+%231 = OpLabel
+OpImageWrite %224 %226 %221
+OpBranch %230
+%230 = OpLabel
+OpReturn
+OpFunctionEnd
+%235 = OpFunction  %2  None %236
+%233 = OpFunctionParameter  %11
+%234 = OpFunctionParameter  %6
+%232 = OpLabel
+%237 = OpLoad  %19  %42
+OpBranch %238
+%238 = OpLabel
+%239 = OpImageQuerySize  %11  %237
+%240 = OpULessThan  %96  %233 %239
+%241 = OpAll  %51  %240
+OpSelectionMerge %242 None
+OpBranchConditional %241 %243 %242
+%243 = OpLabel
+OpImageWrite %237 %233 %234
+OpBranch %242
+%242 = OpLabel
+OpReturn
+OpFunctionEnd

--- a/tests/out/spv/bounds-check-zero.spvasm
+++ b/tests/out/spv/bounds-check-zero.spvasm
@@ -34,22 +34,22 @@ OpDecorate %10 Binding 0
 %19 = OpConstant  %20  10
 %22 = OpTypeBool
 %23 = OpConstant  %20  0
-%28 = OpConstantNull  %5
+%25 = OpConstantNull  %5
 %34 = OpTypePointer StorageBuffer %7
 %35 = OpConstant  %20  1
 %38 = OpConstant  %20  4
-%43 = OpConstantNull  %5
+%40 = OpConstantNull  %5
 %49 = OpTypeFunction %5 %7 %4
-%55 = OpConstantNull  %5
+%52 = OpConstantNull  %5
 %60 = OpTypeFunction %7 %4
 %62 = OpTypePointer StorageBuffer %8
 %63 = OpTypePointer StorageBuffer %7
 %64 = OpConstant  %20  3
 %66 = OpConstant  %20  2
-%71 = OpConstantNull  %7
+%68 = OpConstantNull  %7
 %77 = OpTypeFunction %5 %4 %4
-%84 = OpConstantNull  %7
-%90 = OpConstantNull  %5
+%81 = OpConstantNull  %7
+%87 = OpConstantNull  %5
 %96 = OpTypeFunction %2 %4 %5
 %107 = OpTypePointer StorageBuffer %5
 %116 = OpTypeFunction %2 %4 %7
@@ -60,14 +60,14 @@ OpDecorate %10 Binding 0
 OpBranch %16
 %16 = OpLabel
 %21 = OpULessThan  %22  %13 %19
-OpSelectionMerge %25 None
-OpBranchConditional %21 %26 %25
-%26 = OpLabel
+OpSelectionMerge %26 None
+OpBranchConditional %21 %27 %26
+%27 = OpLabel
 %24 = OpAccessChain  %18  %10 %23 %13
-%27 = OpLoad  %5  %24
-OpBranch %25
-%25 = OpLabel
-%29 = OpPhi  %5  %27 %26 %28 %16
+%28 = OpLoad  %5  %24
+OpBranch %26
+%26 = OpLabel
+%29 = OpPhi  %5  %25 %16 %28 %27
 OpReturnValue %29
 OpFunctionEnd
 %32 = OpFunction  %5  None %15
@@ -78,13 +78,13 @@ OpBranch %33
 %36 = OpAccessChain  %34  %10 %35
 %37 = OpLoad  %7  %36
 %39 = OpULessThan  %22  %31 %38
-OpSelectionMerge %40 None
-OpBranchConditional %39 %41 %40
+OpSelectionMerge %41 None
+OpBranchConditional %39 %42 %41
+%42 = OpLabel
+%43 = OpVectorExtractDynamic  %5  %37 %31
+OpBranch %41
 %41 = OpLabel
-%42 = OpVectorExtractDynamic  %5  %37 %31
-OpBranch %40
-%40 = OpLabel
-%44 = OpPhi  %5  %42 %41 %43 %33
+%44 = OpPhi  %5  %40 %33 %43 %42
 OpReturnValue %44
 OpFunctionEnd
 %48 = OpFunction  %5  None %49
@@ -94,13 +94,13 @@ OpFunctionEnd
 OpBranch %50
 %50 = OpLabel
 %51 = OpULessThan  %22  %47 %38
-OpSelectionMerge %52 None
-OpBranchConditional %51 %53 %52
+OpSelectionMerge %53 None
+OpBranchConditional %51 %54 %53
+%54 = OpLabel
+%55 = OpVectorExtractDynamic  %5  %46 %47
+OpBranch %53
 %53 = OpLabel
-%54 = OpVectorExtractDynamic  %5  %46 %47
-OpBranch %52
-%52 = OpLabel
-%56 = OpPhi  %5  %54 %53 %55 %50
+%56 = OpPhi  %5  %52 %50 %55 %54
 OpReturnValue %56
 OpFunctionEnd
 %59 = OpFunction  %7  None %60
@@ -109,14 +109,14 @@ OpFunctionEnd
 OpBranch %61
 %61 = OpLabel
 %65 = OpULessThan  %22  %58 %64
-OpSelectionMerge %68 None
-OpBranchConditional %65 %69 %68
-%69 = OpLabel
+OpSelectionMerge %69 None
+OpBranchConditional %65 %70 %69
+%70 = OpLabel
 %67 = OpAccessChain  %63  %10 %66 %58
-%70 = OpLoad  %7  %67
-OpBranch %68
-%68 = OpLabel
-%72 = OpPhi  %7  %70 %69 %71 %61
+%71 = OpLoad  %7  %67
+OpBranch %69
+%69 = OpLabel
+%72 = OpPhi  %7  %68 %61 %71 %70
 OpReturnValue %72
 OpFunctionEnd
 %76 = OpFunction  %5  None %77
@@ -126,22 +126,22 @@ OpFunctionEnd
 OpBranch %78
 %78 = OpLabel
 %79 = OpULessThan  %22  %74 %64
-OpSelectionMerge %81 None
-OpBranchConditional %79 %82 %81
-%82 = OpLabel
+OpSelectionMerge %82 None
+OpBranchConditional %79 %83 %82
+%83 = OpLabel
 %80 = OpAccessChain  %63  %10 %66 %74
-%83 = OpLoad  %7  %80
-OpBranch %81
-%81 = OpLabel
-%85 = OpPhi  %7  %83 %82 %84 %78
+%84 = OpLoad  %7  %80
+OpBranch %82
+%82 = OpLabel
+%85 = OpPhi  %7  %81 %78 %84 %83
 %86 = OpULessThan  %22  %75 %38
-OpSelectionMerge %87 None
-OpBranchConditional %86 %88 %87
+OpSelectionMerge %88 None
+OpBranchConditional %86 %89 %88
+%89 = OpLabel
+%90 = OpVectorExtractDynamic  %5  %85 %75
+OpBranch %88
 %88 = OpLabel
-%89 = OpVectorExtractDynamic  %5  %85 %75
-OpBranch %87
-%87 = OpLabel
-%91 = OpPhi  %5  %89 %88 %90 %81
+%91 = OpPhi  %5  %87 %82 %90 %89
 OpReturnValue %91
 OpFunctionEnd
 %95 = OpFunction  %2  None %96

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -453,7 +453,7 @@ fn convert_wgsl() {
             .expect("Couldn't find wgsl file");
         match naga::front::wgsl::parse_str(&file) {
             Ok(module) => check_targets(&module, name, targets),
-            Err(e) => panic!("{}", e),
+            Err(e) => panic!("{}", e.emit_to_string(&file)),
         }
     }
 }

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -31,6 +31,10 @@ struct Parameters {
     bounds_check_read_zero_skip_write: bool,
     #[serde(default)]
     bounds_check_restrict: bool,
+    #[serde(default)]
+    image_bounds_check_restrict: bool,
+    #[serde(default)]
+    image_bounds_check_read_zero_skip_write: bool,
 
     #[cfg_attr(not(feature = "spv-out"), allow(dead_code))]
     spv_version: (u8, u8),
@@ -172,6 +176,14 @@ fn write_output_spv(
         } else {
             naga::back::BoundsCheckPolicy::UndefinedBehavior
         },
+        image_bounds_check_policy: if params.image_bounds_check_restrict {
+            naga::back::BoundsCheckPolicy::Restrict
+        } else if params.image_bounds_check_read_zero_skip_write {
+            naga::back::BoundsCheckPolicy::ReadZeroSkipWrite
+        } else {
+            naga::back::BoundsCheckPolicy::UndefinedBehavior
+        },
+        ..spv::Options::default()
     };
 
     let spv = spv::write_vec(module, info, &options).unwrap();
@@ -440,6 +452,8 @@ fn convert_wgsl() {
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,
         ),
         ("bounds-check-zero", Targets::SPIRV),
+        ("bounds-check-image-restrict", Targets::SPIRV),
+        ("bounds-check-image-rzsw", Targets::SPIRV),
         (
             "texture-arg",
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -24,7 +24,7 @@ struct Parameters {
     #[serde(default)]
     god_mode: bool,
 
-    // We can only deserialize `IndexBoundsCheckPolicy` values if `deserialize`
+    // We can only deserialize `BoundsCheckPolicy` values if `deserialize`
     // feature was enabled, but features should not affect snapshot contents, so
     // just take the policy as booleans instead.
     #[serde(default)]
@@ -166,11 +166,11 @@ fn write_output_spv(
             Some(params.spv_capabilities.clone())
         },
         index_bounds_check_policy: if params.bounds_check_restrict {
-            naga::back::IndexBoundsCheckPolicy::Restrict
+            naga::back::BoundsCheckPolicy::Restrict
         } else if params.bounds_check_read_zero_skip_write {
-            naga::back::IndexBoundsCheckPolicy::ReadZeroSkipWrite
+            naga::back::BoundsCheckPolicy::ReadZeroSkipWrite
         } else {
-            naga::back::IndexBoundsCheckPolicy::UndefinedBehavior
+            naga::back::BoundsCheckPolicy::UndefinedBehavior
         },
     };
 


### PR DESCRIPTION
Here's the work-in-progress for bounds checks on `ImageLoad` and `ImageStore` for the SPIR-V back end.

Status: all three `IndexBoundsCheckPolicy` variants, for all texture types:
- [X] for `ImageLoad`
- [x] for `ImageStore`
- [x] Address review comments and squash