### PR TITLE
[0.8] Support unconditional invariance on msl 2.3+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### Unreleased
+  - MSL-out:
+    - Unconditionally output `[[invariant]]` for vertex outputs if it is supported.
+
 ### v0.8.3 (2022-01-20)
   - don't pin `indexmap`
   - MSL-out:

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -321,12 +321,22 @@ impl ResolvedBinding {
         }
     }
 
-    fn try_fmt<W: Write>(&self, out: &mut W) -> Result<(), Error> {
+    fn try_fmt<W: Write>(
+        &self,
+        out: &mut W,
+        stage: crate::ShaderStage,
+        lang_version: (u8, u8),
+    ) -> Result<(), Error> {
         match *self {
             Self::BuiltIn(built_in) => {
                 use crate::BuiltIn as Bi;
                 let name = match built_in {
-                    Bi::Position => "position",
+                    Bi::Position => match stage {
+                        crate::ShaderStage::Vertex if lang_version >= (2, 3) => {
+                            "position, invariant"
+                        }
+                        _ => "position",
+                    },
                     // vertex
                     Bi::BaseInstance => "base_instance",
                     Bi::BaseVertex => "base_vertex",
@@ -381,9 +391,15 @@ impl ResolvedBinding {
         Ok(())
     }
 
-    fn try_fmt_decorated<W: Write>(&self, out: &mut W, terminator: &str) -> Result<(), Error> {
+    fn try_fmt_decorated<W: Write>(
+        &self,
+        out: &mut W,
+        terminator: &str,
+        stage: crate::ShaderStage,
+        lang_version: (u8, u8),
+    ) -> Result<(), Error> {
         write!(out, " [[")?;
-        self.try_fmt(out)?;
+        self.try_fmt(out, stage, lang_version)?;
         write!(out, "]]")?;
         write!(out, "{}", terminator)?;
         Ok(())

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -2820,7 +2820,12 @@ impl<W: Write> Writer<W> {
                     };
                     let resolved = options.resolve_local_binding(binding, in_mode)?;
                     write!(self.out, "{}{} {}", back::INDENT, ty_name, name)?;
-                    resolved.try_fmt_decorated(&mut self.out, "")?;
+                    resolved.try_fmt_decorated(
+                        &mut self.out,
+                        "",
+                        ep.stage,
+                        options.lang_version,
+                    )?;
                     writeln!(self.out, ";")?;
                 }
                 writeln!(self.out, "}};")?;
@@ -2889,7 +2894,12 @@ impl<W: Write> Writer<W> {
                         };
                         let resolved = options.resolve_local_binding(binding, out_mode)?;
                         write!(self.out, "{}{} {}", back::INDENT, ty_name, name)?;
-                        resolved.try_fmt_decorated(&mut self.out, "")?;
+                        resolved.try_fmt_decorated(
+                            &mut self.out,
+                            "",
+                            ep.stage,
+                            options.lang_version,
+                        )?;
                         if let Some(array_len) = array_len {
                             write!(self.out, " [{}]", array_len)?;
                         }
@@ -2944,7 +2954,7 @@ impl<W: Write> Writer<W> {
                     ','
                 };
                 write!(self.out, "{} {} {}", separator, ty_name, name)?;
-                resolved.try_fmt_decorated(&mut self.out, "\n")?;
+                resolved.try_fmt_decorated(&mut self.out, "\n", ep.stage, options.lang_version)?;
             }
             for (handle, var) in module.global_variables.iter() {
                 let usage = fun_info[handle];
@@ -2984,7 +2994,12 @@ impl<W: Write> Writer<W> {
                 write!(self.out, "{} ", separator)?;
                 tyvar.try_fmt(&mut self.out)?;
                 if let Some(resolved) = resolved {
-                    resolved.try_fmt_decorated(&mut self.out, "")?;
+                    resolved.try_fmt_decorated(
+                        &mut self.out,
+                        "",
+                        ep.stage,
+                        options.lang_version,
+                    )?;
                 }
                 if let Some(value) = var.init {
                     let coco = ConstantContext {
@@ -3011,7 +3026,7 @@ impl<W: Write> Writer<W> {
                     "{} constant _mslBufferSizes& _buffer_sizes",
                     separator,
                 )?;
-                resolved.try_fmt_decorated(&mut self.out, "\n")?;
+                resolved.try_fmt_decorated(&mut self.out, "\n", ep.stage, options.lang_version)?;
             }
 
             // end of the entry point argument list
@@ -3235,7 +3250,7 @@ fn test_stack_size() {
         let stack_size = addresses.end - addresses.start;
         // check the size (in debug only)
         // last observed macOS value: 19152 (CI)
-        if !(13000..=20000).contains(&stack_size) {
+        if !(11000..=20000).contains(&stack_size) {
             panic!("`put_block` stack size {} has changed!", stack_size);
         }
     }


### PR DESCRIPTION
Upstream: https://github.com/BVE-Reborn/rend3/issues/317
Blunt-force fix for #1659 

Fixes issues on the M1 when expecting invariance (see https://github.com/gfx-rs/wgpu/pull/2372 for more details).