### PR TITLE
[msl-out] Permit `invariant` qualifier on vertex shader outputs.

### DIFF
--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -249,9 +249,11 @@ impl Options {
                     return Err(Error::UnsupportedAttribute("invariant".to_string()));
                 }
 
+                // The 'invariant' attribute can only appear on vertex
+                // shader outputs, but not fragment shader inputs.
                 Ok(ResolvedBinding::BuiltIn {
                     built_in,
-                    invariant: invariant && matches!(mode, LocationMode::FragmentOutput),
+                    invariant: invariant && matches!(mode, LocationMode::VertexOutput),
                 })
             }
             crate::Binding::Location {

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -3331,11 +3331,11 @@ impl<W: Write> Writer<W> {
                 crate::ShaderStage::Vertex => (
                     "vertex",
                     LocationMode::VertexInput,
-                    LocationMode::Intermediate,
+                    LocationMode::VertexOutput,
                 ),
                 crate::ShaderStage::Fragment { .. } => (
                     "fragment",
-                    LocationMode::Intermediate,
+                    LocationMode::FragmentInput,
                     LocationMode::FragmentOutput,
                 ),
                 crate::ShaderStage::Compute { .. } => {

--- a/tests/out/msl/interface.msl
+++ b/tests/out/msl/interface.msl
@@ -27,7 +27,7 @@ struct vertex_Input {
     uint color [[attribute(10)]];
 };
 struct vertex_Output {
-    metal::float4 position [[position]];
+    metal::float4 position [[position, invariant]];
     float varying [[user(loc1), center_perspective]];
     float _point_size [[point_size]];
 };
@@ -84,7 +84,7 @@ kernel void compute_(
 struct vertex_two_structsInput {
 };
 struct vertex_two_structsOutput {
-    metal::float4 member_3 [[position]];
+    metal::float4 member_3 [[position, invariant]];
     float _point_size [[point_size]];
 };
 vertex vertex_two_structsOutput vertex_two_structs(


### PR DESCRIPTION
Split into two commits for easier review, but it's pretty short either way.