### PR TITLE
glsl-out: Perform casts in int only math functions

### DIFF
--- a/tests/in/math-functions.wgsl
+++ b/tests/in/math-functions.wgsl
@@ -7,4 +7,5 @@ fn main() {
     let c = degrees(v);
     let d = radians(v);
     let const_dot = dot(vec2<i32>(), vec2<i32>());
+    let first_leading_bit_abs = firstLeadingBit(abs(0u));
 }

--- a/tests/out/glsl/math-functions.main.Vertex.glsl
+++ b/tests/out/glsl/math-functions.main.Vertex.glsl
@@ -11,5 +11,6 @@ void main() {
     vec4 c = degrees(v);
     vec4 d = radians(v);
     int const_dot = ( + ivec2(0, 0).x * ivec2(0, 0).x + ivec2(0, 0).y * ivec2(0, 0).y);
+    uint first_leading_bit_abs = uint(findMSB(uint(abs(int(0u)))));
 }
 

--- a/tests/out/hlsl/math-functions.hlsl
+++ b/tests/out/hlsl/math-functions.hlsl
@@ -7,4 +7,5 @@ void main()
     float4 c = degrees(v);
     float4 d = radians(v);
     int const_dot = dot(int2(0, 0), int2(0, 0));
+    uint first_leading_bit_abs = firstbithigh(abs(0u));
 }

--- a/tests/out/msl/math-functions.msl
+++ b/tests/out/msl/math-functions.msl
@@ -14,4 +14,5 @@ vertex void main_(
     metal::float4 c = ((v) * 57.295779513082322865);
     metal::float4 d = ((v) * 0.017453292519943295474);
     int const_dot = ( + const_type.x * const_type.x + const_type.y * const_type.y);
+    uint first_leading_bit_abs = (((metal::clz(metal::abs(0u)) + 1) % 33) - 1);
 }

--- a/tests/out/spv/math-functions.spvasm
+++ b/tests/out/spv/math-functions.spvasm
@@ -1,38 +1,42 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 29
+; Bound: 33
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Vertex %11 "main"
+OpEntryPoint Vertex %13 "main"
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpConstant  %4  1.0
 %5 = OpConstant  %4  0.0
 %7 = OpTypeInt 32 1
 %6 = OpConstant  %7  0
-%8 = OpTypeVector %7 2
-%9 = OpConstantComposite  %8  %6 %6
-%12 = OpTypeFunction %2
-%14 = OpTypeVector %4 4
-%21 = OpConstantNull  %7
-%11 = OpFunction  %2  None %12
-%10 = OpLabel
-OpBranch %13
-%13 = OpLabel
-%15 = OpCompositeConstruct  %14  %5 %5 %5 %5
-%16 = OpExtInst  %4  %1 Degrees %3
-%17 = OpExtInst  %4  %1 Radians %3
-%18 = OpExtInst  %14  %1 Degrees %15
-%19 = OpExtInst  %14  %1 Radians %15
-%22 = OpCompositeExtract  %7  %9 0
-%23 = OpCompositeExtract  %7  %9 0
-%24 = OpIMul  %7  %22 %23
-%25 = OpIAdd  %7  %21 %24
-%26 = OpCompositeExtract  %7  %9 1
-%27 = OpCompositeExtract  %7  %9 1
-%28 = OpIMul  %7  %26 %27
-%20 = OpIAdd  %7  %25 %28
+%9 = OpTypeInt 32 0
+%8 = OpConstant  %9  0
+%10 = OpTypeVector %7 2
+%11 = OpConstantComposite  %10  %6 %6
+%14 = OpTypeFunction %2
+%16 = OpTypeVector %4 4
+%23 = OpConstantNull  %7
+%13 = OpFunction  %2  None %14
+%12 = OpLabel
+OpBranch %15
+%15 = OpLabel
+%17 = OpCompositeConstruct  %16  %5 %5 %5 %5
+%18 = OpExtInst  %4  %1 Degrees %3
+%19 = OpExtInst  %4  %1 Radians %3
+%20 = OpExtInst  %16  %1 Degrees %17
+%21 = OpExtInst  %16  %1 Radians %17
+%24 = OpCompositeExtract  %7  %11 0
+%25 = OpCompositeExtract  %7  %11 0
+%26 = OpIMul  %7  %24 %25
+%27 = OpIAdd  %7  %23 %26
+%28 = OpCompositeExtract  %7  %11 1
+%29 = OpCompositeExtract  %7  %11 1
+%30 = OpIMul  %7  %28 %29
+%22 = OpIAdd  %7  %27 %30
+%31 = OpCopyObject  %9  %8
+%32 = OpExtInst  %9  %1 FindUMsb %31
 OpReturn
 OpFunctionEnd

--- a/tests/out/wgsl/math-functions.wgsl
+++ b/tests/out/wgsl/math-functions.wgsl
@@ -6,4 +6,5 @@ fn main() {
     let c = degrees(v);
     let d = radians(v);
     let const_dot = dot(vec2<i32>(0, 0), vec2<i32>(0, 0));
+    let first_leading_bit_abs = firstLeadingBit(abs(0u));
 }


### PR DESCRIPTION
Some functions like abs only accept signed integers while naga's IR
accepts both signed and unsigned integers, this wasn't accounted for in
the glsl backend causing it to produce code that wouldn't type check.

This commit addresses it by performing casts from uint to int of the
function argument and then back from int to uint for the function
return.


closes #1968

~~Edit: found some problems that need to be fixed first~~

Edit2: Good to go now