### PR TITLE
glsl-out: push constants use anonymous uniforms

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -86,9 +86,7 @@ impl crate::AtomicFunction {
 impl crate::StorageClass {
     fn is_buffer(&self) -> bool {
         match *self {
-            crate::StorageClass::PushConstant
-            | crate::StorageClass::Uniform
-            | crate::StorageClass::Storage { .. } => true,
+            crate::StorageClass::Uniform | crate::StorageClass::Storage { .. } => true,
             _ => false,
         }
     }
@@ -230,8 +228,6 @@ pub struct Options {
     pub writer_flags: WriterFlags,
     /// Map of resources association to binding locations.
     pub binding_map: BindingMap,
-    /// The binding to give the push constant buffer if it's present
-    pub push_constant_binding: u32,
 }
 
 impl Default for Options {
@@ -240,7 +236,6 @@ impl Default for Options {
             version: Version::Embedded(310),
             writer_flags: WriterFlags::ADJUST_COORDINATE_SPACE,
             binding_map: BindingMap::default(),
-            push_constant_binding: 0,
         }
     }
 }
@@ -263,7 +258,6 @@ pub struct PipelineOptions {
 pub struct ReflectionInfo {
     pub texture_mapping: crate::FastHashMap<String, TextureMapping>,
     pub uniforms: crate::FastHashMap<Handle<crate::GlobalVariable>, String>,
-    pub push_constant: Option<String>,
 }
 
 /// Structure that connects a texture to a sampler or not
@@ -894,13 +888,7 @@ impl<'a, W: Write> Writer<'a, W> {
         global: &crate::GlobalVariable,
     ) -> BackendResult {
         if self.options.version.supports_explicit_locations() {
-            if let crate::StorageClass::PushConstant = global.class {
-                write!(
-                    self.out,
-                    "layout(std140, binding = {}) ",
-                    self.options.push_constant_binding
-                )?
-            } else if let Some(ref br) = global.binding {
+            if let Some(ref br) = global.binding {
                 match self.options.binding_map.get(br) {
                     Some(binding) => {
                         let layout = match global.class {
@@ -911,9 +899,7 @@ impl<'a, W: Write> Writer<'a, W> {
                                     "std140, "
                                 }
                             }
-                            crate::StorageClass::Uniform | crate::StorageClass::PushConstant => {
-                                "std140, "
-                            }
+                            crate::StorageClass::Uniform => "std140, ",
                             _ => "",
                         };
                         write!(self.out, "layout({}binding = {}) ", layout, binding)?
@@ -976,6 +962,11 @@ impl<'a, W: Write> Writer<'a, W> {
             self.write_type(global.ty)?;
             false
         };
+
+        if let crate::StorageClass::PushConstant = global.class {
+            let global_name = self.get_global_name(handle, global);
+            self.reflection_names_globals.insert(handle, global_name);
+        }
 
         // Finally write the global name and end the global with a `;` and a newline
         // Leading space is important
@@ -2873,7 +2864,6 @@ impl<'a, W: Write> Writer<'a, W> {
         let info = self.info.get_entry_point(self.entry_point_idx as usize);
         let mut texture_mapping = crate::FastHashMap::default();
         let mut uniforms = crate::FastHashMap::default();
-        let mut push_constant = None;
 
         for sampling in info.sampling_set.iter() {
             let tex_name = self.reflection_names_globals[&sampling.image].clone();
@@ -2904,10 +2894,6 @@ impl<'a, W: Write> Writer<'a, W> {
                         let name = self.reflection_names_globals[&handle].clone();
                         uniforms.insert(handle, name);
                     }
-                    crate::StorageClass::PushConstant => {
-                        let name = self.reflection_names_globals[&handle].clone();
-                        push_constant = Some(name)
-                    }
                     _ => (),
                 },
                 crate::TypeInner::Image { .. } => {
@@ -2931,7 +2917,6 @@ impl<'a, W: Write> Writer<'a, W> {
         Ok(ReflectionInfo {
             texture_mapping,
             uniforms,
-            push_constant,
         })
     }
 }

--- a/tests/in/functions-webgl.param.ron
+++ b/tests/in/functions-webgl.param.ron
@@ -3,6 +3,5 @@
 		version: Embedded(300),
 		writer_flags: (bits: 0),
 		binding_map: {},
-		push_constant_binding: 0,
 	),
 )

--- a/tests/in/interpolate.param.ron
+++ b/tests/in/interpolate.param.ron
@@ -10,6 +10,5 @@
 		version: Desktop(400),
 		writer_flags: (bits: 0),
 		binding_map: {},
-		push_constant_binding: 0,
 	),
 )

--- a/tests/in/push-constants.param.ron
+++ b/tests/in/push-constants.param.ron
@@ -4,6 +4,5 @@
 		version: Embedded(320),
 		writer_flags: (bits: 0),
 		binding_map: {},
-		push_constant_binding: 4,
 	),
 )

--- a/tests/in/quad.param.ron
+++ b/tests/in/quad.param.ron
@@ -8,6 +8,5 @@
 		version: Embedded(300),
 		writer_flags: (bits: 0),
 		binding_map: {},
-		push_constant_binding: 0,
 	),
 )

--- a/tests/in/skybox.param.ron
+++ b/tests/in/skybox.param.ron
@@ -43,7 +43,6 @@
 			(group: 0, binding: 0): 0,
 			(group: 0, binding: 1): 0,
 		},
-		push_constant_binding: 0,
 	),
 	hlsl: (
 		shader_model: V5_1,

--- a/tests/out/glsl/push-constants.main.Fragment.glsl
+++ b/tests/out/glsl/push-constants.main.Fragment.glsl
@@ -9,7 +9,7 @@ struct PushConstants {
 struct FragmentIn {
     vec4 color;
 };
-layout(std140, binding = 4) uniform PushConstants_block_0Fragment { PushConstants pc; };
+uniform PushConstants pc;
 
 layout(location = 0) smooth in vec4 _vs2fs_location0;
 layout(location = 0) out vec4 _fs2p_location0;


### PR DESCRIPTION
Previously this was done with UBOs but this posed some problems when
integrating with wgpu (see https://github.com/gfx-rs/wgpu/pull/2400)

It basically reverses the previous PR retaining only the feature detection changes