### PR TITLE
glsl-in: switch statement fixes

### DIFF
--- a/tests/in/glsl/statements.frag
+++ b/tests/in/glsl/statements.frag
@@ -1,0 +1,27 @@
+#version 460 core
+
+void switchEmpty(int a) {
+    switch (a) {}
+
+    return;
+}
+
+void switchNoDefault(int a) {
+    switch (a) {
+        case 0:
+            break;
+    }
+
+    return;
+}
+
+void switchNoLastBreak(int a) {
+    switch (a) {
+        default:
+            int b = a;
+    }
+
+    return;
+}
+
+void main() {}

--- a/tests/out/wgsl/statements-frag.wgsl
+++ b/tests/out/wgsl/statements-frag.wgsl
@@ -1,0 +1,50 @@
+fn switchEmpty(a: i32) {
+    var a_1: i32;
+
+    a_1 = a;
+    let _e2 = a_1;
+    switch _e2 {
+        default: {
+        }
+    }
+    return;
+}
+
+fn switchNoDefault(a_2: i32) {
+    var a_3: i32;
+
+    a_3 = a_2;
+    let _e2 = a_3;
+    switch _e2 {
+        case 0: {
+        }
+        default: {
+        }
+    }
+    return;
+}
+
+fn switchNoLastBreak(a_4: i32) {
+    var a_5: i32;
+    var b: i32;
+
+    a_5 = a_4;
+    let _e2 = a_5;
+    switch _e2 {
+        default: {
+            let _e3 = a_5;
+            b = _e3;
+        }
+    }
+    return;
+}
+
+fn main_1() {
+    return;
+}
+
+@fragment 
+fn main() {
+    main_1();
+    return;
+}


### PR DESCRIPTION
GLSL allows the last case of a switch statement to not have a `break`
statement causing it to be marked as fall-trough, naga's IR on the other
hand doesn't allow the last case to be fall-trough, this is fixed by
force marking it in the glsl frontend as not fall-trough.

GLSL also allows empty switch statements and without default cases,
naga's IR requires there be a default case, this is fixed by adding an
empty default case in the glsl frontend if no default case was present
in the switch statement.

Finally, the GLSL spec forbids switch statements with an empty last case, so we
check that now and throw an error if necessary.

closes #1959