### PR TITLE
wgsl-out: vector bitcast

### DIFF
--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -1287,12 +1287,17 @@ impl<W: Write> Writer<W> {
                         )?;
                     }
                     TypeInner::Vector { size, .. } => {
-                        write!(
-                            self.out,
-                            "vec{}<{}>",
-                            back::vector_size_str(size),
-                            scalar_kind_str(kind)
-                        )?;
+                        let vector_size_str = back::vector_size_str(size);
+                        let scalar_kind_str = scalar_kind_str(kind);
+                        if convert.is_some() {
+                            write!(self.out, "vec{}<{}>", vector_size_str, scalar_kind_str)?;
+                        } else {
+                            write!(
+                                self.out,
+                                "bitcast<vec{}<{}>>",
+                                vector_size_str, scalar_kind_str
+                            )?;
+                        }
                     }
                     TypeInner::Scalar { .. } => {
                         if convert.is_some() {

--- a/tests/out/wgsl/operators.wgsl
+++ b/tests/out/wgsl/operators.wgsl
@@ -14,7 +14,7 @@ fn builtins() -> vec4<f32> {
     let m1_: vec4<f32> = mix(vec4<f32>(0.0, 0.0, 0.0, 0.0), vec4<f32>(1.0, 1.0, 1.0, 1.0), vec4<f32>(0.5, 0.5, 0.5, 0.5));
     let m2_: vec4<f32> = mix(vec4<f32>(0.0, 0.0, 0.0, 0.0), vec4<f32>(1.0, 1.0, 1.0, 1.0), 0.10000000149011612);
     let b1_: f32 = bitcast<f32>(vec4<i32>(1, 1, 1, 1).x);
-    let b2_: vec4<f32> = vec4<f32>(vec4<i32>(1, 1, 1, 1));
+    let b2_: vec4<f32> = bitcast<vec4<f32>>(vec4<i32>(1, 1, 1, 1));
     let v_i32_zero: vec4<i32> = vec4<i32>(vec4<f32>(0.0, 0.0, 0.0, 0.0));
     return (((((vec4<f32>((vec4<i32>(s1_) + v_i32_zero)) + s2_) + m1_) + m2_) + vec4<f32>(b1_)) + b2_);
 }


### PR DESCRIPTION
Bitcasting a vector to a vector is valid according to the WGSL spec: https://www.w3.org/TR/WGSL/#bitcast-expr

The current wgsl-out code generates an unsigned-integer-to-float  conversion expression when compiling `uintBitsToFloat(uvec3)`, instead of the expected bitcast.