### PR TITLE
Replace `unicode-id` with `unicode-xid`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serialize = ["serde", "indexmap/serde-1"]
 deserialize = ["serde", "indexmap/serde-1"]
 spv-in = ["petgraph", "spirv"]
 spv-out = ["spirv"]
-wgsl-in = ["codespan-reporting", "hexf-parse", "unicode-id"]
+wgsl-in = ["codespan-reporting", "hexf-parse", "unicode-xid"]
 wgsl-out = []
 hlsl-out = []
 span = ["codespan-reporting"]
@@ -61,7 +61,10 @@ serde = { version = "1.0.103", features = ["derive"], optional = true }
 petgraph = { version ="0.6", optional = true }
 pp-rs = { version = "0.2.1", optional = true }
 hexf-parse = { version = "0.2.1", optional = true }
-unicode-id = { version = "0.3", optional = true }
+# update unicode-xid to the next version since it has been updated to unicode v14
+# (but has no release that includes it yet)
+# https://github.com/unicode-rs/unicode-xid/pull/27
+unicode-xid = { version = "0.2.2", optional = true }
 
 [dev-dependencies]
 bincode = "1"

--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -410,12 +410,12 @@ const fn is_blankspace(c: char) -> bool {
 
 /// Returns whether or not a char is a word start (Unicode XID_Start + '_')
 fn is_word_start(c: char) -> bool {
-    c == '_' || unicode_id::UnicodeID::is_id_start(c)
+    c == '_' || unicode_xid::UnicodeXID::is_xid_start(c)
 }
 
 /// Returns whether or not a char is a word part (Unicode XID_Continue)
 fn is_word_part(c: char) -> bool {
-    unicode_id::UnicodeID::is_id_continue(c)
+    unicode_xid::UnicodeXID::is_xid_continue(c)
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
In 743c8aa387cbfbd3c47e6097c8c2694b3f6ad0a0 I mistakenly used `unicode-id` instead of `unicode-xid`.

Unicode defines both `ID_{Start,Continue}` and `XID_{Start,Continue}` in [Table_Lexical_Classes_for_Identifiers](https://www.unicode.org/reports/tr31/tr31-35.html#Table_Lexical_Classes_for_Identifiers).