### PR TITLE
Add support for multi view extensions

### DIFF
--- a/src/back/glsl/features.rs
+++ b/src/back/glsl/features.rs
@@ -34,6 +34,7 @@ bitflags::bitflags! {
         const SAMPLE_VARIABLES = 1 << 15;
         /// Arrays with a dynamic length
         const DYNAMIC_ARRAY_SIZE = 1 << 16;
+        const MULTI_VIEW = 1 << 17;
     }
 }
 
@@ -101,6 +102,7 @@ impl FeaturesManager {
         check_feature!(CULL_DISTANCE, 450, 300);
         check_feature!(SAMPLE_VARIABLES, 400, 300);
         check_feature!(DYNAMIC_ARRAY_SIZE, 430, 310);
+        check_feature!(MULTI_VIEW, 140, 310);
 
         // Return an error if there are missing features
         if missing.is_empty() {
@@ -192,6 +194,16 @@ impl FeaturesManager {
         if self.0.contains(Features::SAMPLE_VARIABLES) && version.is_es() {
             // https://www.khronos.org/registry/OpenGL/extensions/OES/OES_sample_variables.txt
             writeln!(out, "#extension GL_OES_sample_variables : require")?;
+        }
+
+        if self.0.contains(Features::SAMPLE_VARIABLES) && version.is_es() {
+            // https://www.khronos.org/registry/OpenGL/extensions/OES/OES_sample_variables.txt
+            writeln!(out, "#extension GL_OES_sample_variables : require")?;
+        }
+
+        if self.0.contains(Features::MULTI_VIEW) {
+            // https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GL_EXT_multiview.txt
+            writeln!(out, "#extension GL_EXT_multiview : require")?;
         }
 
         Ok(())
@@ -371,6 +383,9 @@ impl<'a, W> Writer<'a, W> {
                             }
                             crate::BuiltIn::SampleIndex => {
                                 self.features.request(Features::SAMPLE_VARIABLES)
+                            }
+                            crate::BuiltIn::ViewIndex => {
+                                self.features.request(Features::MULTI_VIEW)
                             }
                             _ => {}
                         },

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -2625,6 +2625,7 @@ fn glsl_built_in(built_in: crate::BuiltIn, output: bool) -> &'static str {
                 "gl_FragCoord"
             }
         }
+        Bi::ViewIndex => "gl_ViewIndex",
         // vertex
         Bi::BaseInstance => "uint(gl_BaseInstance)",
         Bi::BaseVertex => "uint(gl_BaseVertex)",

--- a/src/back/hlsl/conv.rs
+++ b/src/back/hlsl/conv.rs
@@ -103,6 +103,9 @@ impl crate::BuiltIn {
             Self::BaseInstance | Self::BaseVertex | Self::WorkGroupSize => {
                 return Err(Error::Unimplemented(format!("builtin {:?}", self)))
             }
+            Self::ViewIndex => {
+                return Err(Error::Custom(format!("Unsupported builtin {:?}", self)))
+            }
         })
     }
 }

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -358,7 +358,9 @@ impl ResolvedBinding {
                     Bi::WorkGroupId => "threadgroup_position_in_grid",
                     Bi::WorkGroupSize => "dispatch_threads_per_threadgroup",
                     Bi::NumWorkGroups => "threadgroups_per_grid",
-                    Bi::CullDistance => return Err(Error::UnsupportedBuiltIn(built_in)),
+                    Bi::CullDistance | Bi::ViewIndex => {
+                        return Err(Error::UnsupportedBuiltIn(built_in))
+                    }
                 };
                 write!(out, "{}", name)?;
             }

--- a/src/front/spv/convert.rs
+++ b/src/front/spv/convert.rs
@@ -121,6 +121,7 @@ pub(super) fn map_builtin(word: spirv::Word) -> Result<crate::BuiltIn, Error> {
     use spirv::BuiltIn as Bi;
     Ok(match spirv::BuiltIn::from_u32(word) {
         Some(Bi::Position) | Some(Bi::FragCoord) => crate::BuiltIn::Position,
+        Some(Bi::ViewIndex) => crate::BuiltIn::ViewIndex,
         // vertex
         Some(Bi::BaseInstance) => crate::BuiltIn::BaseInstance,
         Some(Bi::BaseVertex) => crate::BuiltIn::BaseVertex,

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -75,6 +75,7 @@ pub const SUPPORTED_CAPABILITIES: &[spirv::Capability] = &[
 pub const SUPPORTED_EXTENSIONS: &[&str] = &[
     "SPV_KHR_storage_buffer_storage_class",
     "SPV_KHR_vulkan_memory_model",
+    "SPV_KHR_multiview",
 ];
 pub const SUPPORTED_EXT_SETS: &[&str] = &["GLSL.std.450"];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,6 +307,7 @@ pub enum StorageClass {
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub enum BuiltIn {
     Position,
+    ViewIndex,
     // vertex
     BaseInstance,
     BaseVertex,

--- a/src/valid/interface.rs
+++ b/src/valid/interface.rs
@@ -158,6 +158,17 @@ impl VaryingContext<'_> {
                                 width,
                             },
                     ),
+                    Bi::ViewIndex => (
+                        match self.stage {
+                            St::Vertex | St::Fragment => !self.output,
+                            St::Compute => false,
+                        },
+                        *ty_inner
+                            == Ti::Scalar {
+                                kind: Sk::Sint,
+                                width,
+                            },
+                    ),
                     Bi::FragDepth => (
                         self.stage == St::Fragment && self.output,
                         *ty_inner


### PR DESCRIPTION
Adds support for [`VK_KHR_multiview`](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_multiview.html).

Adds the `ViewIndex` builtin which is only supported in spirv and glsl (2/5 backends), spirv-cross has two types of handling for this, for metal it uses a variable with the value 0, for hlsl it throws an error. This PR errors on both backends.

I understand that since this is not part of webgpu it's not a priority, but I needed it for a project which consumed spirv and used it in both vulkan and gles for stereo rendering and spirv-cross was not liking being cross compiled so I ended up patching naga and using it, so feel free to close.