### PR TITLE
Add HLSL validation via FXC to CI

### DIFF
--- a/.github/workflows/validation-windows.yml
+++ b/.github/workflows/validation-windows.yml
@@ -5,12 +5,28 @@ on:
       - 'tests/out/hlsl/*.hlsl'
 
 jobs:
-  validate-windows:
-    name: HLSL
+  validate-windows-dxc:
+    name: HLSL via DXC
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - name: Add DirectXShaderCompiler
         uses: napokue/setup-dxc@v1.0.0
-      - run: make validate-hlsl
+      - run: make validate-hlsl-dxc
+        shell: sh
+
+  validate-windows-fxc:
+    name: HLSL via FXC
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Add fxc bin to PATH
+        run: |
+          Get-Childitem -Path "C:\Program Files (x86)\Windows Kits\10\bin\**\x64\fxc.exe" `
+          | Sort-Object -Property LastWriteTime -Descending `
+          | Select-Object -First 1 `
+          | Split-Path -Parent `
+          | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
+        shell: powershell
+      - run: make validate-hlsl-fxc
         shell: sh

--- a/README.md
+++ b/README.md
@@ -81,5 +81,7 @@ make validate-msl # for Metal shaders, requires XCode command-line tools install
 make validate-glsl # for OpenGL shaders, requires GLSLang installed
 make validate-dot # for dot files, requires GraphViz installed
 make validate-wgsl # for WGSL shaders
-make validate-hlsl # for HLSL shaders. Note: this Make target makes use of the "sh" shell. This is not the default shell in Windows.
+make validate-hlsl-dxc # for HLSL shaders via DXC
+make validate-hlsl-fxc # for HLSL shaders via FXC
+# Note: HLSL Make targets make use of the "sh" shell. This is not the default shell in Windows.
 ```


### PR DESCRIPTION
Added HLSL validation via FXC to CI since `wgpu` currently uses FXC for the D3D backends.

There are 4 issues with our current tests/backend that have to be resolved for FXC validation to succeed.

- #1919
- #1920
- #1921
- #1922