### PR TITLE
Remove Namer::call_unique.

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1370,7 +1370,7 @@ impl<'a, W: Write> Writer<'a, W> {
                         // But we write them to step by step. We need to recache them
                         // Otherwise, we could accidentally write variable name instead of full expression.
                         // Also, we use sanitized names! It defense backend from generating variable with name from reserved keywords.
-                        Some(self.namer.call_unique(name))
+                        Some(self.namer.call(name))
                     } else {
                         let min_ref_count = ctx.expressions[handle].bake_ref_count();
                         if min_ref_count <= info.ref_count {

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1397,7 +1397,7 @@ impl<W: Write> Writer<W> {
                             // But we write them to step by step. We need to recache them
                             // Otherwise, we could accidentally write variable name instead of full expression.
                             // Also, we use sanitized names! It defense backend from generating variable with name from reserved keywords.
-                            Some(self.namer.call_unique(name))
+                            Some(self.namer.call(name))
                         } else {
                             let min_ref_count =
                                 context.expression.function.expressions[handle].bake_ref_count();

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -676,7 +676,7 @@ impl<W: Write> Writer<W> {
                         // But we write them to step by step. We need to recache them
                         // Otherwise, we could accidentally write variable name instead of full expression.
                         // Also, we use sanitized names! It defense backend from generating variable with name from reserved keywords.
-                        Some(self.namer.call_unique(name))
+                        Some(self.namer.call(name))
                     } else {
                         let expr = &func_ctx.expressions[handle];
                         let min_ref_count = expr.bake_ref_count();

--- a/src/proc/namer.rs
+++ b/src/proc/namer.rs
@@ -50,28 +50,6 @@ impl Namer {
         base
     }
 
-    /// Helper function that return unique name without cache update.
-    /// This function should be used **after** [`Namer`](crate::proc::Namer) initialization by [`reset`](Self::reset()) function.
-    pub fn call_unique(&mut self, string: &str) -> String {
-        let base = self.sanitize(string);
-        match self.unique.entry(base) {
-            Entry::Occupied(mut e) => {
-                *e.get_mut() += 1;
-                format!("{}{}", e.key(), e.get())
-            }
-            Entry::Vacant(e) => {
-                let name = e.key();
-                if self.keywords.contains(e.key()) {
-                    let name = format!("{}1", name);
-                    e.insert(1);
-                    name
-                } else {
-                    name.to_string()
-                }
-            }
-        }
-    }
-
     pub fn call(&mut self, label_raw: &str) -> String {
         let base = self.sanitize(label_raw);
         match self.unique.entry(base) {
@@ -94,7 +72,7 @@ impl Namer {
         }
     }
 
-    fn call_or(&mut self, label: &Option<String>, fallback: &str) -> String {
+    pub fn call_or(&mut self, label: &Option<String>, fallback: &str) -> String {
         self.call(match *label {
             Some(ref name) => name,
             None => fallback,

--- a/tests/out/hlsl/access.hlsl
+++ b/tests/out/hlsl/access.hlsl
@@ -53,7 +53,7 @@ void atomics()
 {
     int tmp = (int)0;
 
-    int value = asint(bar.Load(64));
+    int value1 = asint(bar.Load(64));
     int _e6; bar.InterlockedAdd(64, 5, _e6);
     tmp = _e6;
     int _e9; bar.InterlockedAdd(64, -5, _e9);
@@ -70,6 +70,6 @@ void atomics()
     tmp = _e24;
     int _e27; bar.InterlockedExchange(64, 5, _e27);
     tmp = _e27;
-    bar.Store(64, asuint(value));
+    bar.Store(64, asuint(value1));
     return;
 }

--- a/tests/out/hlsl/image.hlsl
+++ b/tests/out/hlsl/image.hlsl
@@ -208,8 +208,8 @@ float4 sample1() : SV_Target0
 
 float sample_comparison() : SV_Target0
 {
-    float2 tc = float2(0.5.xx);
-    float s2d_depth = image_2d_depth.SampleCmp(sampler_cmp, tc, 0.5);
-    float s2d_depth_level = image_2d_depth.SampleCmpLevelZero(sampler_cmp, tc, 0.5);
+    float2 tc1 = float2(0.5.xx);
+    float s2d_depth = image_2d_depth.SampleCmp(sampler_cmp, tc1, 0.5);
+    float s2d_depth_level = image_2d_depth.SampleCmpLevelZero(sampler_cmp, tc1, 0.5);
     return (s2d_depth + s2d_depth_level);
 }

--- a/tests/out/hlsl/interface.hlsl
+++ b/tests/out/hlsl/interface.hlsl
@@ -24,8 +24,8 @@ struct VertexOutput_vertex {
 };
 
 struct FragmentInput_fragment {
-    float varying : LOC1;
-    float4 position : SV_Position;
+    float varying1 : LOC1;
+    float4 position1 : SV_Position;
     bool front_facing1 : SV_IsFrontFace;
     uint sample_index1 : SV_SampleIndex;
     uint sample_mask1 : SV_Coverage;
@@ -56,7 +56,7 @@ FragmentOutput ConstructFragmentOutput(float arg0, uint arg1, float arg2) {
 
 FragmentOutput fragment(FragmentInput_fragment fragmentinput_fragment)
 {
-    VertexOutput in1 = { fragmentinput_fragment.position, fragmentinput_fragment.varying };
+    VertexOutput in1 = { fragmentinput_fragment.position1, fragmentinput_fragment.varying1 };
     bool front_facing = fragmentinput_fragment.front_facing1;
     uint sample_index = fragmentinput_fragment.sample_index1;
     uint sample_mask = fragmentinput_fragment.sample_mask1;

--- a/tests/out/hlsl/interpolate.hlsl
+++ b/tests/out/hlsl/interpolate.hlsl
@@ -22,14 +22,14 @@ struct VertexOutput_main {
 };
 
 struct FragmentInput_main {
-    uint flat : LOC0;
+    uint flat1 : LOC0;
     float linear2 : LOC1;
-    float2 linear_centroid : LOC2;
-    float3 linear_sample : LOC3;
-    float4 perspective : LOC4;
-    float perspective_centroid : LOC5;
-    float perspective_sample : LOC6;
-    float4 position : SV_Position;
+    float2 linear_centroid1 : LOC2;
+    float3 linear_sample1 : LOC3;
+    float4 perspective1 : LOC4;
+    float perspective_centroid1 : LOC5;
+    float perspective_sample1 : LOC6;
+    float4 position1 : SV_Position;
 };
 
 VertexOutput_main main()
@@ -52,6 +52,6 @@ VertexOutput_main main()
 
 void main1(FragmentInput_main fragmentinput_main)
 {
-    FragmentInput val = { fragmentinput_main.position, fragmentinput_main.flat, fragmentinput_main.linear2, fragmentinput_main.linear_centroid, fragmentinput_main.linear_sample, fragmentinput_main.perspective, fragmentinput_main.perspective_centroid, fragmentinput_main.perspective_sample };
+    FragmentInput val = { fragmentinput_main.position1, fragmentinput_main.flat1, fragmentinput_main.linear2, fragmentinput_main.linear_centroid1, fragmentinput_main.linear_sample1, fragmentinput_main.perspective1, fragmentinput_main.perspective_centroid1, fragmentinput_main.perspective_sample1 };
     return;
 }

--- a/tests/out/hlsl/skybox.hlsl
+++ b/tests/out/hlsl/skybox.hlsl
@@ -25,8 +25,8 @@ struct VertexOutput_vs_main {
 };
 
 struct FragmentInput_fs_main {
-    float3 uv : LOC0;
-    float4 position : SV_Position;
+    float3 uv1 : LOC0;
+    float4 position1 : SV_Position;
 };
 
 VertexOutput ConstructVertexOutput(float4 arg0, float3 arg1) {
@@ -59,7 +59,7 @@ VertexOutput_vs_main vs_main(uint vertex_index : SV_VertexID)
 
 float4 fs_main(FragmentInput_fs_main fragmentinput_fs_main) : SV_Target0
 {
-    VertexOutput in1 = { fragmentinput_fs_main.position, fragmentinput_fs_main.uv };
+    VertexOutput in1 = { fragmentinput_fs_main.position1, fragmentinput_fs_main.uv1 };
     float4 _expr5 = r_texture.Sample(r_sampler, in1.uv);
     return _expr5;
 }

--- a/tests/out/msl/access.msl
+++ b/tests/out/msl/access.msl
@@ -62,7 +62,7 @@ kernel void atomics(
 , constant _mslBufferSizes& _buffer_sizes [[buffer(24)]]
 ) {
     int tmp;
-    int value = metal::atomic_load_explicit(&bar.atom, metal::memory_order_relaxed);
+    int value1 = metal::atomic_load_explicit(&bar.atom, metal::memory_order_relaxed);
     int _e6 = metal::atomic_fetch_add_explicit(&bar.atom, 5, metal::memory_order_relaxed);
     tmp = _e6;
     int _e9 = metal::atomic_fetch_sub_explicit(&bar.atom, 5, metal::memory_order_relaxed);
@@ -79,6 +79,6 @@ kernel void atomics(
     tmp = _e24;
     int _e27 = metal::atomic_exchange_explicit(&bar.atom, 5, metal::memory_order_relaxed);
     tmp = _e27;
-    metal::atomic_store_explicit(&bar.atom, value, metal::memory_order_relaxed);
+    metal::atomic_store_explicit(&bar.atom, value1, metal::memory_order_relaxed);
     return;
 }

--- a/tests/out/msl/image.msl
+++ b/tests/out/msl/image.msl
@@ -86,8 +86,8 @@ fragment sample_comparisonOutput sample_comparison(
   metal::sampler sampler_cmp [[user(fake0)]]
 , metal::depth2d<float, metal::access::sample> image_2d_depth [[user(fake0)]]
 ) {
-    metal::float2 tc = metal::float2(0.5);
-    float s2d_depth = image_2d_depth.sample_compare(sampler_cmp, tc, 0.5);
-    float s2d_depth_level = image_2d_depth.sample_compare(sampler_cmp, tc, 0.5);
+    metal::float2 tc1 = metal::float2(0.5);
+    float s2d_depth = image_2d_depth.sample_compare(sampler_cmp, tc1, 0.5);
+    float s2d_depth_level = image_2d_depth.sample_compare(sampler_cmp, tc1, 0.5);
     return sample_comparisonOutput { s2d_depth + s2d_depth_level };
 }

--- a/tests/out/wgsl/access.wgsl
+++ b/tests/out/wgsl/access.wgsl
@@ -40,7 +40,7 @@ fn foo([[builtin(vertex_index)]] vi: u32) -> [[builtin(position)]] vec4<f32> {
 fn atomics() {
     var tmp: i32;
 
-    let value: i32 = atomicLoad((&bar.atom));
+    let value1: i32 = atomicLoad((&bar.atom));
     let e6: i32 = atomicAdd((&bar.atom), 5);
     tmp = e6;
     let e9: i32 = atomicSub((&bar.atom), 5);
@@ -57,6 +57,6 @@ fn atomics() {
     tmp = e24;
     let e27: i32 = atomicExchange((&bar.atom), 5);
     tmp = e27;
-    atomicStore((&bar.atom), value);
+    atomicStore((&bar.atom), value1);
     return;
 }

--- a/tests/out/wgsl/image.wgsl
+++ b/tests/out/wgsl/image.wgsl
@@ -83,8 +83,8 @@ fn sample() -> [[location(0)]] vec4<f32> {
 
 [[stage(fragment)]]
 fn sample_comparison() -> [[location(0)]] f32 {
-    let tc: vec2<f32> = vec2<f32>(0.5);
-    let s2d_depth: f32 = textureSampleCompare(image_2d_depth, sampler_cmp, tc, 0.5);
-    let s2d_depth_level: f32 = textureSampleCompareLevel(image_2d_depth, sampler_cmp, tc, 0.5);
+    let tc1: vec2<f32> = vec2<f32>(0.5);
+    let s2d_depth: f32 = textureSampleCompare(image_2d_depth, sampler_cmp, tc1, 0.5);
+    let s2d_depth_level: f32 = textureSampleCompareLevel(image_2d_depth, sampler_cmp, tc1, 0.5);
     return (s2d_depth + s2d_depth_level);
 }


### PR DESCRIPTION
Replace uses of `call_unique` with uses of `call` and `call_or`, which becomes public. It's not clear when `call_unique` is correct to use, and avoiding a few numeric suffixes here and there isn't worth it.