### PR TITLE
[hlsl-out] Fix array constructor return type (for FXC)

### DIFF
--- a/tests/out/hlsl/access.hlsl
+++ b/tests/out/hlsl/access.hlsl
@@ -8,12 +8,14 @@ struct Baz {
     float2 m_0; float2 m_1; float2 m_2;
 };
 
-float Constructarray10_float_(float arg0, float arg1, float arg2, float arg3, float arg4, float arg5, float arg6, float arg7, float arg8, float arg9)[10] {
+typedef float ret_Constructarray10_float_[10];
+ret_Constructarray10_float_ Constructarray10_float_(float arg0, float arg1, float arg2, float arg3, float arg4, float arg5, float arg6, float arg7, float arg8, float arg9) {
     float ret[10] = { arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 };
     return ret;
 }
 
-float Constructarray5_array10_float__(float arg0[10], float arg1[10], float arg2[10], float arg3[10], float arg4[10])[5][10] {
+typedef float ret_Constructarray5_array10_float__[5][10];
+ret_Constructarray5_array10_float__ Constructarray5_array10_float__(float arg0[10], float arg1[10], float arg2[10], float arg3[10], float arg4[10]) {
     float ret[5][10] = { arg0, arg1, arg2, arg3, arg4 };
     return ret;
 }
@@ -118,7 +120,8 @@ uint NagaBufferLengthRW(RWByteAddressBuffer buffer)
     return ret;
 }
 
-int Constructarray5_int_(int arg0, int arg1, int arg2, int arg3, int arg4)[5] {
+typedef int ret_Constructarray5_int_[5];
+ret_Constructarray5_int_ Constructarray5_int_(int arg0, int arg1, int arg2, int arg3, int arg4) {
     int ret[5] = { arg0, arg1, arg2, arg3, arg4 };
     return ret;
 }
@@ -147,7 +150,8 @@ float4 foo_vert(uint vi : SV_VertexID) : SV_Position
     return float4(mul(float4((value).xxxx), _matrix), 2.0);
 }
 
-uint2 Constructarray2_uint2_(uint2 arg0, uint2 arg1)[2] {
+typedef uint2 ret_Constructarray2_uint2_[2];
+ret_Constructarray2_uint2_ Constructarray2_uint2_(uint2 arg0, uint2 arg1) {
     uint2 ret[2] = { arg0, arg1 };
     return ret;
 }

--- a/tests/out/hlsl/operators.hlsl
+++ b/tests/out/hlsl/operators.hlsl
@@ -18,7 +18,8 @@ Foo ConstructFoo(float4 arg0, int arg1) {
     return ret;
 }
 
-Foo Constructarray3_Foo_(Foo arg0, Foo arg1, Foo arg2)[3] {
+typedef Foo ret_Constructarray3_Foo_[3];
+ret_Constructarray3_Foo_ Constructarray3_Foo_(Foo arg0, Foo arg1, Foo arg2) {
     Foo ret[3] = { arg0, arg1, arg2 };
     return ret;
 }
@@ -49,7 +50,8 @@ float3 bool_cast(float3 x)
     return float3(y);
 }
 
-int Constructarray4_int_(int arg0, int arg1, int arg2, int arg3)[4] {
+typedef int ret_Constructarray4_int_[4];
+ret_Constructarray4_int_ Constructarray4_int_(int arg0, int arg1, int arg2, int arg3) {
     int ret[4] = { arg0, arg1, arg2, arg3 };
     return ret;
 }

--- a/tests/out/hlsl/quad-vert.hlsl
+++ b/tests/out/hlsl/quad-vert.hlsl
@@ -11,7 +11,8 @@ struct type_9 {
     float4 gl_Position : SV_Position;
 };
 
-float Constructarray1_float_(float arg0)[1] {
+typedef float ret_Constructarray1_float_[1];
+ret_Constructarray1_float_ Constructarray1_float_(float arg0) {
     float ret[1] = { arg0 };
     return ret;
 }


### PR DESCRIPTION
According to https://github.com/microsoft/DirectXShaderCompiler/issues/1808 the syntax used for returning arrays (which was added in https://github.com/gfx-rs/naga/pull/1814) is specific to DXC. This PR changes it to use a typedef which is supported by both FXC and DXC.

fixes https://github.com/gfx-rs/naga/issues/1913