### PR TITLE
glsl-in: Fix freestanding constructor parsing

### DIFF
--- a/src/front/glsl/error.rs
+++ b/src/front/glsl/error.rs
@@ -104,6 +104,11 @@ pub enum ErrorKind {
     /// An error was returned by the preprocessor.
     #[error("{0:?}")]
     PreprocessorError(PreprocessorError),
+    /// The parser entered an illegal state and exited
+    ///
+    /// This obviously is a bug and as such should be reported in the github issue tracker
+    #[error("Internal error: {0}")]
+    InternalError(&'static str),
 }
 
 impl From<ConstantSolvingError> for ErrorKind {

--- a/tests/in/glsl/expressions.frag
+++ b/tests/in/glsl/expressions.frag
@@ -109,6 +109,10 @@ void testArrayConstructor() {
     float tree[1] = float[1](0.0);
 }
 
+void testFreestandingConstructor() {
+    vec4(1.0);
+}
+
 float global;
 void privatePointer(inout float a) {}
 

--- a/tests/out/wgsl/expressions-frag.wgsl
+++ b/tests/out/wgsl/expressions-frag.wgsl
@@ -282,6 +282,10 @@ fn testArrayConstructor() {
 
 }
 
+fn testFreestandingConstructor() {
+    return;
+}
+
 fn privatePointer(a_18: ptr<function, f32>) {
     return;
 }


### PR DESCRIPTION
This required doing backtracking in order to select between a declaration statement and a expression statement.

This PR is divided into 2 parts, each with it's own commit that can be reviewed and tested individually:
- Implementing backtracking
- Fixing the constructor freestanding parsing  

Closes #1554