### PR TITLE
[WGSL] Only single bracket for attributes

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1307,7 +1307,7 @@ impl<W: Write> Writer<W> {
                             let name = &self.names[&NameKey::StructMember(result_ty, index as u32)];
                             // HACK: we are forcefully deduplicating the expression here
                             // to convert from a wrapped struct to a raw array, e.g.
-                            // `float gl_ClipDistance1 [clip_distance] [1];`.
+                            // `float gl_ClipDistance1 [[clip_distance]] [1];`.
                             if let crate::TypeInner::Array {
                                 size: crate::ArraySize::Constant(const_handle),
                                 ..

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1307,7 +1307,7 @@ impl<W: Write> Writer<W> {
                             let name = &self.names[&NameKey::StructMember(result_ty, index as u32)];
                             // HACK: we are forcefully deduplicating the expression here
                             // to convert from a wrapped struct to a raw array, e.g.
-                            // `float gl_ClipDistance1 [[clip_distance]] [1];`.
+                            // `float gl_ClipDistance1 [clip_distance] [1];`.
                             if let crate::TypeInner::Array {
                                 size: crate::ArraySize::Constant(const_handle),
                                 ..

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -321,7 +321,7 @@ impl<W: Write> Writer<W> {
     /// # Notes
     /// Adds an extra space if required
     fn write_attributes(&mut self, attributes: &[Attribute], extra_space: bool) -> BackendResult {
-        write!(self.out, "[[")?;
+        write!(self.out, "[")?;
 
         let mut need_last_comma = true;
         if let Some(last_attrib) = attributes.last() {
@@ -400,7 +400,7 @@ impl<W: Write> Writer<W> {
             }
         }
 
-        write!(self.out, "]]")?;
+        write!(self.out, "]")?;
         if extra_space {
             write!(self.out, " ")?;
         }

--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -329,11 +329,7 @@ fn consume_token(mut input: &str, generic: bool) -> (Token<'_>, &str) {
         }
         '[' | ']' => {
             input = chars.as_str();
-            if chars.next() == Some(cur) {
-                (Token::DoubleParen(cur), chars.as_str())
-            } else {
-                (Token::Paren(cur), input)
-            }
+            (Token::Paren(cur), input)
         }
         '0'..='9' => consume_number(input),
         'a'..='z' | 'A'..='Z' => {
@@ -662,9 +658,9 @@ fn test_tokens() {
 #[test]
 fn test_variable_decl() {
     sub_test(
-        "[[ group(0 )]] var< uniform> texture:   texture_multisampled_2d <f32 >;",
+        "[ group(0 )] var< uniform> texture:   texture_multisampled_2d <f32 >;",
         &[
-            Token::DoubleParen('['),
+            Token::Paren('['),
             Token::Word("group"),
             Token::Paren('('),
             Token::Number {
@@ -673,7 +669,7 @@ fn test_variable_decl() {
                 width: None,
             },
             Token::Paren(')'),
-            Token::DoubleParen(']'),
+            Token::Paren(']'),
             Token::Word("var"),
             Token::Paren('<'),
             Token::Word("uniform"),

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -57,7 +57,6 @@ pub enum Token<'a> {
     Separator(char),
     DoubleColon,
     Paren(char),
-    DoubleParen(char),
     Number {
         value: &'a str,
         ty: NumberType,
@@ -182,7 +181,6 @@ impl<'a> Error<'a> {
                                 Token::Separator(c) => format!("'{}'", c),
                                 Token::DoubleColon => "'::'".to_string(),
                                 Token::Paren(c) => format!("'{}'", c),
-                                Token::DoubleParen(c) => format!("'{}{}'", c, c),
                                 Token::Number { value, .. } => {
                                     format!("number ({})", value)
                                 }
@@ -2668,11 +2666,11 @@ impl Parser {
             let (mut size, mut align) = (None, None);
             self.push_scope(Scope::Attribute, lexer);
             let mut bind_parser = BindingParser::default();
-            if lexer.skip(Token::DoubleParen('[')) {
+            if lexer.skip(Token::Paren('[')) {
                 let mut ready = true;
                 loop {
                     match lexer.next() {
-                        (Token::DoubleParen(']'), _) => {
+                        (Token::Paren(']'), _) => {
                             break;
                         }
                         (Token::Separator(','), _) if !ready => {
@@ -3106,7 +3104,7 @@ impl Parser {
         self.push_scope(Scope::TypeDecl, lexer);
         let mut attribute = TypeAttributes::default();
 
-        if lexer.skip(Token::DoubleParen('[')) {
+        if lexer.skip(Token::Paren('[')) {
             self.push_scope(Scope::Attribute, lexer);
             loop {
                 match lexer.next() {
@@ -3118,7 +3116,7 @@ impl Parser {
                             Some(NonZeroU32::new(stride).ok_or(Error::ZeroStride(span))?);
                         lexer.expect(Token::Paren(')'))?;
                     }
-                    (Token::DoubleParen(']'), _) => break,
+                    (Token::Paren(']'), _) => break,
                     other => return Err(Error::Unexpected(other, ExpectedToken::TypeAttribute)),
                 }
             }
@@ -3795,7 +3793,7 @@ impl Parser {
     ) -> Result<Option<crate::Binding>, Error<'a>> {
         self.push_scope(Scope::Attribute, lexer);
 
-        if !lexer.skip(Token::DoubleParen('[')) {
+        if !lexer.skip(Token::Paren('[')) {
             self.pop_scope(lexer);
             return Ok(None);
         }
@@ -3805,7 +3803,7 @@ impl Parser {
             let (word, span) = lexer.next_ident_with_span()?;
             bind_parser.parse(lexer, word, span)?;
             match lexer.next() {
-                (Token::DoubleParen(']'), _) => {
+                (Token::Paren(']'), _) => {
                     break;
                 }
                 (Token::Separator(','), _) => {}
@@ -3950,7 +3948,7 @@ impl Parser {
         let mut workgroup_size = [0u32; 3];
         let mut early_depth_test = None;
 
-        if lexer.skip(Token::DoubleParen('[')) {
+        if lexer.skip(Token::Paren('[')) {
             let (mut bind_index, mut bind_group) = (None, None);
             self.push_scope(Scope::Attribute, lexer);
             loop {
@@ -4009,7 +4007,7 @@ impl Parser {
                     (_, word_span) => return Err(Error::UnknownAttribute(word_span)),
                 }
                 match lexer.next() {
-                    (Token::DoubleParen(']'), _) => {
+                    (Token::Paren(']'), _) => {
                         break;
                     }
                     (Token::Separator(','), _) => {}

--- a/src/front/wgsl/tests.rs
+++ b/src/front/wgsl/tests.rs
@@ -157,11 +157,11 @@ fn parse_type_cast() {
 fn parse_struct() {
     parse_str(
         "
-        [[block]] struct Foo { x: i32; };
+        [block] struct Foo { x: i32; };
         struct Bar {
-            [[size(16)]] x: vec2<i32>;
-            [[align(16)]] y: f32;
-            [[size(32), align(8)]] z: vec3<f32>;
+            [size(16)] x: vec2<i32>;
+            [align(16)] y: f32;
+            [size(32), align(8)] z: vec3<f32>;
         };
         struct Empty {};
         var<storage,read_write> s: Foo;
@@ -384,7 +384,7 @@ fn parse_struct_instantiation() {
         b: vec3<f32>;
     };
     
-    [[stage(fragment)]]
+    [stage(fragment)]
     fn fs_main() {
         var foo: Foo = Foo(0.0, vec3<f32>(0.0, 1.0, 42.0));
     }
@@ -397,15 +397,15 @@ fn parse_struct_instantiation() {
 fn parse_array_length() {
     parse_str(
         "
-        [[block]]
+        [block]
         struct Foo {
-            data: [[stride(4)]] array<u32>;
+            data: [stride(4)] array<u32>;
         }; // this is used as both input and output for convenience
 
-        [[group(0), binding(0)]]
+        [group(0), binding(0)]
         var<storage> foo: Foo;
 
-        [[group(0), binding(1)]]
+        [group(0), binding(1)]
         var<storage> bar: array<u32>;
 
         fn foo() {
@@ -421,28 +421,28 @@ fn parse_array_length() {
 fn parse_storage_buffers() {
     parse_str(
         "
-        [[group(0), binding(0)]]
+        [group(0), binding(0)]
         var<storage> foo: array<u32>;
         ",
     )
     .unwrap();
     parse_str(
         "
-        [[group(0), binding(0)]]
+        [group(0), binding(0)]
         var<storage,read> foo: array<u32>;
         ",
     )
     .unwrap();
     parse_str(
         "
-        [[group(0), binding(0)]]
+        [group(0), binding(0)]
         var<storage,write> foo: array<u32>;
         ",
     )
     .unwrap();
     parse_str(
         "
-        [[group(0), binding(0)]]
+        [group(0), binding(0)]
         var<storage,read_write> foo: array<u32>;
         ",
     )

--- a/tests/in/access.wgsl
+++ b/tests/in/access.wgsl
@@ -1,22 +1,22 @@
 // This snapshot tests accessing various containers, dereferencing pointers.
 
-[[block]]
+[block]
 struct Bar {
 	matrix: mat4x4<f32>;
 	atom: atomic<i32>;
-	arr: [[stride(8)]] array<vec2<u32>, 2>;
-	data: [[stride(8)]] array<i32>;
+	arr: [stride(8)] array<vec2<u32>, 2>;
+	data: [stride(8)] array<i32>;
 };
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var<storage,read_write> bar: Bar;
 
 fn read_from_private(foo: ptr<function, f32>) -> f32 {
     return *foo;
 }
 
-[[stage(vertex)]]
-fn foo([[builtin(vertex_index)]] vi: u32) -> [[builtin(position)]] vec4<f32> {
+[stage(vertex)]
+fn foo([builtin(vertex_index)] vi: u32) -> [builtin(position)] vec4<f32> {
     var foo: f32 = 0.0;
     // We should check that backed doesn't skip this expression
     let baz: f32 = foo;
@@ -47,7 +47,7 @@ fn foo([[builtin(vertex_index)]] vi: u32) -> [[builtin(position)]] vec4<f32> {
 	return matrix * vec4<f32>(vec4<i32>(value));
 }
 
-[[stage(compute), workgroup_size(1)]]
+[stage(compute), workgroup_size(1)]
 fn atomics() {
 	var tmp: i32;
 	let value = atomicLoad(&bar.atom);

--- a/tests/in/bits.wgsl
+++ b/tests/in/bits.wgsl
@@ -1,4 +1,4 @@
-[[stage(compute), workgroup_size(1)]]
+[stage(compute), workgroup_size(1)]
 fn main() {
     var i = 0;
     var i2 = vec2<i32>(0);

--- a/tests/in/boids.wgsl
+++ b/tests/in/boids.wgsl
@@ -5,7 +5,7 @@ struct Particle {
   vel : vec2<f32>;
 };
 
-[[block]]
+[block]
 struct SimParams {
   deltaT : f32;
   rule1Distance : f32;
@@ -16,18 +16,18 @@ struct SimParams {
   rule3Scale : f32;
 };
 
-[[block]]
+[block]
 struct Particles {
-  particles : [[stride(16)]] array<Particle>;
+  particles : [stride(16)] array<Particle>;
 };
 
-[[group(0), binding(0)]] var<uniform> params : SimParams;
-[[group(0), binding(1)]] var<storage> particlesSrc : Particles;
-[[group(0), binding(2)]] var<storage,read_write> particlesDst : Particles;
+[group(0), binding(0)] var<uniform> params : SimParams;
+[group(0), binding(1)] var<storage> particlesSrc : Particles;
+[group(0), binding(2)] var<storage,read_write> particlesDst : Particles;
 
 // https://github.com/austinEng/Project6-Vulkan-Flocking/blob/master/data/shaders/computeparticles/particle.comp
-[[stage(compute), workgroup_size(64)]]
-fn main([[builtin(global_invocation_id)]] global_invocation_id : vec3<u32>) {
+[stage(compute), workgroup_size(64)]
+fn main([builtin(global_invocation_id)] global_invocation_id : vec3<u32>) {
   let index : u32 = global_invocation_id.x;
   if (index >= NUM_PARTICLES) {
     return;

--- a/tests/in/bounds-check-image-restrict.wgsl
+++ b/tests/in/bounds-check-image-restrict.wgsl
@@ -1,81 +1,81 @@
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_1d: texture_1d<f32>;
 
 fn test_textureLoad_1d(coords: i32, level: i32) -> vec4<f32> {
    return textureLoad(image_1d, coords, level);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_2d: texture_2d<f32>;
 
 fn test_textureLoad_2d(coords: vec2<i32>, level: i32) -> vec4<f32> {
    return textureLoad(image_2d, coords, level);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_2d_array: texture_2d_array<f32>;
 
 fn test_textureLoad_2d_array(coords: vec2<i32>, index: i32, level: i32) -> vec4<f32> {
    return textureLoad(image_2d_array, coords, index, level);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_3d: texture_3d<f32>;
 
 fn test_textureLoad_3d(coords: vec3<i32>, level: i32) -> vec4<f32> {
    return textureLoad(image_3d, coords, level);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_multisampled_2d: texture_multisampled_2d<f32>;
 
 fn test_textureLoad_multisampled_2d(coords: vec2<i32>, sample: i32) -> vec4<f32> {
    return textureLoad(image_multisampled_2d, coords, sample);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_depth_2d: texture_depth_2d;
 
 fn test_textureLoad_depth_2d(coords: vec2<i32>, level: i32) -> f32 {
    return textureLoad(image_depth_2d, coords, level);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_depth_2d_array: texture_depth_2d_array;
 
 fn test_textureLoad_depth_2d_array(coords: vec2<i32>, index: i32, level: i32) -> f32 {
    return textureLoad(image_depth_2d_array, coords, index, level);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_depth_multisampled_2d: texture_depth_multisampled_2d;
 
 fn test_textureLoad_depth_multisampled_2d(coords: vec2<i32>, sample: i32) -> f32 {
    return textureLoad(image_depth_multisampled_2d, coords, sample);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_storage_1d: texture_storage_1d<rgba8unorm, write>;
 
 fn test_textureStore_1d(coords: i32, value: vec4<f32>) {
     textureStore(image_storage_1d, coords, value);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_storage_2d: texture_storage_2d<rgba8unorm, write>;
 
 fn test_textureStore_2d(coords: vec2<i32>, value: vec4<f32>) {
     textureStore(image_storage_2d, coords, value);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_storage_2d_array: texture_storage_2d_array<rgba8unorm, write>;
 
 fn test_textureStore_2d_array(coords: vec2<i32>, array_index: i32, value: vec4<f32>) {
  textureStore(image_storage_2d_array, coords, array_index, value);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_storage_3d: texture_storage_3d<rgba8unorm, write>;
 
 fn test_textureStore_3d(coords: vec3<i32>, value: vec4<f32>) {

--- a/tests/in/bounds-check-image-rzsw.wgsl
+++ b/tests/in/bounds-check-image-rzsw.wgsl
@@ -1,81 +1,81 @@
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_1d: texture_1d<f32>;
 
 fn test_textureLoad_1d(coords: i32, level: i32) -> vec4<f32> {
    return textureLoad(image_1d, coords, level);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_2d: texture_2d<f32>;
 
 fn test_textureLoad_2d(coords: vec2<i32>, level: i32) -> vec4<f32> {
    return textureLoad(image_2d, coords, level);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_2d_array: texture_2d_array<f32>;
 
 fn test_textureLoad_2d_array(coords: vec2<i32>, index: i32, level: i32) -> vec4<f32> {
    return textureLoad(image_2d_array, coords, index, level);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_3d: texture_3d<f32>;
 
 fn test_textureLoad_3d(coords: vec3<i32>, level: i32) -> vec4<f32> {
    return textureLoad(image_3d, coords, level);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_multisampled_2d: texture_multisampled_2d<f32>;
 
 fn test_textureLoad_multisampled_2d(coords: vec2<i32>, sample: i32) -> vec4<f32> {
    return textureLoad(image_multisampled_2d, coords, sample);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_depth_2d: texture_depth_2d;
 
 fn test_textureLoad_depth_2d(coords: vec2<i32>, level: i32) -> f32 {
    return textureLoad(image_depth_2d, coords, level);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_depth_2d_array: texture_depth_2d_array;
 
 fn test_textureLoad_depth_2d_array(coords: vec2<i32>, index: i32, level: i32) -> f32 {
    return textureLoad(image_depth_2d_array, coords, index, level);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_depth_multisampled_2d: texture_depth_multisampled_2d;
 
 fn test_textureLoad_depth_multisampled_2d(coords: vec2<i32>, sample: i32) -> f32 {
    return textureLoad(image_depth_multisampled_2d, coords, sample);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_storage_1d: texture_storage_1d<rgba8unorm, write>;
 
 fn test_textureStore_1d(coords: i32, value: vec4<f32>) {
     textureStore(image_storage_1d, coords, value);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_storage_2d: texture_storage_2d<rgba8unorm, write>;
 
 fn test_textureStore_2d(coords: vec2<i32>, value: vec4<f32>) {
     textureStore(image_storage_2d, coords, value);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_storage_2d_array: texture_storage_2d_array<rgba8unorm, write>;
 
 fn test_textureStore_2d_array(coords: vec2<i32>, array_index: i32, value: vec4<f32>) {
  textureStore(image_storage_2d_array, coords, array_index, value);
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_storage_3d: texture_storage_3d<rgba8unorm, write>;
 
 fn test_textureStore_3d(coords: vec3<i32>, value: vec4<f32>) {

--- a/tests/in/bounds-check-zero.wgsl
+++ b/tests/in/bounds-check-zero.wgsl
@@ -1,13 +1,13 @@
 // Tests for `naga::back::BoundsCheckPolicy::ReadZeroSkipWrite`.
 
-[[block]]
+[block]
 struct Globals {
     a: array<f32, 10>;
     v: vec4<f32>;
     m: mat3x4<f32>;
 };
 
-[[group(0), binding(0)]] var<storage> globals: Globals;
+[group(0), binding(0)] var<storage> globals: Globals;
 
 fn index_array(i: i32) -> f32 {
    return globals.a[i];

--- a/tests/in/collatz.wgsl
+++ b/tests/in/collatz.wgsl
@@ -1,9 +1,9 @@
-[[block]]
+[block]
 struct PrimeIndices {
-    data: [[stride(4)]] array<u32>;
+    data: [stride(4)] array<u32>;
 }; // this is used as both input and output for convenience
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var<storage,read_write> v_indices: PrimeIndices;
 
 // The Collatz Conjecture states that for any integer n:
@@ -30,7 +30,7 @@ fn collatz_iterations(n_base: u32) -> u32 {
     return i;
 }
 
-[[stage(compute), workgroup_size(1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+[stage(compute), workgroup_size(1)]
+fn main([builtin(global_invocation_id)] global_id: vec3<u32>) {
     v_indices.data[global_id.x] = collatz_iterations(v_indices.data[global_id.x]);
 }

--- a/tests/in/control-flow.wgsl
+++ b/tests/in/control-flow.wgsl
@@ -1,5 +1,5 @@
-[[stage(compute), workgroup_size(1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+[stage(compute), workgroup_size(1)]
+fn main([builtin(global_invocation_id)] global_id: vec3<u32>) {
     //TODO: execution-only barrier?
     storageBarrier();
     workgroupBarrier();

--- a/tests/in/cubeArrayShadow.wgsl
+++ b/tests/in/cubeArrayShadow.wgsl
@@ -1,10 +1,10 @@
-[[group(0), binding(4)]]
+[group(0), binding(4)]
 var point_shadow_textures: texture_depth_cube_array;
-[[group(0), binding(5)]]
+[group(0), binding(5)]
 var point_shadow_textures_sampler: sampler_comparison;
 
-[[stage(fragment)]]
-fn fragment() -> [[location(0)]] vec4<f32> {
+[stage(fragment)]
+fn fragment() -> [location(0)] vec4<f32> {
     let frag_ls = vec4<f32>(1., 1., 2., 1.).xyz;
     let a = textureSampleCompare(point_shadow_textures, point_shadow_textures_sampler, frag_ls, i32(1), 1.);
 

--- a/tests/in/empty.wgsl
+++ b/tests/in/empty.wgsl
@@ -1,2 +1,2 @@
-[[stage(compute), workgroup_size(1)]]
+[stage(compute), workgroup_size(1)]
 fn main() {}

--- a/tests/in/extra.wgsl
+++ b/tests/in/extra.wgsl
@@ -1,4 +1,4 @@
-[[block]]
+[block]
 struct PushConstants {
     index: u32;
     double: vec2<f64>;
@@ -6,12 +6,12 @@ struct PushConstants {
 var<push_constant> pc: PushConstants;
 
 struct FragmentIn {
-    [[location(0)]] color: vec4<f32>;
-    [[builtin(primitive_index)]] primitive_index: u32;
+    [location(0)] color: vec4<f32>;
+    [builtin(primitive_index)] primitive_index: u32;
 };
 
-[[stage(fragment)]]
-fn main(in: FragmentIn) -> [[location(0)]] vec4<f32> {
+[stage(fragment)]
+fn main(in: FragmentIn) -> [location(0)] vec4<f32> {
     if (in.primitive_index % 2u == 0u) {
         return in.color;
     } else {

--- a/tests/in/globals.wgsl
+++ b/tests/in/globals.wgsl
@@ -5,7 +5,7 @@ let Foo: bool = true;
 var<workgroup> wg : array<f32, 10u>;
 var<workgroup> at: atomic<u32>;
 
-[[stage(compute), workgroup_size(1)]]
+[stage(compute), workgroup_size(1)]
 fn main() {
 	wg[3] = 1.0;
 	atomicStore(&at, 2u);

--- a/tests/in/image.wgsl
+++ b/tests/in/image.wgsl
@@ -1,23 +1,23 @@
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_mipmapped_src: texture_2d<u32>;
-[[group(0), binding(3)]]
+[group(0), binding(3)]
 var image_multisampled_src: texture_multisampled_2d<u32>;
-[[group(0), binding(4)]]
+[group(0), binding(4)]
 var image_depth_multisampled_src: texture_depth_multisampled_2d;
-[[group(0), binding(1)]]
+[group(0), binding(1)]
 var image_storage_src: texture_storage_2d<rgba8uint, read>;
-[[group(0), binding(5)]]
+[group(0), binding(5)]
 var image_array_src: texture_2d_array<u32>;
-[[group(0), binding(6)]]
+[group(0), binding(6)]
 var image_dup_src: texture_storage_1d<r32uint,read>; // for #1307
-[[group(0), binding(2)]]
+[group(0), binding(2)]
 var image_dst: texture_storage_1d<r32uint,write>;
 
-[[stage(compute), workgroup_size(16)]]
+[stage(compute), workgroup_size(16)]
 fn main(
-    [[builtin(local_invocation_id)]] local_id: vec3<u32>,
+    [builtin(local_invocation_id)] local_id: vec3<u32>,
     //TODO: https://github.com/gpuweb/gpuweb/issues/1590
-    //[[builtin(workgroup_size)]] wg_size: vec3<u32>
+    //[builtin(workgroup_size)] wg_size: vec3<u32>
 ) {
     let dim = textureDimensions(image_storage_src);
     let itc = dim * vec2<i32>(local_id.xy) % vec2<i32>(10, 20);
@@ -28,8 +28,8 @@ fn main(
     textureStore(image_dst, itc.x, value1 + value2 + value4 + value5);
 }
 
-[[stage(compute), workgroup_size(16, 1, 1)]]
-fn depth_load([[builtin(local_invocation_id)]] local_id: vec3<u32>) {
+[stage(compute), workgroup_size(16, 1, 1)]
+fn depth_load([builtin(local_invocation_id)] local_id: vec3<u32>) {
     let dim: vec2<i32> = textureDimensions(image_storage_src);
     let itc: vec2<i32> = ((dim * vec2<i32>(local_id.xy)) % vec2<i32>(10, 20));
     let val: f32 = textureLoad(image_depth_multisampled_src, itc, i32(local_id.z));
@@ -37,23 +37,23 @@ fn depth_load([[builtin(local_invocation_id)]] local_id: vec3<u32>) {
     return;
 }
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_1d: texture_1d<f32>;
-[[group(0), binding(1)]]
+[group(0), binding(1)]
 var image_2d: texture_2d<f32>;
-[[group(0), binding(2)]]
+[group(0), binding(2)]
 var image_2d_array: texture_2d_array<f32>;
-[[group(0), binding(3)]]
+[group(0), binding(3)]
 var image_cube: texture_cube<f32>;
-[[group(0), binding(4)]]
+[group(0), binding(4)]
 var image_cube_array: texture_cube_array<f32>;
-[[group(0), binding(5)]]
+[group(0), binding(5)]
 var image_3d: texture_3d<f32>;
-[[group(0), binding(6)]]
+[group(0), binding(6)]
 var image_aa: texture_multisampled_2d<f32>;
 
-[[stage(vertex)]]
-fn queries() -> [[builtin(position)]] vec4<f32> {
+[stage(vertex)]
+fn queries() -> [builtin(position)] vec4<f32> {
     let dim_1d = textureDimensions(image_1d);
     let dim_2d = textureDimensions(image_2d);
     let dim_2d_lod = textureDimensions(image_2d, 1);
@@ -72,8 +72,8 @@ fn queries() -> [[builtin(position)]] vec4<f32> {
     return vec4<f32>(f32(sum));
 }
 
-[[stage(vertex)]]
-fn levels_queries() -> [[builtin(position)]] vec4<f32> {
+[stage(vertex)]
+fn levels_queries() -> [builtin(position)] vec4<f32> {
     let num_levels_2d = textureNumLevels(image_2d);
     let num_levels_2d_array = textureNumLevels(image_2d_array);
     let num_layers_2d = textureNumLayers(image_2d_array);
@@ -88,11 +88,11 @@ fn levels_queries() -> [[builtin(position)]] vec4<f32> {
     return vec4<f32>(f32(sum));
 }
 
-[[group(1), binding(0)]]
+[group(1), binding(0)]
 var sampler_reg: sampler;
 
-[[stage(fragment)]]
-fn sample() -> [[location(0)]] vec4<f32> {
+[stage(fragment)]
+fn sample() -> [location(0)] vec4<f32> {
     let tc = vec2<f32>(0.5);
     let level = 2.3;
     let s1d = textureSample(image_1d, sampler_reg, tc.x);
@@ -103,13 +103,13 @@ fn sample() -> [[location(0)]] vec4<f32> {
     return s1d + s2d + s2d_offset + s2d_level + s2d_level_offset;
 }
 
-[[group(1), binding(1)]]
+[group(1), binding(1)]
 var sampler_cmp: sampler_comparison;
-[[group(1), binding(2)]]
+[group(1), binding(2)]
 var image_2d_depth: texture_depth_2d;
 
-[[stage(fragment)]]
-fn sample_comparison() -> [[location(0)]] f32 {
+[stage(fragment)]
+fn sample_comparison() -> [location(0)] f32 {
     let tc = vec2<f32>(0.5);
     let dref = 0.5;
     let s2d_depth = textureSampleCompare(image_2d_depth, sampler_cmp, tc, dref);

--- a/tests/in/interface.wgsl
+++ b/tests/in/interface.wgsl
@@ -1,32 +1,32 @@
 // Testing various parts of the pipeline interface: locations, built-ins, and entry points
 
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(1)]] varying: f32;
+    [builtin(position)] position: vec4<f32>;
+    [location(1)] varying: f32;
 };
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn vertex(
-    [[builtin(vertex_index)]] vertex_index: u32,
-    [[builtin(instance_index)]] instance_index: u32,
-    [[location(10)]] color: u32,
+    [builtin(vertex_index)] vertex_index: u32,
+    [builtin(instance_index)] instance_index: u32,
+    [location(10)] color: u32,
 ) -> VertexOutput {
     let tmp = vertex_index + instance_index + color;
     return VertexOutput(vec4<f32>(1.0), f32(tmp));
 }
 
 struct FragmentOutput {
-    [[builtin(frag_depth)]] depth: f32;
-    [[builtin(sample_mask)]] sample_mask: u32;
-    [[location(0)]] color: f32;
+    [builtin(frag_depth)] depth: f32;
+    [builtin(sample_mask)] sample_mask: u32;
+    [location(0)] color: f32;
 };
 
-[[stage(fragment)]]
+[stage(fragment)]
 fn fragment(
     in: VertexOutput,
-    [[builtin(front_facing)]] front_facing: bool,
-    [[builtin(sample_index)]] sample_index: u32,
-    [[builtin(sample_mask)]] sample_mask: u32,
+    [builtin(front_facing)] front_facing: bool,
+    [builtin(sample_index)] sample_index: u32,
+    [builtin(sample_mask)] sample_mask: u32,
 ) -> FragmentOutput {
     let mask = sample_mask & (1u << sample_index);
     let color = select(0.0, 1.0, front_facing);
@@ -35,13 +35,13 @@ fn fragment(
 
 var<workgroup> output: array<u32, 1>;
 
-[[stage(compute), workgroup_size(1)]]
+[stage(compute), workgroup_size(1)]
 fn compute(
-    [[builtin(global_invocation_id)]] global_id: vec3<u32>,
-    [[builtin(local_invocation_id)]] local_id: vec3<u32>,
-    [[builtin(local_invocation_index)]] local_index: u32,
-    [[builtin(workgroup_id)]] wg_id: vec3<u32>,
-    [[builtin(num_workgroups)]] num_wgs: vec3<u32>,
+    [builtin(global_invocation_id)] global_id: vec3<u32>,
+    [builtin(local_invocation_id)] local_id: vec3<u32>,
+    [builtin(local_invocation_index)] local_index: u32,
+    [builtin(workgroup_id)] wg_id: vec3<u32>,
+    [builtin(num_workgroups)] num_wgs: vec3<u32>,
 ) {
     output[0] = global_id.x + local_id.x + local_index + wg_id.x + num_wgs.x;
 }

--- a/tests/in/interpolate.wgsl
+++ b/tests/in/interpolate.wgsl
@@ -1,17 +1,17 @@
 //TODO: merge with "interface"?
 
 struct FragmentInput {
-  [[builtin(position)]] position: vec4<f32>;
-  [[location(0), interpolate(flat)]] flat : u32;
-  [[location(1), interpolate(linear)]] linear : f32;
-  [[location(2), interpolate(linear, centroid)]] linear_centroid : vec2<f32>;
-  [[location(3), interpolate(linear, sample)]] linear_sample : vec3<f32>;
-  [[location(4), interpolate(perspective)]] perspective : vec4<f32>;
-  [[location(5), interpolate(perspective, centroid)]] perspective_centroid : f32;
-  [[location(6), interpolate(perspective, sample)]] perspective_sample : f32;
+  [builtin(position)] position: vec4<f32>;
+  [location(0), interpolate(flat)] flat : u32;
+  [location(1), interpolate(linear)] linear : f32;
+  [location(2), interpolate(linear, centroid)] linear_centroid : vec2<f32>;
+  [location(3), interpolate(linear, sample)] linear_sample : vec3<f32>;
+  [location(4), interpolate(perspective)] perspective : vec4<f32>;
+  [location(5), interpolate(perspective, centroid)] perspective_centroid : f32;
+  [location(6), interpolate(perspective, sample)] perspective_sample : f32;
 };
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn main() -> FragmentInput {
    var out: FragmentInput;
 
@@ -27,5 +27,5 @@ fn main() -> FragmentInput {
    return out;
 }
 
-[[stage(fragment)]]
+[stage(fragment)]
 fn main(val : FragmentInput) { }

--- a/tests/in/operators.wgsl
+++ b/tests/in/operators.wgsl
@@ -57,7 +57,7 @@ fn modulo() {
     let d = vec3<f32>(1.0) % vec3<f32>(1.0);
 }
 
-[[stage(compute), workgroup_size(1)]]
+[stage(compute), workgroup_size(1)]
 fn main() {
     let a = builtins();
     let b = splat();

--- a/tests/in/pointers.wgsl
+++ b/tests/in/pointers.wgsl
@@ -4,7 +4,7 @@ fn f() {
    *px = 10;
 }
 
-[[block]]
+[block]
 struct DynamicArray {
     array: array<u32>;
 };

--- a/tests/in/policy-mix.wgsl
+++ b/tests/in/policy-mix.wgsl
@@ -2,20 +2,20 @@
 // implemented separately.
 
 // Storage and Uniform storage classes
-[[block]]
+[block]
 struct InStorage {
   a: array<vec4<f32>, 10>;
 };
-[[group(0), binding(0)]] var<storage> in_storage: InStorage;
+[group(0), binding(0)] var<storage> in_storage: InStorage;
 
-[[block]]
+[block]
 struct InUniform {
   a: array<vec4<f32>, 20>;
 };
-[[group(0), binding(1)]] var<uniform> in_uniform: InUniform;
+[group(0), binding(1)] var<uniform> in_uniform: InUniform;
 
 // Textures automatically land in the `handle` storage class.
-[[group(0), binding(2)]] var image_2d_array: texture_2d_array<f32>;
+[group(0), binding(2)] var image_2d_array: texture_2d_array<f32>;
 
 // None of the above.
 var<workgroup> in_workgroup: array<f32, 30>;

--- a/tests/in/quad.wgsl
+++ b/tests/in/quad.wgsl
@@ -2,24 +2,24 @@
 let c_scale: f32 = 1.2;
 
 struct VertexOutput {
-  [[location(0)]] uv : vec2<f32>;
-  [[builtin(position)]] position : vec4<f32>;
+  [location(0)] uv : vec2<f32>;
+  [builtin(position)] position : vec4<f32>;
 };
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn main(
-  [[location(0)]] pos : vec2<f32>,
-  [[location(1)]] uv : vec2<f32>,
+  [location(0)] pos : vec2<f32>,
+  [location(1)] uv : vec2<f32>,
 ) -> VertexOutput {
   return VertexOutput(uv, vec4<f32>(c_scale * pos, 0.0, 1.0));
 }
 
 // fragment
-[[group(0), binding(0)]] var u_texture : texture_2d<f32>;
-[[group(0), binding(1)]] var u_sampler : sampler;
+[group(0), binding(0)] var u_texture : texture_2d<f32>;
+[group(0), binding(1)] var u_sampler : sampler;
 
-[[stage(fragment)]]
-fn main([[location(0)]] uv : vec2<f32>) -> [[location(0)]] vec4<f32> {
+[stage(fragment)]
+fn main([location(0)] uv : vec2<f32>) -> [location(0)] vec4<f32> {
   let color = textureSample(u_texture, u_sampler, uv);
   if (color.a == 0.0) {
     discard;
@@ -32,7 +32,7 @@ fn main([[location(0)]] uv : vec2<f32>) -> [[location(0)]] vec4<f32> {
 
 
 // We need to make sure that backends are successfully handling multiple entry points for the same shader stage. 
-[[stage(fragment)]]
-fn fs_extra() -> [[location(0)]] vec4<f32> {
+[stage(fragment)]
+fn fs_extra() -> [location(0)] vec4<f32> {
     return vec4<f32>(0.0, 0.5, 0.0, 0.5);
 }

--- a/tests/in/shadow.wgsl
+++ b/tests/in/shadow.wgsl
@@ -1,9 +1,9 @@
-[[block]]
+[block]
 struct Globals {
     num_lights: vec4<u32>;
 };
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var<uniform> u_globals: Globals;
 
 struct Light {
@@ -12,16 +12,16 @@ struct Light {
     color: vec4<f32>;
 };
 
-[[block]]
+[block]
 struct Lights {
-    data: [[stride(96)]] array<Light>;
+    data: [stride(96)] array<Light>;
 };
 
-[[group(0), binding(1)]]
+[group(0), binding(1)]
 var<storage> s_lights: Lights;
-[[group(0), binding(2)]]
+[group(0), binding(2)]
 var t_shadow: texture_depth_2d_array;
-[[group(0), binding(3)]]
+[group(0), binding(3)]
 var sampler_shadow: sampler_comparison;
 
 fn fetch_shadow(light_id: u32, homogeneous_coords: vec4<f32>) -> f32 {
@@ -36,11 +36,11 @@ fn fetch_shadow(light_id: u32, homogeneous_coords: vec4<f32>) -> f32 {
 let c_ambient: vec3<f32> = vec3<f32>(0.05, 0.05, 0.05);
 let c_max_lights: u32 = 10u;
 
-[[stage(fragment)]]
+[stage(fragment)]
 fn fs_main(
-    [[location(0)]] raw_normal: vec3<f32>,
-    [[location(1)]] position: vec4<f32>
-) -> [[location(0)]] vec4<f32> {
+    [location(0)] raw_normal: vec3<f32>,
+    [location(1)] position: vec4<f32>
+) -> [location(0)] vec4<f32> {
     let normal: vec3<f32> = normalize(raw_normal);
     // accumulate color
     var color = c_ambient;

--- a/tests/in/skybox.wgsl
+++ b/tests/in/skybox.wgsl
@@ -1,18 +1,18 @@
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] uv: vec3<f32>;
+    [builtin(position)] position: vec4<f32>;
+    [location(0)] uv: vec3<f32>;
 };
 
-[[block]]
+[block]
 struct Data {
     proj_inv: mat4x4<f32>;
     view: mat4x4<f32>;
 };
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var<uniform> r_data: Data;
 
-[[stage(vertex)]]
-fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> VertexOutput {
+[stage(vertex)]
+fn vs_main([builtin(vertex_index)] vertex_index: u32) -> VertexOutput {
     // hacky way to draw a large triangle
     var tmp1 = i32(vertex_index) / 2;
     var tmp2 = i32(vertex_index) & 1;
@@ -28,12 +28,12 @@ fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> VertexOutput {
     return VertexOutput(pos, inv_model_view * unprojected.xyz);
 }
 
-[[group(0), binding(1)]]
+[group(0), binding(1)]
 var r_texture: texture_cube<f32>;
-[[group(0), binding(2)]]
+[group(0), binding(2)]
 var r_sampler: sampler;
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+[stage(fragment)]
+fn fs_main(in: VertexOutput) -> [location(0)] vec4<f32> {
     return textureSample(r_texture, r_sampler, in.uv);
 }

--- a/tests/in/standard.wgsl
+++ b/tests/in/standard.wgsl
@@ -1,7 +1,7 @@
 // Standard functions.
 
-[[stage(fragment)]]
-fn derivatives([[builtin(position)]] foo: vec4<f32>) -> [[location(0)]] vec4<f32> {
+[stage(fragment)]
+fn derivatives([builtin(position)] foo: vec4<f32>) -> [location(0)] vec4<f32> {
     let x = dpdx(foo);
     let y = dpdy(foo);
     let z = fwidth(foo);

--- a/tests/in/texture-arg.wgsl
+++ b/tests/in/texture-arg.wgsl
@@ -1,13 +1,13 @@
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var Texture: texture_2d<f32>;
-[[group(0), binding(1)]]
+[group(0), binding(1)]
 var Sampler: sampler;
 
 fn test(Passed_Texture: texture_2d<f32>, Passed_Sampler: sampler) -> vec4<f32> {
     return textureSample(Passed_Texture, Passed_Sampler, vec2<f32>(0.0, 0.0));
 }
 
-[[stage(fragment)]]
-fn main() -> [[location(0)]] vec4<f32> {
+[stage(fragment)]
+fn main() -> [location(0)] vec4<f32> {
     return test(Texture, Sampler);
 }

--- a/tests/out/wgsl/210-bevy-2d-shader-frag.wgsl
+++ b/tests/out/wgsl/210-bevy-2d-shader-frag.wgsl
@@ -1,15 +1,15 @@
-[[block]]
+[block]
 struct ColorMaterial_color {
     Color: vec4<f32>;
 };
 
 struct FragmentOutput {
-    [[location(0)]] o_Target: vec4<f32>;
+    [location(0)] o_Target: vec4<f32>;
 };
 
 var<private> v_Uv1: vec2<f32>;
 var<private> o_Target: vec4<f32>;
-[[group(1), binding(0)]]
+[group(1), binding(0)]
 var<uniform> global: ColorMaterial_color;
 
 fn main1() {
@@ -22,8 +22,8 @@ fn main1() {
     return;
 }
 
-[[stage(fragment)]]
-fn main([[location(0)]] v_Uv: vec2<f32>) -> FragmentOutput {
+[stage(fragment)]
+fn main([location(0)] v_Uv: vec2<f32>) -> FragmentOutput {
     v_Uv1 = v_Uv;
     main1();
     let e9: vec4<f32> = o_Target;

--- a/tests/out/wgsl/210-bevy-2d-shader-vert.wgsl
+++ b/tests/out/wgsl/210-bevy-2d-shader-vert.wgsl
@@ -1,32 +1,32 @@
-[[block]]
+[block]
 struct Camera {
     ViewProj: mat4x4<f32>;
 };
 
-[[block]]
+[block]
 struct Transform {
     Model: mat4x4<f32>;
 };
 
-[[block]]
+[block]
 struct Sprite_size {
     size: vec2<f32>;
 };
 
 struct VertexOutput {
-    [[location(0)]] v_Uv: vec2<f32>;
-    [[builtin(position)]] member: vec4<f32>;
+    [location(0)] v_Uv: vec2<f32>;
+    [builtin(position)] member: vec4<f32>;
 };
 
 var<private> Vertex_Position1: vec3<f32>;
 var<private> Vertex_Normal1: vec3<f32>;
 var<private> Vertex_Uv1: vec2<f32>;
 var<private> v_Uv: vec2<f32>;
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var<uniform> global: Camera;
-[[group(2), binding(0)]]
+[group(2), binding(0)]
 var<uniform> global1: Transform;
-[[group(2), binding(1)]]
+[group(2), binding(1)]
 var<uniform> global2: Sprite_size;
 var<private> gl_Position: vec4<f32>;
 
@@ -45,8 +45,8 @@ fn main1() {
     return;
 }
 
-[[stage(vertex)]]
-fn main([[location(0)]] Vertex_Position: vec3<f32>, [[location(1)]] Vertex_Normal: vec3<f32>, [[location(2)]] Vertex_Uv: vec2<f32>) -> VertexOutput {
+[stage(vertex)]
+fn main([location(0)] Vertex_Position: vec3<f32>, [location(1)] Vertex_Normal: vec3<f32>, [location(2)] Vertex_Uv: vec2<f32>) -> VertexOutput {
     Vertex_Position1 = Vertex_Position;
     Vertex_Normal1 = Vertex_Normal;
     Vertex_Uv1 = Vertex_Uv;

--- a/tests/out/wgsl/210-bevy-shader-vert.wgsl
+++ b/tests/out/wgsl/210-bevy-shader-vert.wgsl
@@ -1,18 +1,18 @@
-[[block]]
+[block]
 struct Camera {
     ViewProj: mat4x4<f32>;
 };
 
-[[block]]
+[block]
 struct Transform {
     Model: mat4x4<f32>;
 };
 
 struct VertexOutput {
-    [[location(0)]] v_Position: vec3<f32>;
-    [[location(1)]] v_Normal: vec3<f32>;
-    [[location(2)]] v_Uv: vec2<f32>;
-    [[builtin(position)]] member: vec4<f32>;
+    [location(0)] v_Position: vec3<f32>;
+    [location(1)] v_Normal: vec3<f32>;
+    [location(2)] v_Uv: vec2<f32>;
+    [builtin(position)] member: vec4<f32>;
 };
 
 var<private> Vertex_Position1: vec3<f32>;
@@ -21,9 +21,9 @@ var<private> Vertex_Uv1: vec2<f32>;
 var<private> v_Position: vec3<f32>;
 var<private> v_Normal: vec3<f32>;
 var<private> v_Uv: vec2<f32>;
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var<uniform> global: Camera;
-[[group(2), binding(0)]]
+[group(2), binding(0)]
 var<uniform> global1: Transform;
 var<private> gl_Position: vec4<f32>;
 
@@ -45,8 +45,8 @@ fn main1() {
     return;
 }
 
-[[stage(vertex)]]
-fn main([[location(0)]] Vertex_Position: vec3<f32>, [[location(1)]] Vertex_Normal: vec3<f32>, [[location(2)]] Vertex_Uv: vec2<f32>) -> VertexOutput {
+[stage(vertex)]
+fn main([location(0)] Vertex_Position: vec3<f32>, [location(1)] Vertex_Normal: vec3<f32>, [location(2)] Vertex_Uv: vec2<f32>) -> VertexOutput {
     Vertex_Position1 = Vertex_Position;
     Vertex_Normal1 = Vertex_Normal;
     Vertex_Uv1 = Vertex_Uv;

--- a/tests/out/wgsl/246-collatz-comp.wgsl
+++ b/tests/out/wgsl/246-collatz-comp.wgsl
@@ -1,9 +1,9 @@
-[[block]]
+[block]
 struct PrimeIndices {
-    indices: [[stride(4)]] array<u32>;
+    indices: [stride(4)] array<u32>;
 };
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var<storage, read_write> global: PrimeIndices;
 var<private> gl_GlobalInvocationID: vec3<u32>;
 
@@ -52,8 +52,8 @@ fn main1() {
     return;
 }
 
-[[stage(compute), workgroup_size(1, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] param: vec3<u32>) {
+[stage(compute), workgroup_size(1, 1, 1)]
+fn main([builtin(global_invocation_id)] param: vec3<u32>) {
     gl_GlobalInvocationID = param;
     main1();
     return;

--- a/tests/out/wgsl/277-casting-vert.wgsl
+++ b/tests/out/wgsl/277-casting-vert.wgsl
@@ -3,7 +3,7 @@ fn main1() {
 
 }
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/280-matrix-cast-vert.wgsl
+++ b/tests/out/wgsl/280-matrix-cast-vert.wgsl
@@ -4,7 +4,7 @@ fn main1() {
     let e1: f32 = f32(1);
 }
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/484-preprocessor-if-vert.wgsl
+++ b/tests/out/wgsl/484-preprocessor-if-vert.wgsl
@@ -2,7 +2,7 @@ fn main1() {
     return;
 }
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/800-out-of-bounds-panic-vert.wgsl
+++ b/tests/out/wgsl/800-out-of-bounds-panic-vert.wgsl
@@ -1,19 +1,19 @@
-[[block]]
+[block]
 struct Globals {
     view_matrix: mat4x4<f32>;
 };
 
-[[block]]
+[block]
 struct VertexPushConstants {
     world_matrix: mat4x4<f32>;
 };
 
 struct VertexOutput {
-    [[location(0)]] frag_color: vec4<f32>;
-    [[builtin(position)]] member: vec4<f32>;
+    [location(0)] frag_color: vec4<f32>;
+    [builtin(position)] member: vec4<f32>;
 };
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var<uniform> global: Globals;
 var<push_constant> global1: VertexPushConstants;
 var<private> position1: vec2<f32>;
@@ -34,8 +34,8 @@ fn main1() {
     return;
 }
 
-[[stage(vertex)]]
-fn main([[location(0)]] position: vec2<f32>, [[location(1)]] color: vec4<f32>) -> VertexOutput {
+[stage(vertex)]
+fn main([location(0)] position: vec2<f32>, [location(1)] color: vec4<f32>) -> VertexOutput {
     position1 = position;
     color1 = color;
     main1();

--- a/tests/out/wgsl/896-push-constant-vert.wgsl
+++ b/tests/out/wgsl/896-push-constant-vert.wgsl
@@ -1,4 +1,4 @@
-[[block]]
+[block]
 struct PushConstants {
     example: f32;
 };
@@ -9,7 +9,7 @@ fn main1() {
     return;
 }
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/900-implicit-conversions-vert.wgsl
+++ b/tests/out/wgsl/900-implicit-conversions-vert.wgsl
@@ -61,7 +61,7 @@ fn main1() {
     return;
 }
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/901-lhs-field-select-vert.wgsl
+++ b/tests/out/wgsl/901-lhs-field-select-vert.wgsl
@@ -5,7 +5,7 @@ fn main1() {
     return;
 }
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/931-constant-emitting-vert.wgsl
+++ b/tests/out/wgsl/931-constant-emitting-vert.wgsl
@@ -6,7 +6,7 @@ fn main1() {
     return;
 }
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/932-for-loop-if-vert.wgsl
+++ b/tests/out/wgsl/932-for-loop-if-vert.wgsl
@@ -16,7 +16,7 @@ fn main1() {
     return;
 }
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/access.wgsl
+++ b/tests/out/wgsl/access.wgsl
@@ -1,12 +1,12 @@
-[[block]]
+[block]
 struct Bar {
     matrix: mat4x4<f32>;
     atom: atomic<i32>;
-    arr: [[stride(8)]] array<vec2<u32>,2>;
-    data: [[stride(8)]] array<i32>;
+    arr: [stride(8)] array<vec2<u32>,2>;
+    data: [stride(8)] array<i32>;
 };
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var<storage, read_write> bar: Bar;
 
 fn read_from_private(foo2: ptr<function, f32>) -> f32 {
@@ -14,8 +14,8 @@ fn read_from_private(foo2: ptr<function, f32>) -> f32 {
     return e2;
 }
 
-[[stage(vertex)]]
-fn foo([[builtin(vertex_index)]] vi: u32) -> [[builtin(position)]] vec4<f32> {
+[stage(vertex)]
+fn foo([builtin(vertex_index)] vi: u32) -> [builtin(position)] vec4<f32> {
     var foo1: f32 = 0.0;
     var c: array<i32,5>;
 
@@ -37,7 +37,7 @@ fn foo([[builtin(vertex_index)]] vi: u32) -> [[builtin(position)]] vec4<f32> {
     return (matrix * vec4<f32>(vec4<i32>(value)));
 }
 
-[[stage(compute), workgroup_size(1, 1, 1)]]
+[stage(compute), workgroup_size(1, 1, 1)]
 fn atomics() {
     var tmp: i32;
 

--- a/tests/out/wgsl/bevy-pbr-frag.wgsl
+++ b/tests/out/wgsl/bevy-pbr-frag.wgsl
@@ -9,51 +9,51 @@ struct DirectionalLight {
     color: vec4<f32>;
 };
 
-[[block]]
+[block]
 struct CameraViewProj {
     ViewProj: mat4x4<f32>;
 };
 
-[[block]]
+[block]
 struct CameraPosition {
     CameraPos: vec4<f32>;
 };
 
-[[block]]
+[block]
 struct Lights {
     AmbientColor: vec4<f32>;
     NumLights: vec4<u32>;
-    PointLights: [[stride(48)]] array<PointLight,10u>;
-    DirectionalLights: [[stride(32)]] array<DirectionalLight,1u>;
+    PointLights: [stride(48)] array<PointLight,10u>;
+    DirectionalLights: [stride(32)] array<DirectionalLight,1u>;
 };
 
-[[block]]
+[block]
 struct StandardMaterial_base_color {
     base_color: vec4<f32>;
 };
 
-[[block]]
+[block]
 struct StandardMaterial_roughness {
     perceptual_roughness: f32;
 };
 
-[[block]]
+[block]
 struct StandardMaterial_metallic {
     metallic: f32;
 };
 
-[[block]]
+[block]
 struct StandardMaterial_reflectance {
     reflectance: f32;
 };
 
-[[block]]
+[block]
 struct StandardMaterial_emissive {
     emissive: vec4<f32>;
 };
 
 struct FragmentOutput {
-    [[location(0)]] o_Target: vec4<f32>;
+    [location(0)] o_Target: vec4<f32>;
 };
 
 var<private> v_WorldPosition1: vec3<f32>;
@@ -61,41 +61,41 @@ var<private> v_WorldNormal1: vec3<f32>;
 var<private> v_Uv1: vec2<f32>;
 var<private> v_WorldTangent1: vec4<f32>;
 var<private> o_Target: vec4<f32>;
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var<uniform> global: CameraViewProj;
-[[group(0), binding(1)]]
+[group(0), binding(1)]
 var<uniform> global1: CameraPosition;
-[[group(1), binding(0)]]
+[group(1), binding(0)]
 var<uniform> global2: Lights;
-[[group(3), binding(0)]]
+[group(3), binding(0)]
 var<uniform> global3: StandardMaterial_base_color;
-[[group(3), binding(1)]]
+[group(3), binding(1)]
 var StandardMaterial_base_color_texture: texture_2d<f32>;
-[[group(3), binding(2)]]
+[group(3), binding(2)]
 var StandardMaterial_base_color_texture_sampler: sampler;
-[[group(3), binding(3)]]
+[group(3), binding(3)]
 var<uniform> global4: StandardMaterial_roughness;
-[[group(3), binding(4)]]
+[group(3), binding(4)]
 var<uniform> global5: StandardMaterial_metallic;
-[[group(3), binding(5)]]
+[group(3), binding(5)]
 var StandardMaterial_metallic_roughness_texture: texture_2d<f32>;
-[[group(3), binding(6)]]
+[group(3), binding(6)]
 var StandardMaterial_metallic_roughness_texture_sampler: sampler;
-[[group(3), binding(7)]]
+[group(3), binding(7)]
 var<uniform> global6: StandardMaterial_reflectance;
-[[group(3), binding(8)]]
+[group(3), binding(8)]
 var StandardMaterial_normal_map: texture_2d<f32>;
-[[group(3), binding(9)]]
+[group(3), binding(9)]
 var StandardMaterial_normal_map_sampler: sampler;
-[[group(3), binding(10)]]
+[group(3), binding(10)]
 var StandardMaterial_occlusion_texture: texture_2d<f32>;
-[[group(3), binding(11)]]
+[group(3), binding(11)]
 var StandardMaterial_occlusion_texture_sampler: sampler;
-[[group(3), binding(12)]]
+[group(3), binding(12)]
 var<uniform> global7: StandardMaterial_emissive;
-[[group(3), binding(13)]]
+[group(3), binding(13)]
 var StandardMaterial_emissive_texture: texture_2d<f32>;
-[[group(3), binding(14)]]
+[group(3), binding(14)]
 var StandardMaterial_emissive_texture_sampler: sampler;
 var<private> gl_FrontFacing: bool;
 
@@ -903,8 +903,8 @@ fn main1() {
     return;
 }
 
-[[stage(fragment)]]
-fn main([[location(0)]] v_WorldPosition: vec3<f32>, [[location(1)]] v_WorldNormal: vec3<f32>, [[location(2)]] v_Uv: vec2<f32>, [[location(3)]] v_WorldTangent: vec4<f32>, [[builtin(front_facing)]] param: bool) -> FragmentOutput {
+[stage(fragment)]
+fn main([location(0)] v_WorldPosition: vec3<f32>, [location(1)] v_WorldNormal: vec3<f32>, [location(2)] v_Uv: vec2<f32>, [location(3)] v_WorldTangent: vec4<f32>, [builtin(front_facing)] param: bool) -> FragmentOutput {
     v_WorldPosition1 = v_WorldPosition;
     v_WorldNormal1 = v_WorldNormal;
     v_Uv1 = v_Uv;

--- a/tests/out/wgsl/bevy-pbr-vert.wgsl
+++ b/tests/out/wgsl/bevy-pbr-vert.wgsl
@@ -1,19 +1,19 @@
-[[block]]
+[block]
 struct CameraViewProj {
     ViewProj: mat4x4<f32>;
 };
 
-[[block]]
+[block]
 struct Transform {
     Model: mat4x4<f32>;
 };
 
 struct VertexOutput {
-    [[location(0)]] v_WorldPosition: vec3<f32>;
-    [[location(1)]] v_WorldNormal: vec3<f32>;
-    [[location(2)]] v_Uv: vec2<f32>;
-    [[location(3)]] v_WorldTangent: vec4<f32>;
-    [[builtin(position)]] member: vec4<f32>;
+    [location(0)] v_WorldPosition: vec3<f32>;
+    [location(1)] v_WorldNormal: vec3<f32>;
+    [location(2)] v_Uv: vec2<f32>;
+    [location(3)] v_WorldTangent: vec4<f32>;
+    [builtin(position)] member: vec4<f32>;
 };
 
 var<private> Vertex_Position1: vec3<f32>;
@@ -23,10 +23,10 @@ var<private> Vertex_Tangent1: vec4<f32>;
 var<private> v_WorldPosition: vec3<f32>;
 var<private> v_WorldNormal: vec3<f32>;
 var<private> v_Uv: vec2<f32>;
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var<uniform> global: CameraViewProj;
 var<private> v_WorldTangent: vec4<f32>;
-[[group(2), binding(0)]]
+[group(2), binding(0)]
 var<uniform> global1: Transform;
 var<private> gl_Position: vec4<f32>;
 
@@ -53,8 +53,8 @@ fn main1() {
     return;
 }
 
-[[stage(vertex)]]
-fn main([[location(0)]] Vertex_Position: vec3<f32>, [[location(1)]] Vertex_Normal: vec3<f32>, [[location(2)]] Vertex_Uv: vec2<f32>, [[location(3)]] Vertex_Tangent: vec4<f32>) -> VertexOutput {
+[stage(vertex)]
+fn main([location(0)] Vertex_Position: vec3<f32>, [location(1)] Vertex_Normal: vec3<f32>, [location(2)] Vertex_Uv: vec2<f32>, [location(3)] Vertex_Tangent: vec4<f32>) -> VertexOutput {
     Vertex_Position1 = Vertex_Position;
     Vertex_Normal1 = Vertex_Normal;
     Vertex_Uv1 = Vertex_Uv;

--- a/tests/out/wgsl/binop-frag.wgsl
+++ b/tests/out/wgsl/binop-frag.wgsl
@@ -180,7 +180,7 @@ fn main1() {
     return;
 }
 
-[[stage(fragment)]]
+[stage(fragment)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/bits.wgsl
+++ b/tests/out/wgsl/bits.wgsl
@@ -1,4 +1,4 @@
-[[stage(compute), workgroup_size(1, 1, 1)]]
+[stage(compute), workgroup_size(1, 1, 1)]
 fn main() {
     var i: i32 = 0;
     var i2: vec2<i32>;

--- a/tests/out/wgsl/bits_glsl-frag.wgsl
+++ b/tests/out/wgsl/bits_glsl-frag.wgsl
@@ -73,7 +73,7 @@ fn main1() {
     return;
 }
 
-[[stage(fragment)]]
+[stage(fragment)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/boids.wgsl
+++ b/tests/out/wgsl/boids.wgsl
@@ -3,7 +3,7 @@ struct Particle {
     vel: vec2<f32>;
 };
 
-[[block]]
+[block]
 struct SimParams {
     deltaT: f32;
     rule1Distance: f32;
@@ -14,22 +14,22 @@ struct SimParams {
     rule3Scale: f32;
 };
 
-[[block]]
+[block]
 struct Particles {
-    particles: [[stride(16)]] array<Particle>;
+    particles: [stride(16)] array<Particle>;
 };
 
 let NUM_PARTICLES: u32 = 1500u;
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var<uniform> params: SimParams;
-[[group(0), binding(1)]]
+[group(0), binding(1)]
 var<storage> particlesSrc: Particles;
-[[group(0), binding(2)]]
+[group(0), binding(2)]
 var<storage, read_write> particlesDst: Particles;
 
-[[stage(compute), workgroup_size(64, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_invocation_id: vec3<u32>) {
+[stage(compute), workgroup_size(64, 1, 1)]
+fn main([builtin(global_invocation_id)] global_invocation_id: vec3<u32>) {
     var vPos: vec2<f32>;
     var vVel: vec2<f32>;
     var cMass: vec2<f32>;

--- a/tests/out/wgsl/bool-select-frag.wgsl
+++ b/tests/out/wgsl/bool-select-frag.wgsl
@@ -1,5 +1,5 @@
 struct FragmentOutput {
-    [[location(0)]] o_color: vec4<f32>;
+    [location(0)] o_color: vec4<f32>;
 };
 
 var<private> o_color: vec4<f32>;
@@ -37,7 +37,7 @@ fn main1() {
     return;
 }
 
-[[stage(fragment)]]
+[stage(fragment)]
 fn main() -> FragmentOutput {
     main1();
     let e3: vec4<f32> = o_color;

--- a/tests/out/wgsl/clamp-splat-vert.wgsl
+++ b/tests/out/wgsl/clamp-splat-vert.wgsl
@@ -1,5 +1,5 @@
 struct VertexOutput {
-    [[builtin(position)]] member: vec4<f32>;
+    [builtin(position)] member: vec4<f32>;
 };
 
 var<private> a_pos1: vec2<f32>;
@@ -11,8 +11,8 @@ fn main1() {
     return;
 }
 
-[[stage(vertex)]]
-fn main([[location(0)]] a_pos: vec2<f32>) -> VertexOutput {
+[stage(vertex)]
+fn main([location(0)] a_pos: vec2<f32>) -> VertexOutput {
     a_pos1 = a_pos;
     main1();
     let e5: vec4<f32> = gl_Position;

--- a/tests/out/wgsl/collatz.wgsl
+++ b/tests/out/wgsl/collatz.wgsl
@@ -1,9 +1,9 @@
-[[block]]
+[block]
 struct PrimeIndices {
-    data: [[stride(4)]] array<u32>;
+    data: [stride(4)] array<u32>;
 };
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var<storage, read_write> v_indices: PrimeIndices;
 
 fn collatz_iterations(n_base: u32) -> u32 {
@@ -31,8 +31,8 @@ fn collatz_iterations(n_base: u32) -> u32 {
     return e24;
 }
 
-[[stage(compute), workgroup_size(1, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+[stage(compute), workgroup_size(1, 1, 1)]
+fn main([builtin(global_invocation_id)] global_id: vec3<u32>) {
     let e8: u32 = v_indices.data[global_id.x];
     let e9: u32 = collatz_iterations(e8);
     v_indices.data[global_id.x] = e9;

--- a/tests/out/wgsl/constant-array-size-vert.wgsl
+++ b/tests/out/wgsl/constant-array-size-vert.wgsl
@@ -1,9 +1,9 @@
-[[block]]
+[block]
 struct Data {
-    vecs: [[stride(16)]] array<vec4<f32>,42u>;
+    vecs: [stride(16)] array<vec4<f32>,42u>;
 };
 
-[[group(1), binding(0)]]
+[group(1), binding(0)]
 var<uniform> global: Data;
 
 fn function1() -> vec4<f32> {
@@ -34,7 +34,7 @@ fn main1() {
     return;
 }
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/control-flow.wgsl
+++ b/tests/out/wgsl/control-flow.wgsl
@@ -26,8 +26,8 @@ fn loop_switch_continue(x: i32) {
     return;
 }
 
-[[stage(compute), workgroup_size(1, 1, 1)]]
-fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+[stage(compute), workgroup_size(1, 1, 1)]
+fn main([builtin(global_invocation_id)] global_id: vec3<u32>) {
     var pos: i32;
 
     storageBarrier();

--- a/tests/out/wgsl/empty-global-name.wgsl
+++ b/tests/out/wgsl/empty-global-name.wgsl
@@ -1,9 +1,9 @@
-[[block]]
+[block]
 struct type2 {
     member: i32;
 };
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var<storage, read_write> global: type2;
 
 fn function1() {
@@ -12,7 +12,7 @@ fn function1() {
     return;
 }
 
-[[stage(compute), workgroup_size(64, 1, 1)]]
+[stage(compute), workgroup_size(64, 1, 1)]
 fn main() {
     function1();
 }

--- a/tests/out/wgsl/empty.wgsl
+++ b/tests/out/wgsl/empty.wgsl
@@ -1,4 +1,4 @@
-[[stage(compute), workgroup_size(1, 1, 1)]]
+[stage(compute), workgroup_size(1, 1, 1)]
 fn main() {
     return;
 }

--- a/tests/out/wgsl/expressions-frag.wgsl
+++ b/tests/out/wgsl/expressions-frag.wgsl
@@ -206,7 +206,7 @@ fn main1() {
     return;
 }
 
-[[stage(fragment)]]
+[stage(fragment)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/extra.wgsl
+++ b/tests/out/wgsl/extra.wgsl
@@ -1,18 +1,18 @@
-[[block]]
+[block]
 struct PushConstants {
     index: u32;
     double: vec2<f32>;
 };
 
 struct FragmentIn {
-    [[location(0)]] color: vec4<f32>;
-    [[builtin(primitive_index)]] primitive_index: u32;
+    [location(0)] color: vec4<f32>;
+    [builtin(primitive_index)] primitive_index: u32;
 };
 
 var<push_constant> pc: PushConstants;
 
-[[stage(fragment)]]
-fn main(in: FragmentIn) -> [[location(0)]] vec4<f32> {
+[stage(fragment)]
+fn main(in: FragmentIn) -> [location(0)] vec4<f32> {
     if (((in.primitive_index % 2u) == 0u)) {
         return in.color;
     } else {

--- a/tests/out/wgsl/fma-frag.wgsl
+++ b/tests/out/wgsl/fma-frag.wgsl
@@ -37,7 +37,7 @@ fn main1() {
     return;
 }
 
-[[stage(fragment)]]
+[stage(fragment)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/global-constant-array-vert.wgsl
+++ b/tests/out/wgsl/global-constant-array-vert.wgsl
@@ -6,7 +6,7 @@ fn main1() {
     let e2: u32 = i;
 }
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/globals.wgsl
+++ b/tests/out/wgsl/globals.wgsl
@@ -3,7 +3,7 @@ let Foo: bool = true;
 var<workgroup> wg: array<f32,10u>;
 var<workgroup> at: atomic<u32>;
 
-[[stage(compute), workgroup_size(1, 1, 1)]]
+[stage(compute), workgroup_size(1, 1, 1)]
 fn main() {
     wg[3] = 1.0;
     atomicStore((&at), 2u);

--- a/tests/out/wgsl/image.wgsl
+++ b/tests/out/wgsl/image.wgsl
@@ -1,40 +1,40 @@
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_mipmapped_src: texture_2d<u32>;
-[[group(0), binding(3)]]
+[group(0), binding(3)]
 var image_multisampled_src: texture_multisampled_2d<u32>;
-[[group(0), binding(4)]]
+[group(0), binding(4)]
 var image_depth_multisampled_src: texture_depth_multisampled_2d;
-[[group(0), binding(1)]]
+[group(0), binding(1)]
 var image_storage_src: texture_storage_2d<rgba8uint,read>;
-[[group(0), binding(5)]]
+[group(0), binding(5)]
 var image_array_src: texture_2d_array<u32>;
-[[group(0), binding(6)]]
+[group(0), binding(6)]
 var image_dup_src: texture_storage_1d<r32uint,read>;
-[[group(0), binding(2)]]
+[group(0), binding(2)]
 var image_dst: texture_storage_1d<r32uint,write>;
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var image_1d: texture_1d<f32>;
-[[group(0), binding(1)]]
+[group(0), binding(1)]
 var image_2d: texture_2d<f32>;
-[[group(0), binding(2)]]
+[group(0), binding(2)]
 var image_2d_array: texture_2d_array<f32>;
-[[group(0), binding(3)]]
+[group(0), binding(3)]
 var image_cube: texture_cube<f32>;
-[[group(0), binding(4)]]
+[group(0), binding(4)]
 var image_cube_array: texture_cube_array<f32>;
-[[group(0), binding(5)]]
+[group(0), binding(5)]
 var image_3d: texture_3d<f32>;
-[[group(0), binding(6)]]
+[group(0), binding(6)]
 var image_aa: texture_multisampled_2d<f32>;
-[[group(1), binding(0)]]
+[group(1), binding(0)]
 var sampler_reg: sampler;
-[[group(1), binding(1)]]
+[group(1), binding(1)]
 var sampler_cmp: sampler_comparison;
-[[group(1), binding(2)]]
+[group(1), binding(2)]
 var image_2d_depth: texture_depth_2d;
 
-[[stage(compute), workgroup_size(16, 1, 1)]]
-fn main([[builtin(local_invocation_id)]] local_id: vec3<u32>) {
+[stage(compute), workgroup_size(16, 1, 1)]
+fn main([builtin(local_invocation_id)] local_id: vec3<u32>) {
     let dim: vec2<i32> = textureDimensions(image_storage_src);
     let itc: vec2<i32> = ((dim * vec2<i32>(local_id.xy)) % vec2<i32>(10, 20));
     let value1: vec4<u32> = textureLoad(image_mipmapped_src, itc, i32(local_id.z));
@@ -45,8 +45,8 @@ fn main([[builtin(local_invocation_id)]] local_id: vec3<u32>) {
     return;
 }
 
-[[stage(compute), workgroup_size(16, 1, 1)]]
-fn depth_load([[builtin(local_invocation_id)]] local_id1: vec3<u32>) {
+[stage(compute), workgroup_size(16, 1, 1)]
+fn depth_load([builtin(local_invocation_id)] local_id1: vec3<u32>) {
     let dim1: vec2<i32> = textureDimensions(image_storage_src);
     let itc1: vec2<i32> = ((dim1 * vec2<i32>(local_id1.xy)) % vec2<i32>(10, 20));
     let val: f32 = textureLoad(image_depth_multisampled_src, itc1, i32(local_id1.z));
@@ -54,8 +54,8 @@ fn depth_load([[builtin(local_invocation_id)]] local_id1: vec3<u32>) {
     return;
 }
 
-[[stage(vertex)]]
-fn queries() -> [[builtin(position)]] vec4<f32> {
+[stage(vertex)]
+fn queries() -> [builtin(position)] vec4<f32> {
     let dim_1d: i32 = textureDimensions(image_1d);
     let dim_2d: vec2<i32> = textureDimensions(image_2d);
     let dim_2d_lod: vec2<i32> = textureDimensions(image_2d, 1);
@@ -71,8 +71,8 @@ fn queries() -> [[builtin(position)]] vec4<f32> {
     return vec4<f32>(f32(sum));
 }
 
-[[stage(vertex)]]
-fn levels_queries() -> [[builtin(position)]] vec4<f32> {
+[stage(vertex)]
+fn levels_queries() -> [builtin(position)] vec4<f32> {
     let num_levels_2d: i32 = textureNumLevels(image_2d);
     let num_levels_2d_array: i32 = textureNumLevels(image_2d_array);
     let num_layers_2d: i32 = textureNumLayers(image_2d_array);
@@ -85,8 +85,8 @@ fn levels_queries() -> [[builtin(position)]] vec4<f32> {
     return vec4<f32>(f32(sum1));
 }
 
-[[stage(fragment)]]
-fn sample() -> [[location(0)]] vec4<f32> {
+[stage(fragment)]
+fn sample() -> [location(0)] vec4<f32> {
     let tc: vec2<f32> = vec2<f32>(0.5);
     let s1d: vec4<f32> = textureSample(image_1d, sampler_reg, tc.x);
     let s2d: vec4<f32> = textureSample(image_2d, sampler_reg, tc);
@@ -96,8 +96,8 @@ fn sample() -> [[location(0)]] vec4<f32> {
     return ((((s1d + s2d) + s2d_offset) + s2d_level) + s2d_level_offset);
 }
 
-[[stage(fragment)]]
-fn sample_comparison() -> [[location(0)]] f32 {
+[stage(fragment)]
+fn sample_comparison() -> [location(0)] f32 {
     let tc1: vec2<f32> = vec2<f32>(0.5);
     let s2d_depth: f32 = textureSampleCompare(image_2d_depth, sampler_cmp, tc1, 0.5);
     let s2d_depth_level: f32 = textureSampleCompareLevel(image_2d_depth, sampler_cmp, tc1, 0.5);

--- a/tests/out/wgsl/interface.wgsl
+++ b/tests/out/wgsl/interface.wgsl
@@ -1,31 +1,31 @@
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(1)]] varying: f32;
+    [builtin(position)] position: vec4<f32>;
+    [location(1)] varying: f32;
 };
 
 struct FragmentOutput {
-    [[builtin(frag_depth)]] depth: f32;
-    [[builtin(sample_mask)]] sample_mask: u32;
-    [[location(0)]] color: f32;
+    [builtin(frag_depth)] depth: f32;
+    [builtin(sample_mask)] sample_mask: u32;
+    [location(0)] color: f32;
 };
 
 var<workgroup> output: array<u32,1>;
 
-[[stage(vertex)]]
-fn vertex([[builtin(vertex_index)]] vertex_index: u32, [[builtin(instance_index)]] instance_index: u32, [[location(10)]] color: u32) -> VertexOutput {
+[stage(vertex)]
+fn vertex([builtin(vertex_index)] vertex_index: u32, [builtin(instance_index)] instance_index: u32, [location(10)] color: u32) -> VertexOutput {
     let tmp: u32 = ((vertex_index + instance_index) + color);
     return VertexOutput(vec4<f32>(1.0), f32(tmp));
 }
 
-[[stage(fragment)]]
-fn fragment(in: VertexOutput, [[builtin(front_facing)]] front_facing: bool, [[builtin(sample_index)]] sample_index: u32, [[builtin(sample_mask)]] sample_mask: u32) -> FragmentOutput {
+[stage(fragment)]
+fn fragment(in: VertexOutput, [builtin(front_facing)] front_facing: bool, [builtin(sample_index)] sample_index: u32, [builtin(sample_mask)] sample_mask: u32) -> FragmentOutput {
     let mask: u32 = (sample_mask & (1u << sample_index));
     let color1: f32 = select(0.0, 1.0, front_facing);
     return FragmentOutput(in.varying, mask, color1);
 }
 
-[[stage(compute), workgroup_size(1, 1, 1)]]
-fn compute([[builtin(global_invocation_id)]] global_id: vec3<u32>, [[builtin(local_invocation_id)]] local_id: vec3<u32>, [[builtin(local_invocation_index)]] local_index: u32, [[builtin(workgroup_id)]] wg_id: vec3<u32>, [[builtin(num_workgroups)]] num_wgs: vec3<u32>) {
+[stage(compute), workgroup_size(1, 1, 1)]
+fn compute([builtin(global_invocation_id)] global_id: vec3<u32>, [builtin(local_invocation_id)] local_id: vec3<u32>, [builtin(local_invocation_index)] local_index: u32, [builtin(workgroup_id)] wg_id: vec3<u32>, [builtin(num_workgroups)] num_wgs: vec3<u32>) {
     output[0] = ((((global_id.x + local_id.x) + local_index) + wg_id.x) + num_wgs.x);
     return;
 }

--- a/tests/out/wgsl/interpolate.wgsl
+++ b/tests/out/wgsl/interpolate.wgsl
@@ -1,15 +1,15 @@
 struct FragmentInput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] flat: u32;
-    [[location(1), interpolate(linear)]] linear: f32;
-    [[location(2), interpolate(linear, centroid)]] linear_centroid: vec2<f32>;
-    [[location(3), interpolate(linear, sample)]] linear_sample: vec3<f32>;
-    [[location(4)]] perspective: vec4<f32>;
-    [[location(5), interpolate(perspective, centroid)]] perspective_centroid: f32;
-    [[location(6), interpolate(perspective, sample)]] perspective_sample: f32;
+    [builtin(position)] position: vec4<f32>;
+    [location(0)] flat: u32;
+    [location(1), interpolate(linear)] linear: f32;
+    [location(2), interpolate(linear, centroid)] linear_centroid: vec2<f32>;
+    [location(3), interpolate(linear, sample)] linear_sample: vec3<f32>;
+    [location(4)] perspective: vec4<f32>;
+    [location(5), interpolate(perspective, centroid)] perspective_centroid: f32;
+    [location(6), interpolate(perspective, sample)] perspective_sample: f32;
 };
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn main() -> FragmentInput {
     var out: FragmentInput;
 
@@ -25,7 +25,7 @@ fn main() -> FragmentInput {
     return e30;
 }
 
-[[stage(fragment)]]
+[stage(fragment)]
 fn main1(val: FragmentInput) {
     return;
 }

--- a/tests/out/wgsl/inv-hyperbolic-trig-functions.wgsl
+++ b/tests/out/wgsl/inv-hyperbolic-trig-functions.wgsl
@@ -14,7 +14,7 @@ fn main1() {
     return;
 }
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn main() {
     main1();
 }

--- a/tests/out/wgsl/long-form-matrix-vert.wgsl
+++ b/tests/out/wgsl/long-form-matrix-vert.wgsl
@@ -23,7 +23,7 @@ fn main1() {
     let e109: vec4<f32> = vec4<f32>(f32(1));
 }
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/math-functions-vert.wgsl
+++ b/tests/out/wgsl/math-functions-vert.wgsl
@@ -147,7 +147,7 @@ fn main1() {
     return;
 }
 
-[[stage(vertex)]]
+[stage(vertex)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/operators.wgsl
+++ b/tests/out/wgsl/operators.wgsl
@@ -53,7 +53,7 @@ fn modulo() {
     let d: vec3<f32> = (vec3<f32>(1.0) % vec3<f32>(1.0));
 }
 
-[[stage(compute), workgroup_size(1, 1, 1)]]
+[stage(compute), workgroup_size(1, 1, 1)]
 fn main() {
     let e4: vec4<f32> = builtins();
     let e5: vec4<f32> = splat();

--- a/tests/out/wgsl/pointers.wgsl
+++ b/tests/out/wgsl/pointers.wgsl
@@ -1,6 +1,6 @@
-[[block]]
+[block]
 struct DynamicArray {
-    array1: [[stride(4)]] array<u32>;
+    array1: [stride(4)] array<u32>;
 };
 
 fn f() {

--- a/tests/out/wgsl/prepostfix-frag.wgsl
+++ b/tests/out/wgsl/prepostfix-frag.wgsl
@@ -33,7 +33,7 @@ fn main1() {
     return;
 }
 
-[[stage(fragment)]]
+[stage(fragment)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/quad-vert.wgsl
+++ b/tests/out/wgsl/quad-vert.wgsl
@@ -1,11 +1,11 @@
-[[block]]
+[block]
 struct gl_PerVertex {
-    [[builtin(position)]] gl_Position: vec4<f32>;
+    [builtin(position)] gl_Position: vec4<f32>;
 };
 
 struct VertexOutput {
-    [[location(0)]] member: vec2<f32>;
-    [[builtin(position)]] gl_Position: vec4<f32>;
+    [location(0)] member: vec2<f32>;
+    [builtin(position)] gl_Position: vec4<f32>;
 };
 
 var<private> v_uv: vec2<f32>;
@@ -21,8 +21,8 @@ fn main1() {
     return;
 }
 
-[[stage(vertex)]]
-fn main([[location(1)]] a_uv: vec2<f32>, [[location(0)]] a_pos: vec2<f32>) -> VertexOutput {
+[stage(vertex)]
+fn main([location(1)] a_uv: vec2<f32>, [location(0)] a_pos: vec2<f32>) -> VertexOutput {
     a_uv1 = a_uv;
     a_pos1 = a_pos;
     main1();

--- a/tests/out/wgsl/quad.wgsl
+++ b/tests/out/wgsl/quad.wgsl
@@ -1,22 +1,22 @@
 struct VertexOutput {
-    [[location(0)]] uv: vec2<f32>;
-    [[builtin(position)]] position: vec4<f32>;
+    [location(0)] uv: vec2<f32>;
+    [builtin(position)] position: vec4<f32>;
 };
 
 let c_scale: f32 = 1.2000000476837158;
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var u_texture: texture_2d<f32>;
-[[group(0), binding(1)]]
+[group(0), binding(1)]
 var u_sampler: sampler;
 
-[[stage(vertex)]]
-fn main([[location(0)]] pos: vec2<f32>, [[location(1)]] uv: vec2<f32>) -> VertexOutput {
+[stage(vertex)]
+fn main([location(0)] pos: vec2<f32>, [location(1)] uv: vec2<f32>) -> VertexOutput {
     return VertexOutput(uv, vec4<f32>((c_scale * pos), 0.0, 1.0));
 }
 
-[[stage(fragment)]]
-fn main1([[location(0)]] uv1: vec2<f32>) -> [[location(0)]] vec4<f32> {
+[stage(fragment)]
+fn main1([location(0)] uv1: vec2<f32>) -> [location(0)] vec4<f32> {
     let color: vec4<f32> = textureSample(u_texture, u_sampler, uv1);
     if ((color.w == 0.0)) {
         discard;
@@ -25,7 +25,7 @@ fn main1([[location(0)]] uv1: vec2<f32>) -> [[location(0)]] vec4<f32> {
     return premultiplied;
 }
 
-[[stage(fragment)]]
-fn fs_extra() -> [[location(0)]] vec4<f32> {
+[stage(fragment)]
+fn fs_extra() -> [location(0)] vec4<f32> {
     return vec4<f32>(0.0, 0.5, 0.0, 0.5);
 }

--- a/tests/out/wgsl/quad_glsl-frag.wgsl
+++ b/tests/out/wgsl/quad_glsl-frag.wgsl
@@ -1,5 +1,5 @@
 struct FragmentOutput {
-    [[location(0)]] o_color: vec4<f32>;
+    [location(0)] o_color: vec4<f32>;
 };
 
 var<private> v_uv1: vec2<f32>;
@@ -10,8 +10,8 @@ fn main1() {
     return;
 }
 
-[[stage(fragment)]]
-fn main([[location(0)]] v_uv: vec2<f32>) -> FragmentOutput {
+[stage(fragment)]
+fn main([location(0)] v_uv: vec2<f32>) -> FragmentOutput {
     v_uv1 = v_uv;
     main1();
     let e7: vec4<f32> = o_color;

--- a/tests/out/wgsl/quad_glsl-vert.wgsl
+++ b/tests/out/wgsl/quad_glsl-vert.wgsl
@@ -1,6 +1,6 @@
 struct VertexOutput {
-    [[location(0)]] v_uv: vec2<f32>;
-    [[builtin(position)]] member: vec4<f32>;
+    [location(0)] v_uv: vec2<f32>;
+    [builtin(position)] member: vec4<f32>;
 };
 
 var<private> a_pos1: vec2<f32>;
@@ -16,8 +16,8 @@ fn main1() {
     return;
 }
 
-[[stage(vertex)]]
-fn main([[location(0)]] a_pos: vec2<f32>, [[location(1)]] a_uv: vec2<f32>) -> VertexOutput {
+[stage(vertex)]
+fn main([location(0)] a_pos: vec2<f32>, [location(1)] a_uv: vec2<f32>) -> VertexOutput {
     a_pos1 = a_pos;
     a_uv1 = a_uv;
     main1();

--- a/tests/out/wgsl/samplers-frag.wgsl
+++ b/tests/out/wgsl/samplers-frag.wgsl
@@ -1,30 +1,30 @@
-[[group(1), binding(0)]]
+[group(1), binding(0)]
 var tex1D: texture_1d<f32>;
-[[group(1), binding(1)]]
+[group(1), binding(1)]
 var tex1DArray: texture_1d_array<f32>;
-[[group(1), binding(2)]]
+[group(1), binding(2)]
 var tex2D: texture_2d<f32>;
-[[group(1), binding(3)]]
+[group(1), binding(3)]
 var tex2DArray: texture_2d_array<f32>;
-[[group(1), binding(4)]]
+[group(1), binding(4)]
 var texCube: texture_cube<f32>;
-[[group(1), binding(5)]]
+[group(1), binding(5)]
 var texCubeArray: texture_cube_array<f32>;
-[[group(1), binding(6)]]
+[group(1), binding(6)]
 var tex3D: texture_3d<f32>;
-[[group(1), binding(7)]]
+[group(1), binding(7)]
 var samp: sampler;
-[[group(1), binding(12)]]
+[group(1), binding(12)]
 var tex2DShadow: texture_depth_2d;
-[[group(1), binding(13)]]
+[group(1), binding(13)]
 var tex2DArrayShadow: texture_depth_2d_array;
-[[group(1), binding(14)]]
+[group(1), binding(14)]
 var texCubeShadow: texture_depth_cube;
-[[group(1), binding(15)]]
+[group(1), binding(15)]
 var texCubeArrayShadow: texture_depth_cube_array;
-[[group(1), binding(16)]]
+[group(1), binding(16)]
 var tex3DShadow: texture_3d<f32>;
-[[group(1), binding(17)]]
+[group(1), binding(17)]
 var sampShadow: sampler_comparison;
 var<private> texcoord1: vec4<f32>;
 
@@ -566,8 +566,8 @@ fn main1() {
     return;
 }
 
-[[stage(fragment)]]
-fn main([[location(0)]] texcoord: vec4<f32>) {
+[stage(fragment)]
+fn main([location(0)] texcoord: vec4<f32>) {
     texcoord1 = texcoord;
     main1();
     return;

--- a/tests/out/wgsl/shadow.wgsl
+++ b/tests/out/wgsl/shadow.wgsl
@@ -1,4 +1,4 @@
-[[block]]
+[block]
 struct Globals {
     num_lights: vec4<u32>;
 };
@@ -9,21 +9,21 @@ struct Light {
     color: vec4<f32>;
 };
 
-[[block]]
+[block]
 struct Lights {
-    data: [[stride(96)]] array<Light>;
+    data: [stride(96)] array<Light>;
 };
 
 let c_ambient: vec3<f32> = vec3<f32>(0.05000000074505806, 0.05000000074505806, 0.05000000074505806);
 let c_max_lights: u32 = 10u;
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var<uniform> u_globals: Globals;
-[[group(0), binding(1)]]
+[group(0), binding(1)]
 var<storage> s_lights: Lights;
-[[group(0), binding(2)]]
+[group(0), binding(2)]
 var t_shadow: texture_depth_2d_array;
-[[group(0), binding(3)]]
+[group(0), binding(3)]
 var sampler_shadow: sampler_comparison;
 
 fn fetch_shadow(light_id: u32, homogeneous_coords: vec4<f32>) -> f32 {
@@ -36,8 +36,8 @@ fn fetch_shadow(light_id: u32, homogeneous_coords: vec4<f32>) -> f32 {
     return e26;
 }
 
-[[stage(fragment)]]
-fn fs_main([[location(0)]] raw_normal: vec3<f32>, [[location(1)]] position: vec4<f32>) -> [[location(0)]] vec4<f32> {
+[stage(fragment)]
+fn fs_main([location(0)] raw_normal: vec3<f32>, [location(1)] position: vec4<f32>) -> [location(0)] vec4<f32> {
     var color: vec3<f32> = vec3<f32>(0.05000000074505806, 0.05000000074505806, 0.05000000074505806);
     var i: u32 = 0u;
 

--- a/tests/out/wgsl/skybox.wgsl
+++ b/tests/out/wgsl/skybox.wgsl
@@ -1,23 +1,23 @@
 struct VertexOutput {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(0)]] uv: vec3<f32>;
+    [builtin(position)] position: vec4<f32>;
+    [location(0)] uv: vec3<f32>;
 };
 
-[[block]]
+[block]
 struct Data {
     proj_inv: mat4x4<f32>;
     view: mat4x4<f32>;
 };
 
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var<uniform> r_data: Data;
-[[group(0), binding(1)]]
+[group(0), binding(1)]
 var r_texture: texture_cube<f32>;
-[[group(0), binding(2)]]
+[group(0), binding(2)]
 var r_sampler: sampler;
 
-[[stage(vertex)]]
-fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> VertexOutput {
+[stage(vertex)]
+fn vs_main([builtin(vertex_index)] vertex_index: u32) -> VertexOutput {
     var tmp1: i32;
     var tmp2: i32;
 
@@ -35,8 +35,8 @@ fn vs_main([[builtin(vertex_index)]] vertex_index: u32) -> VertexOutput {
     return VertexOutput(pos, (inv_model_view * unprojected.xyz));
 }
 
-[[stage(fragment)]]
-fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+[stage(fragment)]
+fn fs_main(in: VertexOutput) -> [location(0)] vec4<f32> {
     let e5: vec4<f32> = textureSample(r_texture, r_sampler, in.uv);
     return e5;
 }

--- a/tests/out/wgsl/standard.wgsl
+++ b/tests/out/wgsl/standard.wgsl
@@ -1,5 +1,5 @@
-[[stage(fragment)]]
-fn derivatives([[builtin(position)]] foo: vec4<f32>) -> [[location(0)]] vec4<f32> {
+[stage(fragment)]
+fn derivatives([builtin(position)] foo: vec4<f32>) -> [location(0)] vec4<f32> {
     let x: vec4<f32> = dpdx(foo);
     let y: vec4<f32> = dpdy(foo);
     let z: vec4<f32> = fwidth(foo);

--- a/tests/out/wgsl/swizzle_write-frag.wgsl
+++ b/tests/out/wgsl/swizzle_write-frag.wgsl
@@ -13,7 +13,7 @@ fn main1() {
     return;
 }
 
-[[stage(fragment)]]
+[stage(fragment)]
 fn main() {
     main1();
     return;

--- a/tests/out/wgsl/texture-arg.wgsl
+++ b/tests/out/wgsl/texture-arg.wgsl
@@ -1,6 +1,6 @@
-[[group(0), binding(0)]]
+[group(0), binding(0)]
 var Texture: texture_2d<f32>;
-[[group(0), binding(1)]]
+[group(0), binding(1)]
 var Sampler: sampler;
 
 fn test(Passed_Texture: texture_2d<f32>, Passed_Sampler: sampler) -> vec4<f32> {
@@ -8,8 +8,8 @@ fn test(Passed_Texture: texture_2d<f32>, Passed_Sampler: sampler) -> vec4<f32> {
     return e7;
 }
 
-[[stage(fragment)]]
-fn main() -> [[location(0)]] vec4<f32> {
+[stage(fragment)]
+fn main() -> [location(0)] vec4<f32> {
     let e2: vec4<f32> = test(Texture, Sampler);
     return e2;
 }

--- a/tests/spirv-capabilities.rs
+++ b/tests/spirv-capabilities.rs
@@ -62,7 +62,7 @@ fn sampler1d() {
     require(
         &[Ca::Sampled1D],
         r#"
-        [[group(0), binding(0)]]
+        [group(0), binding(0)]
         var image_1d: texture_1d<f32>;
     "#,
     );
@@ -73,7 +73,7 @@ fn storage1d() {
     require(
         &[Ca::Image1D],
         r#"
-        [[group(0), binding(0)]]
+        [group(0), binding(0)]
         var image_1d: texture_storage_1d<rgba8unorm,write>;
     "#,
     );
@@ -87,7 +87,7 @@ fn cube_array() {
         &[Ca::SampledCubeArray],
         &[Ca::ImageCubeArray],
         r#"
-        [[group(0), binding(0)]]
+        [group(0), binding(0)]
         var image_cube: texture_cube_array<f32>;
     "#,
     );
@@ -134,16 +134,16 @@ fn sample_rate_shading() {
     require(
         &[Ca::SampleRateShading],
         r#"
-        [[stage(fragment)]]
-        fn f([[location(0), interpolate(perspective, sample)]] x: f32) { }
+        [stage(fragment)]
+        fn f([location(0), interpolate(perspective, sample)] x: f32) { }
     "#,
     );
 
     require(
         &[Ca::SampleRateShading],
         r#"
-        [[stage(fragment)]]
-        fn f([[builtin(sample_index)]] x: u32) { }
+        [stage(fragment)]
+        fn f([builtin(sample_index)] x: u32) { }
     "#,
     );
 }
@@ -153,8 +153,8 @@ fn geometry() {
     require(
         &[Ca::Geometry],
         r#"
-        [[stage(fragment)]]
-        fn f([[builtin(primitive_index)]] x: u32) { }
+        [stage(fragment)]
+        fn f([builtin(primitive_index)] x: u32) { }
     "#,
     );
 }
@@ -165,7 +165,7 @@ fn storage_image_formats() {
         &[Ca::Shader],
         &[Ca::StorageImageExtendedFormats],
         r#"
-            [[group(0), binding(0)]]
+            [group(0), binding(0)]
             var image_rg32f: texture_storage_2d<rgba16uint, read>;
         "#,
     );
@@ -173,7 +173,7 @@ fn storage_image_formats() {
     require(
         &[Ca::StorageImageExtendedFormats],
         r#"
-            [[group(0), binding(0)]]
+            [group(0), binding(0)]
             var image_rg32f: texture_storage_2d<rg32float, read>;
         "#,
     );

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -35,11 +35,11 @@ fn function_without_identifier() {
 fn invalid_integer() {
     check(
         "fn foo([location(1.)] x: i32) {}",
-        r###"error: expected identifier, found '['
-  ┌─ wgsl:1:8
+        r###"error: expected signed integer literal of 32-bit width, found '1.'
+  ┌─ wgsl:1:18
   │
 1 │ fn foo([location(1.)] x: i32) {}
-  │        ^ expected identifier
+  │                  ^^ expected signed integer literal of 32-bit width
 
 "###,
     );
@@ -114,10 +114,10 @@ fn negative_index() {
 fn bad_texture() {
     check(
         r#"
-            [[group(0), binding(0)]] var sampler : sampler;
+            [group(0), binding(0)] var sampler : sampler;
 
-            [[stage(fragment)]]
-            fn main() -> [[location(0)]] vec4<f32> {
+            [stage(fragment)]
+            fn main() -> [location(0)] vec4<f32> {
                 let a = 3;
                 return textureSample(a, sampler, vec2<f32>(0.0));
             }
@@ -154,19 +154,19 @@ fn bad_type_cast() {
 fn bad_texture_sample_type() {
     check(
         r#"
-            [[group(0), binding(0)]] var sampler : sampler;
-            [[group(0), binding(1)]] var texture : texture_2d<bool>;
+            [group(0), binding(0)] var sampler : sampler;
+            [group(0), binding(1)] var texture : texture_2d<bool>;
 
-            [[stage(fragment)]]
-            fn main() -> [[location(0)]] vec4<f32> {
+            [stage(fragment)]
+            fn main() -> [location(0)] vec4<f32> {
                 return textureSample(texture, sampler, vec2<f32>(0.0));
             }
         "#,
         r#"error: texture sample type must be one of f32, i32 or u32, but found bool
-  ┌─ wgsl:3:63
+  ┌─ wgsl:3:61
   │
-3 │             [[group(0), binding(1)]] var texture : texture_2d<bool>;
-  │                                                               ^^^^ must be one of f32, i32 or u32
+3 │             [group(0), binding(1)] var texture : texture_2d<bool>;
+  │                                                             ^^^^ must be one of f32, i32 or u32
 
 "#,
     );
@@ -194,13 +194,13 @@ fn bad_for_initializer() {
 fn unknown_storage_class() {
     check(
         r#"
-            [[group(0), binding(0)]] var<bad> texture: texture_2d<f32>;
+            [group(0), binding(0)] var<bad> texture: texture_2d<f32>;
         "#,
         r#"error: unknown storage class: 'bad'
-  ┌─ wgsl:2:42
+  ┌─ wgsl:2:40
   │
-2 │             [[group(0), binding(0)]] var<bad> texture: texture_2d<f32>;
-  │                                          ^^^ unknown storage class
+2 │             [group(0), binding(0)] var<bad> texture: texture_2d<f32>;
+  │                                        ^^^ unknown storage class
 
 "#,
     );
@@ -210,14 +210,14 @@ fn unknown_storage_class() {
 fn unknown_attribute() {
     check(
         r#"
-            [[a]]
+            [a]
             fn x() {}
         "#,
         r#"error: unknown attribute: 'a'
-  ┌─ wgsl:2:15
+  ┌─ wgsl:2:14
   │
-2 │             [[a]]
-  │               ^ unknown attribute
+2 │             [a]
+  │              ^ unknown attribute
 
 "#,
     );
@@ -227,13 +227,13 @@ fn unknown_attribute() {
 fn unknown_built_in() {
     check(
         r#"
-            fn x([[builtin(unknown_built_in)]] y: u32) {}
+            fn x([builtin(unknown_built_in)] y: u32) {}
         "#,
         r#"error: unknown builtin: 'unknown_built_in'
-  ┌─ wgsl:2:28
+  ┌─ wgsl:2:27
   │
-2 │             fn x([[builtin(unknown_built_in)]] y: u32) {}
-  │                            ^^^^^^^^^^^^^^^^ unknown builtin
+2 │             fn x([builtin(unknown_built_in)] y: u32) {}
+  │                           ^^^^^^^^^^^^^^^^ unknown builtin
 
 "#,
     );
@@ -259,13 +259,13 @@ fn unknown_access() {
 fn unknown_shader_stage() {
     check(
         r#"
-            [[stage(geometry)]] fn main() {}
+            [stage(geometry)] fn main() {}
         "#,
         r#"error: unknown shader stage: 'geometry'
-  ┌─ wgsl:2:21
+  ┌─ wgsl:2:20
   │
-2 │             [[stage(geometry)]] fn main() {}
-  │                     ^^^^^^^^ unknown shader stage
+2 │             [stage(geometry)] fn main() {}
+  │                    ^^^^^^^^ unknown shader stage
 
 "#,
     );
@@ -343,13 +343,13 @@ fn unknown_storage_format() {
 fn unknown_conservative_depth() {
     check(
         r#"
-            [[early_depth_test(abc)]] fn main() {}
+            [early_depth_test(abc)] fn main() {}
         "#,
         r#"error: unknown conservative depth: 'abc'
-  ┌─ wgsl:2:32
+  ┌─ wgsl:2:31
   │
-2 │             [[early_depth_test(abc)]] fn main() {}
-  │                                ^^^ unknown conservative depth
+2 │             [early_depth_test(abc)] fn main() {}
+  │                               ^^^ unknown conservative depth
 
 "#,
     );
@@ -359,13 +359,13 @@ fn unknown_conservative_depth() {
 fn zero_array_stride() {
     check(
         r#"
-            type zero = [[stride(0)]] array<f32>;
+            type zero = [stride(0)] array<f32>;
         "#,
         r#"error: array stride must not be zero
-  ┌─ wgsl:2:34
+  ┌─ wgsl:2:33
   │
-2 │             type zero = [[stride(0)]] array<f32>;
-  │                                  ^ array stride must not be zero
+2 │             type zero = [stride(0)] array<f32>;
+  │                                 ^ array stride must not be zero
 
 "#,
     );
@@ -376,14 +376,14 @@ fn struct_member_zero_size() {
     check(
         r#"
             struct Bar {
-                [[size(0)]] data: array<f32>;
+                [size(0)] data: array<f32>;
             };
         "#,
         r#"error: struct member size or alignment must not be 0
-  ┌─ wgsl:3:24
+  ┌─ wgsl:3:23
   │
-3 │                 [[size(0)]] data: array<f32>;
-  │                        ^ struct member size or alignment must not be 0
+3 │                 [size(0)] data: array<f32>;
+  │                       ^ struct member size or alignment must not be 0
 
 "#,
     );
@@ -394,14 +394,14 @@ fn struct_member_zero_align() {
     check(
         r#"
             struct Bar {
-                [[align(0)]] data: array<f32>;
+                [align(0)] data: array<f32>;
             };
         "#,
         r#"error: struct member size or alignment must not be 0
-  ┌─ wgsl:3:25
+  ┌─ wgsl:3:24
   │
-3 │                 [[align(0)]] data: array<f32>;
-  │                         ^ struct member size or alignment must not be 0
+3 │                 [align(0)] data: array<f32>;
+  │                        ^ struct member size or alignment must not be 0
 
 "#,
     );
@@ -411,13 +411,13 @@ fn struct_member_zero_align() {
 fn inconsistent_binding() {
     check(
         r#"
-        fn foo([[builtin(vertex_index), location(0)]] x: u32) {}
+        fn foo([builtin(vertex_index), location(0)] x: u32) {}
         "#,
         r#"error: input/output binding is not consistent
   ┌─ wgsl:2:16
   │
-2 │         fn foo([[builtin(vertex_index), location(0)]] x: u32) {}
-  │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ input/output binding is not consistent
+2 │         fn foo([builtin(vertex_index), location(0)] x: u32) {}
+  │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ input/output binding is not consistent
 
 "#,
     );
@@ -597,7 +597,7 @@ fn invalid_arrays() {
 
     check_validation_error! {
         r#"
-            [[block]] struct Block { value: f32; };
+            [block] struct Block { value: f32; };
             type Bad = array<Block, 4>;
         "#:
         Err(naga::valid::ValidationError::Type {
@@ -608,7 +608,7 @@ fn invalid_arrays() {
 
     check_validation_error! {
         r#"
-            type Bad = [[stride(2)]] array<f32, 4>;
+            type Bad = [stride(2)] array<f32, 4>;
         "#:
         Err(naga::valid::ValidationError::Type {
             error: naga::valid::TypeError::InsufficientArrayStride { stride: 2, base_size: 4 },
@@ -726,8 +726,8 @@ fn pointer_type_equivalence() {
 fn missing_bindings() {
     check_validation_error! {
         "
-        [[stage(vertex)]]
-        fn vertex(input: vec4<f32>) -> [[location(0)]] vec4<f32> {
+        [stage(vertex)]
+        fn vertex(input: vec4<f32>) -> [location(0)] vec4<f32> {
            return input;
         }
         ":
@@ -743,8 +743,8 @@ fn missing_bindings() {
 
     check_validation_error! {
         "
-        [[stage(vertex)]]
-        fn vertex([[location(0)]] input: vec4<f32>, more_input: f32) -> [[location(0)]] vec4<f32> {
+        [stage(vertex)]
+        fn vertex([location(0)] input: vec4<f32>, more_input: f32) -> [location(0)] vec4<f32> {
            return input + more_input;
         }
         ":
@@ -760,8 +760,8 @@ fn missing_bindings() {
 
     check_validation_error! {
         "
-        [[stage(vertex)]]
-        fn vertex([[location(0)]] input: vec4<f32>) -> vec4<f32> {
+        [stage(vertex)]
+        fn vertex([location(0)] input: vec4<f32>) -> vec4<f32> {
            return input;
         }
         ":
@@ -777,12 +777,12 @@ fn missing_bindings() {
     check_validation_error! {
         "
         struct VertexIn {
-          [[location(0)]] pos: vec4<f32>;
+          [location(0)] pos: vec4<f32>;
           uv: vec2<f32>;
         };
 
-        [[stage(vertex)]]
-        fn vertex(input: VertexIn) -> [[location(0)]] vec4<f32> {
+        [stage(vertex)]
+        fn vertex(input: VertexIn) -> [location(0)] vec4<f32> {
            return input.pos;
         }
         ":
@@ -926,13 +926,13 @@ fn invalid_runtime_sized_arrays() {
             arr: array<f32>;
         };
 
-        [[block]]
+        [block]
         struct Outer {
             legit: i32;
             unsized: Unsized;
         };
 
-        [[group(0), binding(0)]] var<storage> outer: Outer;
+        [group(0), binding(0)] var<storage> outer: Outer;
 
         fn fetch(i: i32) -> f32 {
            return outer.unsized.arr[i];


### PR DESCRIPTION
This PR implements single brackets for attributes which enables middleware developers to adopt syntax like [[ and ]], #[ and ], @[ and ], ![ and ] for their tagging purposes and significantly reduces horizontal bloat while enabling much faster authoring on digital and physical mediums.