### PR TITLE
[spv-out] Fix scalar-times-matrix operations

### DIFF
--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -346,6 +346,10 @@ impl<'w> BlockContext<'w> {
                         (Dimension::Matrix, Dimension::Scalar { .. }) => {
                             spirv::Op::MatrixTimesScalar
                         }
+                        (Dimension::Scalar, Dimension::Matrix { .. }) => {
+                            preserve_order = false;
+                            spirv::Op::MatrixTimesScalar
+                        }
                         (Dimension::Matrix, Dimension::Vector) => spirv::Op::MatrixTimesVector,
                         (Dimension::Matrix, Dimension::Matrix) => spirv::Op::MatrixTimesMatrix,
                         (Dimension::Vector, Dimension::Vector)
@@ -356,7 +360,6 @@ impl<'w> BlockContext<'w> {
                         }
                         (Dimension::Vector, Dimension::Vector)
                         | (Dimension::Scalar, Dimension::Scalar) => spirv::Op::IMul,
-                        other => unimplemented!("Mul {:?}", other),
                     },
                     crate::BinaryOperator::Divide => match left_ty_inner.scalar_kind() {
                         Some(crate::ScalarKind::Sint) => spirv::Op::SDiv,

--- a/tests/in/operators.wgsl
+++ b/tests/in/operators.wgsl
@@ -57,6 +57,17 @@ fn modulo() {
     let d = vec3<f32>(1.0) % vec3<f32>(1.0);
 }
 
+fn scalar_times_matrix() {
+    let model = mat4x4<f32>(
+        vec4<f32>(1.0, 0.0, 0.0, 0.0),
+        vec4<f32>(0.0, 1.0, 0.0, 0.0),
+        vec4<f32>(0.0, 0.0, 1.0, 0.0),
+        vec4<f32>(0.0, 0.0, 0.0, 1.0),
+    );
+
+    let assertion: mat4x4<f32> = 2.0 * model;
+}
+
 [[stage(compute), workgroup_size(1)]]
 fn main() {
     let a = builtins();
@@ -65,4 +76,5 @@ fn main() {
     let d = bool_cast(v_f32_one.xyz);
     let e = constructors();
     modulo();
+    scalar_times_matrix();
 }

--- a/tests/out/glsl/operators.main.Compute.glsl
+++ b/tests/out/glsl/operators.main.Compute.glsl
@@ -56,6 +56,11 @@ void modulo() {
     vec3 d = (vec3(1.0) - vec3(1.0) * trunc(vec3(1.0) / vec3(1.0)));
 }
 
+void scalar_times_matrix() {
+    mat4x4 model = mat4x4(vec4(1.0, 0.0, 0.0, 0.0), vec4(0.0, 1.0, 0.0, 0.0), vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0));
+    mat4x4 assertion = (2.0 * model);
+}
+
 void main() {
     vec4 _e4 = builtins();
     vec4 _e5 = splat();
@@ -63,6 +68,7 @@ void main() {
     vec3 _e8 = bool_cast(vec4(1.0, 1.0, 1.0, 1.0).xyz);
     float _e9 = constructors();
     modulo();
+    scalar_times_matrix();
     return;
 }
 

--- a/tests/out/hlsl/operators.hlsl
+++ b/tests/out/hlsl/operators.hlsl
@@ -67,6 +67,12 @@ void modulo()
     float3 d = (float3(1.0.xxx) % float3(1.0.xxx));
 }
 
+void scalar_times_matrix()
+{
+    float4x4 model = float4x4(float4(1.0, 0.0, 0.0, 0.0), float4(0.0, 1.0, 0.0, 0.0), float4(0.0, 0.0, 1.0, 0.0), float4(0.0, 0.0, 0.0, 1.0));
+    float4x4 assertion = mul(model, 2.0);
+}
+
 [numthreads(1, 1, 1)]
 void main()
 {
@@ -76,5 +82,6 @@ void main()
     const float3 _e8 = bool_cast(float4(1.0, 1.0, 1.0, 1.0).xyz);
     const float _e9 = constructors();
     modulo();
+    scalar_times_matrix();
     return;
 }

--- a/tests/out/msl/operators.msl
+++ b/tests/out/msl/operators.msl
@@ -63,6 +63,12 @@ void modulo(
     metal::float3 d = metal::fmod(metal::float3(1.0), metal::float3(1.0));
 }
 
+void scalar_times_matrix(
+) {
+    metal::float4x4 model = metal::float4x4(metal::float4(1.0, 0.0, 0.0, 0.0), metal::float4(0.0, 1.0, 0.0, 0.0), metal::float4(0.0, 0.0, 1.0, 0.0), metal::float4(0.0, 0.0, 0.0, 1.0));
+    metal::float4x4 assertion = 2.0 * model;
+}
+
 kernel void main_(
 ) {
     metal::float4 _e4 = builtins();
@@ -71,5 +77,6 @@ kernel void main_(
     metal::float3 _e8 = bool_cast(v_f32_one.xyz);
     float _e9 = constructors();
     modulo();
+    scalar_times_matrix();
     return;
 }

--- a/tests/out/spv/operators.spvasm
+++ b/tests/out/spv/operators.spvasm
@@ -1,12 +1,12 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 128
+; Bound: 139
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %119 "main"
-OpExecutionMode %119 LocalSize 1 1 1
+OpEntryPoint GLCompute %129 "main"
+OpExecutionMode %129 LocalSize 1 1 1
 OpMemberDecorate %23 0 Offset 0
 OpMemberDecorate %23 1 Offset 16
 %2 = OpTypeVoid
@@ -31,133 +31,147 @@ OpMemberDecorate %23 1 Offset 16
 %21 = OpTypeVector %10 4
 %22 = OpTypeVector %4 3
 %23 = OpTypeStruct %19 %8
-%24 = OpConstantComposite  %19  %3 %3 %3 %3
-%25 = OpConstantComposite  %19  %5 %5 %5 %5
-%26 = OpConstantComposite  %19  %6 %6 %6 %6
-%27 = OpConstantComposite  %20  %7 %7 %7 %7
-%30 = OpTypeFunction %19
-%56 = OpTypeVector %4 2
-%72 = OpTypeFunction %8
-%79 = OpConstantNull  %8
-%83 = OpTypeFunction %22 %22
-%85 = OpTypeVector %10 3
-%92 = OpTypePointer Function %23
-%95 = OpTypeFunction %4
-%99 = OpTypePointer Function %19
-%100 = OpTypePointer Function %4
-%102 = OpTypeInt 32 0
-%101 = OpConstant  %102  0
-%107 = OpTypeFunction %2
-%111 = OpTypeVector %8 3
-%29 = OpFunction  %19  None %30
-%28 = OpLabel
-OpBranch %31
-%31 = OpLabel
-%32 = OpSelect  %8  %9 %7 %11
-%34 = OpCompositeConstruct  %21  %9 %9 %9 %9
-%33 = OpSelect  %19  %34 %24 %25
-%35 = OpCompositeConstruct  %21  %12 %12 %12 %12
-%36 = OpSelect  %19  %35 %25 %24
-%37 = OpExtInst  %19  %1 FMix %25 %24 %26
-%39 = OpCompositeConstruct  %19  %13 %13 %13 %13
-%38 = OpExtInst  %19  %1 FMix %25 %24 %39
-%40 = OpCompositeExtract  %8  %27 0
-%41 = OpBitcast  %4  %40
-%42 = OpBitcast  %19  %27
-%43 = OpConvertFToS  %20  %25
-%44 = OpCompositeConstruct  %20  %32 %32 %32 %32
-%45 = OpIAdd  %20  %44 %43
-%46 = OpConvertSToF  %19  %45
-%47 = OpFAdd  %19  %46 %33
-%48 = OpFAdd  %19  %47 %37
+%24 = OpTypeMatrix %19 4
+%25 = OpConstantComposite  %19  %3 %3 %3 %3
+%26 = OpConstantComposite  %19  %5 %5 %5 %5
+%27 = OpConstantComposite  %19  %6 %6 %6 %6
+%28 = OpConstantComposite  %20  %7 %7 %7 %7
+%31 = OpTypeFunction %19
+%57 = OpTypeVector %4 2
+%73 = OpTypeFunction %8
+%80 = OpConstantNull  %8
+%84 = OpTypeFunction %22 %22
+%86 = OpTypeVector %10 3
+%93 = OpTypePointer Function %23
+%96 = OpTypeFunction %4
+%100 = OpTypePointer Function %19
+%101 = OpTypePointer Function %4
+%103 = OpTypeInt 32 0
+%102 = OpConstant  %103  0
+%108 = OpTypeFunction %2
+%112 = OpTypeVector %8 3
+%30 = OpFunction  %19  None %31
+%29 = OpLabel
+OpBranch %32
+%32 = OpLabel
+%33 = OpSelect  %8  %9 %7 %11
+%35 = OpCompositeConstruct  %21  %9 %9 %9 %9
+%34 = OpSelect  %19  %35 %25 %26
+%36 = OpCompositeConstruct  %21  %12 %12 %12 %12
+%37 = OpSelect  %19  %36 %26 %25
+%38 = OpExtInst  %19  %1 FMix %26 %25 %27
+%40 = OpCompositeConstruct  %19  %13 %13 %13 %13
+%39 = OpExtInst  %19  %1 FMix %26 %25 %40
+%41 = OpCompositeExtract  %8  %28 0
+%42 = OpBitcast  %4  %41
+%43 = OpBitcast  %19  %28
+%44 = OpConvertFToS  %20  %26
+%45 = OpCompositeConstruct  %20  %33 %33 %33 %33
+%46 = OpIAdd  %20  %45 %44
+%47 = OpConvertSToF  %19  %46
+%48 = OpFAdd  %19  %47 %34
 %49 = OpFAdd  %19  %48 %38
-%50 = OpCompositeConstruct  %19  %41 %41 %41 %41
-%51 = OpFAdd  %19  %49 %50
-%52 = OpFAdd  %19  %51 %42
-OpReturnValue %52
+%50 = OpFAdd  %19  %49 %39
+%51 = OpCompositeConstruct  %19  %42 %42 %42 %42
+%52 = OpFAdd  %19  %50 %51
+%53 = OpFAdd  %19  %52 %43
+OpReturnValue %53
 OpFunctionEnd
-%54 = OpFunction  %19  None %30
-%53 = OpLabel
-OpBranch %55
-%55 = OpLabel
-%57 = OpCompositeConstruct  %56  %14 %14
-%58 = OpCompositeConstruct  %56  %3 %3
-%59 = OpFAdd  %56  %58 %57
-%60 = OpCompositeConstruct  %56  %15 %15
-%61 = OpFSub  %56  %59 %60
-%62 = OpCompositeConstruct  %56  %16 %16
-%63 = OpFDiv  %56  %61 %62
-%64 = OpCompositeConstruct  %20  %17 %17 %17 %17
-%65 = OpCompositeConstruct  %20  %18 %18 %18 %18
-%66 = OpSMod  %20  %64 %65
-%67 = OpVectorShuffle  %19  %63 %63 0 1 0 1
-%68 = OpConvertSToF  %19  %66
-%69 = OpFAdd  %19  %67 %68
-OpReturnValue %69
+%55 = OpFunction  %19  None %31
+%54 = OpLabel
+OpBranch %56
+%56 = OpLabel
+%58 = OpCompositeConstruct  %57  %14 %14
+%59 = OpCompositeConstruct  %57  %3 %3
+%60 = OpFAdd  %57  %59 %58
+%61 = OpCompositeConstruct  %57  %15 %15
+%62 = OpFSub  %57  %60 %61
+%63 = OpCompositeConstruct  %57  %16 %16
+%64 = OpFDiv  %57  %62 %63
+%65 = OpCompositeConstruct  %20  %17 %17 %17 %17
+%66 = OpCompositeConstruct  %20  %18 %18 %18 %18
+%67 = OpSMod  %20  %65 %66
+%68 = OpVectorShuffle  %19  %64 %64 0 1 0 1
+%69 = OpConvertSToF  %19  %67
+%70 = OpFAdd  %19  %68 %69
+OpReturnValue %70
 OpFunctionEnd
-%71 = OpFunction  %8  None %72
-%70 = OpLabel
-OpBranch %73
-%73 = OpLabel
-%74 = OpLogicalNot  %10  %9
-OpSelectionMerge %75 None
-OpBranchConditional %74 %76 %77
-%76 = OpLabel
-OpReturnValue %7
+%72 = OpFunction  %8  None %73
+%71 = OpLabel
+OpBranch %74
+%74 = OpLabel
+%75 = OpLogicalNot  %10  %9
+OpSelectionMerge %76 None
+OpBranchConditional %75 %77 %78
 %77 = OpLabel
-%78 = OpNot  %8  %7
-OpReturnValue %78
-%75 = OpLabel
+OpReturnValue %7
+%78 = OpLabel
+%79 = OpNot  %8  %7
 OpReturnValue %79
+%76 = OpLabel
+OpReturnValue %80
 OpFunctionEnd
-%82 = OpFunction  %22  None %83
-%81 = OpFunctionParameter  %22
-%80 = OpLabel
-OpBranch %84
-%84 = OpLabel
-%86 = OpCompositeConstruct  %22  %5 %5 %5
-%87 = OpFUnordNotEqual  %85  %81 %86
-%88 = OpCompositeConstruct  %22  %5 %5 %5
-%89 = OpCompositeConstruct  %22  %3 %3 %3
-%90 = OpSelect  %22  %87 %89 %88
-OpReturnValue %90
+%83 = OpFunction  %22  None %84
+%82 = OpFunctionParameter  %22
+%81 = OpLabel
+OpBranch %85
+%85 = OpLabel
+%87 = OpCompositeConstruct  %22  %5 %5 %5
+%88 = OpFUnordNotEqual  %86  %82 %87
+%89 = OpCompositeConstruct  %22  %5 %5 %5
+%90 = OpCompositeConstruct  %22  %3 %3 %3
+%91 = OpSelect  %22  %88 %90 %89
+OpReturnValue %91
 OpFunctionEnd
-%94 = OpFunction  %4  None %95
-%93 = OpLabel
-%91 = OpVariable  %92  Function
-OpBranch %96
-%96 = OpLabel
-%97 = OpCompositeConstruct  %19  %3 %3 %3 %3
-%98 = OpCompositeConstruct  %23  %97 %7
-OpStore %91 %98
-%103 = OpAccessChain  %100  %91 %101 %101
-%104 = OpLoad  %4  %103
-OpReturnValue %104
+%95 = OpFunction  %4  None %96
+%94 = OpLabel
+%92 = OpVariable  %93  Function
+OpBranch %97
+%97 = OpLabel
+%98 = OpCompositeConstruct  %19  %3 %3 %3 %3
+%99 = OpCompositeConstruct  %23  %98 %7
+OpStore %92 %99
+%104 = OpAccessChain  %101  %92 %102 %102
+%105 = OpLoad  %4  %104
+OpReturnValue %105
 OpFunctionEnd
-%106 = OpFunction  %2  None %107
-%105 = OpLabel
-OpBranch %108
-%108 = OpLabel
-%109 = OpSMod  %8  %7 %7
-%110 = OpFMod  %4  %3 %3
-%112 = OpCompositeConstruct  %111  %7 %7 %7
-%113 = OpCompositeConstruct  %111  %7 %7 %7
-%114 = OpSMod  %111  %112 %113
-%115 = OpCompositeConstruct  %22  %3 %3 %3
+%107 = OpFunction  %2  None %108
+%106 = OpLabel
+OpBranch %109
+%109 = OpLabel
+%110 = OpSMod  %8  %7 %7
+%111 = OpFMod  %4  %3 %3
+%113 = OpCompositeConstruct  %112  %7 %7 %7
+%114 = OpCompositeConstruct  %112  %7 %7 %7
+%115 = OpSMod  %112  %113 %114
 %116 = OpCompositeConstruct  %22  %3 %3 %3
-%117 = OpFMod  %22  %115 %116
+%117 = OpCompositeConstruct  %22  %3 %3 %3
+%118 = OpFMod  %22  %116 %117
 OpReturn
 OpFunctionEnd
-%119 = OpFunction  %2  None %107
-%118 = OpLabel
-OpBranch %120
-%120 = OpLabel
-%121 = OpFunctionCall  %19  %29
-%122 = OpFunctionCall  %19  %54
-%123 = OpFunctionCall  %8  %71
-%124 = OpVectorShuffle  %22  %24 %24 0 1 2
-%125 = OpFunctionCall  %22  %82 %124
-%126 = OpFunctionCall  %4  %94
-%127 = OpFunctionCall  %2  %106
+%120 = OpFunction  %2  None %108
+%119 = OpLabel
+OpBranch %121
+%121 = OpLabel
+%122 = OpCompositeConstruct  %19  %3 %5 %5 %5
+%123 = OpCompositeConstruct  %19  %5 %3 %5 %5
+%124 = OpCompositeConstruct  %19  %5 %5 %3 %5
+%125 = OpCompositeConstruct  %19  %5 %5 %5 %3
+%126 = OpCompositeConstruct  %24  %122 %123 %124 %125
+%127 = OpMatrixTimesScalar  %24  %126 %14
+OpReturn
+OpFunctionEnd
+%129 = OpFunction  %2  None %108
+%128 = OpLabel
+OpBranch %130
+%130 = OpLabel
+%131 = OpFunctionCall  %19  %30
+%132 = OpFunctionCall  %19  %55
+%133 = OpFunctionCall  %8  %72
+%134 = OpVectorShuffle  %22  %25 %25 0 1 2
+%135 = OpFunctionCall  %22  %83 %134
+%136 = OpFunctionCall  %4  %95
+%137 = OpFunctionCall  %2  %107
+%138 = OpFunctionCall  %2  %120
 OpReturn
 OpFunctionEnd

--- a/tests/out/wgsl/operators.wgsl
+++ b/tests/out/wgsl/operators.wgsl
@@ -53,6 +53,11 @@ fn modulo() {
     let d: vec3<f32> = (vec3<f32>(1.0) % vec3<f32>(1.0));
 }
 
+fn scalar_times_matrix() {
+    let model: mat4x4<f32> = mat4x4<f32>(vec4<f32>(1.0, 0.0, 0.0, 0.0), vec4<f32>(0.0, 1.0, 0.0, 0.0), vec4<f32>(0.0, 0.0, 1.0, 0.0), vec4<f32>(0.0, 0.0, 0.0, 1.0));
+    let assertion: mat4x4<f32> = (2.0 * model);
+}
+
 [[stage(compute), workgroup_size(1, 1, 1)]]
 fn main() {
     let e4: vec4<f32> = builtins();
@@ -61,5 +66,6 @@ fn main() {
     let e8: vec3<f32> = bool_cast(vec4<f32>(1.0, 1.0, 1.0, 1.0).xyz);
     let e9: f32 = constructors();
     modulo();
+    scalar_times_matrix();
     return;
 }


### PR DESCRIPTION
Converting some GLSL to WGSL, I ran into a panic in the SpirV backend: `not implemented: Mul (Scalar, Matrix)`. The fix is super simple. Tests are included.

Interesting, the HLSL backend already does this same transformation. Cool!