### PR TITLE
[glsl-in] Allow dynamic indexing on constant variables

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use super::{builtins::MacroCall, SourceMetadata};
+use super::{builtins::MacroCall, context::ExprPos, SourceMetadata};
 use crate::{
     BinaryOperator, Binding, Constant, Expression, Function, GlobalVariable, Handle, Interpolation,
     Sampling, StorageAccess, StorageClass, Type, UnaryOperator,
@@ -212,6 +212,14 @@ impl ParameterQualifier {
         match *self {
             ParameterQualifier::Out | ParameterQualifier::InOut => true,
             _ => false,
+        }
+    }
+
+    /// Converts from a parameter qualifier into a [`ExprPos`](ExprPos)
+    pub fn as_pos(&self) -> ExprPos {
+        match *self {
+            ParameterQualifier::Out | ParameterQualifier::InOut => ExprPos::Lhs,
+            _ => ExprPos::Rhs,
         }
     }
 }

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -1,6 +1,6 @@
 use super::{
     ast::{FunctionKind, Profile, TypeQualifier},
-    context::Context,
+    context::{Context, ExprPos},
     error::ExpectedToken,
     error::{Error, ErrorKind},
     lex::{Lexer, LexerResultKind},
@@ -199,7 +199,7 @@ impl<'source> ParsingContext<'source> {
 
         let mut stmt_ctx = ctx.stmt_ctx();
         let expr = self.parse_conditional(parser, &mut ctx, &mut stmt_ctx, &mut block, None)?;
-        let (root, meta) = ctx.lower_expect(stmt_ctx, parser, expr, false, &mut block)?;
+        let (root, meta) = ctx.lower_expect(stmt_ctx, parser, expr, ExprPos::Rhs, &mut block)?;
 
         Ok((parser.solve_constant(&ctx, root, meta)?, meta))
     }

--- a/src/front/glsl/parser/declarations.rs
+++ b/src/front/glsl/parser/declarations.rs
@@ -4,7 +4,7 @@ use crate::{
             GlobalLookup, GlobalLookupKind, Precision, StorageQualifier, StructLayout,
             TypeQualifier,
         },
-        context::Context,
+        context::{Context, ExprPos},
         error::ExpectedToken,
         offset,
         token::{Token, TokenValue},
@@ -103,7 +103,7 @@ impl<'source> ParsingContext<'source> {
         } else {
             let mut stmt = ctx.stmt_ctx();
             let expr = self.parse_assignment(parser, ctx, &mut stmt, body)?;
-            let (mut init, init_meta) = ctx.lower_expect(stmt, parser, expr, false, body)?;
+            let (mut init, init_meta) = ctx.lower_expect(stmt, parser, expr, ExprPos::Rhs, body)?;
 
             let scalar_components = scalar_components(&parser.module.types[ty].inner);
             if let Some((kind, width)) = scalar_components {

--- a/src/front/glsl/parser_tests.rs
+++ b/src/front/glsl/parser_tests.rs
@@ -812,4 +812,19 @@ fn expressions() {
         "#,
         )
         .unwrap();
+
+    // Dynamic indexing of array
+    parser
+        .parse(
+            &Options::from(ShaderStage::Vertex),
+            r#"
+        #  version 450
+        void main() {
+            const vec4 positions[1] = { vec4(0) };
+
+            gl_Position = positions[gl_VertexIndex];
+        }
+        "#,
+        )
+        .unwrap();
 }


### PR DESCRIPTION
Previously we always set the lhs flag when lowering to generate a
pointer so that dynamic indexing would work, this would produce an error
on constant variables since they can't be in a lhs context.

Now we introduce an enum which distinguishes not only between lhs and
rhs but also in array base, if lowering in a lhs context the base is
also lowered in a lhs context but if lowering in rhs the base is lowered
in a special array base context which bypasses the mutability check.

Fixes #1237