### PR TITLE
Forbid specializable constants as array lengths.

### DIFF
--- a/src/back/spv/index.rs
+++ b/src/back/spv/index.rs
@@ -109,10 +109,6 @@ impl<'w> BlockContext<'w> {
                 let length_id = self.write_runtime_array_length(sequence, block)?;
                 Ok(MaybeKnown::Computed(length_id))
             }
-            crate::proc::IndexableLength::Specializable(constant) => {
-                let length_id = self.writer.constant_ids[constant.index()];
-                Ok(MaybeKnown::Computed(length_id))
-            }
         }
     }
 

--- a/src/proc/index.rs
+++ b/src/proc/index.rs
@@ -49,10 +49,6 @@ pub enum IndexableLength {
     /// Values of this type always have the given number of elements.
     Known(u32),
 
-    /// The value of the given specializable constant is the number of elements.
-    /// (Non-specializable constants are reported as `Known`.)
-    Specializable(crate::Handle<crate::Constant>),
-
     /// The number of elements is determined at runtime.
     Dynamic,
 }
@@ -65,7 +61,11 @@ impl crate::ArraySize {
                 K {
                     specialization: Some(_),
                     ..
-                } => IndexableLength::Specializable(k),
+                } => {
+                    // Specializable constants are not supported as array lengths.
+                    // See valid::TypeError::UnsupportedSpecializedArrayLength.
+                    return Err(ProcError::InvalidArraySizeConstant(k));
+                }
                 ref unspecialized => {
                     let length = unspecialized
                         .to_array_length()


### PR DESCRIPTION
Only the SPIR-V front end can produce such array types, and it seems that our back ends don't support this case well.