### PR TITLE
[spv-in] preserve case order when reusing blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ bitflags = "1"
 bit-set = "0.5"
 codespan-reporting = { version = "0.11.0", optional = true }
 fxhash = "0.2"
+indexmap = "1.6" # 1.7 has MSRV 1.49
 log = "0.4"
 num-traits = "0.2"
 spirv = { version = "0.2", optional = true }


### PR DESCRIPTION
Spir-v allows in the case list of an `OpSwitch` for target block ids to be reused, this caused issues because our frontend didn't check this and emitted them all in the same order they appeared.

With this PR now first they are collected to an `indexmap` (which would've already been introduced with jimb's changes) and then added to the body making sure that cases that share the same target block are contiguous.

Closes #1403