### PR TITLE
[glsl-out] Improve handling of samplerCubeArrayShadow

### DIFF
--- a/tests/in/cubeArrayShadow.wgsl
+++ b/tests/in/cubeArrayShadow.wgsl
@@ -1,0 +1,12 @@
+[[group(0), binding(4)]]
+var point_shadow_textures: texture_depth_cube_array;
+[[group(0), binding(5)]]
+var point_shadow_textures_sampler: sampler_comparison;
+
+[[stage(fragment)]]
+fn fragment() -> [[location(0)]] vec4<f32> {
+    let frag_ls = vec4<f32>(1., 1., 2., 1.).xyz;
+    let a = textureSampleCompare(point_shadow_textures, point_shadow_textures_sampler, frag_ls, i32(1), 1.);
+
+    return vec4<f32>(a, 1., 1., 1.);
+}

--- a/tests/out/glsl/cubeArrayShadow.fragment.Fragment.glsl
+++ b/tests/out/glsl/cubeArrayShadow.fragment.Fragment.glsl
@@ -1,0 +1,17 @@
+#version 310 es
+#extension GL_EXT_texture_cube_map_array : require
+
+precision highp float;
+precision highp int;
+
+uniform highp samplerCubeArrayShadow _group_0_binding_4;
+
+layout(location = 0) out vec4 _fs2p_location0;
+
+void main() {
+    vec3 frag_ls = vec4(1.0, 1.0, 2.0, 1.0).xyz;
+    float a = texture(_group_0_binding_4, vec4(frag_ls, int(1)), 1.0);
+    _fs2p_location0 = vec4(a, 1.0, 1.0, 1.0);
+    return;
+}
+

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -505,6 +505,7 @@ fn convert_wgsl() {
             "texture-arg",
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,
         ),
+        ("cubeArrayShadow", Targets::GLSL),
     ];
 
     for &(name, targets) in inputs.iter() {


### PR DESCRIPTION
Adds checks that it isn't used in an unsupported function and emits the
depth_ref as a separate argument.

Closes #1153