### PR TITLE
glsl-out: Call proper memory barrier functions

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1776,8 +1776,6 @@ impl<'a, W: Write> Writer<'a, W> {
             Statement::Barrier(flags) => {
                 if flags.contains(crate::Barrier::STORAGE) {
                     writeln!(self.out, "{}memoryBarrierBuffer();", level)?;
-                    writeln!(self.out, "{}memoryBarrierImage();", level)?;
-                    writeln!(self.out, "{}memoryBarrierAtomicCounter();", level)?;
                 }
 
                 if flags.contains(crate::Barrier::WORK_GROUP) {

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1771,13 +1771,20 @@ impl<'a, W: Write> Writer<'a, W> {
             // keyword which ceases all further processing in a fragment shader, it's called OpKill
             // in spir-v that's why it's called `Statement::Kill`
             Statement::Kill => writeln!(self.out, "{}discard;", level)?,
-            // Issue an execution or a memory barrier.
+            // Issue a memory barrier. Please note that to ensure visibility,
+            // OpenGL always requires a call to the `barrier()` function after a `memoryBarrier*()`
             Statement::Barrier(flags) => {
-                if flags.is_empty() {
-                    writeln!(self.out, "{}barrier();", level)?;
-                } else {
-                    writeln!(self.out, "{}groupMemoryBarrier();", level)?;
+                if flags.contains(crate::Barrier::STORAGE) {
+                    writeln!(self.out, "{}memoryBarrierBuffer();", level)?;
+                    writeln!(self.out, "{}memoryBarrierImage();", level)?;
+                    writeln!(self.out, "{}memoryBarrierAtomicCounter();", level)?;
                 }
+
+                if flags.contains(crate::Barrier::WORK_GROUP) {
+                    writeln!(self.out, "{}memoryBarrierShared();", level)?;
+                }
+
+                writeln!(self.out, "{}barrier();", level)?;
             }
             // Stores in glsl are just variable assignments written as `pointer = value;`
             Statement::Store { pointer, value } => {

--- a/tests/out/glsl/control-flow.main.Compute.glsl
+++ b/tests/out/glsl/control-flow.main.Compute.glsl
@@ -38,8 +38,12 @@ void loop_switch_continue(int x) {
 void main() {
     uvec3 global_id = gl_GlobalInvocationID;
     int pos = 0;
-    groupMemoryBarrier();
-    groupMemoryBarrier();
+    memoryBarrierBuffer();
+    memoryBarrierImage();
+    memoryBarrierAtomicCounter();
+    barrier();
+    memoryBarrierShared();
+    barrier();
     switch(1) {
         default:
             pos = 1;

--- a/tests/out/glsl/control-flow.main.Compute.glsl
+++ b/tests/out/glsl/control-flow.main.Compute.glsl
@@ -39,8 +39,6 @@ void main() {
     uvec3 global_id = gl_GlobalInvocationID;
     int pos = 0;
     memoryBarrierBuffer();
-    memoryBarrierImage();
-    memoryBarrierAtomicCounter();
     barrier();
     memoryBarrierShared();
     barrier();


### PR DESCRIPTION
This should fix https://github.com/gfx-rs/naga/issues/1677
OpenGL memory barriers and visibility are really confusing to me, but I spent some time researching to the best of my ability to make this correct: I started from https://www.khronos.org/opengl/wiki/Memory_Model#Ensuring_visibility and then read some extra questions/answers/blog posts around the net to confirm that I understood the khronos wiki correctly.

After the code change I did run `cargo test --all-features --workspace` and it reported no error, then I ran `make validate-glsl` and finally committed the new (modified) test output.

Edit: P.S: the `barrier()` GLSL function can only be called in a compute shader, but I am pretty sure this is fine because WGSL synchronization built-in functions can only be called in compute shaders anyway.