### PR TITLE
Add a way to emit errors with a path

### DIFF
--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1173,7 +1173,12 @@ impl ParseError {
 
     /// Emits a summary of the error to standard error stream.
     pub fn emit_to_stderr(&self, source: &str) {
-        let files = SimpleFile::new("wgsl", source);
+        self.emit_to_stderr_with_path(source, &std::path::Path::new("wgsl"))
+    }
+    
+    /// Emits a summary of the error to standard error stream.
+    pub fn emit_to_stderr_with_path(&self, source: &str, path: &std::path::Path) {
+        let files = SimpleFile::new(path, source);
         let config = codespan_reporting::term::Config::default();
         let writer = StandardStream::stderr(ColorChoice::Always);
         term::emit(&mut writer.lock(), &config, &files, &self.diagnostic())

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1175,7 +1175,7 @@ impl ParseError {
     pub fn emit_to_stderr(&self, source: &str) {
         self.emit_to_stderr_with_path(source, "wgsl")
     }
-    
+
     /// Emits a summary of the error to standard error stream.
     pub fn emit_to_stderr_with_path(&self, source: &str, path: &str) {
         let files = SimpleFile::new(path, source);

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1173,11 +1173,11 @@ impl ParseError {
 
     /// Emits a summary of the error to standard error stream.
     pub fn emit_to_stderr(&self, source: &str) {
-        self.emit_to_stderr_with_path(source, &std::path::Path::new("wgsl"))
+        self.emit_to_stderr_with_path(source, "wgsl")
     }
     
     /// Emits a summary of the error to standard error stream.
-    pub fn emit_to_stderr_with_path(&self, source: &str, path: &std::path::Path) {
+    pub fn emit_to_stderr_with_path(&self, source: &str, path: &str) {
         let files = SimpleFile::new(path, source);
         let config = codespan_reporting::term::Config::default();
         let writer = StandardStream::stderr(ColorChoice::Always);


### PR DESCRIPTION
I am using `naga` in my build script to validate all of my shaders, and it would be nice to be able to display the file path inside of the diagnostic, so I added a method `emit_to_stderr_with_path` to `naga::front::wgsl::ParserError`.