### PR TITLE
glsl-in: Fix using swizzle as out arguments

### DIFF
--- a/tests/in/glsl/swizzle_write.frag
+++ b/tests/in/glsl/swizzle_write.frag
@@ -1,9 +1,11 @@
 #version 450
 
+void foo(inout vec2 p) {}
 
 void main() {
     vec3 x = vec3(2.0);
     x.zxy.xy = vec2(3.0, 4.0);
     x.rg *= 5.0;
     x.zy++;
+    foo(x.xz);
 }

--- a/tests/out/wgsl/swizzle_write-frag.wgsl
+++ b/tests/out/wgsl/swizzle_write-frag.wgsl
@@ -1,5 +1,10 @@
+fn foo(p: ptr<function, vec2<f32>>) {
+    return;
+}
+
 fn main_1() {
     var x: vec3<f32> = vec3<f32>(2.0, 2.0, 2.0);
+    var local: vec2<f32>;
 
     let _e3 = x;
     let _e8 = vec2<f32>(3.0, 4.0);
@@ -14,6 +19,14 @@ fn main_1() {
     let _e27 = (_e23.zy + vec2<f32>(1.0));
     x.z = _e27.x;
     x.y = _e27.y;
+    let _e32 = x;
+    let _e34 = x;
+    local = _e34.xz;
+    foo((&local));
+    let _e41 = local.x;
+    x.x = _e41;
+    let _e42 = local.y;
+    x.z = _e42;
     return;
 }
 


### PR DESCRIPTION
This worked at one point but because of some changes to the IR it was
temporarily broken.

Closes #1621