### PR TITLE
Update MSRV to 1.56

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,27 +11,13 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "1.43.0"
+          toolchain: "1.56.0"
           override: true
-      - uses: actions-rs/cargo@v1
-        name: Downgrade bitflags to MSRV
-        with:
-          command: update
-          args: -p bitflags --precise 1.2.1
-      - uses: actions-rs/cargo@v1
-        name: Downgrade indexmap to MSRV
-        with:
-          command: update
-          args: -p indexmap --precise 1.6.2
       - uses: actions-rs/cargo@v1
         name: Test all features
         with:
-          # we could use `test` but `criterion` is a dev dependency,
-          # and it doesn't build with our MSRV
-          command: check
-          # `cli` already enables most features,
-          # except for `arbitrary`, which requires Rust-1.51
-          args: --workspace
+          command: test
+          args: --all-features --workspace
       - name: Check snapshots
         run: git diff --exit-code -- tests/out
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["shader", "SPIR-V", "GLSL", "MSL"]
 license = "MIT OR Apache-2.0"
 exclude = ["bin/**/*", "tests/**/*", "Cargo.lock", "target/**/*"]
 resolver = "2"
+rust-version = "1.56"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -40,11 +41,6 @@ validate = []
 [[bench]]
 name = "criterion"
 harness = false
-
-# MSRV warnings:
-# - arbitrary 1.0.3 requires Rust-1.51
-# - bitflags 1.3 requires Rust-1.46
-# - indexmap 1.7 requires Rust-1.49
 
 [dependencies]
 arbitrary = { version = "1", features = ["derive"], optional = true }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/naga.svg?label=naga)](https://crates.io/crates/naga)
 [![Docs.rs](https://docs.rs/naga/badge.svg)](https://docs.rs/naga)
 [![Build Status](https://github.com/gfx-rs/naga/workflows/pipeline/badge.svg)](https://github.com/gfx-rs/naga/actions)
-![MSRV](https://img.shields.io/badge/rustc-1.43+-blue.svg)
+![MSRV](https://img.shields.io/badge/rustc-1.56+-blue.svg)
 [![codecov.io](https://codecov.io/gh/gfx-rs/naga/branch/master/graph/badge.svg?token=9VOKYO8BM2)](https://codecov.io/gh/gfx-rs/naga)
 
 The shader translation library for the needs of [wgpu](https://github.com/gfx-rs/wgpu) and [gfx-rs](https://github.com/gfx-rs/gfx) projects.
@@ -65,16 +65,4 @@ make validate-glsl # for OpenGL shaders, requires GLSLang installed
 make validate-dot # for dot files, requires GraphViz installed
 make validate-wgsl # for WGSL shaders
 make validate-hlsl # for HLSL shaders. Note: this Make target makes use of the "sh" shell. This is not the default shell in Windows.
-```
-
-## MSRV
-
-The `naga` codebase's MSRV is 1.43. However some newer versions of our dependencies have newer MSRVs than that. Here are a list of all known MSRV breaking dependencies and the versions that hold to MSRV.
-
-- `bitflags`: `>1.3` have an MSRV of 1.46. `<=1.2` has an MSRV of 1.43 or earlier.
-
-If you want to use `naga` with `1.43` add the following to your Cargo.toml dependency list even if you don't use bitflags yourself:
-
-```toml
-bitflags = "<1.3"
 ```

--- a/src/front/glsl/constants.rs
+++ b/src/front/glsl/constants.rs
@@ -599,9 +599,9 @@ fn glsl_float_min(x: f64, y: f64) -> f64 {
 
 /// Helper function to implement the GLSL `clamp` function for floats.
 ///
-/// While Rust does provide a `f64::clamp` method, it requires a version of rust
-/// above our MSRV and it also panics if either `min` or `max` are `NaN`s which
-/// is not the behavior specified by the glsl specification.
+/// While Rust does provide a `f64::clamp` method, it panics if either
+/// `min` or `max` are `NaN`s which is not the behavior specified by
+/// the glsl specification.
 fn glsl_float_clamp(value: f64, min: f64, max: f64) -> f64 {
     glsl_float_min(glsl_float_max(value, min), max)
 }


### PR DESCRIPTION
As mentioned on matrix, `wgpu`'s MSRV has been recently bumped up to 1.59 and I proposed to bump the MSRV of `naga` to 1.56.

Besides API changes, I think thees are the most relevant features for us since 1.43 (our current MSRV):

- [1.56](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html); rust 2021 (can upgrade in the future), `rust-version` in Cargo.toml, multiple bindings in match arms
- [1.55](https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html#faster-more-correct-float-parsing); faster, more correct float parsing
- [1.53](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#or-patterns); ability to nest OR patterns in match arms
- [1.51](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#const-generics-mvp); Const Generics MVP
- [1.50](https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html); const-generic array indexing, `const` value repetition for arrays
- [1.46](https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html#const-fn-improvements); `const fn` improvements

Tested changes locally via `cargo msrv verify -- cargo test --all-features --workspace` ([cargo-msrv](https://github.com/foresterre/cargo-msrv)).