### PR TITLE
glsl-in: use forced conversions for vector/matrix constructors

### DIFF
--- a/src/front/glsl/context.rs
+++ b/src/front/glsl/context.rs
@@ -1279,6 +1279,25 @@ impl Context {
         Ok(())
     }
 
+    pub fn forced_conversion(
+        &mut self,
+        parser: &Parser,
+        expr: &mut Handle<Expression>,
+        meta: Span,
+        kind: ScalarKind,
+        width: crate::Bytes,
+    ) -> Result<()> {
+        if let Some((expr_scalar_kind, expr_width)) =
+            self.expr_scalar_components(parser, *expr, meta)?
+        {
+            if expr_scalar_kind != kind || expr_width != width {
+                self.conversion(expr, meta, kind, width)?;
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn binary_implicit_conversion(
         &mut self,
         parser: &Parser,

--- a/tests/in/glsl/expressions.frag
+++ b/tests/in/glsl/expressions.frag
@@ -113,6 +113,11 @@ void testFreestandingConstructor() {
     vec4(1.0);
 }
 
+void testNonImplicitCastVectorCast() {
+    uint a = 1;
+    ivec4 b = ivec4(a);
+}
+
 float global;
 void privatePointer(inout float a) {}
 

--- a/tests/out/wgsl/expressions-frag.wgsl
+++ b/tests/out/wgsl/expressions-frag.wgsl
@@ -286,7 +286,16 @@ fn testFreestandingConstructor() {
     return;
 }
 
-fn privatePointer(a_18: ptr<function, f32>) {
+fn testNonImplicitCastVectorCast() {
+    var a_18: u32 = 1u;
+    var b_16: vec4<i32>;
+
+    let _e3 = a_18;
+    b_16 = vec4<i32>(i32(_e3));
+    return;
+}
+
+fn privatePointer(a_19: ptr<function, f32>) {
     return;
 }
 


### PR DESCRIPTION
The spec defines that for vector and matrix constructors all arguments
should use the same conversions as scalar constructors (forced conversions)

Fixes #1792