### PR TITLE
glsl-in: Stop emitter in conditional

### DIFF
--- a/src/front/glsl/context.rs
+++ b/src/front/glsl/context.rs
@@ -1174,6 +1174,10 @@ impl Context {
                             self.emit_end(&mut reject_body);
                         }
                     }
+                } else {
+                    // Technically there's nothing to flush but later we will need to
+                    // add some expressions that must not be emitted.
+                    self.emit_end(body)
                 }
 
                 // We need to get the type of the resulting expression to create the local,


### PR DESCRIPTION
This wasn't being done when there were no implicit conversions, causing
the emitter to panic.

closes #1942