### PR TITLE
Allow Newer Bitflags

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.43.0, nightly]
+        rust: ["1.43.0", nightly]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -16,6 +16,12 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      - uses: actions-rs/cargo@v1
+        name: Downgrade bitflags to MSRV
+        if: ${{ matrix.rust }} == "1.43.0"
+        with:
+          command: update
+          args: -p bitflags --precise 1.2.1
       - uses: actions-rs/cargo@v1
         name: Default test
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ resolver = "2"
 all-features = true
 
 [dependencies]
-# bitflags 1.3 requires Rust-1.46
-bitflags = "~1.2"
+# MSRV warning: bitflags 1.3 requires Rust-1.46
+bitflags = "1"
 bit-set = "0.5"
 codespan-reporting = { version = "0.11.0", optional = true }
 fxhash = "0.2"

--- a/README.md
+++ b/README.md
@@ -66,3 +66,15 @@ make validate-dot # for dot files, requires GraphViz installed
 make validate-wgsl # for WGSL shaders
 make validate-hlsl # for HLSL shaders. Note: this Make target makes use of the "sh" shell. This is not the default shell in Windows.
 ```
+
+## MSRV
+
+The `naga` codebase's MSRV is 1.43. However some newer versions of our dependencies have newer MSRVs than that. Here are a list of all known MSRV breaking dependencies and the versions that hold to MSRV.
+
+- `bitflags`: `>1.3` have an MSRV of 1.46. `<=1.2` has an MSRV of 1.43 or earlier.
+
+If you want to use `naga` with `1.43` add the following to your Cargo.toml dependency list even if you don't use bitflags yourself:
+
+```toml
+bitflags = "<1.3"
+```


### PR DESCRIPTION
Puts infrastructure and documentation in place to allow a newer bitflags yet still warning about the MSRV trap.

Would be nice to backport this as well.