### PR TITLE
[hlsl-out] Don't output interpolation modifier if it's the default

### DIFF
--- a/src/back/hlsl/conv.rs
+++ b/src/back/hlsl/conv.rs
@@ -111,12 +111,14 @@ impl crate::BuiltIn {
 }
 
 impl crate::Interpolation {
-    /// Helper function that returns the string corresponding to the HLSL interpolation qualifier
-    pub(super) fn to_hlsl_str(self) -> &'static str {
+    /// Return the string corresponding to the HLSL interpolation qualifier.
+    pub(super) fn to_hlsl_str(self) -> Option<&'static str> {
         match self {
-            Self::Perspective => "linear",
-            Self::Linear => "noperspective",
-            Self::Flat => "nointerpolation",
+            // Would be "linear", but it's the default interpolation in SM4 and up
+            // https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-struct#interpolation-modifiers-introduced-in-shader-model-4
+            Self::Perspective => None,
+            Self::Linear => Some("noperspective"),
+            Self::Flat => Some("nointerpolation"),
         }
     }
 }

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -758,7 +758,9 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                     }) = member.binding
                     {
                         if let Some(interpolation) = interpolation {
-                            write!(self.out, "{} ", interpolation.to_hlsl_str())?
+                            if let Some(string) = interpolation.to_hlsl_str() {
+                                write!(self.out, "{} ", string)?
+                            }
                         }
 
                         if let Some(sampling) = sampling {

--- a/tests/out/hlsl/interface.hlsl
+++ b/tests/out/hlsl/interface.hlsl
@@ -7,13 +7,13 @@ ConstantBuffer<NagaConstants> _NagaConstants: register(b0, space1);
 
 struct VertexOutput {
     float4 position : SV_Position;
-    linear float varying : LOC1;
+    float varying : LOC1;
 };
 
 struct FragmentOutput {
     float depth : SV_Depth;
     uint sample_mask : SV_Coverage;
-    linear float color : SV_Target0;
+    float color : SV_Target0;
 };
 
 struct Input1_ {

--- a/tests/out/hlsl/interpolate.hlsl
+++ b/tests/out/hlsl/interpolate.hlsl
@@ -5,9 +5,9 @@ struct FragmentInput {
     noperspective float linear_ : LOC1;
     noperspective centroid float2 linear_centroid : LOC2;
     noperspective sample float3 linear_sample : LOC3;
-    linear float4 perspective : LOC4;
-    linear centroid float perspective_centroid : LOC5;
-    linear sample float perspective_sample : LOC6;
+    float4 perspective : LOC4;
+    centroid float perspective_centroid : LOC5;
+    sample float perspective_sample : LOC6;
 };
 
 struct VertexOutput_vert_main {

--- a/tests/out/hlsl/quad-vert.hlsl
+++ b/tests/out/hlsl/quad-vert.hlsl
@@ -7,7 +7,7 @@ struct gl_PerVertex {
 };
 
 struct type_9 {
-    linear float2 member : LOC0;
+    float2 member : LOC0;
     float4 gl_Position : SV_Position;
 };
 

--- a/tests/out/hlsl/quad.hlsl
+++ b/tests/out/hlsl/quad.hlsl
@@ -1,7 +1,7 @@
 static const float c_scale = 1.2000000476837158;
 
 struct VertexOutput {
-    linear float2 uv : LOC0;
+    float2 uv : LOC0;
     float4 position : SV_Position;
 };
 

--- a/tests/out/hlsl/shadow.hlsl
+++ b/tests/out/hlsl/shadow.hlsl
@@ -13,8 +13,8 @@ struct Entity {
 
 struct VertexOutput {
     float4 proj_position : SV_Position;
-    linear float3 world_normal : LOC0;
-    linear float4 world_position : LOC1;
+    float3 world_normal : LOC0;
+    float4 world_position : LOC1;
 };
 
 struct Light {

--- a/tests/out/hlsl/skybox.hlsl
+++ b/tests/out/hlsl/skybox.hlsl
@@ -7,7 +7,7 @@ ConstantBuffer<NagaConstants> _NagaConstants: register(b1);
 
 struct VertexOutput {
     float4 position : SV_Position;
-    linear float3 uv : LOC0;
+    float3 uv : LOC0;
 };
 
 struct Data {


### PR DESCRIPTION
Currently, hlsl-out writes the interpolation modifier before most structs, e.g.

```hlsl
struct input_0_ {
    linear float4 SV_Position : LOC0;
};
```

However, [the linear intepolation modifier is the default](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-struct#interpolation-modifiers-introduced-in-shader-model-4) in HLSL.

This pull request makes hlsl-output not output `linear` to make outputted code look more human-like.