### PR TITLE
[spv-in] Handle structs with no offset decorations

### DIFF
--- a/src/front/glsl/offset.rs
+++ b/src/front/glsl/offset.rs
@@ -13,7 +13,7 @@ use super::{
     error::{Error, ErrorKind},
     SourceMetadata,
 };
-use crate::{Arena, Constant, Handle, Type, TypeInner};
+use crate::{front::align_up, Arena, Constant, Handle, Type, TypeInner};
 
 /// Struct with information needed for defining a struct member.
 ///
@@ -169,21 +169,4 @@ pub fn calculate_offset(
     };
 
     TypeAlignSpan { ty, align, span }
-}
-
-/// Helper function used for aligning `value` to the next multiple of `align`
-///
-/// # Notes:
-/// - `align` must be a power of two.
-/// - The returned value will be greater or equal to `value`.
-/// # Examples:
-/// ```ignore
-/// assert_eq!(0, align_up(0, 16));
-/// assert_eq!(16, align_up(1, 16));
-/// assert_eq!(16, align_up(16, 16));
-/// assert_eq!(334, align_up(333, 2));
-/// assert_eq!(384, align_up(257, 128));
-/// ```
-pub fn align_up(value: u32, align: u32) -> u32 {
-    ((value.wrapping_sub(1)) & !(align - 1)).wrapping_add(align)
 }

--- a/src/front/glsl/parser/declarations.rs
+++ b/src/front/glsl/parser/declarations.rs
@@ -597,7 +597,7 @@ impl<'source> ParsingContext<'source> {
                 &mut parser.errors,
             );
 
-            span = offset::align_up(span, info.align);
+            span = crate::front::align_up(span, info.align);
             align = align.max(info.align);
 
             members.push(StructMember {
@@ -614,7 +614,7 @@ impl<'source> ParsingContext<'source> {
             }
         }
 
-        span = offset::align_up(span, align);
+        span = crate::front::align_up(span, align);
 
         Ok(span)
     }

--- a/src/front/mod.rs
+++ b/src/front/mod.rs
@@ -127,3 +127,20 @@ impl ops::Index<Handle<crate::Expression>> for Typifier {
         &self.resolutions[handle.index()]
     }
 }
+
+/// Helper function used for aligning `value` to the next multiple of `align`
+///
+/// # Notes:
+/// - `align` must be a power of two.
+/// - The returned value will be greater or equal to `value`.
+/// # Examples:
+/// ```ignore
+/// assert_eq!(0, align_up(0, 16));
+/// assert_eq!(16, align_up(1, 16));
+/// assert_eq!(16, align_up(16, 16));
+/// assert_eq!(334, align_up(333, 2));
+/// assert_eq!(384, align_up(257, 128));
+/// ```
+pub fn align_up(value: u32, align: u32) -> u32 {
+    ((value.wrapping_sub(1)) & !(align - 1)).wrapping_add(align)
+}


### PR DESCRIPTION
From the llvm discourse on whether spirv with missing offset decorations
> For non-external storage classes, the struct does not need to be explicitly laid out.

Seems like `shaderc` does this and I had shader where all offsets were 0, this PR fixes it by using a similar strategy to glsl frontend to calculate span/offsets.