### PR TITLE
Fix GLSL output for non-fallthrough switch cases

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1442,8 +1442,18 @@ impl<'a, W: Write> Writer<'a, W> {
                         self.write_stmt(sta, ctx, indent + 2)?;
                     }
 
-                    // Write `break;` if the block isn't fallthrough
-                    if !case.fall_through {
+                    // Write fallthrough comment if the case is fallthrough,
+                    // otherwise write a break, if the case is not already
+                    // broken out of at the end of its body.
+                    if case.fall_through {
+                        writeln!(self.out, "{}/* fallthrough */", INDENT.repeat(indent + 2))?;
+                    } else if !matches!(
+                        case.body.last(),
+                        Some(&Statement::Break)
+                            | Some(&Statement::Continue)
+                            | Some(&Statement::Return { .. })
+                            | Some(&Statement::Kill)
+                    ) {
                         writeln!(self.out, "{}break;", INDENT.repeat(indent + 2))?;
                     }
                 }

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1441,6 +1441,11 @@ impl<'a, W: Write> Writer<'a, W> {
                     for sta in case.body.iter() {
                         self.write_stmt(sta, ctx, indent + 2)?;
                     }
+
+                    // Write `break;` if the block isn't fallthrough
+                    if !case.fall_through {
+                        writeln!(self.out, "{}break;", INDENT.repeat(indent + 2))?;
+                    }
                 }
 
                 // Only write the default block if the block isn't empty

--- a/tests/in/control-flow.wgsl
+++ b/tests/in/control-flow.wgsl
@@ -12,6 +12,27 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
         }
     }
 
+    // non-empty switch *not* in last-statement-in-function position
+    // (return statements might be inserted into the switch cases otherwise)
+    switch (pos) {
+        case 1: {
+            pos = 0;
+            break;
+        }
+        case 2: {
+            pos = 1;
+        }
+        case 3: {
+            pos = 2;
+            fallthrough;
+        }
+        case 4: {}
+        default: {
+            pos = 3;
+        }
+    }
+
+    // non-empty switch in last-statement-in-function position
     switch (pos) {
         case 1: {
             pos = 0;

--- a/tests/in/control-flow.wgsl
+++ b/tests/in/control-flow.wgsl
@@ -1,59 +1,59 @@
 [[stage(compute), workgroup_size(1)]]
 fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
-	//TODO: execution-only barrier?
-	storageBarrier();
-	workgroupBarrier();
+    //TODO: execution-only barrier?
+    storageBarrier();
+    workgroupBarrier();
 
-	var pos: i32;
-	// switch without cases
+    var pos: i32;
+    // switch without cases
     switch (1) {
         default: {
-			pos = 1;
-		}
+            pos = 1;
+        }
     }
 
-	switch (pos) {
-		case 1: {
-			pos = 0;
-			break;
-		}
-		case 2: {
-			pos = 1;
-		}
-		case 3: {
-			pos = 2;
-			fallthrough;
-		}
-		case 4: {}
+    switch (pos) {
+        case 1: {
+            pos = 0;
+            break;
+        }
+        case 2: {
+            pos = 1;
+        }
+        case 3: {
+            pos = 2;
+            fallthrough;
+        }
+        case 4: {}
         default: {
-			pos = 3;
-		}
+            pos = 3;
+        }
     }
 }
 
 fn switch_default_break(i: i32) {
-  switch (i) {
-    default: {
-      break;
+    switch (i) {
+        default: {
+            break;
+        }
     }
-  }
 }
 
 fn switch_case_break() {
-  switch(0) {
-    case 0: {
-      break;
+    switch(0) {
+        case 0: {
+            break;
+        }
     }
-  }
-  return;
+    return;
 }
 
 fn loop_switch_continue(x: i32) {
-   loop {
-       switch (x) {
-           case 1: {
-               continue;
-           }
-       }
-   }
+    loop {
+        switch (x) {
+            case 1: {
+                continue;
+            }
+        }
+    }
 }

--- a/tests/out/glsl/control-flow.main.Compute.glsl
+++ b/tests/out/glsl/control-flow.main.Compute.glsl
@@ -17,7 +17,6 @@ void switch_case_break() {
     switch(0) {
         case 0:
             break;
-            break;
     }
     return;
 }
@@ -27,7 +26,6 @@ void loop_switch_continue(int x) {
         switch(x) {
             case 1:
                 continue;
-                break;
         }
     }
     return;
@@ -47,16 +45,30 @@ void main() {
         case 1:
             pos = 0;
             break;
+        case 2:
+            pos = 1;
+            break;
+        case 3:
+            pos = 2;
+            /* fallthrough */
+        case 4:
+            break;
+        default:
+            pos = 3;
+    }
+    int _e9 = pos;
+    switch(_e9) {
+        case 1:
+            pos = 0;
             break;
         case 2:
             pos = 1;
             return;
-            break;
         case 3:
             pos = 2;
+            /* fallthrough */
         case 4:
             return;
-            break;
         default:
             pos = 3;
             return;

--- a/tests/out/glsl/control-flow.main.Compute.glsl
+++ b/tests/out/glsl/control-flow.main.Compute.glsl
@@ -17,6 +17,7 @@ void switch_case_break() {
     switch(0) {
         case 0:
             break;
+            break;
     }
     return;
 }
@@ -26,6 +27,7 @@ void loop_switch_continue(int x) {
         switch(x) {
             case 1:
                 continue;
+                break;
         }
     }
     return;
@@ -45,13 +47,16 @@ void main() {
         case 1:
             pos = 0;
             break;
+            break;
         case 2:
             pos = 1;
             return;
+            break;
         case 3:
             pos = 2;
         case 4:
             return;
+            break;
         default:
             pos = 3;
             return;

--- a/tests/out/hlsl/control-flow.hlsl
+++ b/tests/out/hlsl/control-flow.hlsl
@@ -53,6 +53,30 @@ void main(uint3 global_id : SV_DispatchThreadID)
         }
         case 2: {
             pos = 1;
+            break;
+        }
+        case 3: {
+            /* fallthrough */
+            {
+                pos = 2;
+            }
+        }
+        case 4: {
+            break;
+        }
+        default: {
+            pos = 3;
+        }
+    }
+    int _expr9 = pos;
+    switch(_expr9) {
+        case 1: {
+            pos = 0;
+            break;
+            break;
+        }
+        case 2: {
+            pos = 1;
             return;
             break;
         }

--- a/tests/out/msl/control-flow.msl
+++ b/tests/out/msl/control-flow.msl
@@ -64,6 +64,27 @@ kernel void main1(
         }
         case 2: {
             pos = 1;
+            break;
+        }
+        case 3: {
+            pos = 2;
+        }
+        case 4: {
+            break;
+        }
+        default: {
+            pos = 3;
+        }
+    }
+    int _e9 = pos;
+    switch(_e9) {
+        case 1: {
+            pos = 0;
+            break;
+            break;
+        }
+        case 2: {
+            pos = 1;
             return;
             break;
         }

--- a/tests/out/spv/control-flow.spvasm
+++ b/tests/out/spv/control-flow.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 56
+; Bound: 63
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
@@ -95,15 +95,33 @@ OpStore %35 %5
 OpBranch %50
 %53 = OpLabel
 OpStore %35 %3
-OpReturn
+OpBranch %50
 %54 = OpLabel
 OpStore %35 %6
 OpBranch %55
 %55 = OpLabel
-OpReturn
+OpBranch %50
 %51 = OpLabel
 OpStore %35 %7
-OpReturn
+OpBranch %50
 %50 = OpLabel
+%56 = OpLoad  %4  %35
+OpSelectionMerge %57 None
+OpSwitch %56 %58 1 %59 2 %60 3 %61 4 %62
+%59 = OpLabel
+OpStore %35 %5
+OpBranch %57
+%60 = OpLabel
+OpStore %35 %3
+OpReturn
+%61 = OpLabel
+OpStore %35 %6
+OpBranch %62
+%62 = OpLabel
+OpReturn
+%58 = OpLabel
+OpStore %35 %7
+OpReturn
+%57 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/tests/out/wgsl/control-flow.wgsl
+++ b/tests/out/wgsl/control-flow.wgsl
@@ -45,6 +45,25 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
         }
         case 2: {
             pos = 1;
+        }
+        case 3: {
+            pos = 2;
+            fallthrough;
+        }
+        case 4: {
+        }
+        default: {
+            pos = 3;
+        }
+    }
+    let _e9: i32 = pos;
+    switch(_e9) {
+        case 1: {
+            pos = 0;
+            break;
+        }
+        case 2: {
+            pos = 1;
             return;
         }
         case 3: {


### PR DESCRIPTION
Fixes #1309 by partially reverting 02c74b50021379092a9d4567fd11aeb0879c5405.
Also cleans up the GLSL output by only inserting a `break` where a case is not already broken out of at the end of the case body and inserts a comment indicating explicitly fallthrough cases.

Also adds a test case for switch statements not in the last statement position of a function, because those might have return statements inserted, which previously might have made it harder to notice some missing `break`s that should have been inserted.