### PR TITLE
[glsl-out] Fix select order

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -2188,10 +2188,12 @@ impl<'a, W: Write> Writer<'a, W> {
 
                 // TODO: Boolean mix on desktop required GL_EXT_shader_integer_mix
                 if vec_select {
+                    // Glsl defines that for mix when the condition is a boolean the first element
+                    // is picked if condition is false and the second if condition is true
                     write!(self.out, "mix(")?;
-                    self.write_expr(accept, ctx)?;
-                    write!(self.out, ", ")?;
                     self.write_expr(reject, ctx)?;
+                    write!(self.out, ", ")?;
+                    self.write_expr(accept, ctx)?;
                     write!(self.out, ", ")?;
                     self.write_expr(condition, ctx)?;
                 } else {

--- a/tests/out/glsl/operators.main.Compute.glsl
+++ b/tests/out/glsl/operators.main.Compute.glsl
@@ -14,7 +14,7 @@ struct Foo {
 vec4 builtins() {
     int s1_ = (true ? 1 : 0);
     vec4 s2_ = (true ? vec4(1.0, 1.0, 1.0, 1.0) : vec4(0.0, 0.0, 0.0, 0.0));
-    vec4 s3_ = mix(vec4(0.0, 0.0, 0.0, 0.0), vec4(1.0, 1.0, 1.0, 1.0), bvec4(false, false, false, false));
+    vec4 s3_ = mix(vec4(1.0, 1.0, 1.0, 1.0), vec4(0.0, 0.0, 0.0, 0.0), bvec4(false, false, false, false));
     vec4 m1_ = mix(vec4(0.0, 0.0, 0.0, 0.0), vec4(1.0, 1.0, 1.0, 1.0), vec4(0.5, 0.5, 0.5, 0.5));
     vec4 m2_ = mix(vec4(0.0, 0.0, 0.0, 0.0), vec4(1.0, 1.0, 1.0, 1.0), 0.10000000149011612);
     float b1_ = intBitsToFloat(ivec4(1, 1, 1, 1).x);


### PR DESCRIPTION
When there is a vector as the condition for `Expression::Select` we use a `mix` in the glsl backend but the first argument is the reject and the second the accept this was inverted.

This should probably be backported as can cause surprising results.