### PR TITLE
[glsl-in] Use Span instead of SourceMetadata

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -465,9 +465,11 @@ pub fn emit_glsl_parser_error(errors: Vec<naga::front::glsl::Error>, filename: &
     let writer = StandardStream::stderr(ColorChoice::Auto);
 
     for err in errors {
-        let diagnostic = Diagnostic::error()
-            .with_message(err.kind.to_string())
-            .with_labels(vec![Label::primary((), err.meta.start..err.meta.end)]);
+        let mut diagnostic = Diagnostic::error().with_message(err.kind.to_string());
+
+        if let Some(range) = err.meta.to_range() {
+            diagnostic = diagnostic.with_labels(vec![Label::primary((), range)]);
+        }
 
         term::emit(&mut writer.lock(), &config, &files, &diagnostic).expect("cannot write error");
     }

--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use super::{builtins::MacroCall, context::ExprPos, SourceMetadata};
+use super::{builtins::MacroCall, context::ExprPos, Span};
 use crate::{
     BinaryOperator, Binding, Constant, Expression, Function, GlobalVariable, Handle, Interpolation,
     Sampling, StorageAccess, StorageClass, Type, UnaryOperator,
@@ -89,7 +89,7 @@ pub struct VariableReference {
 #[derive(Debug, Clone)]
 pub struct HirExpr {
     pub kind: HirExprKind,
-    pub meta: SourceMetadata,
+    pub meta: Span,
 }
 
 #[derive(Debug, Clone)]

--- a/src/front/glsl/error.rs
+++ b/src/front/glsl/error.rs
@@ -1,7 +1,5 @@
-use super::{
-    constants::ConstantSolvingError,
-    token::{SourceMetadata, TokenValue},
-};
+use super::{constants::ConstantSolvingError, token::TokenValue};
+use crate::Span;
 use pp_rs::token::PreprocessorError;
 use std::borrow::Cow;
 use thiserror::Error;
@@ -122,5 +120,5 @@ pub struct Error {
     /// Holds the information about the error itself.
     pub kind: ErrorKind,
     /// Holds information about the range of the source code where the error happened.
-    pub meta: SourceMetadata,
+    pub meta: Span,
 }

--- a/src/front/glsl/lex.rs
+++ b/src/front/glsl/lex.rs
@@ -1,9 +1,9 @@
 use super::{
     ast::Precision,
-    token::{Directive, DirectiveKind, SourceMetadata, Token, TokenValue},
+    token::{Directive, DirectiveKind, Token, TokenValue},
     types::parse_type,
 };
-use crate::{FastHashMap, StorageAccess};
+use crate::{FastHashMap, Span, StorageAccess};
 use pp_rs::{
     pp::Preprocessor,
     token::{PreprocessorError, Punct, TokenValue as PPTokenValue},
@@ -13,7 +13,7 @@ use pp_rs::{
 #[cfg_attr(test, derive(PartialEq))]
 pub struct LexerResult {
     pub kind: LexerResultKind,
-    pub meta: SourceMetadata,
+    pub meta: Span,
 }
 
 #[derive(Debug)]
@@ -202,9 +202,10 @@ mod tests {
     use pp_rs::token::{Integer, Location, Token as PPToken, TokenValue as PPTokenValue};
 
     use super::{
-        super::token::{Directive, DirectiveKind, SourceMetadata, Token, TokenValue},
+        super::token::{Directive, DirectiveKind, Token, TokenValue},
         Lexer, LexerResult, LexerResultKind,
     };
+    use crate::Span;
 
     #[test]
     fn lex_tokens() {
@@ -231,7 +232,7 @@ mod tests {
                         location
                     }]
                 }),
-                meta: SourceMetadata { start: 1, end: 8 }
+                meta: Span::new(1, 8)
             }
         );
         assert_eq!(
@@ -239,9 +240,9 @@ mod tests {
             LexerResult {
                 kind: LexerResultKind::Token(Token {
                     value: TokenValue::Void,
-                    meta: SourceMetadata { start: 13, end: 17 }
+                    meta: Span::new(13, 17)
                 }),
-                meta: SourceMetadata { start: 13, end: 17 }
+                meta: Span::new(13, 17)
             }
         );
         assert_eq!(
@@ -249,9 +250,9 @@ mod tests {
             LexerResult {
                 kind: LexerResultKind::Token(Token {
                     value: TokenValue::Identifier("main".into()),
-                    meta: SourceMetadata { start: 18, end: 22 }
+                    meta: Span::new(18, 22)
                 }),
-                meta: SourceMetadata { start: 18, end: 22 }
+                meta: Span::new(18, 22)
             }
         );
         assert_eq!(
@@ -259,9 +260,9 @@ mod tests {
             LexerResult {
                 kind: LexerResultKind::Token(Token {
                     value: TokenValue::LeftParen,
-                    meta: SourceMetadata { start: 23, end: 24 }
+                    meta: Span::new(23, 24)
                 }),
-                meta: SourceMetadata { start: 23, end: 24 }
+                meta: Span::new(23, 24)
             }
         );
         assert_eq!(
@@ -269,9 +270,9 @@ mod tests {
             LexerResult {
                 kind: LexerResultKind::Token(Token {
                     value: TokenValue::RightParen,
-                    meta: SourceMetadata { start: 24, end: 25 }
+                    meta: Span::new(24, 25)
                 }),
-                meta: SourceMetadata { start: 24, end: 25 }
+                meta: Span::new(24, 25)
             }
         );
         assert_eq!(
@@ -279,9 +280,9 @@ mod tests {
             LexerResult {
                 kind: LexerResultKind::Token(Token {
                     value: TokenValue::LeftBrace,
-                    meta: SourceMetadata { start: 26, end: 27 }
+                    meta: Span::new(26, 27)
                 }),
-                meta: SourceMetadata { start: 26, end: 27 }
+                meta: Span::new(26, 27)
             }
         );
         assert_eq!(
@@ -289,9 +290,9 @@ mod tests {
             LexerResult {
                 kind: LexerResultKind::Token(Token {
                     value: TokenValue::RightBrace,
-                    meta: SourceMetadata { start: 27, end: 28 }
+                    meta: Span::new(27, 28)
                 }),
-                meta: SourceMetadata { start: 27, end: 28 }
+                meta: Span::new(27, 28)
             }
         );
         assert_eq!(lex.next(), None);

--- a/src/front/glsl/mod.rs
+++ b/src/front/glsl/mod.rs
@@ -8,9 +8,9 @@
 
 pub use ast::{Precision, Profile};
 pub use error::{Error, ErrorKind, ExpectedToken};
-pub use token::{SourceMetadata, TokenValue};
+pub use token::TokenValue;
 
-use crate::{FastHashMap, FastHashSet, Handle, Module, ShaderStage, Type};
+use crate::{FastHashMap, FastHashSet, Handle, Module, ShaderStage, Span, Type};
 use ast::{EntryArg, FunctionDeclaration, GlobalLookup};
 use parser::ParsingContext;
 

--- a/src/front/glsl/offset.rs
+++ b/src/front/glsl/offset.rs
@@ -11,7 +11,7 @@
 use super::{
     ast::StructLayout,
     error::{Error, ErrorKind},
-    SourceMetadata,
+    Span,
 };
 use crate::{front::align_up, Arena, Constant, Handle, Type, TypeInner};
 
@@ -37,7 +37,7 @@ pub struct TypeAlignSpan {
 /// change the stride and as such need to have a different type.
 pub fn calculate_offset(
     mut ty: Handle<Type>,
-    meta: SourceMetadata,
+    meta: Span,
     layout: StructLayout,
     types: &mut Arena<Type>,
     constants: &Arena<Constant>,

--- a/src/front/glsl/parser.rs
+++ b/src/front/glsl/parser.rs
@@ -5,11 +5,11 @@ use super::{
     error::{Error, ErrorKind},
     lex::{Lexer, LexerResultKind},
     token::{Directive, DirectiveKind},
-    token::{SourceMetadata, Token, TokenValue},
+    token::{Token, TokenValue},
     variables::{GlobalOrConstant, VarDeclaration},
     Parser, Result,
 };
-use crate::{arena::Handle, Block, Constant, ConstantInner, Expression, ScalarValue, Type};
+use crate::{arena::Handle, Block, Constant, ConstantInner, Expression, ScalarValue, Span, Type};
 use core::convert::TryFrom;
 use pp_rs::token::{PreprocessorError, Token as PPToken, TokenValue as PPTokenValue};
 use std::iter::Peekable;
@@ -21,18 +21,18 @@ mod types;
 
 pub struct ParsingContext<'source> {
     lexer: Peekable<Lexer<'source>>,
-    last_meta: SourceMetadata,
+    last_meta: Span,
 }
 
 impl<'source> ParsingContext<'source> {
     pub fn new(lexer: Lexer<'source>) -> Self {
         ParsingContext {
             lexer: lexer.peekable(),
-            last_meta: SourceMetadata::none(),
+            last_meta: Span::default(),
         }
     }
 
-    pub fn expect_ident(&mut self, parser: &mut Parser) -> Result<(String, SourceMetadata)> {
+    pub fn expect_ident(&mut self, parser: &mut Parser) -> Result<(String, Span)> {
         let token = self.bump(parser)?;
 
         match token.value {
@@ -153,14 +153,14 @@ impl<'source> ParsingContext<'source> {
             Some(handle) => parser.add_entry_point(handle, body, ctx.expressions),
             None => parser.errors.push(Error {
                 kind: ErrorKind::SemanticError("Missing entry point".into()),
-                meta: SourceMetadata::none(),
+                meta: Span::default(),
             }),
         }
 
         Ok(())
     }
 
-    fn parse_uint_constant(&mut self, parser: &mut Parser) -> Result<(u32, SourceMetadata)> {
+    fn parse_uint_constant(&mut self, parser: &mut Parser) -> Result<(u32, Span)> {
         let (value, meta) = self.parse_constant_expression(parser)?;
 
         let int = match parser.module.constants[value].inner {
@@ -192,7 +192,7 @@ impl<'source> ParsingContext<'source> {
     fn parse_constant_expression(
         &mut self,
         parser: &mut Parser,
-    ) -> Result<(Handle<Constant>, SourceMetadata)> {
+    ) -> Result<(Handle<Constant>, Span)> {
         let mut block = Block::new();
 
         let mut ctx = Context::new(parser, &mut block);
@@ -206,7 +206,7 @@ impl<'source> ParsingContext<'source> {
 }
 
 impl Parser {
-    fn handle_directive(&mut self, directive: Directive, meta: SourceMetadata) {
+    fn handle_directive(&mut self, directive: Directive, meta: Span) {
         let mut tokens = directive.tokens.into_iter();
 
         match directive.kind {
@@ -367,7 +367,7 @@ impl Parser {
 }
 
 pub struct DeclarationContext<'ctx> {
-    qualifiers: Vec<(TypeQualifier, SourceMetadata)>,
+    qualifiers: Vec<(TypeQualifier, Span)>,
     external: bool,
 
     ctx: &'ctx mut Context,
@@ -381,7 +381,7 @@ impl<'ctx> DeclarationContext<'ctx> {
         ty: Handle<Type>,
         name: String,
         init: Option<Handle<Constant>>,
-        meta: SourceMetadata,
+        meta: Span,
     ) -> Result<Handle<Expression>> {
         let decl = VarDeclaration {
             qualifiers: &self.qualifiers,

--- a/src/front/glsl/parser/declarations.rs
+++ b/src/front/glsl/parser/declarations.rs
@@ -10,7 +10,7 @@ use crate::{
         token::{Token, TokenValue},
         types::scalar_components,
         variables::{GlobalOrConstant, VarDeclaration},
-        Error, ErrorKind, Parser, SourceMetadata,
+        Error, ErrorKind, Parser, Span,
     },
     Block, Expression, FunctionResult, Handle, ScalarKind, Statement, StorageClass, StructMember,
     Type, TypeInner,
@@ -54,7 +54,7 @@ impl<'source> ParsingContext<'source> {
         ty: Handle<Type>,
         ctx: &mut Context,
         body: &mut Block,
-    ) -> Result<(Handle<Expression>, SourceMetadata)> {
+    ) -> Result<(Handle<Expression>, Span)> {
         // initializer:
         //     assignment_expression
         //     LEFT_BRACE initializer_list RIGHT_BRACE
@@ -76,12 +76,12 @@ impl<'source> ParsingContext<'source> {
                         if let Some(Token { meta: end_meta, .. }) =
                             self.bump_if(parser, TokenValue::RightBrace)
                         {
-                            meta = meta.union(&end_meta);
+                            meta.subsume(end_meta);
                             break;
                         }
                     }
                     TokenValue::RightBrace => {
-                        meta = meta.union(&token.meta);
+                        meta.subsume(token.meta);
                         break;
                     }
                     _ => {
@@ -190,7 +190,7 @@ impl<'source> ParsingContext<'source> {
                             .implicit_conversion(parser, &mut expr, init_meta, kind, width)?;
                     }
 
-                    meta = meta.union(&init_meta);
+                    meta.subsume(init_meta);
 
                     Ok((expr, init_meta))
                 })
@@ -206,8 +206,7 @@ impl<'source> ParsingContext<'source> {
 
             if let Some((value, _)) = init.filter(|_| maybe_constant.is_none()) {
                 ctx.flush_expressions();
-                ctx.body
-                    .push(Statement::Store { pointer, value }, meta.as_span());
+                ctx.body.push(Statement::Store { pointer, value }, meta);
             }
 
             let token = self.bump(parser)?;
@@ -236,7 +235,7 @@ impl<'source> ParsingContext<'source> {
         ctx: &mut Context,
         body: &mut Block,
         external: bool,
-    ) -> Result<Option<SourceMetadata>> {
+    ) -> Result<Option<Span>> {
         //declaration:
         //    function_prototype  SEMICOLON
         //
@@ -272,7 +271,7 @@ impl<'source> ParsingContext<'source> {
                             self.parse_function_args(parser, &mut context, &mut body)?;
 
                             let end_meta = self.expect(parser, TokenValue::RightParen)?.meta;
-                            meta = meta.union(&end_meta);
+                            meta.subsume(end_meta);
 
                             let token = self.bump(parser)?;
                             return match token.value {
@@ -379,7 +378,7 @@ impl<'source> ParsingContext<'source> {
                     TokenValue::Semicolon => {
                         let mut meta_all = token.meta;
                         for &(ref qualifier, meta) in qualifiers.iter() {
-                            meta_all = meta_all.union(&meta);
+                            meta_all.subsume(meta);
                             match *qualifier {
                                 TypeQualifier::WorkGroupSize(i, value) => {
                                     parser.meta.workgroup_size[i] = value
@@ -471,10 +470,10 @@ impl<'source> ParsingContext<'source> {
         parser: &mut Parser,
         ctx: &mut Context,
         body: &mut Block,
-        qualifiers: &[(TypeQualifier, SourceMetadata)],
+        qualifiers: &[(TypeQualifier, Span)],
         ty_name: String,
-        meta: SourceMetadata,
-    ) -> Result<SourceMetadata> {
+        meta: Span,
+    ) -> Result<Span> {
         let mut storage = None;
         let mut layout = None;
 
@@ -580,7 +579,7 @@ impl<'source> ParsingContext<'source> {
             let (ty, mut meta) = self.parse_type_non_void(parser)?;
             let (name, end_meta) = self.expect_ident(parser)?;
 
-            meta = meta.union(&end_meta);
+            meta.subsume(end_meta);
 
             let array_specifier = self.parse_array_specifier(parser)?;
             let ty = parser.maybe_array(ty, meta, array_specifier);

--- a/src/front/glsl/parser_tests.rs
+++ b/src/front/glsl/parser_tests.rs
@@ -3,7 +3,7 @@ use super::{
     error::ExpectedToken,
     error::{Error, ErrorKind},
     token::TokenValue,
-    Options, Parser, SourceMetadata,
+    Options, Parser, Span,
 };
 use crate::ShaderStage;
 use pp_rs::token::PreprocessorError;
@@ -23,7 +23,7 @@ fn version() {
             .unwrap(),
         vec![Error {
             kind: ErrorKind::InvalidVersion(99000),
-            meta: SourceMetadata { start: 9, end: 14 }
+            meta: Span::new(9, 14)
         }],
     );
 
@@ -37,7 +37,7 @@ fn version() {
             .unwrap(),
         vec![Error {
             kind: ErrorKind::InvalidVersion(449),
-            meta: SourceMetadata { start: 9, end: 12 }
+            meta: Span::new(9, 12)
         }]
     );
 
@@ -51,7 +51,7 @@ fn version() {
             .unwrap(),
         vec![Error {
             kind: ErrorKind::InvalidProfile("smart".into()),
-            meta: SourceMetadata { start: 13, end: 18 },
+            meta: Span::new(13, 18),
         }]
     );
 
@@ -66,14 +66,14 @@ fn version() {
         vec![
             Error {
                 kind: ErrorKind::PreprocessorError(PreprocessorError::UnexpectedHash,),
-                meta: SourceMetadata { start: 27, end: 28 },
+                meta: Span::new(27, 28),
             },
             Error {
                 kind: ErrorKind::InvalidToken(
                     TokenValue::Identifier("version".into()),
                     vec![ExpectedToken::Eof]
                 ),
-                meta: SourceMetadata { start: 28, end: 35 }
+                meta: Span::new(28, 35)
             }
         ]
     );
@@ -449,10 +449,7 @@ fn functions() {
             .unwrap(),
         vec![Error {
             kind: ErrorKind::SemanticError("Function already defined".into()),
-            meta: SourceMetadata {
-                start: 134,
-                end: 152
-            },
+            meta: Span::new(134, 152),
         }]
     );
 
@@ -608,10 +605,7 @@ fn implicit_conversions() {
             .unwrap(),
         vec![Error {
             kind: ErrorKind::SemanticError("Unknown function \'test\'".into()),
-            meta: SourceMetadata {
-                start: 156,
-                end: 165
-            },
+            meta: Span::new(156, 165),
         }]
     );
 
@@ -633,10 +627,7 @@ fn implicit_conversions() {
             .unwrap(),
         vec![Error {
             kind: ErrorKind::SemanticError("Ambiguous best function for \'test\'".into()),
-            meta: SourceMetadata {
-                start: 158,
-                end: 165
-            },
+            meta: Span::new(158, 165),
         }]
     );
 }

--- a/src/front/glsl/token.rs
+++ b/src/front/glsl/token.rs
@@ -1,85 +1,11 @@
-use pp_rs::token::Location;
-pub use pp_rs::token::{Float, Integer, PreprocessorError, Token as PPToken};
+pub use pp_rs::token::{Float, Integer, Location, PreprocessorError, Token as PPToken};
 
 use super::ast::Precision;
-use crate::{Interpolation, Sampling, Type};
-use std::ops::Range;
+use crate::{Interpolation, Sampling, Span, Type};
 
-/// Represents a range of the source code
-///
-/// The `SourceMetadata` is used in error reporting to indicate a range of the
-/// original source code where the error happened.
-///
-/// For easy interaction with error crates like
-/// [`codespan`][codespan] the [`From`](From) trait is
-/// implemeted for [`Range<usize>`](Range) allowing for conversions from `SourceMetadata`.
-///
-/// ```rust
-/// # use naga::front::glsl::SourceMetadata;
-/// # use std::ops::Range;
-/// # let meta = SourceMetadata::default();
-/// let range: Range<usize> = meta.into();
-/// ```
-///
-/// Or in the case of [`codespan`][codespan]
-///
-/// ```rust
-/// # use naga::front::glsl::SourceMetadata;
-/// # #[cfg(feature = "codespan_reporting")]
-/// # {
-/// use codespan_reporting::diagnostic::Label;
-/// # let file = ();
-/// # let meta = SourceMetadata::default();
-/// let label = Label::primary(file, meta);
-/// # }
-/// ```
-///
-/// # Notes
-///
-/// [`start`](SourceMetadata::start) can be equal to
-/// [`end`](SourceMetadata::end) especially when reporting errors which aren't
-/// associated with a specific portion of the code.
-///
-/// [codespan]: https://docs.rs/codespan-reporting
-#[derive(Debug, Clone, Copy, Default)]
-#[cfg_attr(test, derive(PartialEq))]
-pub struct SourceMetadata {
-    /// Byte offset into the source where the first char starts
-    pub start: usize,
-    /// Byte offset into the source where the first char not belonging to this
-    /// source metadata starts
-    pub end: usize,
-}
-
-impl SourceMetadata {
-    pub(crate) fn union(&self, other: &Self) -> Self {
-        SourceMetadata {
-            start: self.start.min(other.start),
-            end: self.end.max(other.end),
-        }
-    }
-
-    pub fn as_span(&self) -> crate::Span {
-        crate::Span::new(self.start as u32, self.end as u32)
-    }
-
-    pub(crate) fn none() -> Self {
-        SourceMetadata::default()
-    }
-}
-
-impl From<Location> for SourceMetadata {
+impl From<Location> for Span {
     fn from(loc: Location) -> Self {
-        SourceMetadata {
-            start: loc.start as usize,
-            end: loc.end as usize,
-        }
-    }
-}
-
-impl From<SourceMetadata> for Range<usize> {
-    fn from(meta: SourceMetadata) -> Self {
-        meta.start..meta.end
+        Span::new(loc.start, loc.end)
     }
 }
 
@@ -87,7 +13,7 @@ impl From<SourceMetadata> for Range<usize> {
 #[cfg_attr(test, derive(PartialEq))]
 pub struct Token {
     pub value: TokenValue,
-    pub meta: SourceMetadata,
+    pub meta: Span,
 }
 
 /// A token passed from the lexing used in the parsing

--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -2,7 +2,7 @@ use super::{
     ast::*,
     context::Context,
     error::{Error, ErrorKind},
-    Parser, Result, SourceMetadata,
+    Parser, Result, Span,
 };
 use crate::{
     Binding, Block, BuiltIn, Constant, Expression, GlobalVariable, Handle, Interpolation,
@@ -24,11 +24,11 @@ macro_rules! qualifier_arm {
 }
 
 pub struct VarDeclaration<'a> {
-    pub qualifiers: &'a [(TypeQualifier, SourceMetadata)],
+    pub qualifiers: &'a [(TypeQualifier, Span)],
     pub ty: Handle<Type>,
     pub name: Option<String>,
     pub init: Option<Handle<Constant>>,
-    pub meta: SourceMetadata,
+    pub meta: Span,
 }
 
 /// Information about a builtin used in [`add_builtin`](Parser::add_builtin)
@@ -56,14 +56,14 @@ impl Parser {
         body: &mut Block,
         name: &str,
         data: BuiltInData,
-        meta: SourceMetadata,
+        meta: Span,
     ) -> Option<VariableReference> {
         let ty = self.module.types.fetch_or_append(
             Type {
                 name: None,
                 inner: data.inner,
             },
-            meta.as_span(),
+            meta,
         );
 
         let handle = self.module.global_variables.append(
@@ -74,7 +74,7 @@ impl Parser {
                 ty,
                 init: None,
             },
-            meta.as_span(),
+            meta,
         );
 
         let idx = self.entry_args.len();
@@ -114,7 +114,7 @@ impl Parser {
         ctx: &mut Context,
         body: &mut Block,
         name: &str,
-        meta: SourceMetadata,
+        meta: Span,
     ) -> Option<VariableReference> {
         if let Some(local_var) = ctx.lookup_local_var(name) {
             return Some(local_var);
@@ -196,7 +196,7 @@ impl Parser {
                             width: 4,
                         },
                     },
-                    meta.as_span(),
+                    meta,
                 );
 
                 BuiltInData {
@@ -248,7 +248,7 @@ impl Parser {
         body: &mut Block,
         expression: Handle<Expression>,
         name: &str,
-        meta: SourceMetadata,
+        meta: Span,
     ) -> Result<Handle<Expression>> {
         let (ty, is_pointer) = match *self.resolve_type(ctx, expression, meta)? {
             TypeInner::Pointer { base, .. } => (&self.module.types[base].inner, true),
@@ -562,7 +562,7 @@ impl Parser {
                     ty,
                     init,
                 },
-                meta.as_span(),
+                meta,
             );
 
             let idx = self.entry_args.len();
@@ -633,7 +633,7 @@ impl Parser {
                 ty,
                 init,
             },
-            meta.as_span(),
+            meta,
         );
 
         if let Some(name) = name {
@@ -711,7 +711,7 @@ impl Parser {
                 ty,
                 init,
             },
-            meta.as_span(),
+            meta,
         );
         let expr = ctx.add_expression(Expression::LocalVariable(handle), meta, body);
 


### PR DESCRIPTION
Removes the old `SourceMetadata` and replaces it with the crate wide `Span`.

They were but equal conceptually and structurally so there was no reason to keep both of them around, this removes a whole bunch of conversions. 