### PR TITLE
wgsl-in: require storage class to be given

### DIFF
--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -1035,9 +1035,15 @@ impl<W: Write> Writer<W> {
         // operator necessary to correct that.
         let plain = plain_form_indirection(expr, module, func_ctx);
         let opened_paren = match (requested, plain) {
-            (Indirection::Ordinary, Indirection::Reference) => { write!(self.out, "&")?; false },
-            (Indirection::Reference, Indirection::Ordinary) => { write!(self.out, "(*")?; true },
-            (_, _) => { false },
+            (Indirection::Ordinary, Indirection::Reference) => {
+                write!(self.out, "&")?;
+                false
+            }
+            (Indirection::Reference, Indirection::Ordinary) => {
+                write!(self.out, "(*")?;
+                true
+            }
+            (_, _) => false,
         };
 
         let expression = &func_ctx.expressions[expr];

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -3850,27 +3850,10 @@ impl Parser {
             (Token::Word("var"), _) => {
                 let pvar =
                     self.parse_variable_decl(lexer, &mut module.types, &mut module.constants)?;
-                let class = match pvar.class {
-                    Some(c) => c,
-                    None => match module.types[pvar.ty].inner {
-                        crate::TypeInner::Struct { .. } if binding.is_some() => {
-                            crate::StorageClass::Uniform
-                        }
-                        crate::TypeInner::Array { .. } if binding.is_some() => {
-                            crate::StorageClass::Storage {
-                                access: crate::StorageAccess::LOAD,
-                            }
-                        }
-                        crate::TypeInner::Image { .. } | crate::TypeInner::Sampler { .. } => {
-                            crate::StorageClass::Handle
-                        }
-                        _ => crate::StorageClass::Private,
-                    },
-                };
                 let var_handle = module.global_variables.append(
                     crate::GlobalVariable {
                         name: Some(pvar.name.to_owned()),
-                        class,
+                        class: pvar.class.unwrap_or(crate::StorageClass::Handle),
                         binding: binding.take(),
                         ty: pvar.ty,
                         init: pvar.init,

--- a/tests/in/skybox.wgsl
+++ b/tests/in/skybox.wgsl
@@ -9,7 +9,7 @@ struct Data {
     view: mat4x4<f32>;
 };
 [[group(0), binding(0)]]
-var r_data: Data;
+var<uniform> r_data: Data;
 
 [[stage(vertex)]]
 fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> VertexOutput {


### PR DESCRIPTION
See the spec - https://gpuweb.github.io/gpuweb/wgsl/#module-scope-variables
> A variable in the private, workgroup, uniform, or storage storage classes:
>    Must be declared with an explicit storage class decoration.
>    Must use a store type as described in § 4.3.6 Storage Classes.

