### PR TITLE
[spv-in] Add MultiView to SUPPORTED_CAPABILITIES

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -647,6 +647,8 @@ impl<W: Write> Writer<W> {
     }
 
     /// Finishes writing and returns the output.
+    // See https://github.com/rust-lang/rust-clippy/issues/4979.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn finish(self) -> W {
         self.out
     }

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -1859,6 +1859,8 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
+    // See https://github.com/rust-lang/rust-clippy/issues/4979.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn finish(self) -> W {
         self.out
     }

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -71,6 +71,7 @@ pub const SUPPORTED_CAPABILITIES: &[spirv::Capability] = &[
     spirv::Capability::Float16,
     spirv::Capability::Float64,
     spirv::Capability::Geometry,
+    spirv::Capability::MultiView,
     // tricky ones
     spirv::Capability::UniformBufferArrayDynamicIndexing,
     spirv::Capability::StorageBufferArrayDynamicIndexing,

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1193,8 +1193,8 @@ impl Composition {
 #[derive(Default)]
 struct TypeAttributes {
     // Although WGSL nas no type attributes at the moment, it had them in the past
-// (`[[stride]]`) and may as well acquire some again in the future.
-// Therefore, we are leaving the plumbing in for now.
+    // (`[[stride]]`) and may as well acquire some again in the future.
+    // Therefore, we are leaving the plumbing in for now.
 }
 
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
Naga's support for multiview shaders seems pretty good so I think we can enable this SPIR-V capability, especially because `SPV_KHR_multiview` is already in `SUPPORTED_EXTENSIONS`.