### PR TITLE
[valid] Check that switches have a default case

### DIFF
--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -106,6 +106,8 @@ pub enum FunctionError {
     InvalidSwitchType(Handle<crate::Expression>),
     #[error("Multiple `switch` cases for {0:?} are present")]
     ConflictingSwitchCase(i32),
+    #[error("The `switch` is missing a `default` case")]
+    MissingDefaultCase,
     #[error("Multiple `default` cases are present")]
     MultipleDefaultCases,
     #[error("The last `switch` case contains a `falltrough`")]
@@ -470,6 +472,10 @@ impl super::Validator {
                                 default = true
                             }
                         }
+                    }
+                    if !default {
+                        return Err(FunctionError::MissingDefaultCase
+                            .with_span_static(span, "missing default case"));
                     }
                     if let Some(case) = cases.last() {
                         if case.fall_through {

--- a/tests/in/control-flow.wgsl
+++ b/tests/in/control-flow.wgsl
@@ -36,6 +36,8 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 	switch(0u) {
 		case 0u: {
 		}
+        default: {
+        }
 	}
 
     // non-empty switch in last-statement-in-function position
@@ -71,6 +73,7 @@ fn switch_case_break() {
         case 0: {
             break;
         }
+        default: {}
     }
     return;
 }
@@ -81,6 +84,7 @@ fn loop_switch_continue(x: i32) {
             case 1: {
                 continue;
             }
+            default: {}
         }
     }
 }

--- a/tests/out/glsl/control-flow.main.Compute.glsl
+++ b/tests/out/glsl/control-flow.main.Compute.glsl
@@ -17,6 +17,8 @@ void switch_case_break() {
     switch(0) {
         case 0:
             break;
+        default:
+            break;
     }
     return;
 }
@@ -26,6 +28,8 @@ void loop_switch_continue(int x) {
         switch(x) {
             case 1:
                 continue;
+            default:
+                break;
         }
     }
     return;
@@ -60,6 +64,8 @@ void main() {
     }
     switch(0u) {
         case 0u:
+            break;
+        default:
             break;
     }
     int _e10 = pos;

--- a/tests/out/hlsl/control-flow.hlsl
+++ b/tests/out/hlsl/control-flow.hlsl
@@ -14,6 +14,9 @@ void switch_case_break()
         case 0: {
             break;
         }
+        default: {
+            break;
+        }
     }
     return;
 }
@@ -24,6 +27,9 @@ void loop_switch_continue(int x)
         switch(x) {
             case 1: {
                 continue;
+            }
+            default: {
+                break;
             }
         }
     }
@@ -69,6 +75,9 @@ void main(uint3 global_id : SV_DispatchThreadID)
     }
     switch(0u) {
         case 0u: {
+            break;
+        }
+        default: {
             break;
         }
     }

--- a/tests/out/msl/control-flow.msl
+++ b/tests/out/msl/control-flow.msl
@@ -19,6 +19,9 @@ void switch_case_break(
         case 0: {
             break;
         }
+        default: {
+            break;
+        }
     }
     return;
 }
@@ -30,6 +33,9 @@ void loop_switch_continue(
         switch(x) {
             case 1: {
                 continue;
+            }
+            default: {
+                break;
             }
         }
     }
@@ -73,6 +79,9 @@ kernel void main_(
     }
     switch(0u) {
         case 0u: {
+            break;
+        }
+        default: {
             break;
         }
     }

--- a/tests/out/wgsl/control-flow.wgsl
+++ b/tests/out/wgsl/control-flow.wgsl
@@ -11,6 +11,8 @@ fn switch_case_break() {
         case 0: {
             break;
         }
+        default: {
+        }
     }
     return;
 }
@@ -20,6 +22,8 @@ fn loop_switch_continue(x: i32) {
         switch(x) {
             case 1: {
                 continue;
+            }
+            default: {
             }
         }
     }
@@ -58,6 +62,8 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
     }
     switch(0u) {
         case 0u: {
+        }
+        default: {
         }
     }
     let e10: i32 = pos;

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -995,6 +995,7 @@ fn last_case_falltrough() {
         "
         fn test_falltrough() {
           switch(0) {
+            default: {}
             case 0: {
               fallthrough;
             }
@@ -1004,6 +1005,25 @@ fn last_case_falltrough() {
         Err(
             naga::valid::ValidationError::Function {
                 error: naga::valid::FunctionError::LastCaseFallTrough,
+                ..
+            },
+        )
+    }
+}
+
+#[test]
+fn missing_default_case() {
+    check_validation_error! {
+        "
+        fn test_missing_default_case() {
+          switch(0) {
+            case 0: {}
+          }
+        }
+        ":
+        Err(
+            naga::valid::ValidationError::Function {
+                error: naga::valid::FunctionError::MissingDefaultCase,
                 ..
             },
         )


### PR DESCRIPTION
From the WGSL spec: "Each switch statement must have exactly one default clause."

Noticed this because [this switch](https://github.com/hecrj/wgpu_glyph/blob/cd6f154db0e7dd8231fdd34fcac470f975c825d7/src/shader/glyph.wgsl#L35-L52) doesn't get rejected by naga but Chrome/Tint reports:
```
Tint WGSL reader failure:
Parser: 35:5 error: switch statement must have a default clause
    switch (i32(input.vertex_index)) {
    ^^^^^^
```