### PR TITLE
Correctly recognize defined spans.

### DIFF
--- a/src/span.rs
+++ b/src/span.rs
@@ -54,7 +54,7 @@ impl Span {
 
     /// Check wether `self` was defined or is a default/unknown span
     fn is_defined(&self) -> bool {
-        *self == Self::default()
+        *self != Self::default()
     }
 }
 


### PR DESCRIPTION
Without this change, the `to_range` method method returns `None` even when spans are enabled.