### PR TITLE
[spv-out] Fix word order for constants

### DIFF
--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1009,7 +1009,7 @@ impl Writer {
                         &solo[..]
                     }
                     8 => {
-                        pair = [(val >> 32) as u32, val as u32];
+                        pair = [val as u32, (val >> 32) as u32];
                         &pair
                     }
                     _ => unreachable!(),
@@ -1023,7 +1023,7 @@ impl Writer {
                         &solo[..]
                     }
                     8 => {
-                        pair = [(val >> 32) as u32, val as u32];
+                        pair = [val as u32, (val >> 32) as u32];
                         &pair
                     }
                     _ => unreachable!(),
@@ -1038,7 +1038,7 @@ impl Writer {
                     }
                     8 => {
                         let bits = f64::to_bits(val);
-                        pair = [(bits >> 32) as u32, bits as u32];
+                        pair = [bits as u32, (bits >> 32) as u32];
                         &pair
                     }
                     _ => unreachable!(),


### PR DESCRIPTION
Per the SPIR-V spec:

> For a numeric literal, the lower-order words appear first.