### PR TITLE
glsl-in: Resume expression emit after imageStore

### DIFF
--- a/src/front/glsl/builtins.rs
+++ b/src/front/glsl/builtins.rs
@@ -1830,6 +1830,7 @@ impl MacroCall {
                     },
                     meta,
                 );
+                ctx.emit_start();
                 return Ok(None);
             }
             MacroCall::MathFunction(fun) => ctx.add_expression(

--- a/tests/in/glsl/images.frag
+++ b/tests/in/glsl/images.frag
@@ -14,8 +14,8 @@ layout(rgba8, binding = 9) writeonly readonly uniform image2D imgWriteReadOnly;
 
 void testImg1D(in int coord) {
     int size = imageSize(img1D);
-    vec4 c = imageLoad(img1D, coord);
     imageStore(img1D, coord, vec4(2));
+    vec4 c = imageLoad(img1D, coord);
 }
 
 void testImg1DArray(in ivec2 coord) {

--- a/tests/out/wgsl/images-frag.wgsl
+++ b/tests/out/wgsl/images-frag.wgsl
@@ -23,11 +23,11 @@ fn testImg1D(coord: i32) {
     coord_1 = coord;
     let _e10 = textureDimensions(img1D);
     size = _e10;
-    let _e13 = coord_1;
-    let _e14 = textureLoad(img1D, _e13);
-    c = _e14;
-    let _e20 = coord_1;
-    textureStore(img1D, _e20, vec4<f32>(f32(2)));
+    let _e16 = coord_1;
+    textureStore(img1D, _e16, vec4<f32>(f32(2)));
+    let _e21 = coord_1;
+    let _e22 = textureLoad(img1D, _e21);
+    c = _e22;
     return;
 }
 


### PR DESCRIPTION
This wasn't done before which caused the frontend to crash if anything
appeared after it.