### PR TITLE
[glsl-in] Allow expression statements to begin with ++ or --

### DIFF
--- a/src/front/glsl/parser/functions.rs
+++ b/src/front/glsl/parser/functions.rs
@@ -495,6 +495,8 @@ impl<'source> ParsingContext<'source> {
             | TokenValue::Bang
             | TokenValue::Tilde
             | TokenValue::LeftParen
+            | TokenValue::Increment
+            | TokenValue::Decrement
             | TokenValue::Identifier(_)
             | TokenValue::TypeName(_)
             | TokenValue::IntConstant(_)

--- a/src/front/glsl/parser_tests.rs
+++ b/src/front/glsl/parser_tests.rs
@@ -778,9 +778,10 @@ fn swizzles() {
 }
 
 #[test]
-fn vector_indexing() {
+fn expressions() {
     let mut parser = Parser::default();
 
+    // Vector indexing
     parser
         .parse(
             &Options::from(ShaderStage::Vertex),
@@ -792,6 +793,22 @@ fn vector_indexing() {
         }
 
         void main() {}
+        "#,
+        )
+        .unwrap();
+
+    // Prefix increment/decrement
+    parser
+        .parse(
+            &Options::from(ShaderStage::Vertex),
+            r#"
+        #  version 450
+        void main() {
+            uint index = 0;
+            
+            --index;
+            ++index;
+        }
         "#,
         )
         .unwrap();


### PR DESCRIPTION
This would otherwise cause the parser to enter an infinite loop.

Fixes #1232