### PR TITLE
hlsl-out: Fix indentation for continuing block

### DIFF
--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -1505,7 +1505,7 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                     writeln!(self.out, "{}while(true) {{", level)?;
                     writeln!(self.out, "{}if (!{}) {{", l2, gate_name)?;
                     for sta in continuing.iter() {
-                        self.write_stmt(module, sta, func_ctx, l2)?;
+                        self.write_stmt(module, sta, func_ctx, l2.next())?;
                     }
                     writeln!(self.out, "{}}}", level.next())?;
                     writeln!(self.out, "{}{} = false;", level.next(), gate_name)?;

--- a/tests/out/hlsl/boids.hlsl
+++ b/tests/out/hlsl/boids.hlsl
@@ -47,8 +47,8 @@ void main(uint3 global_invocation_id : SV_DispatchThreadID)
     bool loop_init = true;
     while(true) {
         if (!loop_init) {
-        uint _expr86 = i;
-        i = (_expr86 + 1u);
+            uint _expr86 = i;
+            i = (_expr86 + 1u);
         }
         loop_init = false;
         uint _expr37 = i;

--- a/tests/out/hlsl/shadow.hlsl
+++ b/tests/out/hlsl/shadow.hlsl
@@ -95,8 +95,8 @@ float4 fs_main(FragmentInput_fs_main fragmentinput_fs_main) : SV_Target0
     bool loop_init = true;
     while(true) {
         if (!loop_init) {
-        uint _expr20 = i;
-        i = (_expr20 + 1u);
+            uint _expr20 = i;
+            i = (_expr20 + 1u);
         }
         loop_init = false;
         uint _expr14 = i;
@@ -129,8 +129,8 @@ float4 fs_main_without_storage(FragmentInput_fs_main_without_storage fragmentinp
     bool loop_init_1 = true;
     while(true) {
         if (!loop_init_1) {
-        uint _expr20 = i_1;
-        i_1 = (_expr20 + 1u);
+            uint _expr20 = i_1;
+            i_1 = (_expr20 + 1u);
         }
         loop_init_1 = false;
         uint _expr14 = i_1;


### PR DESCRIPTION
The continuing block in hlsl was being generated with the same indentation as the loop body