### PR TITLE
glsl-in: Fix panic when culling nested block

### DIFF
--- a/src/front/glsl/parser/functions.rs
+++ b/src/front/glsl/parser/functions.rs
@@ -486,12 +486,21 @@ impl<'source> ParsingContext<'source> {
                 let mut block = Block::new();
                 ctx.push_scope();
 
-                let meta =
-                    self.parse_compound_statement(meta, parser, ctx, &mut block, terminator)?;
+                let mut block_terminator = None;
+                let meta = self.parse_compound_statement(
+                    meta,
+                    parser,
+                    ctx,
+                    &mut block,
+                    &mut block_terminator,
+                )?;
 
                 ctx.remove_current_scope();
 
                 body.push(Statement::Block(block), meta);
+                if block_terminator.is_some() {
+                    terminator.get_or_insert(body.len());
+                }
 
                 meta
             }


### PR DESCRIPTION
Under certatin circumstances the parser would panic because of culling
using an index out of bound, for example take the following code:

```glsl
{
    x = 1; // Index 0 on nested block
    discard; // Index 1 on nested block
} // Index 0 on block
```

The parser seeing this would attempt to cull the block using the start
index of 1 which would be out of bound and panic. Now instead the nested
block properly does it's internal culling and the outer block culls
everything after the nested block only.