### PR TITLE
glsl-in: inject sampler2DMSArray builtins on use

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -74,6 +74,8 @@ bitflags::bitflags! {
         const DOUBLE = 1 << 1;
         /// Request overloads that use samplerCubeArray(Shadow)
         const CUBE_TEXTURES_ARRAY = 1 << 2;
+        /// Request overloads that use sampler2DMSArray
+        const D2_MULTI_TEXTURES_ARRAY = 1 << 3;
     }
 }
 

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -1498,9 +1498,17 @@ fn builtin_required_variations<'a>(args: impl Iterator<Item = &'a TypeInner>) ->
                     variations |= BuiltinVariations::DOUBLE
                 }
             }
-            TypeInner::Image { dim, arrayed, .. } => {
+            TypeInner::Image {
+                dim,
+                arrayed,
+                class,
+            } => {
                 if dim == crate::ImageDimension::Cube && arrayed {
                     variations |= BuiltinVariations::CUBE_TEXTURES_ARRAY
+                }
+
+                if dim == crate::ImageDimension::D2 && arrayed && class.is_multisampled() {
+                    variations |= BuiltinVariations::D2_MULTI_TEXTURES_ARRAY
                 }
             }
             _ => {}

--- a/tests/in/variations.glsl
+++ b/tests/in/variations.glsl
@@ -1,0 +1,9 @@
+#version 460 core
+
+layout(set = 0, binding = 0) uniform textureCube texCube;
+layout(set = 0, binding = 1) uniform sampler samp;
+
+void main() {
+    ivec2 sizeCube = textureSize(samplerCube(texCube, samp), 0);
+    float a = ceil(1.0);
+}

--- a/tests/out/glsl/variations-glsl.main.Fragment.glsl
+++ b/tests/out/glsl/variations-glsl.main.Fragment.glsl
@@ -1,0 +1,21 @@
+#version 310 es
+
+precision highp float;
+precision highp int;
+
+uniform highp samplerCube _group_0_binding_0_fs;
+
+
+void main_1() {
+    ivec2 sizeCube = ivec2(0);
+    float a = 0.0;
+    sizeCube = textureSize(_group_0_binding_0_fs, 0).xy;
+    a = ceil(1.0);
+    return;
+}
+
+void main() {
+    main_1();
+    return;
+}
+

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -557,6 +557,25 @@ fn convert_spv_all() {
 }
 
 #[cfg(feature = "glsl-in")]
+#[test]
+fn convert_glsl_variations_check() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let file = fs::read_to_string(format!("{}/{}/variations.glsl", root, BASE_DIR_IN))
+        .expect("Couldn't find glsl file");
+    let mut parser = naga::front::glsl::Parser::default();
+    let module = parser
+        .parse(
+            &naga::front::glsl::Options {
+                stage: naga::ShaderStage::Fragment,
+                defines: Default::default(),
+            },
+            &file,
+        )
+        .unwrap();
+    check_targets(&module, "variations-glsl", Targets::GLSL);
+}
+
+#[cfg(feature = "glsl-in")]
 #[allow(unused_variables)]
 #[test]
 fn convert_glsl_folder() {


### PR DESCRIPTION
Also adds a glsl to glsl test to make sure that no unneeded extensions are activated. 