### PR TITLE
Correct error message for `Handle` index overflow.

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -101,7 +101,7 @@ impl<T> Handle<T> {
         let handle_index = u32::try_from(index + 1)
             .ok()
             .and_then(Index::new)
-            .expect("Failed to insert into UniqueArena. Handle overflows");
+            .expect("Failed to insert into arena. Handle overflows");
         Handle::new(handle_index)
     }
 


### PR DESCRIPTION
This function is used from both `Arena` and `UniqueArena`. When its code moved from `Arena` to `Handle`, the error message was adapted incorrectly.