### PR TITLE
wgsl: Do not make error output colorful when the terminal is dumb

### DIFF
--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1181,7 +1181,7 @@ impl ParseError {
     pub fn emit_to_stderr_with_path(&self, source: &str, path: &str) {
         let files = SimpleFile::new(path, source);
         let config = codespan_reporting::term::Config::default();
-        let writer = StandardStream::stderr(ColorChoice::Always);
+        let writer = StandardStream::stderr(ColorChoice::Auto);
         term::emit(&mut writer.lock(), &config, &files, &self.diagnostic())
             .expect("cannot write error");
     }


### PR DESCRIPTION
Recently I'm trying to integrate `naga` command to my text editor to check WGSL sources on the fly.

However, a WGSL parse error output is hard to parse because it contains many color escape sequences. By this PR, error outputs are colorful only when stderr is connected to terminal. By this patch, tools like text editors can get error outputs without color escape sequences and easily parse the outputs.