### PR TITLE
[glsl-in] Use power of two alignment for bad type in struct

### DIFF
--- a/src/front/glsl/offset.rs
+++ b/src/front/glsl/offset.rs
@@ -162,7 +162,7 @@ pub fn calculate_offset(
                 kind: ErrorKind::SemanticError("Invalid struct member type".into()),
                 meta,
             });
-            (0, 0)
+            (1, 0)
         }
     };
 


### PR DESCRIPTION
Fixes #1243