### PR TITLE
Move `#[must_use]` attr on `Capabilities` to where it'll take effect.

### DIFF
--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -47,9 +47,9 @@ impl Default for ValidationFlags {
     }
 }
 
-#[must_use]
 bitflags::bitflags! {
     /// Allowed IR capabilities.
+    #[must_use]
     #[derive(Default)]
     #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
     #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]


### PR DESCRIPTION
This was causing warnings in nightly (1.56.0).