### PR TITLE
[glsl-in] Use local for constant indexing

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -9,7 +9,7 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub enum GlobalLookupKind {
     Variable(Handle<GlobalVariable>),
-    Constant(Handle<Constant>),
+    Constant(Handle<Constant>, Handle<Type>),
     BlockSelect(Handle<GlobalVariable>, u32),
 }
 
@@ -82,6 +82,7 @@ pub struct VariableReference {
     pub expr: Handle<Expression>,
     pub load: bool,
     pub mutable: bool,
+    pub constant: Option<(Handle<Constant>, Handle<Type>)>,
     pub entry_arg: Option<usize>,
 }
 

--- a/src/front/glsl/parser/declarations.rs
+++ b/src/front/glsl/parser/declarations.rs
@@ -544,15 +544,14 @@ impl<'source> ParsingContext<'source> {
             },
         )?;
 
-        for (i, k) in members
-            .into_iter()
-            .enumerate()
-            .filter_map(|(i, m)| m.name.map(|s| (i as u32, s)))
-        {
+        for (i, k, ty) in members.into_iter().enumerate().filter_map(|(i, m)| {
+            let ty = m.ty;
+            m.name.map(|s| (i as u32, s, ty))
+        }) {
             let lookup = GlobalLookup {
                 kind: match global {
                     GlobalOrConstant::Global(handle) => GlobalLookupKind::BlockSelect(handle, i),
-                    GlobalOrConstant::Constant(handle) => GlobalLookupKind::Constant(handle),
+                    GlobalOrConstant::Constant(handle) => GlobalLookupKind::Constant(handle, ty),
                 },
                 entry_arg: None,
                 mutable: true,

--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -101,6 +101,7 @@ impl Parser {
                 expr,
                 load: true,
                 mutable: data.mutable,
+                constant: None,
                 entry_arg: Some(idx),
             },
         );
@@ -595,7 +596,7 @@ impl Parser {
             })?;
             if let Some(name) = name {
                 let lookup = GlobalLookup {
-                    kind: GlobalLookupKind::Constant(init),
+                    kind: GlobalLookupKind::Constant(init, ty),
                     entry_arg: None,
                     mutable: false,
                 };


### PR DESCRIPTION
Constants that are to be dynamically indexed now are first transformed
into locals with them as the initializer.

Closes #1343 