### PR TITLE
glsl-out: Fix feature search in expressions

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -2433,7 +2433,6 @@ impl<'a, W: Write> Writer<'a, W> {
                         }
                     }
                     crate::ImageQuery::NumSamples => {
-                        // assumes ARB_shader_texture_image_samples
                         let fun_name = match class {
                             ImageClass::Sampled { .. } | ImageClass::Depth { .. } => {
                                 "textureSamples"


### PR DESCRIPTION
The fma wasn't being searched in case it wasn't supported which is the
opposite of what we want since if it's used we want to error if it isn't
supported.

It was also searching in all entry points instead of only in the current
one.

All samples queries need the ARB_shader_texture_image_samples extension
so we need to check if any samples queries are made and if so request
the extension.