### PR TITLE
Fix fuzzing setup

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.3"
+libfuzzer-sys = "0.4"
 
 [dependencies.naga]
 path = ".."
-features = ["spirv"]
+features = ["spv-in", "wgsl-in"]
 
 # Prevent this from interfering with workspaces
 [workspace]


### PR DESCRIPTION
Set naga features in `fuzz/Cargo.toml` to those required for SPIR-V and
WGSL input.
Also bump libfuzzer-sys version.

The current fuzzing setup doesn't use the currently required features for SPIR-V and WGSL input (likely due to a feature name / default feature set change), making the compilation of the fuzzing targets fail.
With the adjusted `Cargo.toml` fuzzing works again, and has already found me a stack overflow (I'll open an issue / PR for that later).