### PR TITLE
[hlsl-out] Zero init struct constructor

### DIFF
--- a/src/back/hlsl/help.rs
+++ b/src/back/hlsl/help.rs
@@ -427,8 +427,8 @@ impl<'a, W: Write> super::Writer<'a, W> {
                 let struct_name = &self.names[&NameKey::Type(constructor.ty)];
                 writeln!(
                     self.out,
-                    "{}{} {};",
-                    INDENT, struct_name, RETURN_VARIABLE_NAME
+                    "{}{} {} = ({})0;",
+                    INDENT, struct_name, RETURN_VARIABLE_NAME, struct_name
                 )?;
                 for (i, member) in members.iter().enumerate() {
                     let field_name = &self.names[&NameKey::StructMember(constructor.ty, i as u32)];

--- a/tests/out/hlsl/access.hlsl
+++ b/tests/out/hlsl/access.hlsl
@@ -48,7 +48,7 @@ void SetMatScalarmOnBaz(Baz obj, float scalar, uint mat_idx, uint vec_idx) {
 }
 
 Baz ConstructBaz(float3x2 arg0) {
-    Baz ret;
+    Baz ret = (Baz)0;
     ret.m_0 = arg0[0];
     ret.m_1 = arg0[1];
     ret.m_2 = arg0[2];

--- a/tests/out/hlsl/interface.hlsl
+++ b/tests/out/hlsl/interface.hlsl
@@ -40,7 +40,7 @@ struct FragmentInput_fragment {
 };
 
 VertexOutput ConstructVertexOutput(float4 arg0, float arg1) {
-    VertexOutput ret;
+    VertexOutput ret = (VertexOutput)0;
     ret.position = arg0;
     ret._varying = arg1;
     return ret;
@@ -55,7 +55,7 @@ VertexOutput_vertex vertex(uint vertex_index : SV_VertexID, uint instance_index 
 }
 
 FragmentOutput ConstructFragmentOutput(float arg0, uint arg1, float arg2) {
-    FragmentOutput ret;
+    FragmentOutput ret = (FragmentOutput)0;
     ret.depth = arg0;
     ret.sample_mask = arg1;
     ret.color = arg2;

--- a/tests/out/hlsl/operators.hlsl
+++ b/tests/out/hlsl/operators.hlsl
@@ -12,7 +12,7 @@ struct Foo {
 };
 
 Foo ConstructFoo(float4 arg0, int arg1) {
-    Foo ret;
+    Foo ret = (Foo)0;
     ret.a = arg0;
     ret.b = arg1;
     return ret;

--- a/tests/out/hlsl/quad-vert.hlsl
+++ b/tests/out/hlsl/quad-vert.hlsl
@@ -17,7 +17,7 @@ float Constructarray1_float_(float arg0)[1] {
 }
 
 gl_PerVertex Constructgl_PerVertex(float4 arg0, float arg1, float arg2[1], float arg3[1]) {
-    gl_PerVertex ret;
+    gl_PerVertex ret = (gl_PerVertex)0;
     ret.gl_Position = arg0;
     ret.gl_PointSize = arg1;
     ret.gl_ClipDistance = arg2;
@@ -45,7 +45,7 @@ void main_1()
 }
 
 type_9 Constructtype_9(float2 arg0, float4 arg1) {
-    type_9 ret;
+    type_9 ret = (type_9)0;
     ret.member = arg0;
     ret.gl_Position = arg1;
     return ret;

--- a/tests/out/hlsl/quad.hlsl
+++ b/tests/out/hlsl/quad.hlsl
@@ -18,7 +18,7 @@ struct FragmentInput_frag_main {
 };
 
 VertexOutput ConstructVertexOutput(float2 arg0, float4 arg1) {
-    VertexOutput ret;
+    VertexOutput ret = (VertexOutput)0;
     ret.uv = arg0;
     ret.position = arg1;
     return ret;

--- a/tests/out/hlsl/skybox.hlsl
+++ b/tests/out/hlsl/skybox.hlsl
@@ -30,7 +30,7 @@ struct FragmentInput_fs_main {
 };
 
 VertexOutput ConstructVertexOutput(float4 arg0, float3 arg1) {
-    VertexOutput ret;
+    VertexOutput ret = (VertexOutput)0;
     ret.position = arg0;
     ret.uv = arg1;
     return ret;


### PR DESCRIPTION
Work around for FXC `error X4555: cannot use casts on l-values`.
Both approaches of zero initializing the whole struct (this PR) and explicitly initializing the padding fields generate the same DXBC.

fixes #1886