### PR TITLE
glsl-in: fix composite constructors

### DIFF
--- a/src/front/glsl/context.rs
+++ b/src/front/glsl/context.rs
@@ -881,7 +881,7 @@ impl Context {
 
     pub fn expr_scalar_components(
         &mut self,
-        parser: &mut Parser,
+        parser: &Parser,
         expr: Handle<Expression>,
         meta: Span,
     ) -> Result<Option<(ScalarKind, crate::Bytes)>> {
@@ -891,7 +891,7 @@ impl Context {
 
     pub fn expr_power(
         &mut self,
-        parser: &mut Parser,
+        parser: &Parser,
         expr: Handle<Expression>,
         meta: Span,
     ) -> Result<Option<u32>> {
@@ -921,7 +921,7 @@ impl Context {
 
     pub fn implicit_conversion(
         &mut self,
-        parser: &mut Parser,
+        parser: &Parser,
         expr: &mut Handle<Expression>,
         meta: Span,
         kind: ScalarKind,
@@ -941,7 +941,7 @@ impl Context {
 
     pub fn binary_implicit_conversion(
         &mut self,
-        parser: &mut Parser,
+        parser: &Parser,
         left: &mut Handle<Expression>,
         left_meta: Span,
         right: &mut Handle<Expression>,
@@ -974,7 +974,7 @@ impl Context {
 
     pub fn implicit_splat(
         &mut self,
-        parser: &mut Parser,
+        parser: &Parser,
         expr: &mut Handle<Expression>,
         meta: Span,
         vector_size: Option<VectorSize>,

--- a/tests/in/glsl/declarations.vert
+++ b/tests/in/glsl/declarations.vert
@@ -10,5 +10,16 @@ layout(location = 0) out FragmentData {
     vec2 a;
 } frag;
 
+struct TestStruct {
+    float a;
+    float b;
+};
+
+
 void main() {
+    const vec3 positions[2] = vec3[2](
+        vec3(-1.0, 1.0, 0.0),
+        vec3(-1.0, -1.0, 0.0)
+    );
+    const TestStruct strct = TestStruct( 1, 2 );
 }

--- a/tests/out/wgsl/declarations-vert.wgsl
+++ b/tests/out/wgsl/declarations-vert.wgsl
@@ -8,6 +8,11 @@ struct FragmentData {
     a: vec2<f32>;
 };
 
+struct TestStruct {
+    a: f32;
+    b: f32;
+};
+
 struct VertexOutput {
     [[location(0)]] position: vec2<f32>;
     [[location(1)]] a: vec2<f32>;
@@ -17,6 +22,9 @@ var<private> vert: VertexData;
 var<private> frag: FragmentData;
 
 fn main_1() {
+    var positions: array<vec3<f32>,2u> = array<vec3<f32>,2u>(vec3<f32>(-1.0, 1.0, 0.0), vec3<f32>(-1.0, -1.0, 0.0));
+    var strct: TestStruct = TestStruct(1.0, 2.0);
+
 }
 
 [[stage(vertex)]]


### PR DESCRIPTION
In the recent rework of the constructors it seems that the logic for
composite types (arrays and structs) was accidentally removed by me.

This PR reimplements it, adds implicit conversions that were missing on them and adds tests.

Closes #1623