### PR TITLE
[glsl-in] Implement matrix to matrix constructor

### DIFF
--- a/tests/in/glsl/long-form-matrix.vert
+++ b/tests/in/glsl/long-form-matrix.vert
@@ -5,6 +5,7 @@ void main() {
     // Sane ways to build a matrix
     mat2 splat = mat2(1);
     mat2 normal = mat2(vec2(1), vec2(2));
+    mat2x4 from_matrix = mat2x4(mat3(1.0));
 
     // This is a little bit weirder but still makes some sense
     // Since this matrix has 2 rows we take two numbers to make a column

--- a/tests/out/wgsl/210-bevy-shader-vert.wgsl
+++ b/tests/out/wgsl/210-bevy-shader-vert.wgsl
@@ -32,16 +32,16 @@ fn main_1() {
     let e11: vec3<f32> = Vertex_Normal_1;
     v_Normal = (e10 * vec4<f32>(e11, 1.0)).xyz;
     let e16: mat4x4<f32> = global_1.Model;
-    let e24: vec3<f32> = Vertex_Normal_1;
-    v_Normal = (mat3x3<f32>(e16[0].xyz, e16[1].xyz, e16[2].xyz) * e24);
-    let e26: mat4x4<f32> = global_1.Model;
-    let e27: vec3<f32> = Vertex_Position_1;
-    v_Position = (e26 * vec4<f32>(e27, 1.0)).xyz;
-    let e32: vec2<f32> = Vertex_Uv_1;
-    v_Uv = e32;
-    let e34: mat4x4<f32> = global.ViewProj;
-    let e35: vec3<f32> = v_Position;
-    gl_Position = (e34 * vec4<f32>(e35, 1.0));
+    let e26: vec3<f32> = Vertex_Normal_1;
+    v_Normal = (mat3x3<f32>(e16[0].xyz, e16[1].xyz, e16[2].xyz) * e26);
+    let e28: mat4x4<f32> = global_1.Model;
+    let e29: vec3<f32> = Vertex_Position_1;
+    v_Position = (e28 * vec4<f32>(e29, 1.0)).xyz;
+    let e34: vec2<f32> = Vertex_Uv_1;
+    v_Uv = e34;
+    let e36: mat4x4<f32> = global.ViewProj;
+    let e37: vec3<f32> = v_Position;
+    gl_Position = (e36 * vec4<f32>(e37, 1.0));
     return;
 }
 

--- a/tests/out/wgsl/bevy-pbr-vert.wgsl
+++ b/tests/out/wgsl/bevy-pbr-vert.wgsl
@@ -39,17 +39,17 @@ fn main_1() {
     let e18: vec4<f32> = world_position;
     v_WorldPosition = e18.xyz;
     let e20: mat4x4<f32> = global_1.Model;
-    let e28: vec3<f32> = Vertex_Normal_1;
-    v_WorldNormal = (mat3x3<f32>(e20[0].xyz, e20[1].xyz, e20[2].xyz) * e28);
-    let e30: vec2<f32> = Vertex_Uv_1;
-    v_Uv = e30;
-    let e31: mat4x4<f32> = global_1.Model;
-    let e39: vec4<f32> = Vertex_Tangent_1;
-    let e42: vec4<f32> = Vertex_Tangent_1;
-    v_WorldTangent = vec4<f32>((mat3x3<f32>(e31[0].xyz, e31[1].xyz, e31[2].xyz) * e39.xyz), e42.w);
-    let e46: mat4x4<f32> = global.ViewProj;
-    let e47: vec4<f32> = world_position;
-    gl_Position = (e46 * e47);
+    let e30: vec3<f32> = Vertex_Normal_1;
+    v_WorldNormal = (mat3x3<f32>(e20[0].xyz, e20[1].xyz, e20[2].xyz) * e30);
+    let e32: vec2<f32> = Vertex_Uv_1;
+    v_Uv = e32;
+    let e33: mat4x4<f32> = global_1.Model;
+    let e43: vec4<f32> = Vertex_Tangent_1;
+    let e46: vec4<f32> = Vertex_Tangent_1;
+    v_WorldTangent = vec4<f32>((mat3x3<f32>(e33[0].xyz, e33[1].xyz, e33[2].xyz) * e43.xyz), e46.w);
+    let e50: mat4x4<f32> = global.ViewProj;
+    let e51: vec4<f32> = world_position;
+    gl_Position = (e50 * e51);
     return;
 }
 

--- a/tests/out/wgsl/long-form-matrix-vert.wgsl
+++ b/tests/out/wgsl/long-form-matrix-vert.wgsl
@@ -1,6 +1,7 @@
 fn main_1() {
     var splat: mat2x2<f32> = mat2x2<f32>(vec2<f32>(1.0, 0.0), vec2<f32>(0.0, 1.0));
     var normal: mat2x2<f32> = mat2x2<f32>(vec2<f32>(1.0, 1.0), vec2<f32>(2.0, 2.0));
+    var from_matrix: mat2x4<f32> = mat2x4<f32>(vec4<f32>(1.0, 0.0, 0.0, 0.0), vec4<f32>(0.0, 1.0, 0.0, 0.0));
     var a: mat2x2<f32> = mat2x2<f32>(vec2<f32>(1.0, 2.0), vec2<f32>(3.0, 4.0));
     var b: mat2x2<f32> = mat2x2<f32>(vec2<f32>(1.0, 2.0), vec2<f32>(3.0, 4.0));
     var c: mat3x3<f32> = mat3x3<f32>(vec3<f32>(1.0, 2.0, 3.0), vec3<f32>(1.0, 1.0, 1.0), vec3<f32>(1.0, 1.0, 1.0));
@@ -10,17 +11,18 @@ fn main_1() {
     let e1: f32 = f32(1);
     let e9: vec2<f32> = vec2<f32>(f32(1));
     let e12: vec2<f32> = vec2<f32>(f32(2));
-    let e38: vec2<f32> = vec2<f32>(f32(2), f32(3));
-    let e53: vec3<f32> = vec3<f32>(f32(1));
-    let e56: vec3<f32> = vec3<f32>(f32(1));
-    let e73: vec2<f32> = vec2<f32>(f32(2));
-    let e77: vec3<f32> = vec3<f32>(f32(1));
-    let e80: vec3<f32> = vec3<f32>(f32(1));
-    let e97: vec2<f32> = vec2<f32>(f32(2));
-    let e100: vec4<f32> = vec4<f32>(f32(1));
-    let e103: vec2<f32> = vec2<f32>(f32(2));
-    let e106: vec4<f32> = vec4<f32>(f32(1));
-    let e109: vec4<f32> = vec4<f32>(f32(1));
+    let e26: mat3x3<f32> = mat3x3<f32>(vec3<f32>(1.0, 0.0, 0.0), vec3<f32>(0.0, 1.0, 0.0), vec3<f32>(0.0, 0.0, 1.0));
+    let e58: vec2<f32> = vec2<f32>(f32(2), f32(3));
+    let e73: vec3<f32> = vec3<f32>(f32(1));
+    let e76: vec3<f32> = vec3<f32>(f32(1));
+    let e93: vec2<f32> = vec2<f32>(f32(2));
+    let e97: vec3<f32> = vec3<f32>(f32(1));
+    let e100: vec3<f32> = vec3<f32>(f32(1));
+    let e117: vec2<f32> = vec2<f32>(f32(2));
+    let e120: vec4<f32> = vec4<f32>(f32(1));
+    let e123: vec2<f32> = vec2<f32>(f32(2));
+    let e126: vec4<f32> = vec4<f32>(f32(1));
+    let e129: vec4<f32> = vec4<f32>(f32(1));
 }
 
 [[stage(vertex)]]


### PR DESCRIPTION
> If a matrix is constructed from a matrix, then each component
(column i, row j) in the result that has a corresponding component
(column i, row j) in the argument will be initialized from there. All
other components will be initialized to the identity matrix.

This was previously not implemented causing a matrix to be composed from a matrix which wouldn't pass validation.

Closes #1497