### PR TITLE
Make use of `AddSpan` and `MapErrWithSpan` conditional.

### DIFF
--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -6,7 +6,9 @@ use super::{
     analyzer::{UniformityDisruptor, UniformityRequirements},
     ExpressionError, FunctionInfo, ModuleInfo,
 };
-use crate::span::{AddSpan as _, MapErrWithSpan as _, WithSpan};
+use crate::span::WithSpan;
+#[cfg(feature = "span")]
+use crate::span::{AddSpan as _, MapErrWithSpan as _};
 
 #[cfg(feature = "validate")]
 use bit_set::BitSet;


### PR DESCRIPTION
This avoids warnings in default-feature builds, like `cargo test -p naga`.