### PR TITLE
Implement invariant attribute

### DIFF
--- a/src/back/glsl/features.rs
+++ b/src/back/glsl/features.rs
@@ -404,7 +404,7 @@ impl<'a, W> Writer<'a, W> {
             _ => {
                 if let Some(binding) = binding {
                     match *binding {
-                        Binding::BuiltIn(builtin) => match builtin {
+                        Binding::BuiltIn { built_in, .. } => match built_in {
                             crate::BuiltIn::ClipDistance => {
                                 self.features.request(Features::CLIP_DISTANCE)
                             }

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -336,7 +336,7 @@ impl fmt::Display for VaryingName<'_> {
                 };
                 write!(f, "_{}_location{}", prefix, location,)
             }
-            crate::Binding::BuiltIn(built_in) => {
+            crate::Binding::BuiltIn { built_in, .. } => {
                 write!(f, "{}", glsl_built_in(built_in, self.output))
             }
         }
@@ -1122,6 +1122,13 @@ impl<'a, W: Write> Writer<'a, W> {
                         interpolation,
                         sampling,
                     }) => (location, interpolation, sampling),
+                    Some(&crate::Binding::BuiltIn {
+                        built_in,
+                        invariant: true,
+                    }) => {
+                        writeln!(self.out, "invariant {};", glsl_built_in(built_in, output))?;
+                        return Ok(());
+                    }
                     _ => return Ok(()),
                 };
 
@@ -1772,8 +1779,10 @@ impl<'a, W: Write> Writer<'a, W> {
 
                                     for (index, member) in members.iter().enumerate() {
                                         // TODO: handle builtin in better way
-                                        if let Some(crate::Binding::BuiltIn(builtin)) =
-                                            member.binding
+                                        if let Some(crate::Binding::BuiltIn {
+                                            built_in: builtin,
+                                            ..
+                                        }) = member.binding
                                         {
                                             match builtin {
                                                 crate::BuiltIn::ClipDistance

--- a/src/back/mod.rs
+++ b/src/back/mod.rs
@@ -96,14 +96,14 @@ impl<'a> FunctionCtx<'_> {
             match self.expressions[expression] {
                 crate::Expression::FunctionArgument(arg_index) => {
                     return match ep_function.arguments[arg_index as usize].binding {
-                        Some(crate::Binding::BuiltIn(bi)) => Some(bi),
+                        Some(crate::Binding::BuiltIn { built_in: bi, .. }) => Some(bi),
                         _ => built_in,
                     };
                 }
                 crate::Expression::AccessIndex { base, index } => {
                     match *self.info[base].ty.inner_with(&module.types) {
                         crate::TypeInner::Struct { ref members, .. } => {
-                            if let Some(crate::Binding::BuiltIn(bi)) =
+                            if let Some(crate::Binding::BuiltIn { built_in: bi, .. }) =
                                 members[index as usize].binding
                             {
                                 built_in = Some(bi);

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -233,7 +233,7 @@ impl Options {
 
                 Ok(ResolvedBinding::BuiltIn {
                     built_in,
-                    invariant,
+                    invariant: invariant && matches!(mode, LocationMode::FragmentOutput),
                 })
             }
             crate::Binding::Location {

--- a/src/back/spv/helpers.rs
+++ b/src/back/spv/helpers.rs
@@ -38,7 +38,7 @@ pub(super) fn contains_builtin(
     arena: &UniqueArena<crate::Type>,
     built_in: crate::BuiltIn,
 ) -> bool {
-    if let Some(&crate::Binding::BuiltIn(bi)) = binding {
+    if let Some(&crate::Binding::BuiltIn { built_in: bi, .. }) = binding {
         bi == built_in
     } else if let crate::TypeInner::Struct { ref members, .. } = arena[ty].inner {
         members

--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -174,6 +174,7 @@ pub enum QualifierValue {
 pub struct TypeQualifiers<'a> {
     pub span: Span,
     pub storage: (StorageQualifier, Span),
+    pub invariant: Option<Span>,
     pub interpolation: Option<(Interpolation, Span)>,
     pub precision: Option<(Precision, Span)>,
     pub sampling: Option<(Sampling, Span)>,
@@ -186,6 +187,15 @@ pub struct TypeQualifiers<'a> {
 impl<'a> TypeQualifiers<'a> {
     /// Appends `errors` with errors for all unused qualifiers
     pub fn unused_errors(&self, errors: &mut Vec<super::Error>) {
+        if let Some(meta) = self.invariant {
+            errors.push(super::Error {
+                kind: super::ErrorKind::SemanticError(
+                    "Invariant qualifier can only be used in in/out variables".into(),
+                ),
+                meta,
+            });
+        }
+
         if let Some((_, meta)) = self.interpolation {
             errors.push(super::Error {
                 kind: super::ErrorKind::SemanticError(

--- a/src/front/glsl/lex.rs
+++ b/src/front/glsl/lex.rs
@@ -72,6 +72,7 @@ impl<'a> Iterator for Lexer<'a> {
                     "uniform" => TokenValue::Uniform,
                     "buffer" => TokenValue::Buffer,
                     "shared" => TokenValue::Shared,
+                    "invariant" => TokenValue::Invariant,
                     "flat" => TokenValue::Interpolation(crate::Interpolation::Flat),
                     "noperspective" => TokenValue::Interpolation(crate::Interpolation::Linear),
                     "smooth" => TokenValue::Interpolation(crate::Interpolation::Perspective),

--- a/src/front/glsl/parser/declarations.rs
+++ b/src/front/glsl/parser/declarations.rs
@@ -361,6 +361,14 @@ impl<'source> ParsingContext<'source> {
                             )
                             .map(Some)
                         } else {
+                            if qualifiers.invariant.take().is_some() {
+                                parser.make_variable_invariant(ctx, body, &ty_name, token.meta);
+
+                                qualifiers.unused_errors(&mut parser.errors);
+                                self.expect(parser, TokenValue::Semicolon)?;
+                                return Ok(Some(qualifiers.span));
+                            }
+
                             //TODO: declaration
                             // type_qualifier IDENTIFIER SEMICOLON
                             // type_qualifier IDENTIFIER identifier_list SEMICOLON

--- a/src/front/glsl/token.rs
+++ b/src/front/glsl/token.rs
@@ -44,6 +44,7 @@ pub enum TokenValue {
     /// (for example `writeonly` has an associated value of [`crate::StorageAccess::STORE`])
     MemoryQualifier(crate::StorageAccess),
 
+    Invariant,
     Interpolation(Interpolation),
     Sampling(Sampling),
     Precision,

--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -67,7 +67,10 @@ impl Parser {
         let idx = self.entry_args.len();
         self.entry_args.push(EntryArg {
             name: None,
-            binding: Binding::BuiltIn(data.builtin),
+            binding: Binding::BuiltIn {
+                built_in: data.builtin,
+                invariant: false,
+            },
             handle,
             storage: data.storage,
         });
@@ -226,6 +229,25 @@ impl Parser {
         };
 
         self.add_builtin(ctx, body, name, data, meta)
+    }
+
+    pub(crate) fn make_variable_invariant(
+        &mut self,
+        ctx: &mut Context,
+        body: &mut Block,
+        name: &str,
+        meta: Span,
+    ) {
+        if let Some(var) = self.lookup_variable(ctx, body, name, meta) {
+            if let Some(index) = var.entry_arg {
+                if let Binding::BuiltIn { built_in, .. } = self.entry_args[index].binding {
+                    self.entry_args[index].binding = Binding::BuiltIn {
+                        built_in,
+                        invariant: built_in == BuiltIn::Position,
+                    };
+                }
+            }
+        }
     }
 
     pub(crate) fn field_selection(

--- a/src/front/spv/function.rs
+++ b/src/front/spv/function.rs
@@ -377,9 +377,9 @@ impl<I: Iterator<Item = u32>> super::Parser<I> {
                         } => {
                             for (index, sm) in sub_members.iter().enumerate() {
                                 match sm.binding {
-                                    Some(crate::Binding::BuiltIn(builtin)) => {
+                                    Some(crate::Binding::BuiltIn { built_in, .. }) => {
                                         // Cull unused builtins to preserve performances
-                                        if !self.builtin_usage.contains(&builtin) {
+                                        if !self.builtin_usage.contains(&built_in) {
                                             continue;
                                         }
                                     }
@@ -414,9 +414,10 @@ impl<I: Iterator<Item = u32>> super::Parser<I> {
 
             for (member_index, member) in members.iter().enumerate() {
                 match member.binding {
-                    Some(crate::Binding::BuiltIn(crate::BuiltIn::Position))
-                        if self.options.adjust_coordinate_space =>
-                    {
+                    Some(crate::Binding::BuiltIn {
+                        built_in: crate::BuiltIn::Position,
+                        ..
+                    }) if self.options.adjust_coordinate_space => {
                         let mut emitter = Emitter::default();
                         emitter.start(&function.expressions);
                         let global_expr = components[member_index];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -748,7 +748,11 @@ pub enum ConstantInner {
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub enum Binding {
     /// Built-in shader variable.
-    BuiltIn(BuiltIn),
+    BuiltIn {
+        built_in: BuiltIn,
+        /// can only be `true` for [`BuiltIn::Position`]
+        invariant: bool,
+    },
 
     /// Indexed location.
     ///

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -390,7 +390,7 @@ impl crate::Constant {
 impl crate::Binding {
     pub fn to_built_in(&self) -> Option<crate::BuiltIn> {
         match *self {
-            Self::BuiltIn(bi) => Some(bi),
+            crate::Binding::BuiltIn { built_in, .. } => Some(built_in),
             Self::Location { .. } => None,
         }
     }

--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -455,7 +455,7 @@ impl FunctionInfo {
             E::FunctionArgument(index) => {
                 let arg = &resolve_context.arguments[index as usize];
                 let uniform = match arg.binding {
-                    Some(crate::Binding::BuiltIn(built_in)) => match built_in {
+                    Some(crate::Binding::BuiltIn { built_in, .. }) => match built_in {
                         // per-polygon built-ins are uniform
                         crate::BuiltIn::FrontFacing
                         // per-work-group built-ins are uniform

--- a/src/valid/interface.rs
+++ b/src/valid/interface.rs
@@ -115,7 +115,7 @@ impl VaryingContext<'_> {
 
         let ty_inner = &self.types[self.ty].inner;
         match *binding {
-            crate::Binding::BuiltIn(built_in) => {
+            crate::Binding::BuiltIn { built_in, .. } => {
                 let bit = 1 << built_in as u32;
                 if self.built_in_mask & bit != 0 {
                     return Err(VaryingError::DuplicateBuiltIn(built_in));

--- a/tests/in/interface.param.ron
+++ b/tests/in/interface.param.ron
@@ -16,6 +16,13 @@
 	wgsl: (
 		explicit_types: true,
 	),
+	msl: (
+		lang_version: (2, 1),
+		per_stage_map: (),
+		inline_samplers: [],
+		spirv_cross_compatibility: false,
+		fake_missing_bindings: false,
+	),
 	msl_pipeline: (
 		allow_point_size: true,
 	),

--- a/tests/in/interface.wgsl
+++ b/tests/in/interface.wgsl
@@ -1,7 +1,7 @@
 // Testing various parts of the pipeline interface: locations, built-ins, and entry points
 
 struct VertexOutput {
-    @builtin(position) position: vec4<f32>,
+    @builtin(position) @invariant position: vec4<f32>,
     @location(1) varying: f32,
 }
 
@@ -55,7 +55,7 @@ struct Input2 {
 }
 
 @stage(vertex)
-fn vertex_two_structs(in1: Input1, in2: Input2) -> @builtin(position) vec4<f32> {
+fn vertex_two_structs(in1: Input1, in2: Input2) -> @builtin(position) @invariant vec4<f32> {
     var index = 2u;
     return vec4<f32>(f32(in1.index), f32(in2.index), f32(index), 0.0);
 }

--- a/tests/out/hlsl/interface.hlsl
+++ b/tests/out/hlsl/interface.hlsl
@@ -6,7 +6,7 @@ struct NagaConstants {
 ConstantBuffer<NagaConstants> _NagaConstants: register(b0, space1);
 
 struct VertexOutput {
-    float4 position : SV_Position;
+    precise float4 position : SV_Position;
     float varying : LOC1;
 };
 
@@ -28,12 +28,12 @@ groupshared uint output[1];
 
 struct VertexOutput_vertex {
     float varying : LOC1;
-    float4 position : SV_Position;
+    precise float4 position : SV_Position;
 };
 
 struct FragmentInput_fragment {
     float varying_1 : LOC1;
-    float4 position_1 : SV_Position;
+    precise float4 position_1 : SV_Position;
     bool front_facing_1 : SV_IsFrontFace;
     uint sample_index_1 : SV_SampleIndex;
     uint sample_mask_1 : SV_Coverage;
@@ -81,7 +81,7 @@ void compute(uint3 global_id : SV_DispatchThreadID, uint3 local_id : SV_GroupThr
     return;
 }
 
-float4 vertex_two_structs(Input1_ in1_, Input2_ in2_) : SV_Position
+precise float4 vertex_two_structs(Input1_ in1_, Input2_ in2_) : SV_Position
 {
     uint index = 2u;
 

--- a/tests/out/hlsl/interpolate.hlsl
+++ b/tests/out/hlsl/interpolate.hlsl
@@ -11,24 +11,24 @@ struct FragmentInput {
 };
 
 struct VertexOutput_vert_main {
-    uint flat : LOC0;
-    float linear_ : LOC1;
-    float2 linear_centroid : LOC2;
-    float3 linear_sample : LOC3;
+    nointerpolation uint flat : LOC0;
+    noperspective float linear_ : LOC1;
+    noperspective centroid float2 linear_centroid : LOC2;
+    noperspective sample float3 linear_sample : LOC3;
     float4 perspective : LOC4;
-    float perspective_centroid : LOC5;
-    float perspective_sample : LOC6;
+    centroid float perspective_centroid : LOC5;
+    sample float perspective_sample : LOC6;
     float4 position : SV_Position;
 };
 
 struct FragmentInput_frag_main {
-    uint flat_1 : LOC0;
-    float linear_1 : LOC1;
-    float2 linear_centroid_1 : LOC2;
-    float3 linear_sample_1 : LOC3;
+    nointerpolation uint flat_1 : LOC0;
+    noperspective float linear_1 : LOC1;
+    noperspective centroid float2 linear_centroid_1 : LOC2;
+    noperspective sample float3 linear_sample_1 : LOC3;
     float4 perspective_1 : LOC4;
-    float perspective_centroid_1 : LOC5;
-    float perspective_sample_1 : LOC6;
+    centroid float perspective_centroid_1 : LOC5;
+    sample float perspective_sample_1 : LOC6;
     float4 position_1 : SV_Position;
 };
 

--- a/tests/out/ir/collatz.ron
+++ b/tests/out/ir/collatz.ron
@@ -284,7 +284,10 @@
                     (
                         name: Some("global_id"),
                         ty: 4,
-                        binding: Some(BuiltIn(GlobalInvocationId)),
+                        binding: Some(BuiltIn(
+                            built_in: GlobalInvocationId,
+                            invariant: false,
+                        )),
                     ),
                 ],
                 result: None,

--- a/tests/out/msl/interface.msl
+++ b/tests/out/msl/interface.msl
@@ -27,7 +27,7 @@ struct vertex_Input {
     uint color [[attribute(10)]];
 };
 struct vertex_Output {
-    metal::float4 position [[position, invariant]];
+    metal::float4 position [[position]];
     float varying [[user(loc1), center_perspective]];
     float _point_size [[point_size]];
 };
@@ -53,7 +53,7 @@ struct fragment_Output {
 };
 fragment fragment_Output fragment_(
   fragment_Input varyings_1 [[stage_in]]
-, metal::float4 position [[position, invariant]]
+, metal::float4 position [[position]]
 , bool front_facing [[front_facing]]
 , uint sample_index [[sample_id]]
 , uint sample_mask [[sample_mask]]
@@ -84,7 +84,7 @@ kernel void compute_(
 struct vertex_two_structsInput {
 };
 struct vertex_two_structsOutput {
-    metal::float4 member_3 [[position, invariant]];
+    metal::float4 member_3 [[position]];
     float _point_size [[point_size]];
 };
 vertex vertex_two_structsOutput vertex_two_structs(

--- a/tests/out/msl/interface.msl
+++ b/tests/out/msl/interface.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal2.1
 #include <metal_stdlib>
 #include <simd/simd.h>
 
@@ -27,7 +27,7 @@ struct vertex_Input {
     uint color [[attribute(10)]];
 };
 struct vertex_Output {
-    metal::float4 position [[position]];
+    metal::float4 position [[position, invariant]];
     float varying [[user(loc1), center_perspective]];
     float _point_size [[point_size]];
 };
@@ -53,7 +53,7 @@ struct fragment_Output {
 };
 fragment fragment_Output fragment_(
   fragment_Input varyings_1 [[stage_in]]
-, metal::float4 position [[position]]
+, metal::float4 position [[position, invariant]]
 , bool front_facing [[front_facing]]
 , uint sample_index [[sample_id]]
 , uint sample_mask [[sample_mask]]
@@ -84,7 +84,7 @@ kernel void compute_(
 struct vertex_two_structsInput {
 };
 struct vertex_two_structsOutput {
-    metal::float4 member_3 [[position]];
+    metal::float4 member_3 [[position, invariant]];
     float _point_size [[point_size]];
 };
 vertex vertex_two_structsOutput vertex_two_structs(

--- a/tests/out/msl/skybox.msl
+++ b/tests/out/msl/skybox.msl
@@ -16,7 +16,7 @@ struct Data {
 struct vs_mainInput {
 };
 struct vs_mainOutput {
-    metal::float4 position [[position, invariant]];
+    metal::float4 position [[position]];
     metal::float3 uv [[user(loc0), center_perspective]];
 };
 vertex vs_mainOutput vs_main(

--- a/tests/out/spv/interface.fragment.spvasm
+++ b/tests/out/spv/interface.fragment.spvasm
@@ -18,6 +18,7 @@ OpDecorate %16 ArrayStride 4
 OpMemberDecorate %18 0 Offset 0
 OpMemberDecorate %19 0 Offset 0
 OpDecorate %22 BuiltIn FragCoord
+OpDecorate %22 Invariant
 OpDecorate %25 Location 1
 OpDecorate %28 BuiltIn FrontFacing
 OpDecorate %31 BuiltIn SampleId

--- a/tests/out/spv/interface.vertex.spvasm
+++ b/tests/out/spv/interface.vertex.spvasm
@@ -19,6 +19,7 @@ OpDecorate %24 BuiltIn InstanceIndex
 OpDecorate %26 Location 10
 OpDecorate %26 Flat
 OpDecorate %28 BuiltIn Position
+OpDecorate %28 Invariant
 OpDecorate %30 Location 1
 OpDecorate %32 BuiltIn PointSize
 %2 = OpTypeVoid

--- a/tests/out/spv/interface.vertex_two_structs.spvasm
+++ b/tests/out/spv/interface.vertex_two_structs.spvasm
@@ -17,6 +17,7 @@ OpMemberDecorate %19 0 Offset 0
 OpDecorate %24 BuiltIn VertexIndex
 OpDecorate %28 BuiltIn InstanceIndex
 OpDecorate %30 BuiltIn Position
+OpDecorate %30 Invariant
 OpDecorate %32 BuiltIn PointSize
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32

--- a/tests/out/wgsl/interface.wgsl
+++ b/tests/out/wgsl/interface.wgsl
@@ -1,5 +1,5 @@
 struct VertexOutput {
-    @builtin(position) position: vec4<f32>,
+    @builtin(position) @invariant position: vec4<f32>,
     @location(1) varying: f32,
 }
 
@@ -39,7 +39,7 @@ fn compute(@builtin(global_invocation_id) global_id: vec3<u32>, @builtin(local_i
 }
 
 @stage(vertex) 
-fn vertex_two_structs(in1_: Input1_, in2_: Input2_) -> @builtin(position) vec4<f32> {
+fn vertex_two_structs(in1_: Input1_, in2_: Input2_) -> @builtin(position) @invariant vec4<f32> {
     var index: u32 = 2u;
 
     let _e9: u32 = index;


### PR DESCRIPTION
closes #1659

Implements the invariant attribute in all frontends and backends.

References

[WGSL Invariant Attribute](https://gpuweb.github.io/gpuweb/wgsl/#attribute-invariant)
[SPIR-V Invariant Decoration (\#18)](https://www.khronos.org/registry/SPIR-V/specs/unified1/SPIRV.html#Decoration)
[MSL Invariant Attribute](https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf#page=87)
[GLSL Invariant Qualifier](https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.60.pdf#page=105)
[HLSL Variable Syntax](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-variable-syntax)
[HLSL Function Declaration Syntax](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-function-syntax)
