### PR TITLE
glsl-in: Splat inputs for smoothstep if needed

### DIFF
--- a/src/front/glsl/builtins.rs
+++ b/src/front/glsl/builtins.rs
@@ -1556,7 +1556,7 @@ fn inject_common_builtin(
                 };
                 declaration.overloads.push(module.add_builtin(
                     vec![ty(), ty(), base_ty()],
-                    MacroCall::MathFunction(MathFunction::SmoothStep),
+                    MacroCall::SmoothStep { splatted: size },
                 ))
             }
         }
@@ -1604,6 +1604,12 @@ pub enum MacroCall {
     BitCast(Sk),
     Derivate(DerivativeAxis),
     Barrier,
+    /// SmoothStep needs a separate variant because it might need it's inputs
+    /// to be splatted depending on the overload
+    SmoothStep {
+        /// The size of the splat operation if some
+        splatted: Option<VectorSize>,
+    },
 }
 
 impl MacroCall {
@@ -2071,6 +2077,22 @@ impl MacroCall {
                 ctx.emit_restart(body);
                 body.push(crate::Statement::Barrier(crate::Barrier::all()), meta);
                 return Ok(None);
+            }
+            MacroCall::SmoothStep { splatted } => {
+                ctx.implicit_splat(parser, &mut args[0], meta, splatted)?;
+                ctx.implicit_splat(parser, &mut args[1], meta, splatted)?;
+
+                ctx.add_expression(
+                    Expression::Math {
+                        fun: MathFunction::SmoothStep,
+                        arg: args[0],
+                        arg1: args.get(1).copied(),
+                        arg2: args.get(2).copied(),
+                        arg3: None,
+                    },
+                    Span::default(),
+                    body,
+                )
             }
         }))
     }

--- a/tests/in/glsl/math-functions.vert
+++ b/tests/in/glsl/math-functions.vert
@@ -53,4 +53,7 @@ void main() {
     // float ldexpOut = ldexp(a.x, i);
     vec4 rad = radians(a);
     float deg = degrees(a.x);
+    float smoothStepScalar = smoothstep(0.0, 1.0, 0.5);
+    vec4 smoothStepVector = smoothstep(vec4(0.0), vec4(1.0), vec4(0.5));
+    vec4 smoothStepMixed = smoothstep(0.0, 1.0, vec4(0.5));
 }

--- a/tests/out/wgsl/math-functions-vert.wgsl
+++ b/tests/out/wgsl/math-functions-vert.wgsl
@@ -44,6 +44,9 @@ fn main_1() {
     var stepOut: vec4<f32>;
     var rad: vec4<f32>;
     var deg: f32;
+    var smoothStepScalar: f32;
+    var smoothStepVector: vec4<f32>;
+    var smoothStepMixed: vec4<f32>;
 
     _ = vec4<f32>(1.0);
     _ = vec4<f32>(2.0);
@@ -205,6 +208,13 @@ fn main_1() {
     _ = _e233.x;
     let _e235 = a;
     deg = degrees(_e235.x);
+    smoothStepScalar = smoothstep(0.0, 1.0, 0.5);
+    _ = vec4<f32>(0.0);
+    _ = vec4<f32>(1.0);
+    _ = vec4<f32>(0.5);
+    smoothStepVector = smoothstep(vec4<f32>(0.0), vec4<f32>(1.0), vec4<f32>(0.5));
+    _ = vec4<f32>(0.5);
+    smoothStepMixed = smoothstep(vec4<f32>(0.0), vec4<f32>(1.0), vec4<f32>(0.5));
     return;
 }
 


### PR DESCRIPTION
Glsl defines two overloads for smoothstep that accept `min` and `max` as
scalars and the value as a vector, naga's IR is stricter and only allows
operators with the same dimensions, so this inputs must be splatted.

closes #1971