### PR TITLE
Turn on panic = "abort" by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,12 @@ petgraph = { version ="0.6", optional = true }
 pp-rs = { version = "0.2.1", optional = true }
 hexf-parse = { version = "0.2.1", optional = true }
 
+[profile.release]
+panic = "abort"
+
+[profile.dev]
+panic = "abort"
+
 [features]
 default = []
 dot-out = []


### PR DESCRIPTION
This reduces the size of a release naga binary on macOS
from 3.5MB to 3.2MB. It's also the configuration we use
for naga in Firefox.