### PR TITLE
Split logical and bitwise not

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -2392,23 +2392,15 @@ impl<'a, W: Write> Writer<'a, W> {
             //
             // We also wrap the everything in parentheses to avoid precedence issues
             Expression::Unary { op, expr } => {
-                use crate::{ScalarKind as Sk, UnaryOperator as Uo};
+                use crate::UnaryOperator as Uo;
 
                 write!(
                     self.out,
                     "({} ",
                     match op {
                         Uo::Negate => "-",
-                        Uo::Not => match *ctx.info[expr].ty.inner_with(&self.module.types) {
-                            TypeInner::Scalar { kind: Sk::Sint, .. } => "~",
-                            TypeInner::Scalar { kind: Sk::Uint, .. } => "~",
-                            TypeInner::Scalar { kind: Sk::Bool, .. } => "!",
-                            ref other =>
-                                return Err(Error::Custom(format!(
-                                    "Cannot apply not to type {:?}",
-                                    other
-                                ))),
-                        },
+                        Uo::BitwiseNot => "~",
+                        Uo::LogicalNot => "!",
                     }
                 )?;
 

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -1754,7 +1754,8 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 // https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-operators#unary-operators
                 let op_str = match op {
                     crate::UnaryOperator::Negate => "-",
-                    crate::UnaryOperator::Not => "!",
+                    crate::UnaryOperator::LogicalNot => "!",
+                    crate::UnaryOperator::BitwiseNot => "~",
                 };
                 write!(self.out, "{}", op_str)?;
                 self.write_expr(module, expr, func_ctx)?;

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1408,7 +1408,8 @@ impl<W: Write> Writer<W> {
             crate::Expression::Unary { op, expr } => {
                 let op_str = match op {
                     crate::UnaryOperator::Negate => "-",
-                    crate::UnaryOperator::Not => "!",
+                    crate::UnaryOperator::LogicalNot => "!",
+                    crate::UnaryOperator::BitwiseNot => "~",
                 };
                 write!(self.out, "{}", op_str)?;
                 self.put_expression(expr, context, false)?;

--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -315,10 +315,8 @@ impl<'w> BlockContext<'w> {
                             return Err(Error::FeatureNotImplemented("negation"));
                         }
                     },
-                    crate::UnaryOperator::Not => match expr_ty_inner.scalar_kind() {
-                        Some(crate::ScalarKind::Bool) => spirv::Op::LogicalNot,
-                        _ => spirv::Op::Not,
-                    },
+                    crate::UnaryOperator::LogicalNot => spirv::Op::LogicalNot,
+                    crate::UnaryOperator::BitwiseNot => spirv::Op::Not,
                 };
 
                 block

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -1599,16 +1599,8 @@ impl<W: Write> Writer<W> {
             Expression::Unary { op, expr } => {
                 let unary = match op {
                     crate::UnaryOperator::Negate => "-",
-                    crate::UnaryOperator::Not => {
-                        match *func_ctx.info[expr].ty.inner_with(&module.types) {
-                            TypeInner::Scalar {
-                                kind: crate::ScalarKind::Bool,
-                                ..
-                            }
-                            | TypeInner::Vector { .. } => "!",
-                            _ => "~",
-                        }
-                    }
+                    crate::UnaryOperator::LogicalNot => "!",
+                    crate::UnaryOperator::BitwiseNot => "~",
                 };
 
                 write!(self.out, "{}(", unary)?;

--- a/src/front/glsl/constants.rs
+++ b/src/front/glsl/constants.rs
@@ -361,10 +361,13 @@ impl<'a> ConstantSolver<'a> {
                     ScalarValue::Float(ref mut v) => *v = -*v,
                     _ => return Err(ConstantSolvingError::InvalidUnaryOpArg),
                 },
-                UnaryOperator::Not => match *value {
+                UnaryOperator::LogicalNot => match *value {
+                    ScalarValue::Bool(ref mut v) => *v = !*v,
+                    _ => return Err(ConstantSolvingError::InvalidUnaryOpArg),
+                },
+                UnaryOperator::BitwiseNot => match *value {
                     ScalarValue::Sint(ref mut v) => *v = !*v,
                     ScalarValue::Uint(ref mut v) => *v = !*v,
-                    ScalarValue::Bool(ref mut v) => *v = !*v,
                     _ => return Err(ConstantSolvingError::InvalidUnaryOpArg),
                 },
             },
@@ -584,7 +587,7 @@ mod tests {
 
         let root2 = expressions.append(
             Expression::Unary {
-                op: UnaryOperator::Not,
+                op: UnaryOperator::BitwiseNot,
                 expr,
             },
             Default::default(),
@@ -592,7 +595,7 @@ mod tests {
 
         let root3 = expressions.append(
             Expression::Unary {
-                op: UnaryOperator::Not,
+                op: UnaryOperator::BitwiseNot,
                 expr: expr1,
             },
             Default::default(),

--- a/src/front/glsl/parser/expressions.rs
+++ b/src/front/glsl/parser/expressions.rs
@@ -282,8 +282,12 @@ impl<'source> ParsingContext<'source> {
                         op: UnaryOperator::Negate,
                         expr,
                     },
-                    TokenValue::Bang | TokenValue::Tilde => HirExprKind::Unary {
-                        op: UnaryOperator::Not,
+                    TokenValue::Bang => HirExprKind::Unary {
+                        op: UnaryOperator::LogicalNot,
+                        expr,
+                    },
+                    TokenValue::Tilde => HirExprKind::Unary {
+                        op: UnaryOperator::BitwiseNot,
                         expr,
                     },
                     _ => return Ok(expr),

--- a/src/front/glsl/parser/functions.rs
+++ b/src/front/glsl/parser/functions.rs
@@ -283,7 +283,7 @@ impl<'source> ParsingContext<'source> {
                     ctx.lower_expect(stmt, parser, root, ExprPos::Rhs, &mut loop_body)?;
                 let condition = ctx.add_expression(
                     Expression::Unary {
-                        op: UnaryOperator::Not,
+                        op: UnaryOperator::LogicalNot,
                         expr,
                     },
                     expr_meta,
@@ -341,7 +341,7 @@ impl<'source> ParsingContext<'source> {
                     ctx.lower_expect(stmt, parser, root, ExprPos::Rhs, &mut loop_body)?;
                 let condition = ctx.add_expression(
                     Expression::Unary {
-                        op: UnaryOperator::Not,
+                        op: UnaryOperator::LogicalNot,
                         expr,
                     },
                     expr_meta,
@@ -430,7 +430,7 @@ impl<'source> ParsingContext<'source> {
 
                     let condition = ctx.add_expression(
                         Expression::Unary {
-                            op: UnaryOperator::Not,
+                            op: UnaryOperator::LogicalNot,
                             expr,
                         },
                         expr_meta,

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -2245,7 +2245,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                         &mut block,
                         block_id,
                         body_idx,
-                        crate::UnaryOperator::Not,
+                        crate::UnaryOperator::BitwiseNot,
                     )?;
                 }
                 Op::ShiftRightLogical => {
@@ -2727,7 +2727,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                 // Relational and Logical Instructions
                 Op::LogicalNot => {
                     inst.expect(4)?;
-                    parse_expr_op!(crate::UnaryOperator::Not, UNARY)?;
+                    parse_expr_op!(crate::UnaryOperator::LogicalNot, UNARY)?;
                 }
                 Op::LogicalOr => {
                     inst.expect(5)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -824,7 +824,8 @@ pub struct LocalVariable {
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub enum UnaryOperator {
     Negate,
-    Not,
+    LogicalNot,
+    BitwiseNot,
 }
 
 /// Operation that can be applied on two values.

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -633,11 +633,11 @@ impl super::Validator {
                 use crate::UnaryOperator as Uo;
                 let inner = resolver.resolve(expr)?;
                 match (op, inner.scalar_kind()) {
-                    (_, Some(Sk::Sint))
-                    | (_, Some(Sk::Bool))
-                    //TODO: restrict Negate for bools?
+                    (Uo::LogicalNot, Some(Sk::Bool))
+                    | (Uo::Negate, Some(Sk::Sint))
                     | (Uo::Negate, Some(Sk::Float))
-                    | (Uo::Not, Some(Sk::Uint)) => {}
+                    | (Uo::BitwiseNot, Some(Sk::Sint))
+                    | (Uo::BitwiseNot, Some(Sk::Uint)) => {}
                     other => {
                         log::error!("Op {:?} kind {:?}", op, other);
                         return Err(ExpressionError::InvalidUnaryOperandType(op, expr));

--- a/tests/out/hlsl/operators.hlsl
+++ b/tests/out/hlsl/operators.hlsl
@@ -33,7 +33,7 @@ int unary()
     if (!true) {
         return 1;
     } else {
-        return !1;
+        return ~1;
     }
 }
 

--- a/tests/out/msl/operators.msl
+++ b/tests/out/msl/operators.msl
@@ -38,7 +38,7 @@ int unary(
     if (!true) {
         return 1;
     } else {
-        return !1;
+        return ~1;
     }
 }
 


### PR DESCRIPTION
Fixes #1252

Hi, I wanted to play with Naga and #1252 seems it might be easy to fix, and I ended up with something that looked fine so here it is.

My goal was to fix the Metal issue, but for that I had to change how WGSL unary operators were handled. I guess WGSL probably originally represented bitwise and logical not the same way (like in Rust where both are `!`).
