### PR TITLE
glsl-in: inject samplerCubeArray builtins on use

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -62,14 +62,26 @@ pub struct Overload {
     pub void: bool,
 }
 
+bitflags::bitflags! {
+    /// Tracks the variations of the builtin already generated, this is needed because some
+    /// builtins overloads can't be generated unless explicitly used, since they might cause
+    /// uneeded capabilities to be requested
+    #[derive(Default)]
+    pub struct BuiltinVariations: u32 {
+        /// Request the standard overloads
+        const STANDARD = 1 << 0;
+        /// Request overloads that use the double type
+        const DOUBLE = 1 << 1;
+        /// Request overloads that use samplerCubeArray(Shadow)
+        const CUBE_TEXTURES_ARRAY = 1 << 2;
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct FunctionDeclaration {
     pub overloads: Vec<Overload>,
-    /// Whether or not this function has the name of a builtin.
-    pub builtin: bool,
-    /// If [`builtin`](Self::builtin) is true, this field indicates whether
-    /// this function already has double overloads added or not. Otherwise, it is unused.
-    pub double: bool,
+    /// Tracks the builtin overload variations that were already generated
+    pub variations: BuiltinVariations,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Arrayed cube images require a special capabilities in some backends, so
like how we already do with doubles, we now only inject them if a call
uses one as an argument.

This required some refractoring on the builtins handling of variations
but now the interface is cleaner and adding new variations (if needed)
should be easier.

Closes #1622