### PR TITLE
[wgsl-in] Implement complete validation for size and align attributes

### DIFF
--- a/src/back/hlsl/conv.rs
+++ b/src/back/hlsl/conv.rs
@@ -1,5 +1,7 @@
 use std::borrow::Cow;
 
+use crate::proc::Alignment;
+
 use super::Error;
 
 impl crate::ScalarKind {
@@ -49,8 +51,7 @@ impl crate::TypeInner {
                 rows,
                 width,
             } => {
-                let aligned_rows = if rows > crate::VectorSize::Bi { 4 } else { 2 };
-                let stride = aligned_rows * width as u32;
+                let stride = Alignment::from(rows) * width as u32;
                 let last_row_size = rows as u32 * width as u32;
                 ((columns as u32 - 1) * stride) + last_row_size
             }

--- a/src/back/hlsl/storage.rs
+++ b/src/back/hlsl/storage.rs
@@ -6,7 +6,7 @@ HLSL backend uses byte address buffers for all storage buffers in IR.
 
 use super::{super::FunctionCtx, BackendResult, Error};
 use crate::{
-    proc::{NameKey, TypeResolution},
+    proc::{Alignment, NameKey, TypeResolution},
     Handle,
 };
 
@@ -130,11 +130,7 @@ impl<W: fmt::Write> super::Writer<'_, W> {
                 )?;
 
                 // Note: Matrices containing vec3s, due to padding, act like they contain vec4s.
-                let padded_rows = match rows {
-                    crate::VectorSize::Tri => 4,
-                    rows => rows as u32,
-                };
-                let row_stride = width as u32 * padded_rows;
+                let row_stride = Alignment::from(rows) * width as u32;
                 let iter = (0..columns as u32).map(|i| {
                     let ty_inner = crate::TypeInner::Vector {
                         size: rows,
@@ -277,11 +273,7 @@ impl<W: fmt::Write> super::Writer<'_, W> {
                 writeln!(self.out, ";")?;
 
                 // Note: Matrices containing vec3s, due to padding, act like they contain vec4s.
-                let padded_rows = match rows {
-                    crate::VectorSize::Tri => 4,
-                    rows => rows as u32,
-                };
-                let row_stride = width as u32 * padded_rows;
+                let row_stride = Alignment::from(rows) * width as u32;
 
                 // then iterate the stores
                 for i in 0..columns as u32 {
@@ -409,12 +401,7 @@ impl<W: fmt::Write> super::Writer<'_, W> {
                         stride: width as u32,
                     },
                     crate::TypeInner::Matrix { columns, width, .. } => Parent::Array {
-                        stride: width as u32
-                            * if columns > crate::VectorSize::Bi {
-                                4
-                            } else {
-                                2
-                            },
+                        stride: Alignment::from(columns) * width as u32,
                     },
                     _ => unreachable!(),
                 },

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::{
     arena::{Handle, UniqueArena},
     back::spv::BindingInfo,
-    proc::TypeResolution,
+    proc::{Alignment, TypeResolution},
     valid::{FunctionInfo, ModuleInfo},
 };
 use spirv::Word;
@@ -1379,10 +1379,7 @@ impl Writer {
             width,
         } = *member_array_subty_inner
         {
-            let byte_stride = match rows {
-                crate::VectorSize::Bi => 2 * width,
-                crate::VectorSize::Tri | crate::VectorSize::Quad => 4 * width,
-            };
+            let byte_stride = Alignment::from(rows) * width as u32;
             self.annotations.push(Instruction::member_decorate(
                 struct_id,
                 index as u32,
@@ -1393,7 +1390,7 @@ impl Writer {
                 struct_id,
                 index as u32,
                 Decoration::MatrixStride,
-                &[byte_stride as u32],
+                &[byte_stride],
             ));
         }
 

--- a/src/front/mod.rs
+++ b/src/front/mod.rs
@@ -133,20 +133,3 @@ impl ops::Index<Handle<crate::Expression>> for Typifier {
         &self.resolutions[handle.index()]
     }
 }
-
-/// Helper function used for aligning `value` to the next multiple of `align`
-///
-/// # Notes:
-/// - `align` must be a power of two.
-/// - The returned value will be greater or equal to `value`.
-/// # Examples:
-/// ```ignore
-/// assert_eq!(0, align_up(0, 16));
-/// assert_eq!(16, align_up(1, 16));
-/// assert_eq!(16, align_up(16, 16));
-/// assert_eq!(334, align_up(333, 2));
-/// assert_eq!(384, align_up(257, 128));
-/// ```
-pub const fn align_up(value: u32, align: u32) -> u32 {
-    ((value.wrapping_sub(1)) & !(align - 1)).wrapping_add(align)
-}

--- a/src/front/wgsl/construction.rs
+++ b/src/front/wgsl/construction.rs
@@ -196,9 +196,7 @@ fn parse_constructor_type<'a>(
         }
         (Token::Paren('<'), ConstructorType::PartialArray) => {
             lexer.expect_generic_paren('<')?;
-            let base = parser
-                .parse_type_decl(lexer, None, type_arena, const_arena)?
-                .0;
+            let base = parser.parse_type_decl(lexer, None, type_arena, const_arena)?;
             let size = if lexer.skip(Token::Separator(',')) {
                 let const_handle = parser.parse_const_expression(lexer, type_arena, const_arena)?;
                 ArraySize::Constant(const_handle)

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -2816,7 +2816,7 @@ impl Parser {
                         let (value, span) =
                             lexer.capture_span(Self::parse_non_negative_i32_literal)?;
                         lexer.expect(Token::Paren(')'))?;
-                        align = Some(NonZeroU32::new(value).ok_or(Error::ZeroSizeOrAlign(span))?);
+                        align = Some(Alignment::new(value).ok_or(Error::ZeroSizeOrAlign(span))?);
                     }
                     (word, word_span) => bind_parser.parse(lexer, word, word_span)?,
                 }
@@ -2852,7 +2852,7 @@ impl Parser {
             });
         }
 
-        let span = Layouter::round_up(alignment, offset);
+        let span = alignment.round_up(offset);
         Ok((members, span))
     }
 

--- a/src/front/wgsl/tests.rs
+++ b/src/front/wgsl/tests.rs
@@ -91,7 +91,7 @@ fn parse_struct() {
         struct Bar {
             @size(16) x: vec2<i32>,
             @align(16) y: f32,
-            @size(32) @align(8) z: vec3<f32>,
+            @size(32) @align(128) z: vec3<f32>,
         };
         struct Empty {}
         var<storage,read_write> s: Foo;

--- a/src/proc/layouter.rs
+++ b/src/proc/layouter.rs
@@ -151,32 +151,6 @@ impl Layouter {
         self.layouts.clear();
     }
 
-    /// Return the offset and span of a struct member.
-    ///
-    /// The member must fall at or after `offset`. The member's alignment and
-    /// size are `align` and `size` if given, defaulting to the values this
-    /// `Layouter` has previously determined for `ty`.
-    ///
-    /// The return value is the range of offsets within the containing struct to
-    /// reserve for this member, along with the alignment used. The containing
-    /// struct must have sufficient space and alignment to accommodate these.
-    pub fn member_placement(
-        &self,
-        offset: u32,
-        ty: Handle<crate::Type>,
-        align: Option<Alignment>,
-        size: Option<NonZeroU32>,
-    ) -> (ops::Range<u32>, Alignment) {
-        let layout = self.layouts[ty.index()];
-        let alignment = align.unwrap_or(layout.alignment);
-        let start = alignment.round_up(offset);
-        let span = match size {
-            Some(size) => size.get(),
-            None => layout.size,
-        };
-        (start..start + span, alignment)
-    }
-
     /// Extend this `Layouter` with layouts for any new entries in `types`.
     ///
     /// Ensure that every type in `types` has a corresponding [TypeLayout] in

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -113,10 +113,7 @@ impl super::TypeInner {
                 columns,
                 rows,
                 width,
-            } => {
-                let aligned_rows = if rows > crate::VectorSize::Bi { 4 } else { 2 };
-                columns as u32 * aligned_rows * width as u32
-            }
+            } => Alignment::from(rows) * width as u32 * columns as u32,
             Self::Pointer { .. } | Self::ValuePointer { .. } => POINTER_SPAN,
             Self::Array {
                 base: _,

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -428,36 +428,54 @@ fn unknown_conservative_depth() {
 }
 
 #[test]
-fn struct_member_zero_size() {
+fn struct_member_size_too_low() {
     check(
         r#"
             struct Bar {
                 @size(0) data: array<f32>
             }
         "#,
-        r#"error: struct member size or alignment must not be 0
+        r#"error: struct member size must be at least 4
   ┌─ wgsl:3:23
   │
 3 │                 @size(0) data: array<f32>
-  │                       ^ struct member size or alignment must not be 0
+  │                       ^ must be at least 4
 
 "#,
     );
 }
 
 #[test]
-fn struct_member_zero_align() {
+fn struct_member_align_too_low() {
     check(
         r#"
             struct Bar {
-                @align(0) data: array<f32>
+                @align(8) data: vec3<f32>
             }
         "#,
-        r#"error: struct member size or alignment must not be 0
+        r#"error: struct member alignment must be at least 16
   ┌─ wgsl:3:24
   │
-3 │                 @align(0) data: array<f32>
-  │                        ^ struct member size or alignment must not be 0
+3 │                 @align(8) data: vec3<f32>
+  │                        ^ must be at least 16
+
+"#,
+    );
+}
+
+#[test]
+fn struct_member_non_po2_align() {
+    check(
+        r#"
+            struct Bar {
+                @align(7) data: array<f32>
+            }
+        "#,
+        r#"error: struct member alignment must be a power of 2
+  ┌─ wgsl:3:24
+  │
+3 │                 @align(7) data: array<f32>
+  │                        ^ must be a power of 2
 
 "#,
     );


### PR DESCRIPTION
From the WGSL spec:

### align

> [Must](https://gpuweb.github.io/gpuweb/wgsl/#shader-creation-error) be a power of 2, and [must](https://gpuweb.github.io/gpuweb/wgsl/#shader-creation-error) satisfy the required-alignment for the member type:
> 
> If align(n) is applied to a member of S with type T, and S is the [store type](https://gpuweb.github.io/gpuweb/wgsl/#store-type) or contained in the store type for a variable in address space C, then n [must](https://gpuweb.github.io/gpuweb/wgsl/#shader-creation-error) satisfy: n = k × [RequiredAlignOf](https://gpuweb.github.io/gpuweb/wgsl/#requiredalignof)(T,C) for some positive integer k.

### size

> This number [must](https://gpuweb.github.io/gpuweb/wgsl/#shader-creation-error) be at least the [byte-size](https://gpuweb.github.io/gpuweb/wgsl/#byte-size) of the type of the member:
>
> If size(n) is applied to a member with type T, then [SizeOf](https://gpuweb.github.io/gpuweb/wgsl/#sizeof)(T) ≤ n.

## Note

- tests have been modified accordingly
- commits are self-contained