### PR TITLE
Fix Criterion benchmark build.

### DIFF
--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -255,6 +255,7 @@ fn backends(c: &mut Criterion) {
                         info,
                         &options,
                         &pipeline_options,
+                        naga::proc::BoundsCheckPolicies::default(),
                     ) {
                         Ok(mut writer) => {
                             let _ = writer.write(); // can error if unsupported


### PR DESCRIPTION
As of #1889, the GLSL back end takes an additional argument specifying the bounds checks policies to use.