### PR TITLE
glsl-in: Allow nested accesses in lhs positions

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -97,7 +97,9 @@ pub struct EntryArg {
 #[derive(Debug, Clone)]
 pub struct VariableReference {
     pub expr: Handle<Expression>,
+    /// Wether the variable is of a pointer type (and needs loading) or not
     pub load: bool,
+    /// Wether the value of the variable can be changed or not
     pub mutable: bool,
     pub constant: Option<(Handle<Constant>, Handle<Type>)>,
     pub entry_arg: Option<usize>,

--- a/tests/in/glsl/buffer.frag
+++ b/tests/in/glsl/buffer.frag
@@ -1,0 +1,22 @@
+#version 450
+
+layout(set = 0, binding = 0) buffer testBufferBlock {
+    uint[] data;
+} testBuffer;
+
+layout(set = 0, binding = 1) writeonly buffer testBufferWriteOnlyBlock {
+    uint[] data;
+} testBufferWriteOnly;
+
+layout(set = 0, binding = 2) readonly buffer testBufferReadOnlyBlock {
+    uint[] data;
+} testBufferReadOnly;
+
+void main() {
+    uint a = testBuffer.data[0];
+    testBuffer.data[1] = 2;
+
+    testBufferWriteOnly.data[1] = 2;
+
+    uint b = testBufferReadOnly.data[0];
+}

--- a/tests/out/wgsl/bevy-pbr-frag.wgsl
+++ b/tests/out/wgsl/bevy-pbr-frag.wgsl
@@ -498,21 +498,21 @@ fn point_light(light: PointLight, roughness_8: f32, NdotV: f32, N: vec3<f32>, V_
     R_1 = R;
     F0_1 = F0_;
     diffuseColor_1 = diffuseColor;
-    let _e56 = light_1;
+    let _e57 = light_1.pos;
     let _e59 = v_WorldPosition_1;
-    light_to_frag = (_e56.pos.xyz - _e59.xyz);
+    light_to_frag = (_e57.xyz - _e59.xyz);
     let _e65 = light_to_frag;
     let _e66 = light_to_frag;
     distance_square = dot(_e65, _e66);
-    let _e70 = light_1;
+    let _e71 = light_1.lightParams;
     let _e73 = distance_square;
-    let _e74 = light_1;
-    let _e77 = getDistanceAttenuation(_e73, _e74.lightParams.x);
+    let _e75 = light_1.lightParams;
+    let _e77 = getDistanceAttenuation(_e73, _e75.x);
     rangeAttenuation = _e77;
     let _e79 = roughness_9;
     a_1 = _e79;
-    let _e81 = light_1;
-    radius = _e81.lightParams.y;
+    let _e82 = light_1.lightParams;
+    radius = _e82.y;
     let _e87 = light_to_frag;
     let _e88 = R_1;
     let _e90 = R_1;
@@ -611,10 +611,10 @@ fn point_light(light: PointLight, roughness_8: f32, NdotV: f32, N: vec3<f32>, V_
     diffuse = (_e302 * _e311);
     let _e314 = diffuse;
     let _e315 = specular_1;
-    let _e317 = light_1;
+    let _e318 = light_1.color;
     let _e321 = rangeAttenuation;
     let _e322 = NoL_6;
-    return (((_e314 + _e315) * _e317.color.xyz) * (_e321 * _e322));
+    return (((_e314 + _e315) * _e318.xyz) * (_e321 * _e322));
 }
 
 fn dir_light(light_2: DirectionalLight, roughness_10: f32, NdotV_2: f32, normal: vec3<f32>, view: vec3<f32>, R_2: vec3<f32>, F0_2: vec3<f32>, diffuseColor_2: vec3<f32>) -> vec3<f32> {
@@ -643,8 +643,8 @@ fn dir_light(light_2: DirectionalLight, roughness_10: f32, NdotV_2: f32, normal:
     R_3 = R_2;
     F0_3 = F0_2;
     diffuseColor_3 = diffuseColor_2;
-    let _e56 = light_3;
-    incident_light = _e56.direction.xyz;
+    let _e57 = light_3.direction;
+    incident_light = _e57.xyz;
     let _e60 = incident_light;
     let _e61 = view_1;
     let _e63 = incident_light;
@@ -684,9 +684,9 @@ fn dir_light(light_2: DirectionalLight, roughness_10: f32, NdotV_2: f32, normal:
     specular_2 = _e146;
     let _e148 = specular_2;
     let _e149 = diffuse_1;
-    let _e151 = light_3;
+    let _e152 = light_3.color;
     let _e155 = NoL_7;
-    return (((_e148 + _e149) * _e151.color.xyz) * _e155);
+    return (((_e148 + _e149) * _e152.xyz) * _e155);
 }
 
 fn main_1() {

--- a/tests/out/wgsl/buffer-frag.wgsl
+++ b/tests/out/wgsl/buffer-frag.wgsl
@@ -1,0 +1,37 @@
+struct testBufferBlock {
+    data: array<u32>,
+}
+
+struct testBufferWriteOnlyBlock {
+    data: array<u32>,
+}
+
+struct testBufferReadOnlyBlock {
+    data: array<u32>,
+}
+
+@group(0) @binding(0) 
+var<storage, read_write> testBuffer: testBufferBlock;
+@group(0) @binding(1) 
+var<storage, read_write> testBufferWriteOnly: testBufferWriteOnlyBlock;
+@group(0) @binding(2) 
+var<storage> testBufferReadOnly: testBufferReadOnlyBlock;
+
+fn main_1() {
+    var a: u32;
+    var b: u32;
+
+    let _e12 = testBuffer.data[0];
+    a = _e12;
+    testBuffer.data[1] = u32(2);
+    testBufferWriteOnly.data[1] = u32(2);
+    let _e27 = testBufferReadOnly.data[0];
+    b = _e27;
+    return;
+}
+
+@stage(fragment) 
+fn main() {
+    main_1();
+    return;
+}

--- a/tests/out/wgsl/declarations-vert.wgsl
+++ b/tests/out/wgsl/declarations-vert.wgsl
@@ -34,12 +34,12 @@ fn main_1() {
     var a_1: f32;
     var b: f32;
 
-    let _e34 = in_array_2;
-    from_input_array = _e34[1];
-    let _e39 = array_2d;
-    a_1 = _e39[0][0];
-    let _e50 = array_toomanyd;
-    b = _e50[0][0][0][0][0][0][0];
+    let _e35 = in_array_2[1];
+    from_input_array = _e35;
+    let _e41 = array_2d[0][0];
+    a_1 = _e41;
+    let _e57 = array_toomanyd[0][0][0][0][0][0][0];
+    b = _e57;
     out_array[0] = vec4<f32>(2.0);
     return;
 }

--- a/tests/out/wgsl/fma-frag.wgsl
+++ b/tests/out/wgsl/fma-frag.wgsl
@@ -16,18 +16,18 @@ fn Fma(d: ptr<function, Mat4x3_>, m: Mat4x3_, s: f32) {
 
     m_1 = m;
     s_1 = s;
-    let _e6 = (*d);
-    let _e8 = m_1;
+    let _e7 = (*d).mx;
+    let _e9 = m_1.mx;
     let _e10 = s_1;
-    (*d).mx = (_e6.mx + (_e8.mx * _e10));
-    let _e14 = (*d);
-    let _e16 = m_1;
+    (*d).mx = (_e7 + (_e9 * _e10));
+    let _e15 = (*d).my;
+    let _e17 = m_1.my;
     let _e18 = s_1;
-    (*d).my = (_e14.my + (_e16.my * _e18));
-    let _e22 = (*d);
-    let _e24 = m_1;
+    (*d).my = (_e15 + (_e17 * _e18));
+    let _e23 = (*d).mz;
+    let _e25 = m_1.mz;
     let _e26 = s_1;
-    (*d).mz = (_e22.mz + (_e24.mz * _e26));
+    (*d).mz = (_e23 + (_e25 * _e26));
     return;
 }
 


### PR DESCRIPTION
Also fixes access to runtime sized arrays behind named blocks