### PR TITLE
Forbid unsized structs as final members of structs.

### DIFF
--- a/src/valid/type.rs
+++ b/src/valid/type.rs
@@ -473,9 +473,13 @@ impl super::Validator {
                         handle,
                     );
 
-                    // only the last field can be unsized
+                    // The last field may be an unsized array.
                     if !base_info.flags.contains(TypeFlags::SIZED) {
-                        if i + 1 != members.len() {
+                        let is_array = match types[member.ty].inner {
+                            crate::TypeInner::Array { .. } => true,
+                            _ => false,
+                        };
+                        if !is_array || i + 1 != members.len() {
                             let name = member.name.clone().unwrap_or_default();
                             return Err(TypeError::InvalidDynamicArray(name, member.ty));
                         }


### PR DESCRIPTION
WGSL says:

> - The last member of the structure type defining the store type for a variable ... may be a runtime-sized array.
>
> - A runtime-sized array must not be used as the store type or contained within a store type in any other cases.

Thus, a struct whose final member is a struct whose final member is a runtime-sized array is verboten.