### PR TITLE
Add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Cargo.lock
 .DS_Store
 .fuse_hidden*
 .idea
+.vscode
 /*.dot
 /*.metal
 /*.metallib


### PR DESCRIPTION
The .gitignore already has .idea in it and it can be removed later if there are ever official extensions/tasks/launches.