### PR TITLE
glsl-in: Flatten entry point arguments

### DIFF
--- a/tests/in/glsl/declarations.vert
+++ b/tests/in/glsl/declarations.vert
@@ -1,0 +1,14 @@
+#version 450
+
+layout(location = 0) in VertexData {
+    vec2 position;
+    vec2 a;
+} vert;
+
+layout(location = 0) out FragmentData {
+    vec2 position;
+    vec2 a;
+} frag;
+
+void main() {
+}

--- a/tests/out/wgsl/declarations-vert.wgsl
+++ b/tests/out/wgsl/declarations-vert.wgsl
@@ -1,0 +1,30 @@
+struct VertexData {
+    position: vec2<f32>;
+    a: vec2<f32>;
+};
+
+struct FragmentData {
+    position: vec2<f32>;
+    a: vec2<f32>;
+};
+
+struct VertexOutput {
+    [[location(0)]] position: vec2<f32>;
+    [[location(1)]] a: vec2<f32>;
+};
+
+var<private> vert: VertexData;
+var<private> frag: FragmentData;
+
+fn main_1() {
+}
+
+[[stage(vertex)]]
+fn main([[location(0)]] position: vec2<f32>, [[location(1)]] a: vec2<f32>) -> VertexOutput {
+    vert.position = position;
+    vert.a = a;
+    main_1();
+    let _e17 = frag.position;
+    let _e19 = frag.a;
+    return VertexOutput(_e17, _e19);
+}


### PR DESCRIPTION
The IR doesn't allow having structs has bindings for entry point
input/output, so the glsl frontend must flatten them.

Glsl defines that the locations are sequential from the block base location.

Closes #1278