### PR TITLE
[glsl-out] Fix initializers not being written

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -2756,27 +2756,15 @@ impl<'a, W: Write> Writer<'a, W> {
             TypeInner::Scalar { kind, .. } => {
                 self.write_zero_init_scalar(kind)?;
             }
-            TypeInner::Vector { size, kind, .. } => {
+            TypeInner::Vector { kind, .. } => {
                 self.write_value_type(inner)?;
                 write!(self.out, "(")?;
-                for _ in 1..(size as usize) {
-                    self.write_zero_init_scalar(kind)?;
-                    write!(self.out, ", ")?;
-                }
-                // write last parameter without comma and space
                 self.write_zero_init_scalar(kind)?;
                 write!(self.out, ")")?;
             }
-            TypeInner::Matrix { columns, rows, .. } => {
-                let number_of_components = (columns as usize) * (rows as usize);
+            TypeInner::Matrix { .. } => {
                 self.write_value_type(inner)?;
                 write!(self.out, "(")?;
-                for _ in 1..number_of_components {
-                    // IR supports only float matrix
-                    self.write_zero_init_scalar(crate::ScalarKind::Float)?;
-                    write!(self.out, ", ")?;
-                }
-                // write last parameter without comma and space
                 self.write_zero_init_scalar(crate::ScalarKind::Float)?;
                 write!(self.out, ")")?;
             }

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1343,6 +1343,9 @@ impl<'a, W: Write> Writer<'a, W> {
             // `type(components)` where `components` is a comma separated list of constants
             crate::ConstantInner::Composite { ty, ref components } => {
                 self.write_type(ty)?;
+                if let TypeInner::Array { size, .. } = self.module.types[ty].inner {
+                    self.write_array_size(size)?;
+                }
                 write!(self.out, "(")?;
 
                 // Write the comma separated constants

--- a/tests/out/glsl/access.foo.Vertex.glsl
+++ b/tests/out/glsl/access.foo.Vertex.glsl
@@ -20,7 +20,7 @@ float read_from_private(inout float foo_2) {
 void main() {
     uint vi = uint(gl_VertexID);
     float foo_1 = 0.0;
-    int c[5];
+    int c[5] = int[5](0, 0, 0, 0, 0);
     float baz = foo_1;
     foo_1 = 1.0;
     mat4x4 matrix = _group_0_binding_0_vs.matrix;

--- a/tests/out/glsl/bits.main.Compute.glsl
+++ b/tests/out/glsl/bits.main.Compute.glsl
@@ -8,15 +8,15 @@ layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 void main() {
     int i = 0;
-    ivec2 i2_ = ivec2(0, 0);
-    ivec3 i3_ = ivec3(0, 0, 0);
-    ivec4 i4_ = ivec4(0, 0, 0, 0);
+    ivec2 i2_ = ivec2(0);
+    ivec3 i3_ = ivec3(0);
+    ivec4 i4_ = ivec4(0);
     uint u = 0u;
-    uvec2 u2_ = uvec2(0u, 0u);
-    uvec3 u3_ = uvec3(0u, 0u, 0u);
-    uvec4 u4_ = uvec4(0u, 0u, 0u, 0u);
-    vec2 f2_ = vec2(0.0, 0.0);
-    vec4 f4_ = vec4(0.0, 0.0, 0.0, 0.0);
+    uvec2 u2_ = uvec2(0u);
+    uvec3 u3_ = uvec3(0u);
+    uvec4 u4_ = uvec4(0u);
+    vec2 f2_ = vec2(0.0);
+    vec4 f4_ = vec4(0.0);
     i2_ = ivec2(0);
     i3_ = ivec3(0);
     i4_ = ivec4(0);

--- a/tests/out/glsl/boids.main.Compute.glsl
+++ b/tests/out/glsl/boids.main.Compute.glsl
@@ -31,15 +31,15 @@ layout(std430) buffer Particles_block_2Compute {
 
 void main() {
     uvec3 global_invocation_id = gl_GlobalInvocationID;
-    vec2 vPos = vec2(0.0, 0.0);
-    vec2 vVel = vec2(0.0, 0.0);
-    vec2 cMass = vec2(0.0, 0.0);
-    vec2 cVel = vec2(0.0, 0.0);
-    vec2 colVel = vec2(0.0, 0.0);
+    vec2 vPos = vec2(0.0);
+    vec2 vVel = vec2(0.0);
+    vec2 cMass = vec2(0.0);
+    vec2 cVel = vec2(0.0);
+    vec2 colVel = vec2(0.0);
     int cMassCount = 0;
     int cVelCount = 0;
-    vec2 pos = vec2(0.0, 0.0);
-    vec2 vel = vec2(0.0, 0.0);
+    vec2 pos = vec2(0.0);
+    vec2 vel = vec2(0.0);
     uint i = 0u;
     uint index = global_invocation_id.x;
     if ((index >= 1500u)) {

--- a/tests/out/glsl/interpolate.vert_main.Vertex.glsl
+++ b/tests/out/glsl/interpolate.vert_main.Vertex.glsl
@@ -18,7 +18,7 @@ smooth centroid out float _vs2fs_location5;
 smooth sample out float _vs2fs_location6;
 
 void main() {
-    FragmentInput out_ = FragmentInput(vec4(0.0, 0.0, 0.0, 0.0), 0u, 0.0, vec2(0.0, 0.0), vec3(0.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 0.0), 0.0, 0.0);
+    FragmentInput out_ = FragmentInput(vec4(0.0), 0u, 0.0, vec2(0.0), vec3(0.0), vec4(0.0), 0.0, 0.0);
     out_.position = vec4(2.0, 4.0, 5.0, 6.0);
     out_.flat_ = 8u;
     out_.linear = 27.0;

--- a/tests/out/glsl/interpolate.vert_main.Vertex.glsl
+++ b/tests/out/glsl/interpolate.vert_main.Vertex.glsl
@@ -18,7 +18,7 @@ smooth centroid out float _vs2fs_location5;
 smooth sample out float _vs2fs_location6;
 
 void main() {
-    FragmentInput out_;
+    FragmentInput out_ = FragmentInput(vec4(0.0, 0.0, 0.0, 0.0), 0u, 0.0, vec2(0.0, 0.0), vec3(0.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 0.0), 0.0, 0.0);
     out_.position = vec4(2.0, 4.0, 5.0, 6.0);
     out_.flat_ = 8u;
     out_.linear = 27.0;

--- a/tests/out/glsl/operators.main.Compute.glsl
+++ b/tests/out/glsl/operators.main.Compute.glsl
@@ -42,7 +42,7 @@ vec3 bool_cast(vec3 x) {
 }
 
 float constructors() {
-    Foo foo = Foo(vec4(0.0, 0.0, 0.0, 0.0), 0);
+    Foo foo = Foo(vec4(0.0), 0);
     foo = Foo(vec4(1.0), 1);
     mat2x2 mat2comp = mat2x2(vec2(1.0, 0.0), vec2(0.0, 1.0));
     mat4x4 mat4comp = mat4x4(vec4(1.0, 0.0, 0.0, 0.0), vec4(0.0, 1.0, 0.0, 0.0), vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0));

--- a/tests/out/glsl/operators.main.Compute.glsl
+++ b/tests/out/glsl/operators.main.Compute.glsl
@@ -42,7 +42,7 @@ vec3 bool_cast(vec3 x) {
 }
 
 float constructors() {
-    Foo foo;
+    Foo foo = Foo(vec4(0.0, 0.0, 0.0, 0.0), 0);
     foo = Foo(vec4(1.0), 1);
     mat2x2 mat2comp = mat2x2(vec2(1.0, 0.0), vec2(0.0, 1.0));
     mat4x4 mat4comp = mat4x4(vec4(1.0, 0.0, 0.0, 0.0), vec4(0.0, 1.0, 0.0, 0.0), vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0));

--- a/tests/out/glsl/quad-vert.main.Vertex.glsl
+++ b/tests/out/glsl/quad-vert.main.Vertex.glsl
@@ -13,13 +13,13 @@ struct type_9 {
     vec2 member;
     vec4 gen_gl_Position;
 };
-vec2 v_uv = vec2(0.0, 0.0);
+vec2 v_uv = vec2(0.0);
 
-vec2 a_uv_1 = vec2(0.0, 0.0);
+vec2 a_uv_1 = vec2(0.0);
 
 gen_gl_PerVertex perVertexStruct = gen_gl_PerVertex(vec4(0.0, 0.0, 0.0, 1.0), 1.0, float[1](0.0), float[1](0.0));
 
-vec2 a_pos_1 = vec2(0.0, 0.0);
+vec2 a_pos_1 = vec2(0.0);
 
 layout(location = 1) in vec2 _p2vs_location1;
 layout(location = 0) in vec2 _p2vs_location0;

--- a/tests/out/glsl/quad-vert.main.Vertex.glsl
+++ b/tests/out/glsl/quad-vert.main.Vertex.glsl
@@ -17,7 +17,7 @@ vec2 v_uv = vec2(0.0, 0.0);
 
 vec2 a_uv_1 = vec2(0.0, 0.0);
 
-gen_gl_PerVertex perVertexStruct;
+gen_gl_PerVertex perVertexStruct = gen_gl_PerVertex(vec4(0.0, 0.0, 0.0, 1.0), 1.0, float[1](0.0), float[1](0.0));
 
 vec2 a_pos_1 = vec2(0.0, 0.0);
 


### PR DESCRIPTION
The zero initializing was inhibiting the output of initializers for structs and arrays, this PR reenables the output of initializers for them and for completeness also implements implements zero initialization for them. 

Fixes #1638