### PR TITLE
Fix round in backends and add support for roundEven in frontends

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -2251,7 +2251,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     // decomposition
                     Mf::Ceil => "ceil",
                     Mf::Floor => "floor",
-                    Mf::Round => "round",
+                    Mf::Round => "roundEven",
                     Mf::Fract => "fract",
                     Mf::Trunc => "trunc",
                     Mf::Modf => "modf",

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1146,7 +1146,7 @@ impl<W: Write> Writer<W> {
                     // decomposition
                     Mf::Ceil => "ceil",
                     Mf::Floor => "floor",
-                    Mf::Round => "round",
+                    Mf::Round => "rint",
                     Mf::Fract => "fract",
                     Mf::Trunc => "trunc",
                     Mf::Modf => "modf",

--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -563,7 +563,7 @@ impl<'w> BlockContext<'w> {
                     Mf::Atanh => MathOp::Ext(spirv::GLOp::Atanh),
                     // decomposition
                     Mf::Ceil => MathOp::Ext(spirv::GLOp::Ceil),
-                    Mf::Round => MathOp::Ext(spirv::GLOp::Round),
+                    Mf::Round => MathOp::Ext(spirv::GLOp::RoundEven),
                     Mf::Floor => MathOp::Ext(spirv::GLOp::Floor),
                     Mf::Fract => MathOp::Ext(spirv::GLOp::Fract),
                     Mf::Trunc => MathOp::Ext(spirv::GLOp::Trunc),

--- a/src/front/glsl/builtins.rs
+++ b/src/front/glsl/builtins.rs
@@ -953,8 +953,8 @@ fn inject_common_builtin(
     float_width: crate::Bytes,
 ) {
     match name {
-        "ceil" | "round" | "floor" | "fract" | "trunc" | "sqrt" | "inversesqrt" | "normalize"
-        | "length" | "isinf" | "isnan" => {
+        "ceil" | "round" | "roundEven" | "floor" | "fract" | "trunc" | "sqrt" | "inversesqrt"
+        | "normalize" | "length" | "isinf" | "isnan" => {
             // bits layout
             // bit 0 trough 1 - dims
             for bits in 0..(0b100) {
@@ -980,6 +980,7 @@ fn inject_common_builtin(
                 let fun = match name {
                     "ceil" => MacroCall::MathFunction(MathFunction::Ceil),
                     "round" => MacroCall::MathFunction(MathFunction::Round),
+                    "roundEven" => MacroCall::MathFunction(MathFunction::Round),
                     "floor" => MacroCall::MathFunction(MathFunction::Floor),
                     "fract" => MacroCall::MathFunction(MathFunction::Fract),
                     "trunc" => MacroCall::MathFunction(MathFunction::Trunc),

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -1968,6 +1968,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                     } else {
                         let fun = match gl_op {
                             Glo::Round => Mf::Round,
+                            Glo::RoundEven => Mf::Round,
                             Glo::Trunc => Mf::Trunc,
                             Glo::FAbs | Glo::SAbs => Mf::Abs,
                             Glo::FSign | Glo::SSign => Mf::Sign,


### PR DESCRIPTION
According to https://github.com/gpuweb/gpuweb/issues/1381 `MathFunction::Round` always goes to the even number when the fractional part is `.5`. But in spirv, glsl and msl the default `round` leaves this case as implementation defined, to fix this in spirv and glsl we now use `roundEven` and in msl `rint`.