### PR TITLE
Fix bitflags min version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ harness = false
 
 [dependencies]
 arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
-bitflags = "1.0.4"
+bitflags = "1.0.5"
 bit-set = "0.5"
 termcolor = "1.0.4"
 # remove termcolor dep when updating to the next version of codespan-reporting


### PR DESCRIPTION
https://github.com/bitflags/bitflags/releases/tag/1.0.5

This fixes CI since #1840 landed without being rebased after #1841 got merged.
