### PR TITLE
[wgsl-in] Rework Load Rule handling and indirection.

### DIFF
--- a/tests/out/glsl/access.foo.Vertex.glsl
+++ b/tests/out/glsl/access.foo.Vertex.glsl
@@ -19,8 +19,7 @@ void main() {
     foo1 = 1.0;
     mat4x4 matrix = _group_0_binding_0.matrix;
     uvec2 arr[2] = _group_0_binding_0.arr;
-    vec4 _e13 = _group_0_binding_0.matrix[3];
-    float b = _e13.x;
+    float b = _group_0_binding_0.matrix[3][0];
     int a = _group_0_binding_0.data[(uint(_group_0_binding_0.data.length()) - 2u)];
     _group_0_binding_0.matrix[1][2] = 1.0;
     _group_0_binding_0.matrix = mat4x4(vec4(0.0), vec4(1.0), vec4(2.0), vec4(3.0));

--- a/tests/out/glsl/boids.main.Compute.glsl
+++ b/tests/out/glsl/boids.main.Compute.glsl
@@ -131,20 +131,20 @@ void main() {
     vec2 _e132 = vVel;
     float _e134 = _group_0_binding_0.deltaT;
     vPos = (_e131 + (_e132 * _e134));
-    vec2 _e137 = vPos;
-    if ((_e137.x < -1.0)) {
+    float _e138 = vPos.x;
+    if ((_e138 < -1.0)) {
         vPos.x = 1.0;
     }
-    vec2 _e143 = vPos;
-    if ((_e143.x > 1.0)) {
+    float _e144 = vPos.x;
+    if ((_e144 > 1.0)) {
         vPos.x = -1.0;
     }
-    vec2 _e149 = vPos;
-    if ((_e149.y < -1.0)) {
+    float _e150 = vPos.y;
+    if ((_e150 < -1.0)) {
         vPos.y = 1.0;
     }
-    vec2 _e155 = vPos;
-    if ((_e155.y > 1.0)) {
+    float _e156 = vPos.y;
+    if ((_e156 > 1.0)) {
         vPos.y = -1.0;
     }
     vec2 _e164 = vPos;

--- a/tests/out/glsl/operators.main.Compute.glsl
+++ b/tests/out/glsl/operators.main.Compute.glsl
@@ -40,8 +40,8 @@ int unary() {
 float constructors() {
     Foo foo;
     foo = Foo(vec4(1.0), 1);
-    vec4 _e10 = foo.a;
-    return _e10.x;
+    float _e11 = foo.a.x;
+    return _e11;
 }
 
 void main() {

--- a/tests/out/glsl/shadow.fs_main.Fragment.glsl
+++ b/tests/out/glsl/shadow.fs_main.Fragment.glsl
@@ -47,8 +47,8 @@ void main() {
         }
         loop_init = false;
         uint _e12 = i;
-        uvec4 _e14 = _group_0_binding_0.num_lights;
-        if ((_e12 >= min(_e14.x, 10u))) {
+        uint _e15 = _group_0_binding_0.num_lights.x;
+        if ((_e12 >= min(_e15, 10u))) {
             break;
         }
         uint _e19 = i;

--- a/tests/out/hlsl/access.hlsl
+++ b/tests/out/hlsl/access.hlsl
@@ -17,8 +17,7 @@ float4 foo(uint vi : SV_VertexID) : SV_Position
     foo1 = 1.0;
     float4x4 matrix1 = float4x4(asfloat(bar.Load4(0+0)), asfloat(bar.Load4(0+16)), asfloat(bar.Load4(0+32)), asfloat(bar.Load4(0+48)));
     uint2 arr[2] = {asuint(bar.Load2(72+0)), asuint(bar.Load2(72+8))};
-    float4 _expr13 = asfloat(bar.Load4(48+0));
-    float b = _expr13.x;
+    float b = asfloat(bar.Load(0+48+0));
     int a = asint(bar.Load((((NagaBufferLengthRW(bar) - 88) / 4) - 2u)*4+88));
     bar.Store(8+16+0, asuint(1.0));
     {

--- a/tests/out/hlsl/boids.hlsl
+++ b/tests/out/hlsl/boids.hlsl
@@ -123,20 +123,20 @@ void main(uint3 global_invocation_id : SV_DispatchThreadID)
     float2 _expr132 = vVel;
     float _expr134 = params.deltaT;
     vPos = (_expr131 + (_expr132 * _expr134));
-    float2 _expr137 = vPos;
-    if ((_expr137.x < -1.0)) {
+    float _expr138 = vPos.x;
+    if ((_expr138 < -1.0)) {
         vPos.x = 1.0;
     }
-    float2 _expr143 = vPos;
-    if ((_expr143.x > 1.0)) {
+    float _expr144 = vPos.x;
+    if ((_expr144 > 1.0)) {
         vPos.x = -1.0;
     }
-    float2 _expr149 = vPos;
-    if ((_expr149.y < -1.0)) {
+    float _expr150 = vPos.y;
+    if ((_expr150 < -1.0)) {
         vPos.y = 1.0;
     }
-    float2 _expr155 = vPos;
-    if ((_expr155.y > 1.0)) {
+    float _expr156 = vPos.y;
+    if ((_expr156 > 1.0)) {
         vPos.y = -1.0;
     }
     float2 _expr164 = vPos;

--- a/tests/out/hlsl/operators.hlsl
+++ b/tests/out/hlsl/operators.hlsl
@@ -49,8 +49,8 @@ float constructors()
     Foo foo = (Foo)0;
 
     foo = ConstructFoo(float4(1.0.xxxx), 1);
-    float4 _expr10 = foo.a;
-    return _expr10.x;
+    float _expr11 = foo.a.x;
+    return _expr11;
 }
 
 [numthreads(1, 1, 1)]

--- a/tests/out/hlsl/shadow.hlsl
+++ b/tests/out/hlsl/shadow.hlsl
@@ -48,8 +48,8 @@ float4 fs_main(FragmentInput_fs_main fragmentinput_fs_main) : SV_Target0
         }
         loop_init = false;
         uint _expr12 = i;
-        uint4 _expr14 = u_globals.num_lights;
-        if ((_expr12 >= min(_expr14.x, c_max_lights))) {
+        uint _expr15 = u_globals.num_lights.x;
+        if ((_expr12 >= min(_expr15, c_max_lights))) {
             break;
         }
         uint _expr19 = i;

--- a/tests/out/msl/access.msl
+++ b/tests/out/msl/access.msl
@@ -37,8 +37,7 @@ vertex fooOutput foo(
     foo1 = 1.0;
     metal::float4x4 matrix = bar.matrix;
     type3 arr = bar.arr;
-    metal::float4 _e13 = bar.matrix[3];
-    float b = _e13.x;
+    float b = bar.matrix[3].x;
     int a = bar.data[(1 + (_buffer_sizes.size0 - 88 - 4) / 4) - 2u];
     bar.matrix[1].z = 1.0;
     bar.matrix = metal::float4x4(metal::float4(0.0), metal::float4(1.0), metal::float4(2.0), metal::float4(3.0));

--- a/tests/out/msl/boids.msl
+++ b/tests/out/msl/boids.msl
@@ -135,20 +135,20 @@ kernel void main1(
     metal::float2 _e132 = vVel;
     float _e134 = params.deltaT;
     vPos = _e131 + (_e132 * _e134);
-    metal::float2 _e137 = vPos;
-    if (_e137.x < -1.0) {
+    float _e138 = vPos.x;
+    if (_e138 < -1.0) {
         vPos.x = 1.0;
     }
-    metal::float2 _e143 = vPos;
-    if (_e143.x > 1.0) {
+    float _e144 = vPos.x;
+    if (_e144 > 1.0) {
         vPos.x = -1.0;
     }
-    metal::float2 _e149 = vPos;
-    if (_e149.y < -1.0) {
+    float _e150 = vPos.y;
+    if (_e150 < -1.0) {
         vPos.y = 1.0;
     }
-    metal::float2 _e155 = vPos;
-    if (_e155.y > 1.0) {
+    float _e156 = vPos.y;
+    if (_e156 > 1.0) {
         vPos.y = -1.0;
     }
     metal::float2 _e164 = vPos;

--- a/tests/out/msl/operators.msl
+++ b/tests/out/msl/operators.msl
@@ -44,8 +44,8 @@ float constructors(
 ) {
     Foo foo;
     foo = Foo {metal::float4(1.0), 1};
-    metal::float4 _e10 = foo.a;
-    return _e10.x;
+    float _e11 = foo.a.x;
+    return _e11;
 }
 
 kernel void main1(

--- a/tests/out/msl/shadow.msl
+++ b/tests/out/msl/shadow.msl
@@ -63,8 +63,8 @@ fragment fs_mainOutput fs_main(
         }
         loop_init = false;
         metal::uint _e12 = i;
-        metal::uint4 _e14 = u_globals.num_lights;
-        if (_e12 >= metal::min(_e14.x, c_max_lights)) {
+        uint _e15 = u_globals.num_lights.x;
+        if (_e12 >= metal::min(_e15, c_max_lights)) {
             break;
         }
         metal::uint _e19 = i;

--- a/tests/out/spv/access.spvasm
+++ b/tests/out/spv/access.spvasm
@@ -1,14 +1,14 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 107
+; Bound: 106
 OpCapability Shader
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Vertex %39 "foo" %34 %37
-OpEntryPoint GLCompute %84 "atomics"
-OpExecutionMode %84 LocalSize 1 1 1
+OpEntryPoint GLCompute %83 "atomics"
+OpExecutionMode %83 LocalSize 1 1 1
 OpSource GLSL 450
 OpMemberName %25 0 "matrix"
 OpMemberName %25 1 "atom"
@@ -20,8 +20,8 @@ OpName %29 "foo"
 OpName %31 "c"
 OpName %34 "vi"
 OpName %39 "foo"
-OpName %82 "tmp"
-OpName %84 "atomics"
+OpName %81 "tmp"
+OpName %83 "atomics"
 OpDecorate %23 ArrayStride 8
 OpDecorate %24 ArrayStride 4
 OpDecorate %25 Block
@@ -73,13 +73,13 @@ OpDecorate %37 BuiltIn Position
 %43 = OpTypePointer StorageBuffer %20
 %46 = OpTypePointer StorageBuffer %23
 %49 = OpTypePointer StorageBuffer %21
+%50 = OpTypePointer StorageBuffer %6
 %53 = OpTypePointer StorageBuffer %24
 %56 = OpTypePointer StorageBuffer %4
-%59 = OpTypePointer StorageBuffer %6
-%74 = OpTypePointer Function %4
-%78 = OpTypeVector %4 4
-%86 = OpTypePointer StorageBuffer %4
-%89 = OpConstant  %9  64
+%73 = OpTypePointer Function %4
+%77 = OpTypeVector %4 4
+%85 = OpTypePointer StorageBuffer %4
+%88 = OpConstant  %9  64
 %39 = OpFunction  %2  None %40
 %33 = OpLabel
 %29 = OpVariable  %30  Function %5
@@ -93,73 +93,72 @@ OpStore %29 %7
 %45 = OpLoad  %20  %44
 %47 = OpAccessChain  %46  %27 %10
 %48 = OpLoad  %23  %47
-%50 = OpAccessChain  %49  %27 %14 %8
-%51 = OpLoad  %21  %50
-%52 = OpCompositeExtract  %6  %51 0
+%51 = OpAccessChain  %50  %27 %14 %8 %14
+%52 = OpLoad  %6  %51
 %54 = OpArrayLength  %9  %27 3
 %55 = OpISub  %9  %54 %10
 %57 = OpAccessChain  %56  %27 %8 %55
 %58 = OpLoad  %4  %57
-%60 = OpAccessChain  %59  %27 %14 %15 %10
-OpStore %60 %7
-%61 = OpCompositeConstruct  %21  %5 %5 %5 %5
-%62 = OpCompositeConstruct  %21  %7 %7 %7 %7
-%63 = OpCompositeConstruct  %21  %12 %12 %12 %12
-%64 = OpCompositeConstruct  %21  %13 %13 %13 %13
-%65 = OpCompositeConstruct  %20  %61 %62 %63 %64
-%66 = OpAccessChain  %43  %27 %14
-OpStore %66 %65
-%67 = OpCompositeConstruct  %22  %14 %14
-%68 = OpCompositeConstruct  %22  %15 %15
-%69 = OpCompositeConstruct  %23  %67 %68
-%70 = OpAccessChain  %46  %27 %10
-OpStore %70 %69
-%71 = OpConvertFToS  %4  %52
-%72 = OpCompositeConstruct  %26  %58 %71 %17 %18 %16
-OpStore %31 %72
-%73 = OpIAdd  %9  %36 %15
-%75 = OpAccessChain  %74  %31 %73
-OpStore %75 %19
-%76 = OpAccessChain  %74  %31 %36
-%77 = OpLoad  %4  %76
-%79 = OpCompositeConstruct  %78  %77 %77 %77 %77
-%80 = OpConvertSToF  %21  %79
-%81 = OpMatrixTimesVector  %21  %45 %80
-OpStore %37 %81
+%59 = OpAccessChain  %50  %27 %14 %15 %10
+OpStore %59 %7
+%60 = OpCompositeConstruct  %21  %5 %5 %5 %5
+%61 = OpCompositeConstruct  %21  %7 %7 %7 %7
+%62 = OpCompositeConstruct  %21  %12 %12 %12 %12
+%63 = OpCompositeConstruct  %21  %13 %13 %13 %13
+%64 = OpCompositeConstruct  %20  %60 %61 %62 %63
+%65 = OpAccessChain  %43  %27 %14
+OpStore %65 %64
+%66 = OpCompositeConstruct  %22  %14 %14
+%67 = OpCompositeConstruct  %22  %15 %15
+%68 = OpCompositeConstruct  %23  %66 %67
+%69 = OpAccessChain  %46  %27 %10
+OpStore %69 %68
+%70 = OpConvertFToS  %4  %52
+%71 = OpCompositeConstruct  %26  %58 %70 %17 %18 %16
+OpStore %31 %71
+%72 = OpIAdd  %9  %36 %15
+%74 = OpAccessChain  %73  %31 %72
+OpStore %74 %19
+%75 = OpAccessChain  %73  %31 %36
+%76 = OpLoad  %4  %75
+%78 = OpCompositeConstruct  %77  %76 %76 %76 %76
+%79 = OpConvertSToF  %21  %78
+%80 = OpMatrixTimesVector  %21  %45 %79
+OpStore %37 %80
 OpReturn
 OpFunctionEnd
-%84 = OpFunction  %2  None %40
-%83 = OpLabel
-%82 = OpVariable  %74  Function
-OpBranch %85
-%85 = OpLabel
-%87 = OpAccessChain  %86  %27 %15
-%88 = OpAtomicLoad  %4  %87 %11 %89
-%91 = OpAccessChain  %86  %27 %15
-%90 = OpAtomicIAdd  %4  %91 %11 %89 %16
-OpStore %82 %90
-%93 = OpAccessChain  %86  %27 %15
-%92 = OpAtomicISub  %4  %93 %11 %89 %16
-OpStore %82 %92
-%95 = OpAccessChain  %86  %27 %15
-%94 = OpAtomicAnd  %4  %95 %11 %89 %16
-OpStore %82 %94
-%97 = OpAccessChain  %86  %27 %15
-%96 = OpAtomicOr  %4  %97 %11 %89 %16
-OpStore %82 %96
-%99 = OpAccessChain  %86  %27 %15
-%98 = OpAtomicXor  %4  %99 %11 %89 %16
-OpStore %82 %98
-%101 = OpAccessChain  %86  %27 %15
-%100 = OpAtomicSMin  %4  %101 %11 %89 %16
-OpStore %82 %100
-%103 = OpAccessChain  %86  %27 %15
-%102 = OpAtomicSMax  %4  %103 %11 %89 %16
-OpStore %82 %102
-%105 = OpAccessChain  %86  %27 %15
-%104 = OpAtomicExchange  %4  %105 %11 %89 %16
-OpStore %82 %104
-%106 = OpAccessChain  %86  %27 %15
-OpAtomicStore %106 %11 %89 %88
+%83 = OpFunction  %2  None %40
+%82 = OpLabel
+%81 = OpVariable  %73  Function
+OpBranch %84
+%84 = OpLabel
+%86 = OpAccessChain  %85  %27 %15
+%87 = OpAtomicLoad  %4  %86 %11 %88
+%90 = OpAccessChain  %85  %27 %15
+%89 = OpAtomicIAdd  %4  %90 %11 %88 %16
+OpStore %81 %89
+%92 = OpAccessChain  %85  %27 %15
+%91 = OpAtomicISub  %4  %92 %11 %88 %16
+OpStore %81 %91
+%94 = OpAccessChain  %85  %27 %15
+%93 = OpAtomicAnd  %4  %94 %11 %88 %16
+OpStore %81 %93
+%96 = OpAccessChain  %85  %27 %15
+%95 = OpAtomicOr  %4  %96 %11 %88 %16
+OpStore %81 %95
+%98 = OpAccessChain  %85  %27 %15
+%97 = OpAtomicXor  %4  %98 %11 %88 %16
+OpStore %81 %97
+%100 = OpAccessChain  %85  %27 %15
+%99 = OpAtomicSMin  %4  %100 %11 %88 %16
+OpStore %81 %99
+%102 = OpAccessChain  %85  %27 %15
+%101 = OpAtomicSMax  %4  %102 %11 %88 %16
+OpStore %81 %101
+%104 = OpAccessChain  %85  %27 %15
+%103 = OpAtomicExchange  %4  %104 %11 %88 %16
+OpStore %81 %103
+%105 = OpAccessChain  %85  %27 %15
+OpAtomicStore %105 %11 %88 %87
 OpReturn
 OpFunctionEnd

--- a/tests/out/spv/boids.spvasm
+++ b/tests/out/spv/boids.spvasm
@@ -99,7 +99,7 @@ OpDecorate %40 BuiltIn GlobalInvocationId
 %145 = OpConstant  %4  4
 %151 = OpConstant  %4  5
 %157 = OpConstant  %4  6
-%179 = OpTypePointer Function %6
+%174 = OpTypePointer Function %6
 %43 = OpFunction  %2  None %44
 %39 = OpLabel
 %37 = OpVariable  %38  Function %9
@@ -280,43 +280,43 @@ OpStore %28 %167
 %172 = OpVectorTimesScalar  %15  %169 %171
 %173 = OpFAdd  %15  %168 %172
 OpStore %26 %173
-%174 = OpLoad  %15  %26
-%175 = OpCompositeExtract  %6  %174 0
-%176 = OpFOrdLessThan  %47  %175 %13
-OpSelectionMerge %177 None
-OpBranchConditional %176 %178 %177
-%178 = OpLabel
-%180 = OpAccessChain  %179  %26 %9
+%175 = OpAccessChain  %174  %26 %9
+%176 = OpLoad  %6  %175
+%177 = OpFOrdLessThan  %47  %176 %13
+OpSelectionMerge %178 None
+OpBranchConditional %177 %179 %178
+%179 = OpLabel
+%180 = OpAccessChain  %174  %26 %9
 OpStore %180 %14
-OpBranch %177
-%177 = OpLabel
-%181 = OpLoad  %15  %26
-%182 = OpCompositeExtract  %6  %181 0
+OpBranch %178
+%178 = OpLabel
+%181 = OpAccessChain  %174  %26 %9
+%182 = OpLoad  %6  %181
 %183 = OpFOrdGreaterThan  %47  %182 %14
 OpSelectionMerge %184 None
 OpBranchConditional %183 %185 %184
 %185 = OpLabel
-%186 = OpAccessChain  %179  %26 %9
+%186 = OpAccessChain  %174  %26 %9
 OpStore %186 %13
 OpBranch %184
 %184 = OpLabel
-%187 = OpLoad  %15  %26
-%188 = OpCompositeExtract  %6  %187 1
+%187 = OpAccessChain  %174  %26 %11
+%188 = OpLoad  %6  %187
 %189 = OpFOrdLessThan  %47  %188 %13
 OpSelectionMerge %190 None
 OpBranchConditional %189 %191 %190
 %191 = OpLabel
-%192 = OpAccessChain  %179  %26 %11
+%192 = OpAccessChain  %174  %26 %11
 OpStore %192 %14
 OpBranch %190
 %190 = OpLabel
-%193 = OpLoad  %15  %26
-%194 = OpCompositeExtract  %6  %193 1
+%193 = OpAccessChain  %174  %26 %11
+%194 = OpLoad  %6  %193
 %195 = OpFOrdGreaterThan  %47  %194 %14
 OpSelectionMerge %196 None
 OpBranchConditional %195 %197 %196
 %197 = OpLabel
-%198 = OpAccessChain  %179  %26 %11
+%198 = OpAccessChain  %174  %26 %11
 OpStore %198 %13
 OpBranch %196
 %196 = OpLabel

--- a/tests/out/spv/bounds-check-zero.spvasm
+++ b/tests/out/spv/bounds-check-zero.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 135
+; Bound: 130
 OpCapability Shader
 OpCapability Linkage
 OpExtension "SPV_KHR_storage_buffer_storage_class"
@@ -36,8 +36,9 @@ OpDecorate %10 Binding 0
 %23 = OpConstant  %20  0
 %25 = OpConstantNull  %5
 %34 = OpTypePointer StorageBuffer %7
-%35 = OpConstant  %20  1
-%38 = OpConstant  %20  4
+%35 = OpTypePointer StorageBuffer %5
+%36 = OpConstant  %20  4
+%38 = OpConstant  %20  1
 %40 = OpConstantNull  %5
 %49 = OpTypeFunction %5 %7 %4
 %52 = OpConstantNull  %5
@@ -48,12 +49,10 @@ OpDecorate %10 Binding 0
 %66 = OpConstant  %20  2
 %68 = OpConstantNull  %7
 %77 = OpTypeFunction %5 %4 %4
-%81 = OpConstantNull  %7
-%87 = OpConstantNull  %5
-%96 = OpTypeFunction %2 %4 %5
-%107 = OpTypePointer StorageBuffer %5
-%116 = OpTypeFunction %2 %4 %7
-%127 = OpTypeFunction %2 %4 %4 %5
+%83 = OpConstantNull  %5
+%92 = OpTypeFunction %2 %4 %5
+%111 = OpTypeFunction %2 %4 %7
+%122 = OpTypeFunction %2 %4 %4 %5
 %14 = OpFunction  %5  None %15
 %13 = OpFunctionParameter  %4
 %12 = OpLabel
@@ -75,13 +74,12 @@ OpFunctionEnd
 %30 = OpLabel
 OpBranch %33
 %33 = OpLabel
-%36 = OpAccessChain  %34  %10 %35
-%37 = OpLoad  %7  %36
-%39 = OpULessThan  %22  %31 %38
+%37 = OpULessThan  %22  %31 %36
 OpSelectionMerge %41 None
-OpBranchConditional %39 %42 %41
+OpBranchConditional %37 %42 %41
 %42 = OpLabel
-%43 = OpVectorExtractDynamic  %5  %37 %31
+%39 = OpAccessChain  %35  %10 %38 %31
+%43 = OpLoad  %5  %39
 OpBranch %41
 %41 = OpLabel
 %44 = OpPhi  %5  %40 %33 %43 %42
@@ -93,7 +91,7 @@ OpFunctionEnd
 %45 = OpLabel
 OpBranch %50
 %50 = OpLabel
-%51 = OpULessThan  %22  %47 %38
+%51 = OpULessThan  %22  %47 %36
 OpSelectionMerge %53 None
 OpBranchConditional %51 %54 %53
 %54 = OpLabel
@@ -125,89 +123,83 @@ OpFunctionEnd
 %73 = OpLabel
 OpBranch %78
 %78 = OpLabel
-%79 = OpULessThan  %22  %74 %64
-OpSelectionMerge %82 None
-OpBranchConditional %79 %83 %82
-%83 = OpLabel
-%80 = OpAccessChain  %63  %10 %66 %74
-%84 = OpLoad  %7  %80
-OpBranch %82
-%82 = OpLabel
-%85 = OpPhi  %7  %81 %78 %84 %83
-%86 = OpULessThan  %22  %75 %38
-OpSelectionMerge %88 None
-OpBranchConditional %86 %89 %88
-%89 = OpLabel
-%90 = OpVectorExtractDynamic  %5  %85 %75
-OpBranch %88
+%79 = OpULessThan  %22  %75 %36
+%80 = OpULessThan  %22  %74 %64
+%81 = OpLogicalAnd  %22  %79 %80
+OpSelectionMerge %84 None
+OpBranchConditional %81 %85 %84
+%85 = OpLabel
+%82 = OpAccessChain  %35  %10 %66 %74 %75
+%86 = OpLoad  %5  %82
+OpBranch %84
+%84 = OpLabel
+%87 = OpPhi  %5  %83 %78 %86 %85
+OpReturnValue %87
+OpFunctionEnd
+%91 = OpFunction  %2  None %92
+%89 = OpFunctionParameter  %4
+%90 = OpFunctionParameter  %5
 %88 = OpLabel
-%91 = OpPhi  %5  %87 %82 %90 %89
-OpReturnValue %91
-OpFunctionEnd
-%95 = OpFunction  %2  None %96
-%93 = OpFunctionParameter  %4
-%94 = OpFunctionParameter  %5
-%92 = OpLabel
-OpBranch %97
+OpBranch %93
+%93 = OpLabel
+%94 = OpULessThan  %22  %89 %19
+OpSelectionMerge %96 None
+OpBranchConditional %94 %97 %96
 %97 = OpLabel
-%98 = OpULessThan  %22  %93 %19
-OpSelectionMerge %100 None
-OpBranchConditional %98 %101 %100
-%101 = OpLabel
-%99 = OpAccessChain  %18  %10 %23 %93
-OpStore %99 %94
-OpBranch %100
-%100 = OpLabel
+%95 = OpAccessChain  %18  %10 %23 %89
+OpStore %95 %90
+OpBranch %96
+%96 = OpLabel
 OpReturn
 OpFunctionEnd
-%105 = OpFunction  %2  None %96
-%103 = OpFunctionParameter  %4
-%104 = OpFunctionParameter  %5
+%101 = OpFunction  %2  None %92
+%99 = OpFunctionParameter  %4
+%100 = OpFunctionParameter  %5
+%98 = OpLabel
+OpBranch %102
 %102 = OpLabel
-OpBranch %106
+%103 = OpULessThan  %22  %99 %36
+OpSelectionMerge %105 None
+OpBranchConditional %103 %106 %105
 %106 = OpLabel
-%108 = OpULessThan  %22  %103 %38
-OpSelectionMerge %110 None
-OpBranchConditional %108 %111 %110
-%111 = OpLabel
-%109 = OpAccessChain  %107  %10 %35 %103
-OpStore %109 %104
-OpBranch %110
-%110 = OpLabel
+%104 = OpAccessChain  %35  %10 %38 %99
+OpStore %104 %100
+OpBranch %105
+%105 = OpLabel
 OpReturn
 OpFunctionEnd
-%115 = OpFunction  %2  None %116
-%113 = OpFunctionParameter  %4
-%114 = OpFunctionParameter  %7
+%110 = OpFunction  %2  None %111
+%108 = OpFunctionParameter  %4
+%109 = OpFunctionParameter  %7
+%107 = OpLabel
+OpBranch %112
 %112 = OpLabel
-OpBranch %117
-%117 = OpLabel
-%118 = OpULessThan  %22  %113 %64
-OpSelectionMerge %120 None
-OpBranchConditional %118 %121 %120
-%121 = OpLabel
-%119 = OpAccessChain  %63  %10 %66 %113
-OpStore %119 %114
-OpBranch %120
-%120 = OpLabel
+%113 = OpULessThan  %22  %108 %64
+OpSelectionMerge %115 None
+OpBranchConditional %113 %116 %115
+%116 = OpLabel
+%114 = OpAccessChain  %63  %10 %66 %108
+OpStore %114 %109
+OpBranch %115
+%115 = OpLabel
 OpReturn
 OpFunctionEnd
-%126 = OpFunction  %2  None %127
-%123 = OpFunctionParameter  %4
-%124 = OpFunctionParameter  %4
-%125 = OpFunctionParameter  %5
-%122 = OpLabel
+%121 = OpFunction  %2  None %122
+%118 = OpFunctionParameter  %4
+%119 = OpFunctionParameter  %4
+%120 = OpFunctionParameter  %5
+%117 = OpLabel
+OpBranch %123
+%123 = OpLabel
+%124 = OpULessThan  %22  %119 %36
+%125 = OpULessThan  %22  %118 %64
+%126 = OpLogicalAnd  %22  %124 %125
+OpSelectionMerge %128 None
+OpBranchConditional %126 %129 %128
+%129 = OpLabel
+%127 = OpAccessChain  %35  %10 %66 %118 %119
+OpStore %127 %120
 OpBranch %128
 %128 = OpLabel
-%129 = OpULessThan  %22  %124 %38
-%130 = OpULessThan  %22  %123 %64
-%131 = OpLogicalAnd  %22  %129 %130
-OpSelectionMerge %133 None
-OpBranchConditional %131 %134 %133
-%134 = OpLabel
-%132 = OpAccessChain  %107  %10 %66 %123 %124
-OpStore %132 %125
-OpBranch %133
-%133 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/tests/out/spv/operators.spvasm
+++ b/tests/out/spv/operators.spvasm
@@ -41,8 +41,9 @@ OpMemberDecorate %22 1 Offset 16
 %80 = OpTypePointer Function %22
 %83 = OpTypeFunction %4
 %87 = OpTypePointer Function %19
-%89 = OpTypeInt 32 0
-%88 = OpConstant  %89  0
+%88 = OpTypePointer Function %4
+%90 = OpTypeInt 32 0
+%89 = OpConstant  %90  0
 %95 = OpTypeFunction %2
 %28 = OpFunction  %19  None %29
 %27 = OpLabel
@@ -113,9 +114,8 @@ OpBranch %84
 %85 = OpCompositeConstruct  %19  %3 %3 %3 %3
 %86 = OpCompositeConstruct  %22  %85 %7
 OpStore %79 %86
-%90 = OpAccessChain  %87  %79 %88
-%91 = OpLoad  %19  %90
-%92 = OpCompositeExtract  %4  %91 0
+%91 = OpAccessChain  %88  %79 %89 %89
+%92 = OpLoad  %4  %91
 OpReturnValue %92
 OpFunctionEnd
 %94 = OpFunction  %2  None %95

--- a/tests/out/spv/shadow.spvasm
+++ b/tests/out/spv/shadow.spvasm
@@ -96,6 +96,7 @@ OpDecorate %75 Location 0
 %75 = OpVariable  %76  Output
 %78 = OpTypeFunction %2
 %88 = OpTypePointer Uniform %13
+%89 = OpTypePointer Uniform %10
 %96 = OpTypePointer StorageBuffer %18
 %98 = OpTypePointer StorageBuffer %17
 %36 = OpFunction  %4  None %37
@@ -148,9 +149,8 @@ OpLoopMerge %84 %86 None
 OpBranch %85
 %85 = OpLabel
 %87 = OpLoad  %10  %66
-%89 = OpAccessChain  %88  %25 %11
-%90 = OpLoad  %13  %89
-%91 = OpCompositeExtract  %10  %90 0
+%90 = OpAccessChain  %89  %25 %11 %11
+%91 = OpLoad  %10  %90
 %92 = OpExtInst  %10  %1 UMin %91 %9
 %93 = OpUGreaterThanEqual  %42  %87 %92
 OpSelectionMerge %94 None

--- a/tests/out/wgsl/access.wgsl
+++ b/tests/out/wgsl/access.wgsl
@@ -18,8 +18,7 @@ fn foo([[builtin(vertex_index)]] vi: u32) -> [[builtin(position)]] vec4<f32> {
     foo1 = 1.0;
     let matrix: mat4x4<f32> = bar.matrix;
     let arr: array<vec2<u32>,2> = bar.arr;
-    let _e13: vec4<f32> = bar.matrix[3];
-    let b: f32 = _e13.x;
+    let b: f32 = bar.matrix[3][0];
     let a: i32 = bar.data[(arrayLength(&bar.data) - 2u)];
     bar.matrix[1][2] = 1.0;
     bar.matrix = mat4x4<f32>(vec4<f32>(0.0), vec4<f32>(1.0), vec4<f32>(2.0), vec4<f32>(3.0));

--- a/tests/out/wgsl/boids.wgsl
+++ b/tests/out/wgsl/boids.wgsl
@@ -129,20 +129,20 @@ fn main([[builtin(global_invocation_id)]] global_invocation_id: vec3<u32>) {
     let _e132: vec2<f32> = vVel;
     let _e134: f32 = params.deltaT;
     vPos = (_e131 + (_e132 * _e134));
-    let _e137: vec2<f32> = vPos;
-    if ((_e137.x < -1.0)) {
+    let _e138: f32 = vPos.x;
+    if ((_e138 < -1.0)) {
         vPos.x = 1.0;
     }
-    let _e143: vec2<f32> = vPos;
-    if ((_e143.x > 1.0)) {
+    let _e144: f32 = vPos.x;
+    if ((_e144 > 1.0)) {
         vPos.x = -1.0;
     }
-    let _e149: vec2<f32> = vPos;
-    if ((_e149.y < -1.0)) {
+    let _e150: f32 = vPos.y;
+    if ((_e150 < -1.0)) {
         vPos.y = 1.0;
     }
-    let _e155: vec2<f32> = vPos;
-    if ((_e155.y > 1.0)) {
+    let _e156: f32 = vPos.y;
+    if ((_e156 > 1.0)) {
         vPos.y = -1.0;
     }
     let _e164: vec2<f32> = vPos;

--- a/tests/out/wgsl/operators.wgsl
+++ b/tests/out/wgsl/operators.wgsl
@@ -37,8 +37,8 @@ fn constructors() -> f32 {
     var foo: Foo;
 
     foo = Foo(vec4<f32>(1.0), 1);
-    let _e10: vec4<f32> = foo.a;
-    return _e10.x;
+    let _e11: f32 = foo.a.x;
+    return _e11;
 }
 
 [[stage(compute), workgroup_size(1, 1, 1)]]

--- a/tests/out/wgsl/shadow.wgsl
+++ b/tests/out/wgsl/shadow.wgsl
@@ -44,8 +44,8 @@ fn fs_main([[location(0)]] raw_normal: vec3<f32>, [[location(1)]] position: vec4
     let normal: vec3<f32> = normalize(raw_normal);
     loop {
         let _e12: u32 = i;
-        let _e14: vec4<u32> = u_globals.num_lights;
-        if ((_e12 >= min(_e14.x, c_max_lights))) {
+        let _e15: u32 = u_globals.num_lights.x;
+        if ((_e12 >= min(_e15, c_max_lights))) {
             break;
         }
         let _e19: u32 = i;


### PR DESCRIPTION
Make the parser code more closely follow the spec's grammar around `unary_expression`, `postfix_expression`, and `singular_expression`.

Change the handling of postfix expressions (indexing, member/component access, and swizzling) to apply the indirection at the appropriate time, resulting in code improvements on all output formats. For example, where we used to generate the following MSL:

    metal::float4 _e13 = bar.matrix[3];
    float b = _e13.x;

we now generate, simply:

    float b = bar.matrix[3].x;

Propagate WGSL reference types correctly, so that parenthesizing expressions no longer causes the Load Rule to be applied.

Together with #1332 (already landed), this is a replacement for #1312, and unblocks #1352.

Fixes #1351.