### PR TITLE
glsl-out: Fix indentation for continuing block

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1805,11 +1805,12 @@ impl<'a, W: Write> Writer<'a, W> {
                     let gate_name = self.namer.call("loop_init");
                     writeln!(self.out, "{}bool {} = true;", level, gate_name)?;
                     writeln!(self.out, "{}while(true) {{", level)?;
-                    writeln!(self.out, "{}if (!{}) {{", level.next(), gate_name)?;
+                    let l2 = level.next();
+                    writeln!(self.out, "{}if (!{}) {{", l2, gate_name)?;
                     for sta in continuing {
-                        self.write_stmt(sta, ctx, level.next())?;
+                        self.write_stmt(sta, ctx, l2.next())?;
                     }
-                    writeln!(self.out, "{}}}", level.next())?;
+                    writeln!(self.out, "{}}}", l2)?;
                     writeln!(self.out, "{}{} = false;", level.next(), gate_name)?;
                 } else {
                     writeln!(self.out, "{}while(true) {{", level)?;

--- a/tests/out/glsl/boids.main.Compute.glsl
+++ b/tests/out/glsl/boids.main.Compute.glsl
@@ -55,8 +55,8 @@ void main() {
     bool loop_init = true;
     while(true) {
         if (!loop_init) {
-        uint _e86 = i;
-        i = (_e86 + 1u);
+            uint _e86 = i;
+            i = (_e86 + 1u);
         }
         loop_init = false;
         uint _e37 = i;

--- a/tests/out/glsl/shadow.fs_main.Fragment.glsl
+++ b/tests/out/glsl/shadow.fs_main.Fragment.glsl
@@ -52,8 +52,8 @@ void main() {
     bool loop_init = true;
     while(true) {
         if (!loop_init) {
-        uint _e20 = i;
-        i = (_e20 + 1u);
+            uint _e20 = i;
+            i = (_e20 + 1u);
         }
         loop_init = false;
         uint _e14 = i;

--- a/tests/out/glsl/shadow.fs_main_without_storage.Fragment.glsl
+++ b/tests/out/glsl/shadow.fs_main_without_storage.Fragment.glsl
@@ -52,8 +52,8 @@ void main() {
     bool loop_init = true;
     while(true) {
         if (!loop_init) {
-        uint _e20 = i_1;
-        i_1 = (_e20 + 1u);
+            uint _e20 = i_1;
+            i_1 = (_e20 + 1u);
         }
         loop_init = false;
         uint _e14 = i_1;


### PR DESCRIPTION
The continuing block in glsl was being generated with the same indentation as the loop body