### PR TITLE
Not operator depending on expression type

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1406,9 +1406,15 @@ impl<W: Write> Writer<W> {
                 }
             },
             crate::Expression::Unary { op, expr } => {
+                use crate::{ScalarKind as Sk, UnaryOperator as Uo};
                 let op_str = match op {
-                    crate::UnaryOperator::Negate => "-",
-                    crate::UnaryOperator::Not => "!",
+                    Uo::Negate => "-",
+                    Uo::Not => match *context.resolve_type(expr) {
+                        crate::TypeInner::Scalar { kind: Sk::Sint, .. } => "~",
+                        crate::TypeInner::Scalar { kind: Sk::Uint, .. } => "~",
+                        crate::TypeInner::Scalar { kind: Sk::Bool, .. } => "!",
+                        _ => return Err(Error::Validation),
+                    },
                 };
                 write!(self.out, "{}", op_str)?;
                 self.put_expression(expr, context, false)?;

--- a/tests/out/hlsl/operators.hlsl
+++ b/tests/out/hlsl/operators.hlsl
@@ -33,7 +33,7 @@ int unary()
     if (!true) {
         return 1;
     } else {
-        return !1;
+        return ~1;
     }
 }
 

--- a/tests/out/msl/operators.msl
+++ b/tests/out/msl/operators.msl
@@ -38,7 +38,7 @@ int unary(
     if (!true) {
         return 1;
     } else {
-        return !1;
+        return ~1;
     }
 }
 


### PR DESCRIPTION
Fixes #1252

In HLSL and MSL, when outputting a not operator, look at the expression type to choose the correct operator.

Mostly took code from the GLSL backend and adapted it for the other backends.