### PR TITLE
[wgsl] Uses commas to separate struct members instead of semicolons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.9 (TBD)
   - WGSL:
+    - commas are used to separate struct members intead of semicolons
     - attributes are declared with `@attrib` instead of `[[attrib]]`
     - `stride` attribute is removed
     - block comments are supported

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -419,7 +419,7 @@ impl<W: Write> Writer<W> {
             let member_name = &self.names[&NameKey::StructMember(handle, index as u32)];
             write!(self.out, "{}: ", member_name)?;
             self.write_type(module, member.ty)?;
-            write!(self.out, ";")?;
+            write!(self.out, ",")?;
             writeln!(self.out)?;
         }
 

--- a/src/front/wgsl/tests.rs
+++ b/src/front/wgsl/tests.rs
@@ -157,11 +157,11 @@ fn parse_type_cast() {
 fn parse_struct() {
     parse_str(
         "
-        struct Foo { x: i32; };
+        struct Foo { x: i32 };
         struct Bar {
-            @size(16) x: vec2<i32>;
-            @align(16) y: f32;
-            @size(32) @align(8) z: vec3<f32>;
+            @size(16) x: vec2<i32>,
+            @align(16) y: f32,
+            @size(32) @align(8) z: vec3<f32>,
         };
         struct Empty {};
         var<storage,read_write> s: Foo;
@@ -415,8 +415,8 @@ fn parse_struct_instantiation() {
     parse_str(
         "
     struct Foo {
-        a: f32;
-        b: vec3<f32>;
+        a: f32,
+        b: vec3<f32>,
     };
     
     @stage(fragment)
@@ -433,7 +433,7 @@ fn parse_array_length() {
     parse_str(
         "
         struct Foo {
-            data: array<u32>;
+            data: array<u32>
         }; // this is used as both input and output for convenience
 
         @group(0) @binding(0)

--- a/tests/in/access.wgsl
+++ b/tests/in/access.wgsl
@@ -1,15 +1,15 @@
 // This snapshot tests accessing various containers, dereferencing pointers.
 
 struct AlignedWrapper {
-	@align(8) value: i32;
+	@align(8) value: i32
 };
 
 struct Bar {
-	matrix: mat4x4<f32>;
-	matrix_array: array<mat2x2<f32>, 2>;
-	atom: atomic<i32>;
-	arr: array<vec2<u32>, 2>;
-	data: array<AlignedWrapper>;
+	matrix: mat4x4<f32>,
+	matrix_array: array<mat2x2<f32>, 2>,
+	atom: atomic<i32>,
+	arr: array<vec2<u32>, 2>,
+	data: array<AlignedWrapper>,
 };
 
 @group(0) @binding(0)

--- a/tests/in/boids.wgsl
+++ b/tests/in/boids.wgsl
@@ -1,22 +1,22 @@
 let NUM_PARTICLES: u32 = 1500u;
 
 struct Particle {
-  pos : vec2<f32>;
-  vel : vec2<f32>;
+  pos : vec2<f32>,
+  vel : vec2<f32>,
 };
 
 struct SimParams {
-  deltaT : f32;
-  rule1Distance : f32;
-  rule2Distance : f32;
-  rule3Distance : f32;
-  rule1Scale : f32;
-  rule2Scale : f32;
-  rule3Scale : f32;
+  deltaT : f32,
+  rule1Distance : f32,
+  rule2Distance : f32,
+  rule3Distance : f32,
+  rule1Scale : f32,
+  rule2Scale : f32,
+  rule3Scale : f32,
 };
 
 struct Particles {
-  particles : array<Particle>;
+  particles : array<Particle>
 };
 
 @group(0) @binding(0) var<uniform> params : SimParams;

--- a/tests/in/bounds-check-restrict.wgsl
+++ b/tests/in/bounds-check-restrict.wgsl
@@ -1,10 +1,10 @@
 // Tests for `naga::back::BoundsCheckPolicy::Restrict`.
 
 struct Globals {
-    a: array<f32, 10>;
-    v: vec4<f32>;
-    m: mat3x4<f32>;
-    d: array<f32>;
+    a: array<f32, 10>,
+    v: vec4<f32>,
+    m: mat3x4<f32>,
+    d: array<f32>,
 };
 
 @group(0) @binding(0) var<storage, read_write> globals: Globals;

--- a/tests/in/bounds-check-zero-atomic.wgsl
+++ b/tests/in/bounds-check-zero-atomic.wgsl
@@ -5,9 +5,9 @@
 // be combined.
 
 struct Globals {
-    a: atomic<u32>;
-    b: array<atomic<u32>, 10>;
-    c: array<atomic<u32>>;
+    a: atomic<u32>,
+    b: array<atomic<u32>, 10>,
+    c: array<atomic<u32>>,
 };
 
 @group(0) @binding(0) var<storage, read_write> globals: Globals;

--- a/tests/in/bounds-check-zero.wgsl
+++ b/tests/in/bounds-check-zero.wgsl
@@ -1,10 +1,10 @@
 // Tests for `naga::back::BoundsCheckPolicy::ReadZeroSkipWrite`.
 
 struct Globals {
-    a: array<f32, 10>;
-    v: vec4<f32>;
-    m: mat3x4<f32>;
-    d: array<f32>;
+    a: array<f32, 10>,
+    v: vec4<f32>,
+    m: mat3x4<f32>,
+    d: array<f32>,
 };
 
 @group(0) @binding(0) var<storage, read_write> globals: Globals;

--- a/tests/in/collatz.wgsl
+++ b/tests/in/collatz.wgsl
@@ -1,5 +1,5 @@
 struct PrimeIndices {
-    data: array<u32>;
+    data: array<u32>
 }; // this is used as both input and output for convenience
 
 @group(0) @binding(0)

--- a/tests/in/extra.wgsl
+++ b/tests/in/extra.wgsl
@@ -1,12 +1,12 @@
 struct PushConstants {
-    index: u32;
-    double: vec2<f64>;
+    index: u32,
+    double: vec2<f64>,
 };
 var<push_constant> pc: PushConstants;
 
 struct FragmentIn {
-    @location(0) color: vec4<f32>;
-    @builtin(primitive_index) primitive_index: u32;
+    @location(0) color: vec4<f32>,
+    @builtin(primitive_index) primitive_index: u32,
 };
 
 @stage(fragment)

--- a/tests/in/globals.wgsl
+++ b/tests/in/globals.wgsl
@@ -6,9 +6,9 @@ var<workgroup> wg : array<f32, 10u>;
 var<workgroup> at: atomic<u32>;
 
 struct Foo {
-    v3: vec3<f32>;
+    v3: vec3<f32>,
     // test packed vec3
-    v1: f32;
+    v1: f32,
 };
 @group(0) @binding(1)
 var<storage, read_write> alignment: Foo;

--- a/tests/in/interface.wgsl
+++ b/tests/in/interface.wgsl
@@ -1,8 +1,8 @@
 // Testing various parts of the pipeline interface: locations, built-ins, and entry points
 
 struct VertexOutput {
-    @builtin(position) position: vec4<f32>;
-    @location(1) varying: f32;
+    @builtin(position) position: vec4<f32>,
+    @location(1) varying: f32,
 };
 
 @stage(vertex)
@@ -16,9 +16,9 @@ fn vertex(
 }
 
 struct FragmentOutput {
-    @builtin(frag_depth) depth: f32;
-    @builtin(sample_mask) sample_mask: u32;
-    @location(0) color: f32;
+    @builtin(frag_depth) depth: f32,
+    @builtin(sample_mask) sample_mask: u32,
+    @location(0) color: f32,
 };
 
 @stage(fragment)
@@ -47,11 +47,11 @@ fn compute(
 }
 
 struct Input1 {
-    @builtin(vertex_index) index: u32;
+    @builtin(vertex_index) index: u32,
 };
 
 struct Input2 {
-    @builtin(instance_index) index: u32;
+    @builtin(instance_index) index: u32,
 };
 
 @stage(vertex)

--- a/tests/in/interpolate.wgsl
+++ b/tests/in/interpolate.wgsl
@@ -1,14 +1,14 @@
 //TODO: merge with "interface"?
 
 struct FragmentInput {
-  @builtin(position) position: vec4<f32>;
-  @location(0) @interpolate(flat) flat : u32;
-  @location(1) @interpolate(linear) linear : f32;
-  @location(2) @interpolate(linear, centroid) linear_centroid : vec2<f32>;
-  @location(3) @interpolate(linear, sample) linear_sample : vec3<f32>;
-  @location(4) @interpolate(perspective) perspective : vec4<f32>;
-  @location(5) @interpolate(perspective, centroid) perspective_centroid : f32;
-  @location(6) @interpolate(perspective, sample) perspective_sample : f32;
+  @builtin(position) position: vec4<f32>,
+  @location(0) @interpolate(flat) flat : u32,
+  @location(1) @interpolate(linear) linear : f32,
+  @location(2) @interpolate(linear, centroid) linear_centroid : vec2<f32>,
+  @location(3) @interpolate(linear, sample) linear_sample : vec3<f32>,
+  @location(4) @interpolate(perspective) perspective : vec4<f32>,
+  @location(5) @interpolate(perspective, centroid) perspective_centroid : f32,
+  @location(6) @interpolate(perspective, sample) perspective_sample : f32,
 };
 
 @stage(vertex)

--- a/tests/in/operators.wgsl
+++ b/tests/in/operators.wgsl
@@ -39,8 +39,8 @@ fn bool_cast(x: vec3<f32>) -> vec3<f32> {
 }
 
 struct Foo {
-    a: vec4<f32>;
-    b: i32;
+    a: vec4<f32>,
+    b: i32,
 };
 
 fn constructors() -> f32 {

--- a/tests/in/pointers.wgsl
+++ b/tests/in/pointers.wgsl
@@ -5,7 +5,7 @@ fn f() {
 }
 
 struct DynamicArray {
-    arr: array<u32>;
+    arr: array<u32>
 };
 
 @group(0) @binding(0)

--- a/tests/in/policy-mix.wgsl
+++ b/tests/in/policy-mix.wgsl
@@ -3,12 +3,12 @@
 
 // Storage and Uniform storage classes
 struct InStorage {
-  a: array<vec4<f32>, 10>;
+  a: array<vec4<f32>, 10>
 };
 @group(0) @binding(0) var<storage> in_storage: InStorage;
 
 struct InUniform {
-  a: array<vec4<f32>, 20>;
+  a: array<vec4<f32>, 20>
 };
 @group(0) @binding(1) var<uniform> in_uniform: InUniform;
 

--- a/tests/in/push-constants.wgsl
+++ b/tests/in/push-constants.wgsl
@@ -1,10 +1,10 @@
 struct PushConstants {
-    multiplier: f32;
+    multiplier: f32
 };
 var<push_constant> pc: PushConstants;
 
 struct FragmentIn {
-    @location(0) color: vec4<f32>;
+    @location(0) color: vec4<f32>
 };
 
 @stage(fragment)

--- a/tests/in/quad.wgsl
+++ b/tests/in/quad.wgsl
@@ -2,8 +2,8 @@
 let c_scale: f32 = 1.2;
 
 struct VertexOutput {
-  @location(0) uv : vec2<f32>;
-  @builtin(position) position : vec4<f32>;
+  @location(0) uv : vec2<f32>,
+  @builtin(position) position : vec4<f32>,
 };
 
 @stage(vertex)

--- a/tests/in/shadow.wgsl
+++ b/tests/in/shadow.wgsl
@@ -1,6 +1,6 @@
 struct Globals {
-    view_proj: mat4x4<f32>;
-    num_lights: vec4<u32>;
+    view_proj: mat4x4<f32>,
+    num_lights: vec4<u32>,
 };
 
 @group(0)
@@ -8,8 +8,8 @@ struct Globals {
 var<uniform> u_globals: Globals;
 
 struct Entity {
-    world: mat4x4<f32>;
-    color: vec4<f32>;
+    world: mat4x4<f32>,
+    color: vec4<f32>,
 };
 
 @group(1)
@@ -24,9 +24,9 @@ fn vs_bake(@location(0) position: vec4<i32>) -> @builtin(position) vec4<f32> {
 */
 
 struct VertexOutput {
-    @builtin(position) proj_position: vec4<f32>;
-    @location(0) world_normal: vec3<f32>;
-    @location(1) world_position: vec4<f32>;
+    @builtin(position) proj_position: vec4<f32>,
+    @location(0) world_normal: vec3<f32>,
+    @location(1) world_position: vec4<f32>,
 };
 
 @stage(vertex)
@@ -46,9 +46,9 @@ fn vs_main(
 // fragment shader
 
 struct Light {
-    proj: mat4x4<f32>;
-    pos: vec4<f32>;
-    color: vec4<f32>;
+    proj: mat4x4<f32>,
+    pos: vec4<f32>,
+    color: vec4<f32>,
 };
 
 @group(0)

--- a/tests/in/skybox.wgsl
+++ b/tests/in/skybox.wgsl
@@ -1,11 +1,11 @@
 struct VertexOutput {
-    @builtin(position) position: vec4<f32>;
-    @location(0) uv: vec3<f32>;
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec3<f32>,
 };
 
 struct Data {
-    proj_inv: mat4x4<f32>;
-    view: mat4x4<f32>;
+    proj_inv: mat4x4<f32>,
+    view: mat4x4<f32>,
 };
 @group(0) @binding(0)
 var<uniform> r_data: Data;

--- a/tests/out/wgsl/210-bevy-2d-shader-frag.wgsl
+++ b/tests/out/wgsl/210-bevy-2d-shader-frag.wgsl
@@ -1,9 +1,9 @@
 struct ColorMaterial_color {
-    Color: vec4<f32>;
+    Color: vec4<f32>,
 };
 
 struct FragmentOutput {
-    @location(0) o_Target: vec4<f32>;
+    @location(0) o_Target: vec4<f32>,
 };
 
 var<private> v_Uv_1: vec2<f32>;

--- a/tests/out/wgsl/210-bevy-2d-shader-vert.wgsl
+++ b/tests/out/wgsl/210-bevy-2d-shader-vert.wgsl
@@ -1,18 +1,18 @@
 struct Camera {
-    ViewProj: mat4x4<f32>;
+    ViewProj: mat4x4<f32>,
 };
 
 struct Transform {
-    Model: mat4x4<f32>;
+    Model: mat4x4<f32>,
 };
 
 struct Sprite_size {
-    size: vec2<f32>;
+    size: vec2<f32>,
 };
 
 struct VertexOutput {
-    @location(0) v_Uv: vec2<f32>;
-    @builtin(position) member: vec4<f32>;
+    @location(0) v_Uv: vec2<f32>,
+    @builtin(position) member: vec4<f32>,
 };
 
 var<private> Vertex_Position_1: vec3<f32>;

--- a/tests/out/wgsl/210-bevy-shader-vert.wgsl
+++ b/tests/out/wgsl/210-bevy-shader-vert.wgsl
@@ -1,16 +1,16 @@
 struct Camera {
-    ViewProj: mat4x4<f32>;
+    ViewProj: mat4x4<f32>,
 };
 
 struct Transform {
-    Model: mat4x4<f32>;
+    Model: mat4x4<f32>,
 };
 
 struct VertexOutput {
-    @location(0) v_Position: vec3<f32>;
-    @location(1) v_Normal: vec3<f32>;
-    @location(2) v_Uv: vec2<f32>;
-    @builtin(position) member: vec4<f32>;
+    @location(0) v_Position: vec3<f32>,
+    @location(1) v_Normal: vec3<f32>,
+    @location(2) v_Uv: vec2<f32>,
+    @builtin(position) member: vec4<f32>,
 };
 
 var<private> Vertex_Position_1: vec3<f32>;

--- a/tests/out/wgsl/246-collatz-comp.wgsl
+++ b/tests/out/wgsl/246-collatz-comp.wgsl
@@ -1,5 +1,5 @@
 struct PrimeIndices {
-    indices: array<u32>;
+    indices: array<u32>,
 };
 
 @group(0) @binding(0) 

--- a/tests/out/wgsl/800-out-of-bounds-panic-vert.wgsl
+++ b/tests/out/wgsl/800-out-of-bounds-panic-vert.wgsl
@@ -1,14 +1,14 @@
 struct Globals {
-    view_matrix: mat4x4<f32>;
+    view_matrix: mat4x4<f32>,
 };
 
 struct VertexPushConstants {
-    world_matrix: mat4x4<f32>;
+    world_matrix: mat4x4<f32>,
 };
 
 struct VertexOutput {
-    @location(0) frag_color: vec4<f32>;
-    @builtin(position) member: vec4<f32>;
+    @location(0) frag_color: vec4<f32>,
+    @builtin(position) member: vec4<f32>,
 };
 
 @group(0) @binding(0) 

--- a/tests/out/wgsl/896-push-constant-vert.wgsl
+++ b/tests/out/wgsl/896-push-constant-vert.wgsl
@@ -1,5 +1,5 @@
 struct PushConstants {
-    example: f32;
+    example: f32,
 };
 
 var<push_constant> c: PushConstants;

--- a/tests/out/wgsl/access.wgsl
+++ b/tests/out/wgsl/access.wgsl
@@ -1,13 +1,13 @@
 struct AlignedWrapper {
-    value: i32;
+    value: i32,
 };
 
 struct Bar {
-    matrix: mat4x4<f32>;
-    matrix_array: array<mat2x2<f32>,2>;
-    atom: atomic<i32>;
-    arr: array<vec2<u32>,2>;
-    data: array<AlignedWrapper>;
+    matrix: mat4x4<f32>,
+    matrix_array: array<mat2x2<f32>,2>,
+    atom: atomic<i32>,
+    arr: array<vec2<u32>,2>,
+    data: array<AlignedWrapper>,
 };
 
 @group(0) @binding(0) 

--- a/tests/out/wgsl/bevy-pbr-frag.wgsl
+++ b/tests/out/wgsl/bevy-pbr-frag.wgsl
@@ -1,51 +1,51 @@
 struct PointLight {
-    pos: vec4<f32>;
-    color: vec4<f32>;
-    lightParams: vec4<f32>;
+    pos: vec4<f32>,
+    color: vec4<f32>,
+    lightParams: vec4<f32>,
 };
 
 struct DirectionalLight {
-    direction: vec4<f32>;
-    color: vec4<f32>;
+    direction: vec4<f32>,
+    color: vec4<f32>,
 };
 
 struct CameraViewProj {
-    ViewProj: mat4x4<f32>;
+    ViewProj: mat4x4<f32>,
 };
 
 struct CameraPosition {
-    CameraPos: vec4<f32>;
+    CameraPos: vec4<f32>,
 };
 
 struct Lights {
-    AmbientColor: vec4<f32>;
-    NumLights: vec4<u32>;
-    PointLights: array<PointLight,10u>;
-    DirectionalLights: array<DirectionalLight,1u>;
+    AmbientColor: vec4<f32>,
+    NumLights: vec4<u32>,
+    PointLights: array<PointLight,10u>,
+    DirectionalLights: array<DirectionalLight,1u>,
 };
 
 struct StandardMaterial_base_color {
-    base_color: vec4<f32>;
+    base_color: vec4<f32>,
 };
 
 struct StandardMaterial_roughness {
-    perceptual_roughness: f32;
+    perceptual_roughness: f32,
 };
 
 struct StandardMaterial_metallic {
-    metallic: f32;
+    metallic: f32,
 };
 
 struct StandardMaterial_reflectance {
-    reflectance: f32;
+    reflectance: f32,
 };
 
 struct StandardMaterial_emissive {
-    emissive: vec4<f32>;
+    emissive: vec4<f32>,
 };
 
 struct FragmentOutput {
-    @location(0) o_Target: vec4<f32>;
+    @location(0) o_Target: vec4<f32>,
 };
 
 var<private> v_WorldPosition_1: vec3<f32>;

--- a/tests/out/wgsl/bevy-pbr-vert.wgsl
+++ b/tests/out/wgsl/bevy-pbr-vert.wgsl
@@ -1,17 +1,17 @@
 struct CameraViewProj {
-    ViewProj: mat4x4<f32>;
+    ViewProj: mat4x4<f32>,
 };
 
 struct Transform {
-    Model: mat4x4<f32>;
+    Model: mat4x4<f32>,
 };
 
 struct VertexOutput {
-    @location(0) v_WorldPosition: vec3<f32>;
-    @location(1) v_WorldNormal: vec3<f32>;
-    @location(2) v_Uv: vec2<f32>;
-    @location(3) v_WorldTangent: vec4<f32>;
-    @builtin(position) member: vec4<f32>;
+    @location(0) v_WorldPosition: vec3<f32>,
+    @location(1) v_WorldNormal: vec3<f32>,
+    @location(2) v_Uv: vec2<f32>,
+    @location(3) v_WorldTangent: vec4<f32>,
+    @builtin(position) member: vec4<f32>,
 };
 
 var<private> Vertex_Position_1: vec3<f32>;

--- a/tests/out/wgsl/boids.wgsl
+++ b/tests/out/wgsl/boids.wgsl
@@ -1,20 +1,20 @@
 struct Particle {
-    pos: vec2<f32>;
-    vel: vec2<f32>;
+    pos: vec2<f32>,
+    vel: vec2<f32>,
 };
 
 struct SimParams {
-    deltaT: f32;
-    rule1Distance: f32;
-    rule2Distance: f32;
-    rule3Distance: f32;
-    rule1Scale: f32;
-    rule2Scale: f32;
-    rule3Scale: f32;
+    deltaT: f32,
+    rule1Distance: f32,
+    rule2Distance: f32,
+    rule3Distance: f32,
+    rule1Scale: f32,
+    rule2Scale: f32,
+    rule3Scale: f32,
 };
 
 struct Particles {
-    particles: array<Particle>;
+    particles: array<Particle>,
 };
 
 let NUM_PARTICLES: u32 = 1500u;

--- a/tests/out/wgsl/bool-select-frag.wgsl
+++ b/tests/out/wgsl/bool-select-frag.wgsl
@@ -1,5 +1,5 @@
 struct FragmentOutput {
-    @location(0) o_color: vec4<f32>;
+    @location(0) o_color: vec4<f32>,
 };
 
 var<private> o_color: vec4<f32>;

--- a/tests/out/wgsl/clamp-splat-vert.wgsl
+++ b/tests/out/wgsl/clamp-splat-vert.wgsl
@@ -1,5 +1,5 @@
 struct VertexOutput {
-    @builtin(position) member: vec4<f32>;
+    @builtin(position) member: vec4<f32>,
 };
 
 var<private> a_pos_1: vec2<f32>;

--- a/tests/out/wgsl/collatz.wgsl
+++ b/tests/out/wgsl/collatz.wgsl
@@ -1,5 +1,5 @@
 struct PrimeIndices {
-    data: array<u32>;
+    data: array<u32>,
 };
 
 @group(0) @binding(0) 

--- a/tests/out/wgsl/constant-array-size-vert.wgsl
+++ b/tests/out/wgsl/constant-array-size-vert.wgsl
@@ -1,5 +1,5 @@
 struct Data {
-    vecs: array<vec4<f32>,42u>;
+    vecs: array<vec4<f32>,42u>,
 };
 
 @group(1) @binding(0) 

--- a/tests/out/wgsl/declarations-vert.wgsl
+++ b/tests/out/wgsl/declarations-vert.wgsl
@@ -1,23 +1,23 @@
 struct VertexData {
-    position: vec2<f32>;
-    a: vec2<f32>;
+    position: vec2<f32>,
+    a: vec2<f32>,
 };
 
 struct FragmentData {
-    position: vec2<f32>;
-    a: vec2<f32>;
+    position: vec2<f32>,
+    a: vec2<f32>,
 };
 
 struct TestStruct {
-    a: f32;
-    b: f32;
+    a: f32,
+    b: f32,
 };
 
 struct VertexOutput {
-    @location(0) position: vec2<f32>;
-    @location(1) a: vec2<f32>;
-    @location(2) out_array: vec4<f32>;
-    @location(3) out_array_1: vec4<f32>;
+    @location(0) position: vec2<f32>,
+    @location(1) a: vec2<f32>,
+    @location(2) out_array: vec4<f32>,
+    @location(3) out_array_1: vec4<f32>,
 };
 
 var<private> vert: VertexData;

--- a/tests/out/wgsl/empty-global-name.wgsl
+++ b/tests/out/wgsl/empty-global-name.wgsl
@@ -1,5 +1,5 @@
 struct type_1 {
-    member: i32;
+    member: i32,
 };
 
 @group(0) @binding(0) 

--- a/tests/out/wgsl/expressions-frag.wgsl
+++ b/tests/out/wgsl/expressions-frag.wgsl
@@ -1,9 +1,9 @@
 struct BST {
-    data: i32;
+    data: i32,
 };
 
 struct FragmentOutput {
-    @location(0) o_color: vec4<f32>;
+    @location(0) o_color: vec4<f32>,
 };
 
 var<private> global: f32;

--- a/tests/out/wgsl/extra.wgsl
+++ b/tests/out/wgsl/extra.wgsl
@@ -1,11 +1,11 @@
 struct PushConstants {
-    index: u32;
-    double: vec2<f32>;
+    index: u32,
+    double: vec2<f32>,
 };
 
 struct FragmentIn {
-    @location(0) color: vec4<f32>;
-    @builtin(primitive_index) primitive_index: u32;
+    @location(0) color: vec4<f32>,
+    @builtin(primitive_index) primitive_index: u32,
 };
 
 var<push_constant> pc: PushConstants;

--- a/tests/out/wgsl/fma-frag.wgsl
+++ b/tests/out/wgsl/fma-frag.wgsl
@@ -1,11 +1,11 @@
 struct Mat4x3_ {
-    mx: vec4<f32>;
-    my: vec4<f32>;
-    mz: vec4<f32>;
+    mx: vec4<f32>,
+    my: vec4<f32>,
+    mz: vec4<f32>,
 };
 
 struct FragmentOutput {
-    @location(0) o_color: vec4<f32>;
+    @location(0) o_color: vec4<f32>,
 };
 
 var<private> o_color: vec4<f32>;

--- a/tests/out/wgsl/globals.wgsl
+++ b/tests/out/wgsl/globals.wgsl
@@ -1,6 +1,6 @@
 struct Foo {
-    v3_: vec3<f32>;
-    v1_: f32;
+    v3_: vec3<f32>,
+    v1_: f32,
 };
 
 let Foo_2: bool = true;

--- a/tests/out/wgsl/interface.wgsl
+++ b/tests/out/wgsl/interface.wgsl
@@ -1,20 +1,20 @@
 struct VertexOutput {
-    @builtin(position) position: vec4<f32>;
-    @location(1) varying: f32;
+    @builtin(position) position: vec4<f32>,
+    @location(1) varying: f32,
 };
 
 struct FragmentOutput {
-    @builtin(frag_depth) depth: f32;
-    @builtin(sample_mask) sample_mask: u32;
-    @location(0) color: f32;
+    @builtin(frag_depth) depth: f32,
+    @builtin(sample_mask) sample_mask: u32,
+    @location(0) color: f32,
 };
 
 struct Input1_ {
-    @builtin(vertex_index) index: u32;
+    @builtin(vertex_index) index: u32,
 };
 
 struct Input2_ {
-    @builtin(instance_index) index: u32;
+    @builtin(instance_index) index: u32,
 };
 
 var<workgroup> output: array<u32,1>;

--- a/tests/out/wgsl/interpolate.wgsl
+++ b/tests/out/wgsl/interpolate.wgsl
@@ -1,12 +1,12 @@
 struct FragmentInput {
-    @builtin(position) position: vec4<f32>;
-    @location(0) flat: u32;
-    @location(1) @interpolate(linear) linear: f32;
-    @location(2) @interpolate(linear, centroid) linear_centroid: vec2<f32>;
-    @location(3) @interpolate(linear, sample) linear_sample: vec3<f32>;
-    @location(4) perspective: vec4<f32>;
-    @location(5) @interpolate(perspective, centroid) perspective_centroid: f32;
-    @location(6) @interpolate(perspective, sample) perspective_sample: f32;
+    @builtin(position) position: vec4<f32>,
+    @location(0) flat: u32,
+    @location(1) @interpolate(linear) linear: f32,
+    @location(2) @interpolate(linear, centroid) linear_centroid: vec2<f32>,
+    @location(3) @interpolate(linear, sample) linear_sample: vec3<f32>,
+    @location(4) perspective: vec4<f32>,
+    @location(5) @interpolate(perspective, centroid) perspective_centroid: f32,
+    @location(6) @interpolate(perspective, sample) perspective_sample: f32,
 };
 
 @stage(vertex) 

--- a/tests/out/wgsl/operators.wgsl
+++ b/tests/out/wgsl/operators.wgsl
@@ -1,6 +1,6 @@
 struct Foo {
-    a: vec4<f32>;
-    b: i32;
+    a: vec4<f32>,
+    b: i32,
 };
 
 let v_f32_one: vec4<f32> = vec4<f32>(1.0, 1.0, 1.0, 1.0);

--- a/tests/out/wgsl/pointers.wgsl
+++ b/tests/out/wgsl/pointers.wgsl
@@ -1,5 +1,5 @@
 struct DynamicArray {
-    arr: array<u32>;
+    arr: array<u32>,
 };
 
 @group(0) @binding(0) 

--- a/tests/out/wgsl/quad-vert.wgsl
+++ b/tests/out/wgsl/quad-vert.wgsl
@@ -1,10 +1,10 @@
 struct gl_PerVertex {
-    @builtin(position) gl_Position: vec4<f32>;
+    @builtin(position) gl_Position: vec4<f32>,
 };
 
 struct VertexOutput {
-    @location(0) member: vec2<f32>;
-    @builtin(position) gl_Position: vec4<f32>;
+    @location(0) member: vec2<f32>,
+    @builtin(position) gl_Position: vec4<f32>,
 };
 
 var<private> v_uv: vec2<f32>;

--- a/tests/out/wgsl/quad.wgsl
+++ b/tests/out/wgsl/quad.wgsl
@@ -1,6 +1,6 @@
 struct VertexOutput {
-    @location(0) uv: vec2<f32>;
-    @builtin(position) position: vec4<f32>;
+    @location(0) uv: vec2<f32>,
+    @builtin(position) position: vec4<f32>,
 };
 
 let c_scale: f32 = 1.2000000476837158;

--- a/tests/out/wgsl/quad_glsl-frag.wgsl
+++ b/tests/out/wgsl/quad_glsl-frag.wgsl
@@ -1,5 +1,5 @@
 struct FragmentOutput {
-    @location(0) o_color: vec4<f32>;
+    @location(0) o_color: vec4<f32>,
 };
 
 var<private> v_uv_1: vec2<f32>;

--- a/tests/out/wgsl/quad_glsl-vert.wgsl
+++ b/tests/out/wgsl/quad_glsl-vert.wgsl
@@ -1,6 +1,6 @@
 struct VertexOutput {
-    @location(0) v_uv: vec2<f32>;
-    @builtin(position) member: vec4<f32>;
+    @location(0) v_uv: vec2<f32>,
+    @builtin(position) member: vec4<f32>,
 };
 
 var<private> a_pos_1: vec2<f32>;

--- a/tests/out/wgsl/shadow.wgsl
+++ b/tests/out/wgsl/shadow.wgsl
@@ -1,23 +1,23 @@
 struct Globals {
-    view_proj: mat4x4<f32>;
-    num_lights: vec4<u32>;
+    view_proj: mat4x4<f32>,
+    num_lights: vec4<u32>,
 };
 
 struct Entity {
-    world: mat4x4<f32>;
-    color: vec4<f32>;
+    world: mat4x4<f32>,
+    color: vec4<f32>,
 };
 
 struct VertexOutput {
-    @builtin(position) proj_position: vec4<f32>;
-    @location(0) world_normal: vec3<f32>;
-    @location(1) world_position: vec4<f32>;
+    @builtin(position) proj_position: vec4<f32>,
+    @location(0) world_normal: vec3<f32>,
+    @location(1) world_position: vec4<f32>,
 };
 
 struct Light {
-    proj: mat4x4<f32>;
-    pos: vec4<f32>;
-    color: vec4<f32>;
+    proj: mat4x4<f32>,
+    pos: vec4<f32>,
+    color: vec4<f32>,
 };
 
 let c_ambient: vec3<f32> = vec3<f32>(0.05000000074505806, 0.05000000074505806, 0.05000000074505806);

--- a/tests/out/wgsl/skybox.wgsl
+++ b/tests/out/wgsl/skybox.wgsl
@@ -1,11 +1,11 @@
 struct VertexOutput {
-    @builtin(position) position: vec4<f32>;
-    @location(0) uv: vec3<f32>;
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec3<f32>,
 };
 
 struct Data {
-    proj_inv: mat4x4<f32>;
-    view: mat4x4<f32>;
+    proj_inv: mat4x4<f32>,
+    view: mat4x4<f32>,
 };
 
 @group(0) @binding(0) 

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -376,13 +376,13 @@ fn struct_member_zero_size() {
     check(
         r#"
             struct Bar {
-                @size(0) data: array<f32>;
+                @size(0) data: array<f32>
             };
         "#,
         r#"error: struct member size or alignment must not be 0
   ┌─ wgsl:3:23
   │
-3 │                 @size(0) data: array<f32>;
+3 │                 @size(0) data: array<f32>
   │                       ^ struct member size or alignment must not be 0
 
 "#,
@@ -394,13 +394,13 @@ fn struct_member_zero_align() {
     check(
         r#"
             struct Bar {
-                @align(0) data: array<f32>;
+                @align(0) data: array<f32>
             };
         "#,
         r#"error: struct member size or alignment must not be 0
   ┌─ wgsl:3:24
   │
-3 │                 @align(0) data: array<f32>;
+3 │                 @align(0) data: array<f32>
   │                        ^ struct member size or alignment must not be 0
 
 "#,
@@ -542,7 +542,7 @@ fn postfix_pointers() {
 
     check(
         r#"
-            struct S { m: i32; };
+            struct S { m: i32 };
             fn main() {
                 var s: S = S(42);
                 let ps = &s;
@@ -655,12 +655,12 @@ fn reserved_keyword() {
     // struct member
     check(
         r#"
-            struct Foo { sampler: f32; };
+            struct Foo { sampler: f32 };
         "#,
         r###"error: name `sampler` is a reserved keyword
   ┌─ wgsl:2:26
   │
-2 │             struct Foo { sampler: f32; };
+2 │             struct Foo { sampler: f32 };
   │                          ^^^^^^^ definition of `sampler`
 
 "###,
@@ -843,8 +843,8 @@ fn invalid_arrays() {
 #[test]
 fn invalid_structs() {
     check_validation_error! {
-        "struct Bad { data: sampler; };",
-        "struct Bad { data: texture_2d<f32>; };":
+        "struct Bad { data: sampler };",
+        "struct Bad { data: texture_2d<f32> };":
         Err(naga::valid::ValidationError::Type {
             error: naga::valid::TypeError::InvalidData(_),
             ..
@@ -852,7 +852,7 @@ fn invalid_structs() {
     }
 
     check_validation_error! {
-        "struct Bad { data: array<f32>; other: f32; };":
+        "struct Bad { data: array<f32>, other: f32, };":
         Err(naga::valid::ValidationError::Type {
             error: naga::valid::TypeError::InvalidDynamicArray(_, _),
             ..
@@ -865,7 +865,7 @@ fn invalid_functions() {
     check_validation_error! {
         "fn unacceptable_unsized(arg: array<f32>) { }",
         "
-        struct Unsized { data: array<f32>; };
+        struct Unsized { data: array<f32> };
         fn unacceptable_unsized(arg: Unsized) { }
         ":
         Err(naga::valid::ValidationError::Function {
@@ -883,7 +883,7 @@ fn invalid_functions() {
     check_validation_error! {
         "fn unacceptable_unsized(arg: ptr<workgroup, array<f32>>) { }",
         "
-        struct Unsized { data: array<f32>; };
+        struct Unsized { data: array<f32> };
         fn unacceptable_unsized(arg: ptr<workgroup, Unsized>) { }
         ":
         Err(naga::valid::ValidationError::Type {
@@ -998,8 +998,8 @@ fn missing_bindings() {
     check_validation_error! {
         "
         struct VertexIn {
-          @location(0) pos: vec4<f32>;
-          uv: vec2<f32>;
+          @location(0) pos: vec4<f32>,
+          uv: vec2<f32>
         };
 
         @stage(vertex)
@@ -1088,7 +1088,7 @@ fn valid_access() {
 fn invalid_local_vars() {
     check_validation_error! {
         "
-        struct Unsized { data: array<f32>; };
+        struct Unsized { data: array<f32> };
         fn local_ptr_dynamic_array(okay: ptr<storage, Unsized>) {
             var not_okay: ptr<storage, array<f32>> = &(*okay).data;
         }
@@ -1144,12 +1144,12 @@ fn invalid_runtime_sized_arrays() {
     check_validation_error! {
         "
         struct Unsized {
-            arr: array<f32>;
+            arr: array<f32>
         };
 
         struct Outer {
-            legit: i32;
-            unsized: Unsized;
+            legit: i32,
+            unsized: Unsized
         };
 
         @group(0) @binding(0) var<storage> outer: Outer;
@@ -1187,7 +1187,7 @@ fn select() {
         }
         ",
         "
-        struct S { member: i32; };
+        struct S { member: i32 };
         fn select_structs(which: bool) -> S {
             var x: S = S(1);
             var y: S = S(2);
@@ -1257,7 +1257,7 @@ fn wrong_access_mode() {
     check_validation_error! {
         "
             struct Globals {
-                i: i32;
+                i: i32
             };
 
             @group(0) @binding(0)
@@ -1269,7 +1269,7 @@ fn wrong_access_mode() {
         ",
         "
             struct Globals {
-                i: i32;
+                i: i32
             };
 
             @group(0) @binding(0)


### PR DESCRIPTION
Spec PR: https://github.com/gpuweb/gpuweb/pull/2656