### PR TITLE
Change `!0` to equivalent results for readability

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -340,7 +340,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             println!("Validation successful");
             return Ok(());
         } else {
-            std::process::exit(!0);
+            std::process::exit(-1);
         }
     }
 

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -77,7 +77,7 @@ impl<T> hash::Hash for Handle<T> {
 impl<T> Handle<T> {
     #[cfg(test)]
     pub const DUMMY: Self = Handle {
-        index: unsafe { NonZeroU32::new_unchecked(!0) },
+        index: unsafe { NonZeroU32::new_unchecked(u32::MAX) },
         marker: PhantomData,
     };
 

--- a/src/back/mod.rs
+++ b/src/back/mod.rs
@@ -131,7 +131,7 @@ impl crate::Expression {
     const fn bake_ref_count(&self) -> usize {
         match *self {
             // accesses are never cached, only loads are
-            crate::Expression::Access { .. } | crate::Expression::AccessIndex { .. } => !0,
+            crate::Expression::Access { .. } | crate::Expression::AccessIndex { .. } => usize::MAX,
             // sampling may use the control flow, and image ops look better by themselves
             crate::Expression::ImageSample { .. } | crate::Expression::ImageLoad { .. } => 1,
             // derivatives use the control flow

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -3878,7 +3878,7 @@ fn test_stack_size() {
 
     {
         // check expression stack
-        let mut addresses = !0usize..0usize;
+        let mut addresses = usize::MAX..0usize;
         for pointer in writer.put_expression_stack_pointers {
             addresses.start = addresses.start.min(pointer as usize);
             addresses.end = addresses.end.max(pointer as usize);
@@ -3893,7 +3893,7 @@ fn test_stack_size() {
 
     {
         // check block stack
-        let mut addresses = !0usize..0usize;
+        let mut addresses = usize::MAX..0usize;
         for pointer in writer.put_block_stack_pointers {
             addresses.start = addresses.start.min(pointer as usize);
             addresses.end = addresses.end.max(pointer as usize);

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -2453,7 +2453,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                     let mut max_component = 0;
                     for _ in 5..inst.wc as usize {
                         let mut index = self.next()?;
-                        if index == !0 {
+                        if index == u32::MAX {
                             // treat Undefined as X
                             index = 0;
                         }

--- a/src/front/spv/null.rs
+++ b/src/front/spv/null.rs
@@ -158,7 +158,7 @@ pub fn generate_default_built_in(
             width: 4,
         },
         Some(crate::BuiltIn::SampleMask) => crate::ConstantInner::Scalar {
-            value: crate::ScalarValue::Uint(!0),
+            value: crate::ScalarValue::Uint(u64::MAX),
             width: 4,
         },
         //Note: `crate::BuiltIn::ClipDistance` is intentionally left for the default path

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -241,7 +241,7 @@ impl super::Validator {
                             size: crate::ArraySize::Constant(handle),
                             ..
                         } => module.constants[handle].to_array_length().unwrap(),
-                        Ti::Array { .. } | Ti::BindingArray { .. } => !0, // can't statically know, but need run-time checks
+                        Ti::Array { .. } | Ti::BindingArray { .. } => u32::MAX, // can't statically know, but need run-time checks
                         Ti::Pointer { base, .. } if top_level => {
                             resolve_index_limit(module, top, &module.types[base].inner, false)?
                         }


### PR DESCRIPTION
[What can I say, it screwed me up!](https://github.com/gfx-rs/naga/pull/1862#discussion_r857831242) It didn't register that `!` in Rust performs both boolean and bitwise [negation](https://doc.rust-lang.org/std/ops/trait.Not.html), unlike other languages where it's `!`/`not` vs `~`.

This PR changes all instances of `!0` to equivalent results (`<type>::MAX` or `-1`, depending on signedness) to improve readability and prevent such errors in the future.