### PR TITLE
Compile the validation out of an executable

### DIFF
--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -149,3 +149,14 @@ jobs:
                echo "Result: $(expr $FILE_COUNT - $SUCCESS_RESULT_COUNT) / $FILE_COUNT" > counter
            done
            cat counter
+  check_snapshots_without_validation:
+    name: Check snapshots (without validation)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-rs/cargo@v1
+        name: Test all (without validation)
+        with:
+          command: test
+          args: --features wgsl-in,wgsl-out,glsl-in,glsl-out,spv-in,spv-out,msl-out,hlsl-out,dot-out --workspace
+      - name: Check snapshots (without validation)
+        run: git diff --exit-code -- tests/out

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ wgsl-in = ["codespan-reporting", "hexf-parse"]
 wgsl-out = []
 hlsl-out = []
 span = ["codespan-reporting"]
+validate = []
 
 [dev-dependencies]
 diff = "0.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "naga"
 path = "src/main.rs"
 
 [dependencies]
-naga = { path = "../", features = ["span", "wgsl-in", "wgsl-out", "glsl-in", "glsl-out", "spv-in", "spv-out", "msl-out", "hlsl-out", "dot-out", "glsl-validate"] }
+naga = { path = "../", features = ["validate", "span", "wgsl-in", "wgsl-out", "glsl-in", "glsl-out", "spv-in", "spv-out", "msl-out", "hlsl-out", "dot-out", "glsl-validate"] }
 log = "0.4"
 codespan-reporting = "0.11"
 env_logger = "0.8"

--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -190,6 +190,7 @@ struct Sampling {
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct FunctionInfo {
     /// Validation flags.
+    #[allow(dead_code)]
     flags: ValidationFlags,
     /// Set of shader stages where calling this function is valid.
     pub available_stages: ShaderStages,
@@ -621,6 +622,7 @@ impl FunctionInfo {
                     let mut requirements = UniformityRequirements::empty();
                     for expr in range.clone() {
                         let req = self.expressions[expr.index()].uniformity.requirements;
+                        #[cfg(feature = "validate")]
                         if self
                             .flags
                             .contains(super::ValidationFlags::CONTROL_FLOW_UNIFORMITY)
@@ -854,6 +856,7 @@ impl ModuleInfo {
 }
 
 #[test]
+#[cfg(feature = "validate")]
 fn uniform_control_flow() {
     use crate::{Expression as E, Statement as S};
 

--- a/src/valid/compose.rs
+++ b/src/valid/compose.rs
@@ -1,7 +1,10 @@
+#[cfg(feature = "validate")]
 use crate::{
-    arena::{Arena, Handle, UniqueArena},
+    arena::{Arena, UniqueArena},
     proc::TypeResolution,
 };
+
+use crate::Handle;
 
 #[derive(Clone, Debug, thiserror::Error)]
 #[cfg_attr(test, derive(PartialEq))]
@@ -16,6 +19,7 @@ pub enum ComposeError {
     ComponentType { index: u32 },
 }
 
+#[cfg(feature = "validate")]
 pub fn validate_compose(
     self_ty_handle: Handle<crate::Type>,
     constant_arena: &Arena<crate::Constant>,

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -1,6 +1,10 @@
-use super::{compose::validate_compose, ComposeError, FunctionInfo, ShaderStages, TypeFlags};
+#[cfg(feature = "validate")]
+use super::{compose::validate_compose, FunctionInfo, ShaderStages, TypeFlags};
+#[cfg(feature = "validate")]
+use crate::arena::UniqueArena;
+
 use crate::{
-    arena::{Handle, UniqueArena},
+    arena::Handle,
     proc::{ProcError, ResolveError},
 };
 
@@ -40,7 +44,7 @@ pub enum ExpressionError {
     #[error("Swizzle component {0:?} is outside of vector size {1:?}")]
     InvalidSwizzleComponent(crate::SwizzleComponent, crate::VectorSize),
     #[error(transparent)]
-    Compose(#[from] ComposeError),
+    Compose(#[from] super::ComposeError),
     #[error(transparent)]
     Proc(#[from] ProcError),
     #[error("Operation {0:?} can't work with {1:?}")]
@@ -111,12 +115,14 @@ pub enum ExpressionError {
     InvalidAtomicResultType(crate::ScalarKind, crate::Bytes),
 }
 
+#[cfg(feature = "validate")]
 struct ExpressionTypeResolver<'a> {
     root: Handle<crate::Expression>,
     types: &'a UniqueArena<crate::Type>,
     info: &'a FunctionInfo,
 }
 
+#[cfg(feature = "validate")]
 impl<'a> ExpressionTypeResolver<'a> {
     fn resolve(
         &self,
@@ -130,6 +136,7 @@ impl<'a> ExpressionTypeResolver<'a> {
     }
 }
 
+#[cfg(feature = "validate")]
 impl super::Validator {
     pub(super) fn validate_expression(
         &self,

--- a/src/valid/interface.rs
+++ b/src/valid/interface.rs
@@ -1,12 +1,12 @@
 use super::{
     analyzer::{FunctionInfo, GlobalUse},
-    Capabilities, Disalignment, FunctionError, ModuleInfo, ShaderStages, TypeFlags,
-    ValidationFlags,
+    Capabilities, Disalignment, FunctionError, ModuleInfo,
 };
 use crate::arena::{Handle, UniqueArena};
 
 use bit_set::BitSet;
 
+#[cfg(feature = "validate")]
 const MAX_WORKGROUP_SIZE: u32 = 0x4000;
 
 #[derive(Clone, Debug, thiserror::Error)]
@@ -17,8 +17,8 @@ pub enum GlobalVariableError {
     InvalidType,
     #[error("Type flags {seen:?} do not meet the required {required:?}")]
     MissingTypeFlags {
-        required: TypeFlags,
-        seen: TypeFlags,
+        required: super::TypeFlags,
+        seen: super::TypeFlags,
     },
     #[error("Capability {0:?} is not supported")]
     UnsupportedCapability(Capabilities),
@@ -78,6 +78,7 @@ pub enum EntryPointError {
     Function(#[from] FunctionError),
 }
 
+#[cfg(feature = "validate")]
 fn storage_usage(access: crate::StorageAccess) -> GlobalUse {
     let mut storage_usage = GlobalUse::QUERY;
     if access.contains(crate::StorageAccess::LOAD) {
@@ -317,11 +318,14 @@ impl VaryingContext<'_> {
 }
 
 impl super::Validator {
+    #[cfg(feature = "validate")]
     pub(super) fn validate_global_var(
         &self,
         var: &crate::GlobalVariable,
         types: &UniqueArena<crate::Type>,
     ) -> Result<(), GlobalVariableError> {
+        use super::TypeFlags;
+
         log::debug!("var {:?}", var);
         let type_info = &self.types[var.ty.index()];
 
@@ -329,7 +333,7 @@ impl super::Validator {
             crate::StorageClass::Function => return Err(GlobalVariableError::InvalidUsage),
             crate::StorageClass::Storage { .. } => {
                 if let Err((ty_handle, disalignment)) = type_info.storage_layout {
-                    if self.flags.contains(ValidationFlags::STRUCT_LAYOUTS) {
+                    if self.flags.contains(super::ValidationFlags::STRUCT_LAYOUTS) {
                         return Err(GlobalVariableError::Alignment(ty_handle, disalignment));
                     }
                 }
@@ -340,7 +344,7 @@ impl super::Validator {
             }
             crate::StorageClass::Uniform => {
                 if let Err((ty_handle, disalignment)) = type_info.uniform_layout {
-                    if self.flags.contains(ValidationFlags::STRUCT_LAYOUTS) {
+                    if self.flags.contains(super::ValidationFlags::STRUCT_LAYOUTS) {
                         return Err(GlobalVariableError::Alignment(ty_handle, disalignment));
                     }
                 }
@@ -396,9 +400,12 @@ impl super::Validator {
         module: &crate::Module,
         mod_info: &ModuleInfo,
     ) -> Result<FunctionInfo, EntryPointError> {
+        #[cfg(feature = "validate")]
         if ep.early_depth_test.is_some() && ep.stage != crate::ShaderStage::Fragment {
             return Err(EntryPointError::UnexpectedEarlyDepthTest);
         }
+
+        #[cfg(feature = "validate")]
         if ep.stage == crate::ShaderStage::Compute {
             if ep
                 .workgroup_size
@@ -411,16 +418,21 @@ impl super::Validator {
             return Err(EntryPointError::UnexpectedWorkgroupSize);
         }
 
-        let stage_bit = match ep.stage {
-            crate::ShaderStage::Vertex => ShaderStages::VERTEX,
-            crate::ShaderStage::Fragment => ShaderStages::FRAGMENT,
-            crate::ShaderStage::Compute => ShaderStages::COMPUTE,
-        };
-
         let info = self.validate_function(&ep.function, module, mod_info)?;
 
-        if !info.available_stages.contains(stage_bit) {
-            return Err(EntryPointError::ForbiddenStageOperations);
+        #[cfg(feature = "validate")]
+        {
+            use super::ShaderStages;
+
+            let stage_bit = match ep.stage {
+                crate::ShaderStage::Vertex => ShaderStages::VERTEX,
+                crate::ShaderStage::Fragment => ShaderStages::FRAGMENT,
+                crate::ShaderStage::Compute => ShaderStages::COMPUTE,
+            };
+
+            if !info.available_stages.contains(stage_bit) {
+                return Err(EntryPointError::ForbiddenStageOperations);
+            }
         }
 
         self.location_mask.clear();
@@ -458,6 +470,8 @@ impl super::Validator {
         for bg in self.bind_group_masks.iter_mut() {
             bg.clear();
         }
+
+        #[cfg(feature = "validate")]
         for (var_handle, var) in module.global_variables.iter() {
             let usage = info[var_handle];
             if usage.is_empty() {


### PR DESCRIPTION
This PR will disable shader validation as much as possible by default. Currently in draft status, because I think that implementation is not good enough.

Fix #1213