### PR TITLE
[glsl-in] Allow constructors from non-scalar to scalar

### DIFF
--- a/tests/in/glsl/expressions.frag
+++ b/tests/in/glsl/expressions.frag
@@ -70,6 +70,10 @@ void testStructConstructor() {
     BST tree = BST(1);
 }
 
+void testNonScalarToScalarConstructor() {
+    float f = float(mat2(1.0));
+}
+
 void testArrayConstructor() {
     float tree[1] = float[1](0.0);
 }

--- a/tests/out/wgsl/expressions-frag.wgsl
+++ b/tests/out/wgsl/expressions-frag.wgsl
@@ -180,6 +180,11 @@ fn testStructConstructor() {
 
 }
 
+fn testNonScalarToScalarConstructor() {
+    var f: f32 = 1.0;
+
+}
+
 fn testArrayConstructor() {
     var tree_1: array<f32,1u> = array<f32,1u>(0.0);
 


### PR DESCRIPTION
Glsl defines in section 5.4.1:

> Scalar constructors with non-scalar parameters can be used to take the first element from a non-scalar. For example, the constructor float(vec3) will select the first component of the vec3

From my testing this only applies if the non-scalar argument is either a matrix or a vector.

Closes #1493