### PR TITLE
[glsl-in] Use intermediate local if storage class isn't function

### DIFF
--- a/src/front/glsl/context.rs
+++ b/src/front/glsl/context.rs
@@ -433,7 +433,12 @@ impl Context {
             HirExprKind::Access { base, index } => {
                 let (index, index_meta) =
                     self.lower_expect_inner(stmt, parser, index, ExprPos::Rhs, body)?;
-                let maybe_constant_index = parser.solve_constant(self, index, index_meta).ok();
+                let maybe_constant_index = match pos {
+                    // Don't try to generate `AccessIndex` if in a LHS position, since it
+                    // wouldn't produce a pointer.
+                    ExprPos::Lhs => None,
+                    _ => parser.solve_constant(self, index, index_meta).ok(),
+                };
 
                 let base = self
                     .lower_expect_inner(

--- a/tests/in/glsl/expressions.frag
+++ b/tests/in/glsl/expressions.frag
@@ -63,18 +63,22 @@ void testBinOpUintUVec(uint a, uvec4 b) {
 }
 
 void testStructConstructor() {
-	struct BST {
-		int data;
-	};
+    struct BST {
+        int data;
+    };
 
-	BST tree = BST(1);
+    BST tree = BST(1);
 }
 
 void testArrayConstructor() {
-	float tree[1] = float[1](0.0);
+    float tree[1] = float[1](0.0);
 }
+
+float global;
+void privatePointer(inout float a) {}
 
 out vec4 o_color;
 void main() {
+    privatePointer(global);
     o_color.rgba = vec4(1.0);
 }

--- a/tests/out/wgsl/expressions-frag.wgsl
+++ b/tests/out/wgsl/expressions-frag.wgsl
@@ -2,6 +2,7 @@ struct BST {
     data: i32;
 };
 
+var<private> global: f32;
 var<private> o_color: vec4<f32>;
 
 fn testBinOpVecFloat(a: vec4<f32>, b: f32) {
@@ -184,13 +185,24 @@ fn testArrayConstructor() {
 
 }
 
+fn privatePointer(a12: ptr<function, f32>) {
+    return;
+}
+
 fn main1() {
-    let e1: vec4<f32> = o_color;
-    let e4: vec4<f32> = vec4<f32>(1.0);
-    o_color.x = e4.x;
-    o_color.y = e4.y;
-    o_color.z = e4.z;
-    o_color.w = e4.w;
+    var local: f32;
+
+    let e3: f32 = global;
+    local = e3;
+    privatePointer((&local));
+    let e5: f32 = local;
+    global = e5;
+    let e6: vec4<f32> = o_color;
+    let e9: vec4<f32> = vec4<f32>(1.0);
+    o_color.x = e9.x;
+    o_color.y = e9.y;
+    o_color.z = e9.z;
+    o_color.w = e9.w;
     return;
 }
 


### PR DESCRIPTION
Automatically spills to a local variable function call arguments to
parameters expecting a pointer where the argument storage class isn't
function since the storage classes wouldn't match.

Closes #1341