### PR TITLE
Clarify accepted types for `Expression::AccessIndex`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1108,14 +1108,19 @@ pub enum Expression {
         base: Handle<Expression>,
         index: Handle<Expression>,
     },
-    /// Array access with a known index.
+    /// Access the same types as [`Access`] plus [`Struct`] with a known index.
+    /// 
+    /// [`Array`]s must have a [`Constant`] size.
+    /// 
+    /// [`Access`]: Expression::Access
+    /// [`Struct`]: TypeInner::Struct
+    /// [`Array`]: TypeInner::Array
+    /// [`Constant`]: ArraySize::Constant
     AccessIndex {
         base: Handle<Expression>,
         index: u32,
     },
     /// Constant value.
-    ///
-    /// Every `Constant` expression
     Constant(Handle<Constant>),
     /// Splat scalar into a vector.
     Splat {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1108,14 +1108,10 @@ pub enum Expression {
         base: Handle<Expression>,
         index: Handle<Expression>,
     },
-    /// Access the same types as [`Access`] plus [`Struct`] with a known index.
-    /// 
-    /// [`Array`]s must have a [`Constant`] size.
-    /// 
+    /// Access the same types as [`Access`], plus [`Struct`] with a known index.
+    ///
     /// [`Access`]: Expression::Access
     /// [`Struct`]: TypeInner::Struct
-    /// [`Array`]: TypeInner::Array
-    /// [`Constant`]: ArraySize::Constant
     AccessIndex {
         base: Handle<Expression>,
         index: u32,


### PR DESCRIPTION
The docs for `AccessIndex` only note it can be used with arrays ("Array access with a known index.") and don't mention [it can be used with structs or other types](https://github.com/gfx-rs/naga/blob/1aa9154964238af8c692cf521ff90e1f2395e147/src/valid/expression.rs#L227).

This pull request documents the full list of types relative to those for `Expression::Access`, which already have a more extensive blurb written about them.