### PR TITLE
[glsl-in] Error on a `matCx2` used with the std140 layout

### DIFF
--- a/src/front/glsl/error.rs
+++ b/src/front/glsl/error.rs
@@ -94,6 +94,12 @@ pub enum ErrorKind {
     /// prioritize work.
     #[error("Unknown layout qualifier: {0}")]
     UnknownLayoutQualifier(String),
+    /// Unsupported matrix of the form matCx2
+    ///
+    /// Our IR expects matrices of the form matCx2 to have a stride of 8 however
+    /// matrices in the std140 layout have a stride of at least 16
+    #[error("unsupported matrix of the form matCx2 in std140 block layout")]
+    UnsupportedMatrixTypeInStd140,
     /// A variable with the same name already exists in the current scope.
     #[cfg(feature = "glsl-validate")]
     #[error("Variable already declared: {0}")]

--- a/src/front/glsl/offset.rs
+++ b/src/front/glsl/offset.rs
@@ -121,6 +121,14 @@ pub fn calculate_offset(
                 align = align_up(align, 16);
             }
 
+            // See comment on the error kind
+            if StructLayout::Std140 == layout && rows == crate::VectorSize::Bi {
+                errors.push(Error {
+                    kind: ErrorKind::UnsupportedMatrixTypeInStd140,
+                    meta,
+                });
+            }
+
             (align, align * columns as u32)
         }
         TypeInner::Struct { ref members, .. } => {


### PR DESCRIPTION
Our IR expects matrices of the form `matCx2` to have a stride of 8 however matrices in the std140 layout have a stride of at least 16.