### PR TITLE
cli: Add --version flag

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -64,6 +64,10 @@ struct Args {
     #[argh(option)]
     stdin_file_path: Option<String>,
 
+    /// show version
+    #[argh(switch)]
+    version: bool,
+
     /// the input and output files.
     ///
     /// First positional argument is the input file. If not specified, the
@@ -209,6 +213,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     // Parse commandline arguments
     let args: Args = argh::from_env();
+    if args.version {
+        println!("{}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
     let (input_path, input) = if let Some(path) = args.files.first() {
         let path = Path::new(path);
         (path, fs::read(path)?)


### PR DESCRIPTION
This PR adds `--version` flag to show its version so that users can easily check that the version of `naga` command matches to the version of `wgpu` crate which their projects are depending on.