### PR TITLE
[wgsl-out] Correct handling of named pointer expressions.

### DIFF
--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -3223,7 +3223,7 @@ impl Parser {
                                 .resolve_type(expr_id)?;
                             let expr_inner = context.typifier.get(expr_id, context.types);
                             let given_inner = &context.types[ty].inner;
-                            if given_inner != expr_inner {
+                            if !given_inner.equivalent(expr_inner, context.types) {
                                 log::error!(
                                     "Given type {:?} doesn't match expected {:?}",
                                     given_inner,
@@ -3284,7 +3284,7 @@ impl Parser {
                                 Some(ty) => {
                                     let expr_inner = context.typifier.get(value, context.types);
                                     let given_inner = &context.types[ty].inner;
-                                    if given_inner != expr_inner {
+                                    if !given_inner.equivalent(expr_inner, context.types) {
                                         log::error!(
                                             "Given type {:?} doesn't match expected {:?}",
                                             given_inner,

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -7,6 +7,8 @@ mod namer;
 mod terminator;
 mod typifier;
 
+use std::cmp::PartialEq;
+
 pub use index::IndexableLength;
 pub use layouter::{Alignment, InvalidBaseType, Layouter, TypeLayout};
 pub use namer::{EntryPointIndex, NameKey, Namer};
@@ -129,6 +131,50 @@ impl super::TypeInner {
             Self::Struct { span, .. } => span,
             Self::Image { .. } | Self::Sampler { .. } => 0,
         }
+    }
+
+    /// Return the canoncal form of `self`, or `None` if it's already in
+    /// canonical form.
+    ///
+    /// Certain types have multiple representations in `TypeInner`. This
+    /// function converts all forms of equivalent types to a single
+    /// representative of their class, so that simply applying `Eq` to the
+    /// result indicates whether the types are equivalent, as far as Naga IR is
+    /// concerned.
+    pub fn canonical_form(&self, types: &crate::Arena<crate::Type>) -> Option<crate::TypeInner> {
+        use crate::TypeInner as Ti;
+        match *self {
+            Ti::Pointer { base, class } => match types[base].inner {
+                Ti::Scalar { kind, width } => Some(Ti::ValuePointer {
+                    size: None,
+                    kind,
+                    width,
+                    class,
+                }),
+                Ti::Vector { size, kind, width } => Some(Ti::ValuePointer {
+                    size: Some(size),
+                    kind,
+                    width,
+                    class,
+                }),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Compare `self` and `rhs` as types.
+    ///
+    /// This is mostly the same as `<TypeInner as Eq>::eq`, but it treats
+    /// `ValuePointer` and `Pointer` types as equivalent.
+    ///
+    /// When you know that one side of the comparison is never a pointer, it's
+    /// fine to not bother with canonicalization, and just compare `TypeInner`
+    /// values with `==`.
+    pub fn equivalent(&self, rhs: &crate::TypeInner, types: &crate::Arena<crate::Type>) -> bool {
+        let left = self.canonical_form(types);
+        let right = rhs.canonical_form(types);
+        left.as_ref().unwrap_or(self) == right.as_ref().unwrap_or(rhs)
     }
 }
 

--- a/src/valid/compose.rs
+++ b/src/valid/compose.rs
@@ -96,7 +96,11 @@ pub fn validate_compose(
                 });
             }
             for (index, comp_res) in component_resolutions.enumerate() {
-                if comp_res.inner_with(type_arena) != &type_arena[base].inner {
+                let base_inner = &type_arena[base].inner;
+                let comp_res_inner = comp_res.inner_with(type_arena);
+                // We don't support arrays of pointers, but it seems best not to
+                // embed that assumption here, so use `TypeInner::equivalent`.
+                if !base_inner.equivalent(comp_res_inner, type_arena) {
                     log::error!("Array component[{}] type {:?}", index, comp_res);
                     return Err(ComposeError::ComponentType {
                         index: index as u32,
@@ -113,7 +117,11 @@ pub fn validate_compose(
             }
             for (index, (member, comp_res)) in members.iter().zip(component_resolutions).enumerate()
             {
-                if comp_res.inner_with(type_arena) != &type_arena[member.ty].inner {
+                let member_inner = &type_arena[member.ty].inner;
+                let comp_res_inner = comp_res.inner_with(type_arena);
+                // We don't support pointers in structs, but it seems best not to embed
+                // that assumption here, so use `TypeInner::equivalent`.
+                if !comp_res_inner.equivalent(member_inner, type_arena) {
                     log::error!("Struct component[{}] type {:?}", index, comp_res);
                     return Err(ComposeError::ComponentType {
                         index: index as u32,

--- a/tests/in/pointers.param.ron
+++ b/tests/in/pointers.param.ron
@@ -1,0 +1,7 @@
+(
+	spv: (
+		version: (1, 2),
+		debug: true,
+		adjust_coordinate_space: false,
+	),
+)

--- a/tests/in/pointers.wgsl
+++ b/tests/in/pointers.wgsl
@@ -1,0 +1,5 @@
+fn f() {
+   var v: vec2<i32>;
+   let px = &v.x;
+   *px = 10;
+}

--- a/tests/out/spv/pointers.spvasm
+++ b/tests/out/spv/pointers.spvasm
@@ -1,0 +1,29 @@
+; SPIR-V
+; Version: 1.2
+; Generator: rspirv
+; Bound: 16
+OpCapability Shader
+OpCapability Linkage
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpSource GLSL 450
+OpName %6 "v"
+OpName %9 "f"
+%2 = OpTypeVoid
+%4 = OpTypeInt 32 1
+%3 = OpConstant  %4  10
+%5 = OpTypeVector %4 2
+%7 = OpTypePointer Function %5
+%10 = OpTypeFunction %2
+%12 = OpTypePointer Function %4
+%14 = OpTypeInt 32 0
+%13 = OpConstant  %14  0
+%9 = OpFunction  %2  None %10
+%8 = OpLabel
+%6 = OpVariable  %7  Function
+OpBranch %11
+%11 = OpLabel
+%15 = OpAccessChain  %12  %6 %13
+OpStore %15 %3
+OpReturn
+OpFunctionEnd

--- a/tests/out/wgsl/pointers.wgsl
+++ b/tests/out/wgsl/pointers.wgsl
@@ -1,0 +1,8 @@
+fn f() {
+    var v: vec2<i32>;
+
+    let px: ptr<function, i32> = (&v.x);
+    (*px) = 10;
+    return;
+}
+

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -480,6 +480,7 @@ fn convert_wgsl() {
             "access",
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,
         ),
+        ("pointers", Targets::SPIRV | Targets::WGSL),
         (
             "control-flow",
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -688,6 +688,24 @@ fn invalid_functions() {
 }
 
 #[test]
+fn pointer_type_equivalence() {
+    check_validation_error! {
+        r#"
+            fn f(pv: ptr<function, vec2<f32>>, pf: ptr<function, f32>) { }
+
+            fn g() {
+               var m: mat2x2<f32>;
+               let pv: ptr<function, vec2<f32>> = &m.x;
+               let pf: ptr<function, f32> = &m.x.x;
+
+               f(pv, pf);
+            }
+        "#:
+        Ok(_)
+    }
+}
+
+#[test]
 fn missing_bindings() {
     check_validation_error! {
         "


### PR DESCRIPTION
Depends on #1381.

Treat expressions in `Function::named_expressions` like WGSL `let` declarations,
assuming that the Load Rule was applied to the rhs of the declaration, meaning
that their values are always `Indirection::Ordinary`.

Split `write_expr_plain_form` out from `write_expr_with_indirection`, to clean
up the parenthesis generation: no more `opened_paren` variable, just function
calls. This makes the early return for named expressions neater.

Fixes #1382.

