### PR TITLE
[spv-out] Clean up capability handling.

### DIFF
--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -1108,7 +1108,8 @@ impl<'w> BlockContext<'w> {
                     }
                 };
 
-                self.writer.check(&[spirv::Capability::ImageQuery])?;
+                self.writer
+                    .require_any("image queries", &[spirv::Capability::ImageQuery])?;
 
                 match query {
                     Iq::Size { level } => {

--- a/src/back/spv/recyclable.rs
+++ b/src/back/spv/recyclable.rs
@@ -42,3 +42,10 @@ impl<K, V, S: Clone> Recyclable for std::collections::HashMap<K, V, S> {
         self
     }
 }
+
+impl<K, S: Clone> Recyclable for std::collections::HashSet<K, S> {
+    fn recycle(mut self) -> Self {
+        self.clear();
+        self
+    }
+}


### PR DESCRIPTION
Remove 'forbidden_caps'.

Accumulate capabilities actually used separately from the permitted
capabilities, so that the latter can be retained across Writer resets, while the
former is cleared between modules.