### PR TITLE
[hlsl-out] Emit `row_major` qualifier on matrix uniform globals.

### DIFF
--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -646,6 +646,12 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
 
         if global.space == crate::AddressSpace::Uniform {
             write!(self.out, " {{ ")?;
+            // Even though Naga IR matrices are column-major, we must describe
+            // matrices passed from the CPU as being in row-major order.  See
+            // the module-level comments for details.
+            if let TypeInner::Matrix { .. } = module.types[global.ty].inner {
+                write!(self.out, "row_major ")?;
+            }
             self.write_type(module, global.ty)?;
             let sub_name = &self.names[&NameKey::GlobalVariable(handle)];
             write!(self.out, " {}", sub_name)?;

--- a/tests/out/hlsl/globals.hlsl
+++ b/tests/out/hlsl/globals.hlsl
@@ -11,7 +11,7 @@ RWByteAddressBuffer alignment : register(u1);
 ByteAddressBuffer dummy : register(t2);
 cbuffer float_vecs : register(b3) { float4 float_vecs[20]; }
 cbuffer global_vec : register(b4) { float4 global_vec; }
-cbuffer global_mat : register(b5) { float4x4 global_mat; }
+cbuffer global_mat : register(b5) { row_major float4x4 global_mat; }
 
 void test_msl_packed_vec3_as_arg(float3 arg)
 {


### PR DESCRIPTION
Fixes #1836.