### PR TITLE
Tighten checks on pointers to unsized values, and pointer arguments

### DIFF
--- a/src/back/spv/index.rs
+++ b/src/back/spv/index.rs
@@ -65,10 +65,6 @@ impl<'w> BlockContext<'w> {
                     crate::Expression::GlobalVariable(handle) => {
                         (self.writer.global_variables[handle.index()].id, index)
                     }
-                    crate::Expression::FunctionArgument(index) => {
-                        let parameter_id = self.function.parameter_id(index);
-                        (parameter_id, index)
-                    }
                     _ => return Err(Error::Validation("array length expression")),
                 }
             }

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -2143,23 +2143,7 @@ impl Parser {
                     let _ = lexer.next();
                     self.pop_scope(lexer);
 
-                    // Not all identifiers constitute references in WGSL.
-                    let is_reference = match ctx.expressions[definition.handle] {
-                        // `let`-bound identifiers don't evaluate to references: `let`
-                        // declarations apply the Load Rule to their values.
-                        crate::Expression::LocalVariable(_) => definition.is_reference,
-                        // Global variables in the `Handle` storage class do not evaluate
-                        // to references.
-                        crate::Expression::GlobalVariable(global) => {
-                            ctx.global_vars[global].class != crate::StorageClass::Handle
-                        }
-                        _ => false,
-                    };
-
-                    TypedExpression {
-                        handle: definition.handle,
-                        is_reference,
-                    }
+                    *definition
                 } else if let Some(CalledFunction { result: Some(expr) }) =
                     self.parse_function_call_inner(lexer, word, ctx.reborrow())?
                 {

--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -843,16 +843,6 @@ impl super::Validator {
 
         #[cfg(feature = "validate")]
         for (index, argument) in fun.arguments.iter().enumerate() {
-            if !self.types[argument.ty.index()]
-                .flags
-                .contains(super::TypeFlags::ARGUMENT)
-            {
-                return Err(FunctionError::InvalidArgumentType {
-                    index,
-                    name: argument.name.clone().unwrap_or_default(),
-                }
-                .with_span_handle(argument.ty, &module.types));
-            }
             match module.types[argument.ty].inner.pointer_class() {
                 Some(crate::StorageClass::Private)
                 | Some(crate::StorageClass::Function)
@@ -866,6 +856,17 @@ impl super::Validator {
                     }
                     .with_span_handle(argument.ty, &module.types))
                 }
+            }
+            // Check for the least informative error last.
+            if !self.types[argument.ty.index()]
+                .flags
+                .contains(super::TypeFlags::ARGUMENT)
+            {
+                return Err(FunctionError::InvalidArgumentType {
+                    index,
+                    name: argument.name.clone().unwrap_or_default(),
+                }
+                .with_span_handle(argument.ty, &module.types));
             }
         }
 

--- a/tests/in/pointers.wgsl
+++ b/tests/in/pointers.wgsl
@@ -14,3 +14,20 @@ fn index_dynamic_array(p: ptr<workgroup, DynamicArray>, i: i32, v: u32) -> u32 {
    (*p).array[i] = v;
    return old;
 }
+
+[[group(0), binding(0)]]
+var<storage, read_write> dynamic_array: DynamicArray;
+
+fn index_unsized(i: i32, v: u32) {
+   let p: ptr<storage, DynamicArray, read_write> = &dynamic_array;
+
+   let val = (*p).array[i];
+   (*p).array[i] = val + v;
+}
+
+fn index_dynamic_array(i: i32, v: u32) {
+   let p: ptr<storage, array<u32>, read_write> = &dynamic_array.array;
+
+   let val = (*p)[i];
+   (*p)[i] = val + v;
+}

--- a/tests/in/pointers.wgsl
+++ b/tests/in/pointers.wgsl
@@ -9,12 +9,6 @@ struct DynamicArray {
     array: array<u32>;
 };
 
-fn index_dynamic_array(p: ptr<workgroup, DynamicArray>, i: i32, v: u32) -> u32 {
-   let old = (*p).array[i];
-   (*p).array[i] = v;
-   return old;
-}
-
 [[group(0), binding(0)]]
 var<storage, read_write> dynamic_array: DynamicArray;
 

--- a/tests/out/spv/pointers.spvasm
+++ b/tests/out/spv/pointers.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.2
 ; Generator: rspirv
-; Bound: 65
+; Bound: 41
 OpCapability Shader
 OpCapability Linkage
 OpExtension "SPV_KHR_storage_buffer_storage_class"
@@ -10,24 +10,20 @@ OpMemoryModel Logical GLSL450
 OpSource GLSL 450
 OpMemberName %8 0 "array"
 OpName %8 "DynamicArray"
-OpName %12 "dynamic_array"
-OpName %13 "v"
-OpName %16 "f"
-OpName %23 "p"
-OpName %24 "i"
-OpName %25 "v"
-OpName %26 "index_dynamic_array"
-OpName %46 "i"
-OpName %47 "v"
-OpName %48 "index_unsized"
-OpName %57 "i"
-OpName %58 "v"
-OpName %59 "index_dynamic_array"
+OpName %11 "dynamic_array"
+OpName %12 "v"
+OpName %15 "f"
+OpName %22 "i"
+OpName %23 "v"
+OpName %24 "index_unsized"
+OpName %33 "i"
+OpName %34 "v"
+OpName %35 "index_dynamic_array"
 OpDecorate %7 ArrayStride 4
 OpDecorate %8 Block
 OpMemberDecorate %8 0 Offset 0
-OpDecorate %12 DescriptorSet 0
-OpDecorate %12 Binding 0
+OpDecorate %11 DescriptorSet 0
+OpDecorate %11 Binding 0
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 1
 %3 = OpConstant  %4  10
@@ -35,81 +31,47 @@ OpDecorate %12 Binding 0
 %6 = OpTypeInt 32 0
 %7 = OpTypeRuntimeArray %6
 %8 = OpTypeStruct %7
-%9 = OpTypePointer Workgroup %8
-%10 = OpTypePointer StorageBuffer %8
-%11 = OpTypePointer StorageBuffer %7
-%12 = OpVariable  %10  StorageBuffer
-%14 = OpTypePointer Function %5
-%17 = OpTypeFunction %2
-%19 = OpTypePointer Function %4
-%20 = OpConstant  %6  0
-%27 = OpTypeFunction %6 %9 %4 %6
-%29 = OpTypePointer Workgroup %7
-%30 = OpTypePointer Workgroup %6
-%33 = OpTypeBool
-%35 = OpConstantNull  %6
-%49 = OpTypeFunction %2 %4 %6
-%51 = OpTypePointer StorageBuffer %6
-%16 = OpFunction  %2  None %17
-%15 = OpLabel
-%13 = OpVariable  %14  Function
-OpBranch %18
-%18 = OpLabel
-%21 = OpAccessChain  %19  %13 %20
-OpStore %21 %3
+%9 = OpTypePointer StorageBuffer %8
+%10 = OpTypePointer StorageBuffer %7
+%11 = OpVariable  %9  StorageBuffer
+%13 = OpTypePointer Function %5
+%16 = OpTypeFunction %2
+%18 = OpTypePointer Function %4
+%19 = OpConstant  %6  0
+%25 = OpTypeFunction %2 %4 %6
+%27 = OpTypePointer StorageBuffer %6
+%15 = OpFunction  %2  None %16
+%14 = OpLabel
+%12 = OpVariable  %13  Function
+OpBranch %17
+%17 = OpLabel
+%20 = OpAccessChain  %18  %12 %19
+OpStore %20 %3
 OpReturn
 OpFunctionEnd
-%26 = OpFunction  %6  None %27
-%23 = OpFunctionParameter  %9
-%24 = OpFunctionParameter  %4
-%25 = OpFunctionParameter  %6
-%22 = OpLabel
-OpBranch %28
-%28 = OpLabel
-%31 = OpArrayLength  %6  %23 0
-%32 = OpULessThan  %33  %24 %31
-OpSelectionMerge %36 None
-OpBranchConditional %32 %37 %36
-%37 = OpLabel
-%34 = OpAccessChain  %30  %23 %20 %24
-%38 = OpLoad  %6  %34
+%24 = OpFunction  %2  None %25
+%22 = OpFunctionParameter  %4
+%23 = OpFunctionParameter  %6
+%21 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%28 = OpAccessChain  %27  %11 %19 %22
+%29 = OpLoad  %6  %28
+%30 = OpIAdd  %6  %29 %23
+%31 = OpAccessChain  %27  %11 %19 %22
+OpStore %31 %30
+OpReturn
+OpFunctionEnd
+%35 = OpFunction  %2  None %25
+%33 = OpFunctionParameter  %4
+%34 = OpFunctionParameter  %6
+%32 = OpLabel
 OpBranch %36
 %36 = OpLabel
-%39 = OpPhi  %6  %35 %28 %38 %37
-%40 = OpArrayLength  %6  %23 0
-%41 = OpULessThan  %33  %24 %40
-OpSelectionMerge %43 None
-OpBranchConditional %41 %44 %43
-%44 = OpLabel
-%42 = OpAccessChain  %30  %23 %20 %24
-OpStore %42 %25
-OpBranch %43
-%43 = OpLabel
-OpReturnValue %39
-OpFunctionEnd
-%48 = OpFunction  %2  None %49
-%46 = OpFunctionParameter  %4
-%47 = OpFunctionParameter  %6
-%45 = OpLabel
-OpBranch %50
-%50 = OpLabel
-%52 = OpAccessChain  %51  %12 %20 %46
-%53 = OpLoad  %6  %52
-%54 = OpIAdd  %6  %53 %47
-%55 = OpAccessChain  %51  %12 %20 %46
-OpStore %55 %54
-OpReturn
-OpFunctionEnd
-%59 = OpFunction  %2  None %49
-%57 = OpFunctionParameter  %4
-%58 = OpFunctionParameter  %6
-%56 = OpLabel
-OpBranch %60
-%60 = OpLabel
-%61 = OpAccessChain  %51  %12 %20 %57
-%62 = OpLoad  %6  %61
-%63 = OpIAdd  %6  %62 %58
-%64 = OpAccessChain  %51  %12 %20 %57
-OpStore %64 %63
+%37 = OpAccessChain  %27  %11 %19 %33
+%38 = OpLoad  %6  %37
+%39 = OpIAdd  %6  %38 %34
+%40 = OpAccessChain  %27  %11 %19 %33
+OpStore %40 %39
 OpReturn
 OpFunctionEnd

--- a/tests/out/spv/pointers.spvasm
+++ b/tests/out/spv/pointers.spvasm
@@ -1,23 +1,33 @@
 ; SPIR-V
 ; Version: 1.2
 ; Generator: rspirv
-; Bound: 42
+; Bound: 65
 OpCapability Shader
 OpCapability Linkage
+OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpSource GLSL 450
 OpMemberName %8 0 "array"
 OpName %8 "DynamicArray"
-OpName %10 "v"
-OpName %13 "f"
-OpName %20 "p"
-OpName %21 "i"
-OpName %22 "v"
-OpName %23 "index_dynamic_array"
+OpName %12 "dynamic_array"
+OpName %13 "v"
+OpName %16 "f"
+OpName %23 "p"
+OpName %24 "i"
+OpName %25 "v"
+OpName %26 "index_dynamic_array"
+OpName %46 "i"
+OpName %47 "v"
+OpName %48 "index_unsized"
+OpName %57 "i"
+OpName %58 "v"
+OpName %59 "index_dynamic_array"
 OpDecorate %7 ArrayStride 4
 OpDecorate %8 Block
 OpMemberDecorate %8 0 Offset 0
+OpDecorate %12 DescriptorSet 0
+OpDecorate %12 Binding 0
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 1
 %3 = OpConstant  %4  10
@@ -26,49 +36,80 @@ OpMemberDecorate %8 0 Offset 0
 %7 = OpTypeRuntimeArray %6
 %8 = OpTypeStruct %7
 %9 = OpTypePointer Workgroup %8
-%11 = OpTypePointer Function %5
-%14 = OpTypeFunction %2
-%16 = OpTypePointer Function %4
-%17 = OpConstant  %6  0
-%24 = OpTypeFunction %6 %9 %4 %6
-%26 = OpTypePointer Workgroup %7
-%27 = OpTypePointer Workgroup %6
-%30 = OpTypeBool
-%32 = OpConstantNull  %6
-%13 = OpFunction  %2  None %14
-%12 = OpLabel
-%10 = OpVariable  %11  Function
-OpBranch %15
+%10 = OpTypePointer StorageBuffer %8
+%11 = OpTypePointer StorageBuffer %7
+%12 = OpVariable  %10  StorageBuffer
+%14 = OpTypePointer Function %5
+%17 = OpTypeFunction %2
+%19 = OpTypePointer Function %4
+%20 = OpConstant  %6  0
+%27 = OpTypeFunction %6 %9 %4 %6
+%29 = OpTypePointer Workgroup %7
+%30 = OpTypePointer Workgroup %6
+%33 = OpTypeBool
+%35 = OpConstantNull  %6
+%49 = OpTypeFunction %2 %4 %6
+%51 = OpTypePointer StorageBuffer %6
+%16 = OpFunction  %2  None %17
 %15 = OpLabel
-%18 = OpAccessChain  %16  %10 %17
-OpStore %18 %3
+%13 = OpVariable  %14  Function
+OpBranch %18
+%18 = OpLabel
+%21 = OpAccessChain  %19  %13 %20
+OpStore %21 %3
 OpReturn
 OpFunctionEnd
-%23 = OpFunction  %6  None %24
-%20 = OpFunctionParameter  %9
-%21 = OpFunctionParameter  %4
-%22 = OpFunctionParameter  %6
-%19 = OpLabel
-OpBranch %25
-%25 = OpLabel
-%28 = OpArrayLength  %6  %20 0
-%29 = OpULessThan  %30  %21 %28
-OpSelectionMerge %33 None
-OpBranchConditional %29 %34 %33
-%34 = OpLabel
-%31 = OpAccessChain  %27  %20 %17 %21
-%35 = OpLoad  %6  %31
-OpBranch %33
-%33 = OpLabel
-%36 = OpPhi  %6  %32 %25 %35 %34
-%37 = OpArrayLength  %6  %20 0
-%38 = OpULessThan  %30  %21 %37
-OpSelectionMerge %40 None
-OpBranchConditional %38 %41 %40
-%41 = OpLabel
-%39 = OpAccessChain  %27  %20 %17 %21
-OpStore %39 %22
-OpBranch %40
-%40 = OpLabel
-OpReturnValue %36
+%26 = OpFunction  %6  None %27
+%23 = OpFunctionParameter  %9
+%24 = OpFunctionParameter  %4
+%25 = OpFunctionParameter  %6
+%22 = OpLabel
+OpBranch %28
+%28 = OpLabel
+%31 = OpArrayLength  %6  %23 0
+%32 = OpULessThan  %33  %24 %31
+OpSelectionMerge %36 None
+OpBranchConditional %32 %37 %36
+%37 = OpLabel
+%34 = OpAccessChain  %30  %23 %20 %24
+%38 = OpLoad  %6  %34
+OpBranch %36
+%36 = OpLabel
+%39 = OpPhi  %6  %35 %28 %38 %37
+%40 = OpArrayLength  %6  %23 0
+%41 = OpULessThan  %33  %24 %40
+OpSelectionMerge %43 None
+OpBranchConditional %41 %44 %43
+%44 = OpLabel
+%42 = OpAccessChain  %30  %23 %20 %24
+OpStore %42 %25
+OpBranch %43
+%43 = OpLabel
+OpReturnValue %39
+OpFunctionEnd
+%48 = OpFunction  %2  None %49
+%46 = OpFunctionParameter  %4
+%47 = OpFunctionParameter  %6
+%45 = OpLabel
+OpBranch %50
+%50 = OpLabel
+%52 = OpAccessChain  %51  %12 %20 %46
+%53 = OpLoad  %6  %52
+%54 = OpIAdd  %6  %53 %47
+%55 = OpAccessChain  %51  %12 %20 %46
+OpStore %55 %54
+OpReturn
+OpFunctionEnd
+%59 = OpFunction  %2  None %49
+%57 = OpFunctionParameter  %4
+%58 = OpFunctionParameter  %6
+%56 = OpLabel
+OpBranch %60
+%60 = OpLabel
+%61 = OpAccessChain  %51  %12 %20 %57
+%62 = OpLoad  %6  %61
+%63 = OpIAdd  %6  %62 %58
+%64 = OpAccessChain  %51  %12 %20 %57
+OpStore %64 %63
+OpReturn
 OpFunctionEnd

--- a/tests/out/wgsl/pointers.wgsl
+++ b/tests/out/wgsl/pointers.wgsl
@@ -14,22 +14,16 @@ fn f() {
     return;
 }
 
-fn index_dynamic_array(p: ptr<workgroup, DynamicArray>, i: i32, v_1: u32) -> u32 {
-    let old: u32 = (*p).array_[i];
-    (*p).array_[i] = v_1;
-    return old;
-}
-
-fn index_unsized(i_1: i32, v_2: u32) {
-    let val: u32 = dynamic_array.array_[i_1];
-    dynamic_array.array_[i_1] = (val + v_2);
+fn index_unsized(i: i32, v_1: u32) {
+    let val: u32 = dynamic_array.array_[i];
+    dynamic_array.array_[i] = (val + v_1);
     return;
 }
 
-fn index_dynamic_array_1(i_2: i32, v_3: u32) {
-    let p_1: ptr<storage, array<u32>, read_write> = (&dynamic_array.array_);
-    let val_1: u32 = (*p_1)[i_2];
-    (*p_1)[i_2] = (val_1 + v_3);
+fn index_dynamic_array(i_1: i32, v_2: u32) {
+    let p: ptr<storage, array<u32>, read_write> = (&dynamic_array.array_);
+    let val_1: u32 = (*p)[i_1];
+    (*p)[i_1] = (val_1 + v_2);
     return;
 }
 

--- a/tests/out/wgsl/pointers.wgsl
+++ b/tests/out/wgsl/pointers.wgsl
@@ -3,6 +3,9 @@ struct DynamicArray {
     array_: [[stride(4)]] array<u32>;
 };
 
+[[group(0), binding(0)]]
+var<storage, read_write> dynamic_array: DynamicArray;
+
 fn f() {
     var v: vec2<i32>;
 
@@ -15,5 +18,18 @@ fn index_dynamic_array(p: ptr<workgroup, DynamicArray>, i: i32, v_1: u32) -> u32
     let old: u32 = (*p).array_[i];
     (*p).array_[i] = v_1;
     return old;
+}
+
+fn index_unsized(i_1: i32, v_2: u32) {
+    let val: u32 = dynamic_array.array_[i_1];
+    dynamic_array.array_[i_1] = (val + v_2);
+    return;
+}
+
+fn index_dynamic_array_1(i_2: i32, v_3: u32) {
+    let p_1: ptr<storage, array<u32>, read_write> = (&dynamic_array.array_);
+    let val_1: u32 = (*p_1)[i_2];
+    (*p_1)[i_2] = (val_1 + v_3);
+    return;
 }
 


### PR DESCRIPTION
Pointers should not be `DATA`: they can never be stored in anything. (Function arguments are not storage; they're like `let` bindings.)

Un-`SIZED` values may only live in the `Storage` storage class, so creating pointers to them in other storage classes is meaningless.

The `ARGUMENT` flag should be set only on pointers in those storage classes that are permitted to be passed to functions.

See comments in code for details.

Fixes #1513.

[spv-out] Don't support arguments pointing to unsized types.

Functions with such arguments could never have been called anyway, and now they are forbidden in validation.
