### PR TITLE
wgsl-in: correctly parse `else if`

### DIFF
--- a/src/front/wgsl/tests.rs
+++ b/src/front/wgsl/tests.rs
@@ -215,7 +215,7 @@ fn parse_if() {
             if (0 != 1) {}
             if (false) {
                 return;
-            } elseif (true) {
+            } else if (true) {
                 return;
             } else {}
         }


### PR DESCRIPTION
Fixes #1545. Removes support for `elseif` keyword.