### PR TITLE
[glsl-in] Support function declarations with void as arguments

### DIFF
--- a/src/front/glsl/parser/functions.rs
+++ b/src/front/glsl/parser/functions.rs
@@ -582,6 +582,10 @@ impl<'source> ParsingContext<'source> {
         context: &mut Context,
         body: &mut Block,
     ) -> Result<()> {
+        if self.bump_if(parser, TokenValue::Void).is_some() {
+            return Ok(());
+        }
+
         loop {
             if self.peek_type_name(parser) || self.peek_parameter_qualifier(parser) {
                 let qualifier = self.parse_parameter_qualifier(parser);

--- a/src/front/glsl/parser_tests.rs
+++ b/src/front/glsl/parser_tests.rs
@@ -104,7 +104,7 @@ fn version() {
     parser
         .parse(
             &Options::from(ShaderStage::Vertex),
-            "#version 450 core\nvoid main() {}",
+            "#version 450 core\nvoid main(void) {}",
         )
         .unwrap();
     assert_eq!(


### PR DESCRIPTION
This now allows
```glsl
void main(void) {}
```
to be parsed correctly