### PR TITLE
glsl-in: Fix parameter not changing to depth

### DIFF
--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -671,6 +671,13 @@ impl Parser {
                 let overload_param_ty = &self.module.types[*overload_parameter].inner;
                 let call_arg_ty = self.resolve_type(ctx, call_argument.0, call_argument.1)?;
 
+                log::trace!(
+                    "Testing parameter {}\n\tOverload = {:?}\n\tCall = {:?}",
+                    i,
+                    overload_param_ty,
+                    call_arg_ty
+                );
+
                 // Storage images cannot be directly compared since while the access is part of the
                 // type in naga's IR, in glsl they are a qualifier and don't enter in the match as
                 // long as the access needed is satisfied.

--- a/tests/in/glsl/sampler-functions.frag
+++ b/tests/in/glsl/sampler-functions.frag
@@ -1,0 +1,16 @@
+#version 440
+precision mediump float;
+
+float CalcShadowPCF1(texture2D T_P_t_TextureDepth, samplerShadow S_P_t_TextureDepth, in vec3 t_ProjCoord) {
+    float t_Res = 0.0f;
+    t_Res += texture(sampler2DShadow(T_P_t_TextureDepth, S_P_t_TextureDepth), t_ProjCoord.xyz) * (1.0 / 5.0);
+    return t_Res;
+}
+
+float CalcShadowPCF(texture2D T_P_t_TextureDepth, samplerShadow S_P_t_TextureDepth, in vec3 t_ProjCoord, in float t_Bias) {
+    t_ProjCoord.z += t_Bias;
+    return CalcShadowPCF1(T_P_t_TextureDepth, S_P_t_TextureDepth, t_ProjCoord.xyz);
+}
+
+void main() {
+}

--- a/tests/out/wgsl/sampler-functions-frag.wgsl
+++ b/tests/out/wgsl/sampler-functions-frag.wgsl
@@ -1,0 +1,41 @@
+fn CalcShadowPCF1_(T_P_t_TextureDepth: texture_depth_2d, S_P_t_TextureDepth: sampler_comparison, t_ProjCoord: vec3<f32>) -> f32 {
+    var t_ProjCoord_1: vec3<f32>;
+    var t_Res: f32 = 0.0;
+
+    t_ProjCoord_1 = t_ProjCoord;
+    let _e6 = t_Res;
+    let _e7 = t_ProjCoord_1;
+    _ = _e7.xyz;
+    let _e9 = t_ProjCoord_1;
+    let _e10 = _e9.xyz;
+    let _e13 = textureSampleCompare(T_P_t_TextureDepth, S_P_t_TextureDepth, _e10.xy, _e10.z);
+    t_Res = (_e6 + (_e13 * (1.0 / 5.0)));
+    let _e19 = t_Res;
+    return _e19;
+}
+
+fn CalcShadowPCF(T_P_t_TextureDepth_1: texture_depth_2d, S_P_t_TextureDepth_1: sampler_comparison, t_ProjCoord_2: vec3<f32>, t_Bias: f32) -> f32 {
+    var t_ProjCoord_3: vec3<f32>;
+    var t_Bias_1: f32;
+
+    t_ProjCoord_3 = t_ProjCoord_2;
+    t_Bias_1 = t_Bias;
+    let _e7 = t_ProjCoord_3;
+    let _e9 = t_Bias_1;
+    t_ProjCoord_3.z = (_e7.z + _e9);
+    let _e11 = t_ProjCoord_3;
+    _ = _e11.xyz;
+    let _e13 = t_ProjCoord_3;
+    let _e15 = CalcShadowPCF1_(T_P_t_TextureDepth_1, S_P_t_TextureDepth_1, _e13.xyz);
+    return _e15;
+}
+
+fn main_1() {
+    return;
+}
+
+@fragment 
+fn main() {
+    main_1();
+    return;
+}


### PR DESCRIPTION
The conversion from sampled images to depth changed the `argument` type
but didn't change the `parameter` type (`argument` without pointer
indirection) causing 2+ deep propagation of depth images with function
arguments to fail.