### PR TITLE
[wgsl-in] Always flush expressions in function call

### DIFF
--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -6,6 +6,7 @@ on:
     - 'tests/out/glsl/*.glsl'
     - 'tests/out/dot/*.dot'
     - 'tests/out/wgsl/*.wgsl'
+    - 'src/front/wgsl/*'
 
 jobs:
   validate-linux:

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1891,12 +1891,12 @@ impl Parser {
                         match self.parse_local_function_call(lexer, name, ctx.reborrow())? {
                             Some((function, arguments)) => {
                                 let span = NagaSpan::from(self.peek_scope(lexer));
+                                ctx.block.extend(ctx.emitter.finish(ctx.expressions));
                                 let result = ctx.functions[function].result.as_ref().map(|_| {
-                                    ctx.interrupt_emitter(
-                                        crate::Expression::CallResult(function),
-                                        span,
-                                    )
+                                    ctx.expressions
+                                        .append(crate::Expression::CallResult(function), span)
                                 });
+                                ctx.emitter.start(ctx.expressions);
                                 ctx.block.push(
                                     crate::Statement::Call {
                                         function,


### PR DESCRIPTION
In my last PR (#1476) a error made it in without being noticed, the expressions weren't being flushed if the function didn't return a value.

This PR fixes it and also makes sure to run the validation in case the frontend changes.