### PR TITLE
Improve error messages about address space

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -529,8 +529,11 @@ impl<T: Eq + hash::Hash> UniqueArena<T> {
     }
 
     /// Return this arena's value at `handle`, if that is a valid handle.
-    pub fn get_handle(&self, handle: Handle<T>) -> Option<&T> {
-        self.set.get_index(handle.index())
+    pub fn get_handle(&self, handle: Handle<T>) -> Result<&T, BadHandle> {
+        self.set.get_index(handle.index()).ok_or_else(|| BadHandle {
+            kind: std::any::type_name::<T>(),
+            index: handle.index(),
+        })
     }
 }
 

--- a/src/valid/compose.rs
+++ b/src/valid/compose.rs
@@ -4,13 +4,13 @@ use crate::{
     proc::TypeResolution,
 };
 
-use crate::Handle;
+use crate::arena::{BadHandle, Handle};
 
 #[derive(Clone, Debug, thiserror::Error)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum ComposeError {
-    #[error("Compose type {0:?} doesn't exist")]
-    TypeDoesntExist(Handle<crate::Type>),
+    #[error(transparent)]
+    BadHandle(#[from] BadHandle),
     #[error("Composing of type {0:?} can't be done")]
     Type(Handle<crate::Type>),
     #[error("Composing expects {expected} components but {given} were given")]
@@ -28,9 +28,7 @@ pub fn validate_compose(
 ) -> Result<(), ComposeError> {
     use crate::TypeInner as Ti;
 
-    let self_ty = type_arena
-        .get_handle(self_ty_handle)
-        .ok_or(ComposeError::TypeDoesntExist(self_ty_handle))?;
+    let self_ty = type_arena.get_handle(self_ty_handle)?;
     match self_ty.inner {
         // vectors are composed from scalars or other vectors
         Ti::Vector { size, kind, width } => {

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -1383,10 +1383,11 @@ impl super::Validator {
             }
             E::ArrayLength(expr) => match *resolver.resolve(expr)? {
                 Ti::Pointer { base, .. } => {
-                    if let Some(&Ti::Array {
+                    let base_ty = resolver.types.get_handle(base)?;
+                    if let Ti::Array {
                         size: crate::ArraySize::Dynamic,
                         ..
-                    }) = resolver.types.get_handle(base).map(|ty| &ty.inner)
+                    } = base_ty.inner
                     {
                         ShaderStages::all()
                     } else {

--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -841,12 +841,8 @@ impl super::Validator {
 
         #[cfg(feature = "validate")]
         for (index, argument) in fun.arguments.iter().enumerate() {
-            let ty = module.types.get_handle(argument.ty).ok_or_else(|| {
-                FunctionError::InvalidArgumentType {
-                    index,
-                    name: argument.name.clone().unwrap_or_default(),
-                }
-                .with_span_handle(argument.ty, &module.types)
+            let ty = module.types.get_handle(argument.ty).map_err(|err| {
+                FunctionError::from(err).with_span_handle(argument.ty, &module.types)
             })?;
             match ty.inner.pointer_space() {
                 Some(crate::AddressSpace::Private)

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -9,7 +9,7 @@ mod r#type;
 use crate::arena::{Arena, UniqueArena};
 
 use crate::{
-    arena::Handle,
+    arena::{BadHandle, Handle},
     proc::{LayoutError, Layouter},
     FastHashSet,
 };
@@ -114,6 +114,8 @@ pub struct Validator {
 
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum ConstantError {
+    #[error(transparent)]
+    BadHandle(#[from] BadHandle),
     #[error("The type doesn't match the constant")]
     InvalidType,
     #[error("The component handle {0:?} can not be resolved")]
@@ -240,11 +242,7 @@ impl Validator {
                 }
             }
             crate::ConstantInner::Composite { ty, ref components } => {
-                match types
-                    .get_handle(ty)
-                    .ok_or(ConstantError::InvalidType)?
-                    .inner
-                {
+                match types.get_handle(ty)?.inner {
                     crate::TypeInner::Array {
                         size: crate::ArraySize::Constant(size_handle),
                         ..


### PR DESCRIPTION
It's a bit annoying to see this kind of an error:
```
error: 
  ┌─ uniform.wgsl:2:4
  │
2 │ var buffer: array<vec4<f32>, 4>;
  │    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ naga::GlobalVariable [1]

Global variable [1] 'buffer' is invalid: 
        Type isn't compatible with with the storage class
```

It's unclear what storage class is meant, and what the problem is. This PR changes this into:
```
error: 
  ┌─ uniform.wgsl:2:4
  │
2 │ var buffer: array<vec4<f32>, 4>;
  │    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ naga::GlobalVariable [1]

Global variable [1] 'buffer' is invalid: 
        Type isn't compatible with with address space Handle
```
Which is a bit better...

@jimblandy I feel that defaulting to `Handle` class is not doing WGSL any good, and it should be explicit instead.