### PR TITLE
CI minimal-versions checking for dependencies 

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test-msrv:
-    name: Test MSRV
+    name: Test MSRV and dependencies minimal-versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -13,11 +13,12 @@ jobs:
           profile: minimal
           toolchain: "1.56.0"
           override: true
-      - uses: actions-rs/cargo@v1
-        name: Test all features
-        with:
-          command: test
-          args: --all-features --workspace
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      # nightly is only used by cargo-minimal-versions to regenerate the lock file
+      - run: rustup toolchain add nightly --no-self-update
+      - name: Test all features
+        run: cargo minimal-versions test --all-features --workspace
       - name: Check snapshots
         run: git diff --exit-code -- tests/out
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,13 @@ name = "criterion"
 harness = false
 
 [dependencies]
-arbitrary = { version = "1", features = ["derive"], optional = true }
-bitflags = "1"
+arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
+bitflags = "1.0.4"
 bit-set = "0.5"
+termcolor = "1.0.4"
+# remove termcolor dep when updating to the next version of codespan-reporting
+# termcolor minimum version was wrong and was fixed in
+# https://github.com/brendanzab/codespan/commit/e99c867339a877731437e7ee6a903a3d03b5439e
 codespan-reporting = { version = "0.11.0", optional = true }
 rustc-hash = "1.1.0"
 indexmap = "1.6"
@@ -53,7 +57,7 @@ log = "0.4"
 num-traits = "0.2"
 spirv = { version = "0.2", optional = true }
 thiserror = "1.0.21"
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0.103", features = ["derive"], optional = true }
 petgraph = { version ="0.6", optional = true }
 pp-rs = { version = "0.2.1", optional = true }
 hexf-parse = { version = "0.2.1", optional = true }


### PR DESCRIPTION
Depends on #1838 (will rebase once it lands)

Adds minimal-versions checking for dependencies to CI and fixes minimal versions of some of our dependencies.

Relevant links

- arbitrary: https://github.com/rust-fuzz/arbitrary/blob/master/CHANGELOG.md#102
- bitflags: https://github.com/gfx-rs/rspirv/issues/232 (https://github.com/bitflags/bitflags/releases/tag/1.0.4)
- serde: https://github.com/serde-rs/serde/releases/tag/v1.0.103

Tested locally via
`cargo msrv verify -- cargo minimal-versions test --all-features --workspace` ([cargo-msrv](https://github.com/foresterre/cargo-msrv), [cargo-minimal-versions](https://github.com/taiki-e/cargo-minimal-versions))
