### PR TITLE
Add glsl barrier function

### DIFF
--- a/src/front/glsl/builtins.rs
+++ b/src/front/glsl/builtins.rs
@@ -1998,6 +1998,7 @@ impl MacroCall {
             ),
             MacroCall::Barrier => {
                 ctx.emit_flush(body);
+                ctx.emit_start();
                 body.push(crate::Statement::Barrier(crate::Barrier::all()), meta);
                 return Ok(None);
             }

--- a/src/front/glsl/builtins.rs
+++ b/src/front/glsl/builtins.rs
@@ -995,6 +995,9 @@ fn inject_standard_builtins(
                     .push(module.add_builtin(args, MacroCall::Clamp(size)))
             }
         }
+        "barrier" => declaration
+            .overloads
+            .push(module.add_builtin(Vec::new(), MacroCall::Barrier)),
         // Add common builtins with floats
         _ => inject_common_builtin(declaration, module, name, 4),
     }
@@ -1587,6 +1590,7 @@ pub enum MacroCall {
     Clamp(Option<VectorSize>),
     BitCast(Sk),
     Derivate(DerivativeAxis),
+    Barrier,
 }
 
 impl MacroCall {
@@ -1992,6 +1996,11 @@ impl MacroCall {
                 Span::default(),
                 body,
             ),
+            MacroCall::Barrier => {
+                ctx.emit_flush(body);
+                body.push(crate::Statement::Barrier(crate::Barrier::all()), meta);
+                return Ok(None);
+            }
         }))
     }
 }


### PR DESCRIPTION
This attempts to implement the GLSL `barrier` function based some of the surrounding builtin implementations. However, it panics later when emitting expressions, so it evidentially isn't correct yet. 

Fixes #1771 