### PR TITLE
Avoid case fallthrough when last statement is break, continue, kill or return

### DIFF
--- a/src/front/spv/function.rs
+++ b/src/front/spv/function.rs
@@ -570,11 +570,19 @@ impl<'function> BlockContext<'function> {
                                     .map(|&(value, body_idx)| {
                                         let body = lower_impl(blocks, bodies, body_idx);
 
+                                        // Handle simple cases that would make a fallthrough statement unreachable code
+                                        let fall_through = match body.last() {
+                                            Some(&crate::Statement::Break)
+                                            | Some(&crate::Statement::Continue)
+                                            | Some(&crate::Statement::Kill)
+                                            | Some(&crate::Statement::Return { .. }) => false,
+                                            _ => true,
+                                        };
+
                                         crate::SwitchCase {
                                             value,
                                             body,
-                                            // TODO
-                                            fall_through: true,
+                                            fall_through,
                                         }
                                     })
                                     .collect(),


### PR DESCRIPTION
Naga is generating `break; fallthrough;` statements at the end of each case for any switch statement in my shaders (SPIR-V compiled from GLSL). The tint WGSL compiler used by Chromium rejects these shaders because the `fallthrough;` statement is obviously unreachable code. These changes prevent generating a `fallthrough` when the last statement of the case body always exits the switch.

I've never written Rust before, let me know if this idiomatic code.