### PR TITLE
Add a helper for getting the location of a span in some textual source

### DIFF
--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -1366,8 +1366,7 @@ impl ParseError {
         writer.into_string()
     }
 
-    /// Returns the 1-based line number and column of the first label in the
-    /// error message.
+    /// Returns a [`SourceLocation`] for the first label in the error message.
     pub fn location(&self, source: &str) -> Option<SourceLocation> {
         self.labels
             .get(0)

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     proc::{
         ensure_block_returns, Alignment, Layouter, ResolveContext, ResolveError, TypeResolution,
     },
+    span::SourceLocation,
     span::Span as NagaSpan,
     Bytes, ConstantInner, FastHashMap, ScalarValue,
 };
@@ -29,7 +30,7 @@ use self::{
 };
 use codespan_reporting::{
     diagnostic::{Diagnostic, Label},
-    files::{Files, SimpleFile},
+    files::SimpleFile,
     term::{
         self,
         termcolor::{ColorChoice, ColorSpec, StandardStream, WriteColor},
@@ -1367,17 +1368,10 @@ impl ParseError {
 
     /// Returns the 1-based line number and column of the first label in the
     /// error message.
-    pub fn location(&self, source: &str) -> (usize, usize) {
-        let files = SimpleFile::new("wgsl", source);
-        match self.labels.get(0) {
-            Some(label) => {
-                let location = files
-                    .location((), label.0.start)
-                    .expect("invalid span location");
-                (location.line_number, location.column_number)
-            }
-            None => (1, 1),
-        }
+    pub fn location(&self, source: &str) -> Option<SourceLocation> {
+        self.labels
+            .get(0)
+            .map(|label| NagaSpan::new(label.0.start as u32, label.0.end as u32).location(source))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ pub mod valid;
 
 pub use crate::arena::{Arena, Handle, Range, UniqueArena};
 
-pub use crate::span::{Span, SpanContext, WithSpan};
+pub use crate::span::{SourceLocation, Span, SpanContext, WithSpan};
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 #[cfg(feature = "deserialize")]

--- a/src/span.rs
+++ b/src/span.rs
@@ -60,8 +60,7 @@ impl Span {
         *self != Self::default()
     }
 
-    /// Returns the 1-based line number and column of the this span in
-    /// the provided source.
+    /// Return a [`SourceLocation`] for this span in the provided source.
     pub fn location(&self, source: &str) -> SourceLocation {
         let prefix = &source[..self.start as usize];
         let line_number = prefix.matches('\n').count() as u32 + 1;
@@ -86,10 +85,13 @@ impl From<Range<usize>> for Span {
     }
 }
 
-/// A human-readable representation for span, tailored for text source.
+/// A human-readable representation for a span, tailored for text source.
 ///
-/// Corresponds to the positional members of `GPUCompilationMessage` from the WebGPU specification,
-/// using utf8 instead of utf16 as reference encoding.
+/// Corresponds to the positional members of [`GPUCompilationMessage`][gcm] from
+/// the WebGPU specification, except that `offset` and `length` are in bytes
+/// (UTF-8 code units), instead of UTF-16 code units.
+///
+/// [gcm]: https://www.w3.org/TR/webgpu/#gpucompilationmessage
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct SourceLocation {
     /// 1-based line number.
@@ -220,6 +222,7 @@ impl<E> WithSpan<E> {
     }
 
     #[cfg(feature = "span")]
+    /// Return a [`SourceLocation`] for our first span, if we have one.
     pub fn location(&self, source: &str) -> Option<SourceLocation> {
         if self.spans.is_empty() {
             return None;
@@ -229,6 +232,7 @@ impl<E> WithSpan<E> {
     }
 
     #[cfg(not(feature = "span"))]
+    /// Return a [`SourceLocation`] for our first span, if we have one.
     pub fn location(&self, _source: &str) -> Option<SourceLocation> {
         None
     }


### PR DESCRIPTION
The idea is to get an easily consumable location (line/column/etc.) in the shader source for errors, where "easily consumable" really just means what [the WebGPU spec](https://www.w3.org/TR/webgpu/#shader-module-compilation-information) expects for errors.

r? @jimblandy 