### PR TITLE
Gather operations

### DIFF
--- a/src/back/dot/mod.rs
+++ b/src/back/dot/mod.rs
@@ -231,6 +231,7 @@ fn write_fun(
             E::ImageSample {
                 image,
                 sampler,
+                gather,
                 coordinate,
                 array_index,
                 offset: _,
@@ -260,7 +261,11 @@ fn write_fun(
                 if let Some(expr) = depth_ref {
                     edges.insert("depth_ref", expr);
                 }
-                ("ImageSample".into(), 5)
+                let string = match gather {
+                    Some(component) => Cow::Owned(format!("ImageGather{:?}", component)),
+                    _ => Cow::Borrowed("ImageSample"),
+                };
+                (string, 5)
             }
             E::ImageLoad {
                 image,

--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -891,6 +891,7 @@ impl<'w> BlockContext<'w> {
             crate::Expression::ImageSample {
                 image,
                 sampler,
+                gather,
                 coordinate,
                 array_index,
                 offset,
@@ -900,6 +901,7 @@ impl<'w> BlockContext<'w> {
                 result_type_id,
                 image,
                 sampler,
+                gather,
                 coordinate,
                 array_index,
                 offset,

--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -569,6 +569,33 @@ impl super::Instruction {
         instruction
     }
 
+    pub(super) fn image_gather(
+        result_type_id: Word,
+        id: Word,
+        sampled_image: Word,
+        coordinates: Word,
+        component_id: Word,
+        depth_ref: Option<Word>,
+    ) -> Self {
+        let op = match depth_ref {
+            None => Op::ImageGather,
+            Some(_) => Op::ImageDrefGather,
+        };
+
+        let mut instruction = Self::new(op);
+        instruction.set_type(result_type_id);
+        instruction.set_result(id);
+        instruction.add_operand(sampled_image);
+        instruction.add_operand(coordinates);
+        if let Some(dref) = depth_ref {
+            instruction.add_operand(dref);
+        } else {
+            instruction.add_operand(component_id);
+        }
+
+        instruction
+    }
+
     pub(super) fn image_fetch_or_read(
         op: Op,
         result_type_id: Word,

--- a/src/front/glsl/builtins.rs
+++ b/src/front/glsl/builtins.rs
@@ -1930,6 +1930,7 @@ fn texture_call(
             Expression::ImageSample {
                 image,
                 sampler,
+                gather: None, //TODO
                 coordinate: comps.coordinate,
                 array_index,
                 offset,

--- a/src/front/spv/image.rs
+++ b/src/front/spv/image.rs
@@ -606,6 +606,7 @@ impl<I: Iterator<Item = u32>> super::Parser<I> {
         let expr = crate::Expression::ImageSample {
             image: si_lexp.image,
             sampler: si_lexp.sampler,
+            gather: None, //TODO
             coordinate,
             array_index,
             offset,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -975,7 +975,7 @@ pub enum ImageQuery {
 
 /// Component selection for a vector swizzle.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 pub enum SwizzleComponent {
@@ -1128,6 +1128,9 @@ pub enum Expression {
     ImageSample {
         image: Handle<Expression>,
         sampler: Handle<Expression>,
+        /// If Some(), this operation is a gather operation
+        /// on the selected component.
+        gather: Option<SwizzleComponent>,
         coordinate: Handle<Expression>,
         array_index: Option<Handle<Expression>>,
         offset: Option<Handle<Constant>>,

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -472,6 +472,24 @@ impl<'a> ResolveContext<'a> {
                     return Err(ResolveError::InvalidPointer(pointer));
                 }
             },
+            crate::Expression::ImageSample {
+                image,
+                gather: Some(_),
+                ..
+            } => match *past(image).inner_with(types) {
+                Ti::Image { class, .. } => TypeResolution::Value(Ti::Vector {
+                    kind: match class {
+                        crate::ImageClass::Sampled { kind, multi: _ } => kind,
+                        _ => crate::ScalarKind::Float,
+                    },
+                    width: 4,
+                    size: crate::VectorSize::Quad,
+                }),
+                ref other => {
+                    log::error!("Image type {:?}", other);
+                    return Err(ResolveError::InvalidImage(image));
+                }
+            },
             crate::Expression::ImageSample { image, .. }
             | crate::Expression::ImageLoad { image, .. } => match *past(image).inner_with(types) {
                 Ti::Image { class, .. } => TypeResolution::Value(match class {

--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -462,6 +462,7 @@ impl FunctionInfo {
             E::ImageSample {
                 image,
                 sampler,
+                gather: _,
                 coordinate,
                 array_index,
                 offset: _,

--- a/tests/in/image.param.ron
+++ b/tests/in/image.param.ron
@@ -3,5 +3,5 @@
 		version: (1, 1),
 		debug: true,
 	),
-	glsl_exclude_list: ["depth_load", "levels_queries"]
+	glsl_exclude_list: ["depth_load", "depth_no_comparison", "levels_queries"]
 )

--- a/tests/in/image.wgsl
+++ b/tests/in/image.wgsl
@@ -116,3 +116,22 @@ fn sample_comparison() -> [[location(0)]] f32 {
     let s2d_depth_level = textureSampleCompareLevel(image_2d_depth, sampler_cmp, tc, dref);
     return s2d_depth + s2d_depth_level;
 }
+
+[[stage(fragment)]]
+fn gather() -> [[location(0)]] vec4<f32> {
+    let tc = vec2<f32>(0.5);
+    let dref = 0.5;
+    let s2d = textureGather(1, image_2d, sampler_reg, tc);
+    let s2d_offset = textureGather(3, image_2d, sampler_reg, tc, vec2<i32>(3, 1));
+    let s2d_depth = textureGatherCompare(image_2d_depth, sampler_cmp, tc, dref);
+    let s2d_depth_offset = textureGatherCompare(image_2d_depth, sampler_cmp, tc, dref, vec2<i32>(3, 1));
+    return s2d + s2d_offset + s2d_depth + s2d_depth_offset;
+}
+
+[[stage(fragment)]]
+fn depth_no_comparison() -> [[location(0)]] vec4<f32> {
+    let tc = vec2<f32>(0.5);
+    let s2d = textureSample(image_2d_depth, sampler_reg, tc);
+    let s2d_gather = textureGather(image_2d_depth, sampler_reg, tc);
+    return s2d + s2d_gather;
+}

--- a/tests/out/glsl/image.gather.Fragment.glsl
+++ b/tests/out/glsl/image.gather.Fragment.glsl
@@ -1,0 +1,22 @@
+#version 310 es
+#extension GL_EXT_texture_cube_map_array : require
+
+precision highp float;
+precision highp int;
+
+uniform highp sampler2D _group_0_binding_1;
+
+uniform highp sampler2DShadow _group_1_binding_2;
+
+layout(location = 0) out vec4 _fs2p_location0;
+
+void main() {
+    vec2 tc = vec2(0.5);
+    vec4 s2d = textureGather(_group_0_binding_1, vec2(tc), 1);
+    vec4 s2d_offset = textureGatherOffset(_group_0_binding_1, vec2(tc), ivec2(3, 1), 3);
+    vec4 s2d_depth = textureGather(_group_1_binding_2, vec2(tc), 0.5);
+    vec4 s2d_depth_offset = textureGatherOffset(_group_1_binding_2, vec2(tc), 0.5, ivec2(3, 1));
+    _fs2p_location0 = (((s2d + s2d_offset) + s2d_depth) + s2d_depth_offset);
+    return;
+}
+

--- a/tests/out/hlsl/image.hlsl
+++ b/tests/out/hlsl/image.hlsl
@@ -229,3 +229,21 @@ float sample_comparison() : SV_Target0
     float s2d_depth_level = image_2d_depth.SampleCmpLevelZero(sampler_cmp, tc_1, 0.5);
     return (s2d_depth + s2d_depth_level);
 }
+
+float4 gather() : SV_Target0
+{
+    float2 tc_2 = float2(0.5.xx);
+    float4 s2d_1 = image_2d.GatherGreen(sampler_reg, tc_2);
+    float4 s2d_offset_1 = image_2d.GatherAlpha(sampler_reg, tc_2, int2(3, 1));
+    float4 s2d_depth_1 = image_2d_depth.GatherCmp(sampler_cmp, tc_2, 0.5);
+    float4 s2d_depth_offset = image_2d_depth.GatherCmp(sampler_cmp, tc_2, 0.5, int2(3, 1));
+    return (((s2d_1 + s2d_offset_1) + s2d_depth_1) + s2d_depth_offset);
+}
+
+float4 depth_no_comparison() : SV_Target0
+{
+    float2 tc_3 = float2(0.5.xx);
+    float s2d_2 = image_2d_depth.Sample(sampler_reg, tc_3);
+    float4 s2d_gather = image_2d_depth.Gather(sampler_reg, tc_3);
+    return (float4(s2d_2.xxxx) + s2d_gather);
+}

--- a/tests/out/hlsl/image.hlsl.config
+++ b/tests/out/hlsl/image.hlsl.config
@@ -1,3 +1,3 @@
 vertex=(queries:vs_5_1 levels_queries:vs_5_1 )
-fragment=(sample_:ps_5_1 sample_comparison:ps_5_1 )
+fragment=(sample_:ps_5_1 sample_comparison:ps_5_1 gather:ps_5_1 depth_no_comparison:ps_5_1 )
 compute=(main:cs_5_1 depth_load:cs_5_1 )

--- a/tests/out/ir/shadow.ron
+++ b/tests/out/ir/shadow.ron
@@ -870,6 +870,7 @@
                 ImageSample(
                     image: 4,
                     sampler: 5,
+                    gather: None,
                     coordinate: 72,
                     array_index: Some(74),
                     offset: None,

--- a/tests/out/msl/image.msl
+++ b/tests/out/msl/image.msl
@@ -122,3 +122,35 @@ fragment sample_comparisonOutput sample_comparison(
     float s2d_depth_level = image_2d_depth.sample_compare(sampler_cmp, tc_1, 0.5);
     return sample_comparisonOutput { s2d_depth + s2d_depth_level };
 }
+
+
+struct gatherOutput {
+    metal::float4 member_6 [[color(0)]];
+};
+fragment gatherOutput gather(
+  metal::texture2d<float, metal::access::sample> image_2d [[user(fake0)]]
+, metal::sampler sampler_reg [[user(fake0)]]
+, metal::sampler sampler_cmp [[user(fake0)]]
+, metal::depth2d<float, metal::access::sample> image_2d_depth [[user(fake0)]]
+) {
+    metal::float2 tc_2 = metal::float2(0.5);
+    metal::float4 s2d_1 = image_2d.gather(sampler_reg, tc_2, int2(0), metal::component::y);
+    metal::float4 s2d_offset_1 = image_2d.gather(sampler_reg, tc_2, const_type_8_, metal::component::w);
+    metal::float4 s2d_depth_1 = image_2d_depth.gather_compare(sampler_cmp, tc_2, 0.5);
+    metal::float4 s2d_depth_offset = image_2d_depth.gather_compare(sampler_cmp, tc_2, 0.5, const_type_8_);
+    return gatherOutput { ((s2d_1 + s2d_offset_1) + s2d_depth_1) + s2d_depth_offset };
+}
+
+
+struct depth_no_comparisonOutput {
+    metal::float4 member_7 [[color(0)]];
+};
+fragment depth_no_comparisonOutput depth_no_comparison(
+  metal::sampler sampler_reg [[user(fake0)]]
+, metal::depth2d<float, metal::access::sample> image_2d_depth [[user(fake0)]]
+) {
+    metal::float2 tc_3 = metal::float2(0.5);
+    float s2d_2 = image_2d_depth.sample(sampler_reg, tc_3);
+    metal::float4 s2d_gather = image_2d_depth.gather(sampler_reg, tc_3);
+    return depth_no_comparisonOutput { metal::float4(s2d_2) + s2d_gather };
+}

--- a/tests/out/spv/image.spvasm
+++ b/tests/out/spv/image.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 244
+; Bound: 280
 OpCapability SampledCubeArray
 OpCapability ImageQuery
 OpCapability Image1D
@@ -15,10 +15,14 @@ OpEntryPoint Vertex %128 "queries" %126
 OpEntryPoint Vertex %176 "levels_queries" %175
 OpEntryPoint Fragment %205 "sample" %204
 OpEntryPoint Fragment %232 "sample_comparison" %230
+OpEntryPoint Fragment %246 "gather" %245
+OpEntryPoint Fragment %268 "depth_no_comparison" %267
 OpExecutionMode %69 LocalSize 16 1 1
 OpExecutionMode %107 LocalSize 16 1 1
 OpExecutionMode %205 OriginUpperLeft
 OpExecutionMode %232 OriginUpperLeft
+OpExecutionMode %246 OriginUpperLeft
+OpExecutionMode %268 OriginUpperLeft
 OpSource GLSL 450
 OpName %31 "image_mipmapped_src"
 OpName %33 "image_multisampled_src"
@@ -45,6 +49,8 @@ OpName %128 "queries"
 OpName %176 "levels_queries"
 OpName %205 "sample"
 OpName %232 "sample_comparison"
+OpName %246 "gather"
+OpName %268 "depth_no_comparison"
 OpDecorate %31 DescriptorSet 0
 OpDecorate %31 Binding 0
 OpDecorate %33 DescriptorSet 0
@@ -88,6 +94,8 @@ OpDecorate %126 BuiltIn Position
 OpDecorate %175 BuiltIn Position
 OpDecorate %204 Location 0
 OpDecorate %230 Location 0
+OpDecorate %245 Location 0
+OpDecorate %267 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 1
 %3 = OpConstant  %4  10
@@ -170,6 +178,10 @@ OpDecorate %230 Location 0
 %230 = OpVariable  %231  Output
 %237 = OpTypeSampledImage %29
 %242 = OpConstant  %8  0.0
+%245 = OpVariable  %127  Output
+%255 = OpConstant  %12  1
+%258 = OpConstant  %12  3
+%267 = OpVariable  %127  Output
 %69 = OpFunction  %2  None %70
 %65 = OpLabel
 %68 = OpLoad  %18  %66
@@ -352,5 +364,45 @@ OpBranch %235
 %241 = OpImageSampleDrefExplicitLod  %8  %240 %236 %7 Lod %242
 %243 = OpFAdd  %8  %239 %241
 OpStore %230 %243
+OpReturn
+OpFunctionEnd
+%246 = OpFunction  %2  None %70
+%244 = OpLabel
+%247 = OpLoad  %21  %47
+%248 = OpLoad  %28  %59
+%249 = OpLoad  %28  %61
+%250 = OpLoad  %29  %63
+OpBranch %251
+%251 = OpLabel
+%252 = OpCompositeConstruct  %210  %7 %7
+%253 = OpSampledImage  %216  %247 %248
+%254 = OpImageGather  %27  %253 %252 %255
+%256 = OpSampledImage  %216  %247 %248
+%257 = OpImageGather  %27  %256 %252 %258 ConstOffset %30
+%259 = OpSampledImage  %237  %250 %249
+%260 = OpImageDrefGather  %27  %259 %252 %7
+%261 = OpSampledImage  %237  %250 %249
+%262 = OpImageDrefGather  %27  %261 %252 %7 ConstOffset %30
+%263 = OpFAdd  %27  %254 %257
+%264 = OpFAdd  %27  %263 %260
+%265 = OpFAdd  %27  %264 %262
+OpStore %245 %265
+OpReturn
+OpFunctionEnd
+%268 = OpFunction  %2  None %70
+%266 = OpLabel
+%269 = OpLoad  %28  %59
+%270 = OpLoad  %29  %63
+OpBranch %271
+%271 = OpLabel
+%272 = OpCompositeConstruct  %210  %7 %7
+%273 = OpSampledImage  %237  %270 %269
+%274 = OpImageSampleImplicitLod  %27  %273 %272
+%275 = OpCompositeExtract  %8  %274 0
+%276 = OpSampledImage  %237  %270 %269
+%277 = OpImageGather  %27  %276 %272 %136
+%278 = OpCompositeConstruct  %27  %275 %275 %275 %275
+%279 = OpFAdd  %27  %278 %277
+OpStore %267 %279
 OpReturn
 OpFunctionEnd

--- a/tests/out/wgsl/image.wgsl
+++ b/tests/out/wgsl/image.wgsl
@@ -103,3 +103,21 @@ fn sample_comparison() -> [[location(0)]] f32 {
     let s2d_depth_level = textureSampleCompareLevel(image_2d_depth, sampler_cmp, tc_1, 0.5);
     return (s2d_depth + s2d_depth_level);
 }
+
+[[stage(fragment)]]
+fn gather() -> [[location(0)]] vec4<f32> {
+    let tc_2 = vec2<f32>(0.5);
+    let s2d_1 = textureGather(1, image_2d, sampler_reg, tc_2);
+    let s2d_offset_1 = textureGather(3, image_2d, sampler_reg, tc_2, vec2<i32>(3, 1));
+    let s2d_depth_1 = textureGatherCompare(image_2d_depth, sampler_cmp, tc_2, 0.5);
+    let s2d_depth_offset = textureGatherCompare(image_2d_depth, sampler_cmp, tc_2, 0.5, vec2<i32>(3, 1));
+    return (((s2d_1 + s2d_offset_1) + s2d_depth_1) + s2d_depth_offset);
+}
+
+[[stage(fragment)]]
+fn depth_no_comparison() -> [[location(0)]] vec4<f32> {
+    let tc_3 = vec2<f32>(0.5);
+    let s2d_2 = textureSample(image_2d_depth, sampler_reg, tc_3);
+    let s2d_gather = textureGather(image_2d_depth, sampler_reg, tc_3);
+    return (vec4<f32>(s2d_2) + s2d_gather);
+}


### PR DESCRIPTION
Closes #1570
See https://github.com/gpuweb/gpuweb/issues/2327
Doesn't implement parsing new SPV-in or GLSL-in instructions, but covers all backends and WGSL-in.