### PR TITLE
Update README for glsl-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Front-end       |       Status       | Feature | Notes |
 --------------- | ------------------ | ------- | ----- |
 SPIR-V (binary) | :white_check_mark: | spv-in  |       |
 WGSL            | :white_check_mark: | wgsl-in | Fully validated |
-GLSL            | :ok:               | glsl-in | GLSL 440+ |
+GLSL            | :ok:               | glsl-in | GLSL 440+ and Vulkan semantics only |
 
 Back-end        |       Status       | Feature  | Notes |
 --------------- | ------------------ | -------- | ----- |


### PR DESCRIPTION
This updates it to state that only Vulkan semantics are supported.