### PR TITLE
Fix some clippy suggestions

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -2621,7 +2621,7 @@ fn test_stack_size() {
         let stack_size = addresses.end - addresses.start;
         // check the size (in debug only)
         // last observed macOS value: 18304
-        if stack_size < 15000 || stack_size > 20000 {
+        if !(15000..=20000).contains(&stack_size) {
             panic!("`put_expression` stack size {} has changed!", stack_size);
         }
     }
@@ -2636,7 +2636,7 @@ fn test_stack_size() {
         let stack_size = addresses.end - addresses.start;
         // check the size (in debug only)
         // last observed macOS value: 17504
-        if stack_size < 13000 || stack_size > 19000 {
+        if !(13000..=19000).contains(&stack_size) {
             panic!("`put_block` stack size {} has changed!", stack_size);
         }
     }

--- a/src/back/spv/layout.rs
+++ b/src/back/spv/layout.rs
@@ -135,10 +135,8 @@ impl Instruction {
             inst_index += 1;
         }
 
-        let mut op_index = 0;
-        for i in inst_index..wc as usize {
+        for (op_index, i) in (inst_index..wc as usize).enumerate() {
             assert_eq!(words[i], self.operands[op_index]);
-            op_index += 1;
         }
     }
 }
@@ -178,7 +176,7 @@ fn test_logical_layout_in_words() {
         "Function Definitions",
     ];
 
-    for i in 0..layout_vectors {
+    for (i, _) in vector_names.iter().enumerate().take(layout_vectors) {
         let mut dummy_instruction = Instruction::new(Op::Constant);
         dummy_instruction.set_type((i + 1) as u32);
         dummy_instruction.set_result((i + 2) as u32);

--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -992,7 +992,7 @@ fn uniform_control_flow() {
     let stmt_if_non_uniform = S::If {
         condition: non_uniform_global_expr,
         accept: vec![
-            S::Emit(emit_range_constant_derivative.clone()),
+            S::Emit(emit_range_constant_derivative),
             S::Store {
                 pointer: constant_expr,
                 value: derivative_expr,

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -1,7 +1,7 @@
 //TODO: move this to a binary target once Rust supports
 // binary-specific dependencies.
 
-use std::{fs, path::PathBuf};
+use std::{fs, path::Path, path::PathBuf};
 
 const BASE_DIR_IN: &str = "tests/in";
 const BASE_DIR_OUT: &str = "tests/out";
@@ -143,7 +143,7 @@ fn check_targets(module: &naga::Module, name: &str, targets: Targets) {
 fn write_output_spv(
     module: &naga::Module,
     info: &naga::valid::ModuleInfo,
-    destination: &PathBuf,
+    destination: &Path,
     file_name: &str,
     params: &Parameters,
 ) {
@@ -172,7 +172,6 @@ fn write_output_spv(
         } else {
             naga::back::IndexBoundsCheckPolicy::UndefinedBehavior
         },
-        ..spv::Options::default()
     };
 
     let spv = spv::write_vec(module, info, &options).unwrap();
@@ -188,7 +187,7 @@ fn write_output_spv(
 fn write_output_msl(
     module: &naga::Module,
     info: &naga::valid::ModuleInfo,
-    destination: &PathBuf,
+    destination: &Path,
     file_name: &str,
     params: &Parameters,
 ) {
@@ -225,7 +224,7 @@ fn write_output_msl(
 fn write_output_glsl(
     module: &naga::Module,
     info: &naga::valid::ModuleInfo,
-    destination: &PathBuf,
+    destination: &Path,
     file_name: &str,
     stage: naga::ShaderStage,
     ep_name: &str,
@@ -252,7 +251,7 @@ fn write_output_glsl(
 
     let mut buffer = String::new();
     let mut writer =
-        glsl::Writer::new(&mut buffer, module, info, &options, &pipeline_options).unwrap();
+        glsl::Writer::new(&mut buffer, module, info, options, &pipeline_options).unwrap();
     writer.write().unwrap();
 
     fs::write(
@@ -266,7 +265,7 @@ fn write_output_glsl(
 fn write_output_hlsl(
     module: &naga::Module,
     info: &naga::valid::ModuleInfo,
-    destination: &PathBuf,
+    destination: &Path,
     file_name: &str,
     params: &Parameters,
 ) {
@@ -355,7 +354,7 @@ fn write_output_hlsl(
 fn write_output_wgsl(
     module: &naga::Module,
     info: &naga::valid::ModuleInfo,
-    destination: &PathBuf,
+    destination: &Path,
     file_name: &str,
 ) {
     use naga::back::wgsl;


### PR DESCRIPTION
Passes cargo check and cargo test. 

PS: Running cargo test changes some files in tests/out (`#version 310 es`, seems to upgrade the shader to 310), but I didn't include them here because they are not changed by this PR. I think these should be under the .gitignore, as it's the shader output of the tests? Might be helpful to track the changes of the output shaders over time, though, in which case you can simply clone the repo and run cargo test, it edits these files: 
![image](https://user-images.githubusercontent.com/69441971/130277157-173324ad-7b92-41a2-a953-6531b7ec8ed2.png)