### PR TITLE
add methods on the error types for reusability in wgsl-analyzer

### DIFF
--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1287,6 +1287,16 @@ pub struct ParseError {
 }
 
 impl ParseError {
+    pub fn labels(&self) -> impl Iterator<Item = (Span, &str)> + ExactSizeIterator + '_ {
+        self.labels
+            .iter()
+            .map(|(span, msg)| (span.clone(), msg.as_ref()))
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
     fn diagnostic(&self) -> Diagnostic<()> {
         let diagnostic = Diagnostic::error()
             .with_message(self.message.to_string())

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1290,7 +1290,7 @@ impl ParseError {
     pub fn labels(&self) -> impl Iterator<Item = (Span, &str)> + ExactSizeIterator + '_ {
         self.labels
             .iter()
-            .map(|(span, msg)| (span.clone(), msg.as_ref()))
+            .map(|&(ref span, ref msg)| (span.clone(), msg.as_ref()))
     }
 
     pub fn message(&self) -> &str {

--- a/src/span.rs
+++ b/src/span.rs
@@ -124,8 +124,12 @@ impl<E> WithSpan<E> {
         self.inner
     }
 
+    pub fn as_inner(&self) -> &E {
+        &self.inner
+    }
+
     /// Iterator over stored [`SpanContext`]s.
-    pub fn spans(&self) -> impl Iterator<Item = &SpanContext> {
+    pub fn spans(&self) -> impl Iterator<Item = &SpanContext> + ExactSizeIterator {
         #[cfg(feature = "span")]
         return self.spans.iter();
         #[cfg(not(feature = "span"))]


### PR DESCRIPTION
I integrated naga error messages into [wgsl-analyzer](https://github.com/wgsl-analyzer/wgsl-analyzer) and in doing so made a few improvements to the error types allowing me to extract information I need.

Namely:
- expose `message` and `labels` from `frong::wgsl::ParseError`
- add `as_inner(&self) -> &E` to `WithSpan` (`into_inner(self) -> E` already exists)
- add `+ ExactSizeIterator` to the label/span iterators. This is not required but nice to have when checking whether any spans exist at all with `iter.len() == 0`