### PR TITLE
impl Clone for `WithSpan<E>`

### DIFF
--- a/src/span.rs
+++ b/src/span.rs
@@ -73,7 +73,7 @@ impl From<Range<usize>> for Span {
 pub type SpanContext = (Span, String);
 
 /// Wrapper class for [`Error`], augmenting it with a list of [`SpanContext`]s.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WithSpan<E> {
     inner: E,
     #[cfg(feature = "span")]


### PR DESCRIPTION
I wanted to create a `CreateShaderModuleError` from a `&WithSpan<ValidationError>` to reuse `wgpu`'s shader error formatting, but that isn't possible right now because `WithSpan` can't be cloned and you can't get an `&E` from `&WithSpan<E>`.

Solution: `#[derive(Clone)]`