### PR TITLE
Better dead code detection

### DIFF
--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -848,3 +848,31 @@ fn invalid_local_vars() {
         if local_var_name == "not_okay"
     }
 }
+
+#[test]
+fn invalid_dead_code() {
+    check_validation_error! {
+        "
+        fn dead_code_after_if(condition: bool) -> i32 {
+            if (condition) {
+                return 1;
+            } else {
+                return 2;
+            }
+            return 3;
+        }
+        ",
+        "
+        fn dead_code_after_block() -> i32 {
+            {
+                return 1;
+            }
+            return 2;
+        }
+        ":
+        Err(naga::valid::ValidationError::Function {
+            error: naga::valid::FunctionError::InstructionsAfterReturn,
+            ..
+        })
+    }
+}


### PR DESCRIPTION
Introduces a new enum `FinishState` which is passed with the `valid_stages` trough `BlockInfo` for parent scope analysis. The enum has three states

- `None` - the block didn't have any instruction that would cause execution to finish in that scope
- `Finished` - the block had an instruction that caused execution to end in that scope
- `Returned` - the block had an instruction that caused execution to end in the function scope, possibly the invocation (`Kill`)

If the current `FinishState` is `None` now further statements are allowed.

The tree states are needed to compute `FinishState` in branching/looping constructs, if the current statement is an
- `If` - if both blocks are `Returned`, the parent scope also is, otherwise if both aren't `None` the parent scope is `Finished`, else the parent scope is `None`.
- `Switch` - the same logic as `If` applies but instead of it applying to just the `accept` and `reject` it applies to all cases including the default case.
- `Loop` - the loop has special logic, if the loop body is `Returned` than so is the parent otherwise it's `None`.

Closes #1019