### PR TITLE
Properly type-check `Expression::Select` arguments.

### DIFF
--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -795,7 +795,14 @@ impl super::Validator {
                     Ti::Scalar {
                         kind: Sk::Bool,
                         width: _,
-                    } => accept_inner.is_sized(),
+                    } => {
+                        // When `condition` is a single boolean, `accept` and
+                        // `reject` can be vectors or scalars.
+                        match *accept_inner {
+                            Ti::Scalar { .. } | Ti::Vector { .. } => true,
+                            _ => false,
+                        }
+                    }
                     Ti::Vector {
                         size,
                         kind: Sk::Bool,


### PR DESCRIPTION
Require the `accept` and `reject` arguments to `select` to be scalars or vectors, per WGSL spec.