### PR TITLE
Add view_index wgsl builtin

### DIFF
--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -1841,6 +1841,7 @@ fn builtin_str(built_in: crate::BuiltIn) -> Option<&'static str> {
         Bi::SampleIndex => Some("sample_index"),
         Bi::SampleMask => Some("sample_mask"),
         Bi::PrimitiveIndex => Some("primitive_index"),
+        Bi::ViewIndex => Some("view_index"),
         _ => None,
     }
 }

--- a/src/front/wgsl/conv.rs
+++ b/src/front/wgsl/conv.rs
@@ -20,6 +20,7 @@ pub fn map_built_in(word: &str, span: Span) -> Result<crate::BuiltIn, Error<'_>>
         // vertex
         "vertex_index" => crate::BuiltIn::VertexIndex,
         "instance_index" => crate::BuiltIn::InstanceIndex,
+        "view_index" => crate::BuiltIn::ViewIndex,
         // fragment
         "front_facing" => crate::BuiltIn::FrontFacing,
         "frag_depth" => crate::BuiltIn::FragDepth,


### PR DESCRIPTION
This builtin isn't part of the specification, but is a simple addition to add multi-view support for WGSL. Is there an extension mechanism we can make use of here? I'm too unfamiliar with WGSL what the best approach here is to take.

Related to: https://github.com/gfx-rs/wgpu/issues/2186