### PR TITLE
glsl-in: Fix matrix multiplication check

### DIFF
--- a/src/front/glsl/context.rs
+++ b/src/front/glsl/context.rs
@@ -617,11 +617,14 @@ impl Context {
                             width: right_width,
                         },
                     ) => {
+                        let dimensions_ok = if op == BinaryOperator::Multiply {
+                            left_columns == right_rows
+                        } else {
+                            left_columns == right_columns && left_rows == right_rows
+                        };
+
                         // Check that the two arguments have the same dimensions
-                        if left_columns != right_columns
-                            || left_rows != right_rows
-                            || left_width != right_width
-                        {
+                        if !dimensions_ok || left_width != right_width {
                             parser.errors.push(Error {
                                 kind: ErrorKind::SemanticError(
                                     format!(

--- a/tests/in/glsl/expressions.frag
+++ b/tests/in/glsl/expressions.frag
@@ -128,6 +128,10 @@ void ternary(bool a) {
     uint nested = a ? (a ? (a ? 2u : 3) : 4u) : 5;
 }
 
+void testMatrixMultiplication(mat4x3 a, mat4x4 b) {
+    mat4x3 c = a * b;
+}
+
 out vec4 o_color;
 void main() {
     privatePointer(global);

--- a/tests/out/wgsl/expressions-frag.wgsl
+++ b/tests/out/wgsl/expressions-frag.wgsl
@@ -356,6 +356,19 @@ fn ternary(a_20: bool) {
     return;
 }
 
+fn testMatrixMultiplication(a_22: mat4x3<f32>, b_18: mat4x4<f32>) {
+    var a_23: mat4x3<f32>;
+    var b_19: mat4x4<f32>;
+    var c_2: mat4x3<f32>;
+
+    a_23 = a_22;
+    b_19 = b_18;
+    let _e5 = a_23;
+    let _e6 = b_19;
+    c_2 = (_e5 * _e6);
+    return;
+}
+
 fn main_1() {
     var local_5: f32;
 


### PR DESCRIPTION
The previous check compared rows to rows and columns to columns but
multiplication of matrices only needs the columns of the left matrix to
be equal to the rows of the right matrix.

closes #1947