### PR TITLE
Patch ron version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,10 @@ unicode-xid = { version = "0.2.3", optional = true }
 bincode = "1"
 criterion = { version = "0.3", features = [] }
 diff = "0.1"
-ron = "0.7"
+# Require at least version 0.7.1 of ron, this version changed how floating points are
+# serialized by forcing them to always have the decimal part, this makes it backwards
+# incompatible with our tests because we do a syntatic diff and not a semantic one.
+ron = "~0.7.1"
 serde = { version = "1.0", features = ["derive"] }
 spirv = { version = "0.2", features = ["deserialize"] }
 rspirv = "0.11"

--- a/tests/out/ir/shadow.ron
+++ b/tests/out/ir/shadow.ron
@@ -324,7 +324,7 @@
             specialization: None,
             inner: Scalar(
                 width: 4,
-                value: Float(0),
+                value: Float(0.0),
             ),
         ),
         (
@@ -332,7 +332,7 @@
             specialization: None,
             inner: Scalar(
                 width: 4,
-                value: Float(1),
+                value: Float(1.0),
             ),
         ),
         (
@@ -400,7 +400,7 @@
             specialization: None,
             inner: Scalar(
                 width: 4,
-                value: Float(0),
+                value: Float(0.0),
             ),
         ),
         (


### PR DESCRIPTION
Require at least version 0.7.1 of ron, this version changed how floating points are
serialized by forcing them to always have the decimal part, this makes it backwards
incompatible with our tests because we do a syntatic diff and not a semantic one.