### PR TITLE
cli: Include file path in WGSL parse error

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -281,7 +281,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             match result {
                 Ok(v) => (v, Some(input)),
                 Err(ref e) => {
-                    e.emit_to_stderr(&input);
+                    let path = input_path.to_string_lossy();
+                    e.emit_to_stderr_with_path(&input, &path);
                     return Err(CliError("Could not parse WGSL").into());
                 }
             }


### PR DESCRIPTION
Adding the file path to WGSL parse error output from `naga` would be better since a tool which uses the output can easily parse the file path from it

Before:

```
error: expected global item ('struct', 'let', 'var', 'type', ';', 'fn') or the end of the file, found '['
  ┌─ wgsl:5:1
  │
5 │ [[group(1), binding(0)]]
  │ ^ expected global item ('struct', 'let', 'var', 'type', ';', 'fn') or the end of the file

Could not parse WGSL
```

After:

```
error: expected global item ('struct', 'let', 'var', 'type', ';', 'fn') or the end of the file, found '['
  ┌─ /path/to/test.wgsl:5:1
  │
5 │ [[group(1), binding(0)]]
  │ ^ expected global item ('struct', 'let', 'var', 'type', ';', 'fn') or the end of the file

Could not parse WGSL
```