### PR TITLE
[msl-out]: Properly write default values for non-scalar types.

### DIFF
--- a/src/back/msl/keywords.rs
+++ b/src/back/msl/keywords.rs
@@ -210,4 +210,6 @@ pub const RESERVED: &[&str] = &[
     "M_2_SQRTPI",
     "M_SQRT2",
     "M_SQRT1_2",
+    // Naga utilities
+    "DefaultConstructible",
 ];

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -2470,6 +2470,12 @@ impl<W: Write> Writer<W> {
     ) -> Result<TranslationInfo, Error> {
         let mut pass_through_globals = Vec::new();
         for (fun_handle, fun) in module.functions.iter() {
+            log::trace!(
+                "function {:?}, handle {:?}",
+                fun.name.as_deref().unwrap_or("(anonymous)"),
+                fun_handle
+            );
+
             let fun_info = &mod_info[fun_handle];
             pass_through_globals.clear();
             let mut supports_array_length = false;
@@ -2600,6 +2606,12 @@ impl<W: Write> Writer<W> {
             let fun_info = mod_info.get_entry_point(ep_index);
             let mut ep_error = None;
             let mut supports_array_length = false;
+
+            log::trace!(
+                "entry point {:?}, index {:?}",
+                fun.name.as_deref().unwrap_or("(anonymous)"),
+                ep_index
+            );
 
             // skip this entry point if any global bindings are missing,
             // or their types are incompatible.

--- a/src/proc/index.rs
+++ b/src/proc/index.rs
@@ -148,6 +148,11 @@ impl BoundsCheckPolicies {
             _ => self.index,
         }
     }
+
+    /// Return `true` if any of `self`'s policies are `policy`.
+    pub fn contains(&self, policy: BoundsCheckPolicy) -> bool {
+        self.index == policy || self.buffer == policy || self.image == policy
+    }
 }
 
 /// An index that may be statically known, or may need to be computed at runtime.
@@ -204,9 +209,7 @@ pub fn find_checked_indexes(
     let mut guarded_indices = BitSet::new();
 
     // Don't bother scanning if we never need `ReadZeroSkipWrite`.
-    if policies.index == BoundsCheckPolicy::ReadZeroSkipWrite
-        || policies.buffer == BoundsCheckPolicy::ReadZeroSkipWrite
-    {
+    if policies.contains(BoundsCheckPolicy::ReadZeroSkipWrite) {
         for (_handle, expr) in function.expressions.iter() {
             // There's no need to handle `AccessIndex` expressions, as their
             // indices never need to be cached.

--- a/tests/out/msl/bounds-check-zero.msl
+++ b/tests/out/msl/bounds-check-zero.msl
@@ -2,6 +2,12 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
+struct DefaultConstructible {
+    template<typename T>
+    operator T() && {
+        return T {};
+    }
+};
 struct _mslBufferSizes {
     metal::uint size0;
 };
@@ -23,7 +29,7 @@ float index_array(
     device Globals& globals,
     constant _mslBufferSizes& _buffer_sizes
 ) {
-    float _e4 = metal::uint(i) < 10 ? globals.a.inner[i] : 0;
+    float _e4 = metal::uint(i) < 10 ? globals.a.inner[i] : DefaultConstructible();
     return _e4;
 }
 
@@ -32,7 +38,7 @@ float index_dynamic_array(
     device Globals& globals,
     constant _mslBufferSizes& _buffer_sizes
 ) {
-    float _e4 = metal::uint(i_1) < 1 + (_buffer_sizes.size0 - 112 - 4) / 4 ? globals.d[i_1] : 0;
+    float _e4 = metal::uint(i_1) < 1 + (_buffer_sizes.size0 - 112 - 4) / 4 ? globals.d[i_1] : DefaultConstructible();
     return _e4;
 }
 
@@ -41,7 +47,7 @@ float index_vector(
     device Globals& globals,
     constant _mslBufferSizes& _buffer_sizes
 ) {
-    float _e4 = metal::uint(i_2) < 4 ? globals.v[i_2] : 0;
+    float _e4 = metal::uint(i_2) < 4 ? globals.v[i_2] : DefaultConstructible();
     return _e4;
 }
 
@@ -49,7 +55,7 @@ float index_vector_by_value(
     metal::float4 v,
     int i_3
 ) {
-    return metal::uint(i_3) < 4 ? v[i_3] : 0;
+    return metal::uint(i_3) < 4 ? v[i_3] : DefaultConstructible();
 }
 
 metal::float4 index_matrix(
@@ -57,7 +63,7 @@ metal::float4 index_matrix(
     device Globals& globals,
     constant _mslBufferSizes& _buffer_sizes
 ) {
-    metal::float4 _e4 = metal::uint(i_4) < 3 ? globals.m[i_4] : 0;
+    metal::float4 _e4 = metal::uint(i_4) < 3 ? globals.m[i_4] : DefaultConstructible();
     return _e4;
 }
 
@@ -67,7 +73,7 @@ float index_twice(
     device Globals& globals,
     constant _mslBufferSizes& _buffer_sizes
 ) {
-    float _e6 = metal::uint(j) < 4 && metal::uint(i_5) < 3 ? globals.m[i_5][j] : 0;
+    float _e6 = metal::uint(j) < 4 && metal::uint(i_5) < 3 ? globals.m[i_5][j] : DefaultConstructible();
     return _e6;
 }
 
@@ -77,7 +83,7 @@ float index_expensive(
     constant _mslBufferSizes& _buffer_sizes
 ) {
     int _e9 = static_cast<int>(metal::sin(static_cast<float>(i_6) / 100.0) * 100.0);
-    float _e11 = metal::uint(_e9) < 10 ? globals.a.inner[_e9] : 0;
+    float _e11 = metal::uint(_e9) < 10 ? globals.a.inner[_e9] : DefaultConstructible();
     return _e11;
 }
 

--- a/tests/out/msl/policy-mix.msl
+++ b/tests/out/msl/policy-mix.msl
@@ -2,6 +2,12 @@
 #include <metal_stdlib>
 #include <simd/simd.h>
 
+struct DefaultConstructible {
+    template<typename T>
+    operator T() && {
+        return T {};
+    }
+};
 struct type_1 {
     metal::float4 inner[10];
 };


### PR DESCRIPTION
Fixes #1585.

Commits should be individually CI-clean.