### PR TITLE
Require unicode-xid 0.2.2, not 0.2.3, for Firefox.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ serde = { version = "1.0.103", features = ["derive"], optional = true }
 petgraph = { version ="0.6", optional = true }
 pp-rs = { version = "0.2.1", optional = true }
 hexf-parse = { version = "0.2.1", optional = true }
-unicode-xid = { version = "0.2.3", optional = true }
+unicode-xid = { version = "0.2.2", optional = true }
 
 [dev-dependencies]
 bincode = "1"


### PR DESCRIPTION
Firefox tries to avoid having multiple copies of crates in the tree, and currently it is using `unicode-xid` 0.2.2. Since Naga does not specifically require 0.2.3, we can relax this requirement to make Firefox `wgpu` updates easier.