### PR TITLE
Output parentheses around dereference

### DIFF
--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -1034,11 +1034,11 @@ impl<W: Write> Writer<W> {
         // If the plain form of the expression is not what we need, emit the
         // operator necessary to correct that.
         let plain = plain_form_indirection(expr, module, func_ctx);
-        match (requested, plain) {
-            (Indirection::Ordinary, Indirection::Reference) => write!(self.out, "&")?,
-            (Indirection::Reference, Indirection::Ordinary) => write!(self.out, "*")?,
-            (_, _) => {}
-        }
+        let opened_paren = match (requested, plain) {
+            (Indirection::Ordinary, Indirection::Reference) => { write!(self.out, "&")?; false },
+            (Indirection::Reference, Indirection::Ordinary) => { write!(self.out, "(*")?; true },
+            (_, _) => { false },
+        };
 
         let expression = &func_ctx.expressions[expr];
 
@@ -1542,6 +1542,10 @@ impl<W: Write> Writer<W> {
             // Nothing to do here, since call expression already cached
             Expression::CallResult(_) | Expression::AtomicResult { .. } => {}
         }
+
+        if opened_paren {
+            write!(self.out, ")")?
+        };
 
         Ok(())
     }

--- a/tests/in/glsl/fma.frag
+++ b/tests/in/glsl/fma.frag
@@ -1,0 +1,9 @@
+#version 440 core
+
+struct Mat4x3 { vec4 mx; vec4 my; vec4 mz; };
+void Fma(inout Mat4x3 d, Mat4x3 m, float s) { d.mx += m.mx * s; d.my += m.my * s; d.mz += m.mz * s; }
+
+out vec4 o_color;
+void main() {
+    o_color.rgba = vec4(1.0);
+}

--- a/tests/out/wgsl/fma-frag.wgsl
+++ b/tests/out/wgsl/fma-frag.wgsl
@@ -1,0 +1,44 @@
+struct Mat4x3_ {
+    mx: vec4<f32>;
+    my: vec4<f32>;
+    mz: vec4<f32>;
+};
+
+var<private> o_color: vec4<f32>;
+
+fn Fma(d: ptr<function, Mat4x3_>, m: Mat4x3_, s: f32) {
+    var m1: Mat4x3_;
+    var s1: f32;
+
+    m1 = m;
+    s1 = s;
+    let _e6: Mat4x3_ = (*d);
+    let _e8: Mat4x3_ = m1;
+    let _e10: f32 = s1;
+    (*d).mx = (_e6.mx + (_e8.mx * _e10));
+    let _e14: Mat4x3_ = (*d);
+    let _e16: Mat4x3_ = m1;
+    let _e18: f32 = s1;
+    (*d).my = (_e14.my + (_e16.my * _e18));
+    let _e22: Mat4x3_ = (*d);
+    let _e24: Mat4x3_ = m1;
+    let _e26: f32 = s1;
+    (*d).mz = (_e22.mz + (_e24.mz * _e26));
+    return;
+}
+
+fn main1() {
+    let _e1: vec4<f32> = o_color;
+    let _e4: vec4<f32> = vec4<f32>(1.0);
+    o_color.x = _e4.x;
+    o_color.y = _e4.y;
+    o_color.z = _e4.z;
+    o_color.w = _e4.w;
+    return;
+}
+
+[[stage(fragment)]]
+fn main() {
+    main1();
+    return;
+}


### PR DESCRIPTION
Regression from ce676cf13090b87e1405640ea8ee43e1a1666005.

We need to output (*d).mx rather than *d.mx, at least according to Tint.
wgsl-in seems to handle *d.mx just fine, which is likely a separate bug.