### PR TITLE
Add support for break if

### DIFF
--- a/src/back/dot/mod.rs
+++ b/src/back/dot/mod.rs
@@ -81,11 +81,15 @@ impl StatementGraph {
                 S::Loop {
                     ref body,
                     ref continuing,
+                    break_if,
                 } => {
                     let body_id = self.add(body);
                     self.flow.push((id, body_id, "body"));
                     let continuing_id = self.add(continuing);
                     self.flow.push((body_id, continuing_id, "continuing"));
+                    if let Some(expr) = break_if {
+                        self.dependencies.push((id, expr, "break if"));
+                    }
                     "Loop"
                 }
                 S::Return { value } => {

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -574,7 +574,12 @@ impl Writer {
         context
             .function
             .consume(prelude, Instruction::branch(main_id));
-        context.write_block(main_id, &ir_function.body, None, LoopContext::default())?;
+        context.write_block(
+            main_id,
+            &ir_function.body,
+            super::block::BlockExit::Return,
+            LoopContext::default(),
+        )?;
 
         // Consume the `BlockContext`, ending its borrows and letting the
         // `Writer` steal back its cached expression table and temp_list.

--- a/src/front/glsl/parser/functions.rs
+++ b/src/front/glsl/parser/functions.rs
@@ -358,6 +358,7 @@ impl<'source> ParsingContext<'source> {
                     Statement::Loop {
                         body: loop_body,
                         continuing: Block::new(),
+                        break_if: None,
                     },
                     meta,
                 );
@@ -411,6 +412,7 @@ impl<'source> ParsingContext<'source> {
                     Statement::Loop {
                         body: loop_body,
                         continuing: Block::new(),
+                        break_if: None,
                     },
                     meta,
                 );
@@ -513,6 +515,7 @@ impl<'source> ParsingContext<'source> {
                     Statement::Loop {
                         body: block,
                         continuing,
+                        break_if: None,
                     },
                     meta,
                 );

--- a/src/front/spv/function.rs
+++ b/src/front/spv/function.rs
@@ -556,7 +556,11 @@ impl<'function> BlockContext<'function> {
                         let continuing = lower_impl(blocks, bodies, continuing);
 
                         block.push(
-                            crate::Statement::Loop { body, continuing },
+                            crate::Statement::Loop {
+                                body,
+                                continuing,
+                                break_if: None,
+                            },
                             crate::Span::default(),
                         )
                     }

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -3565,6 +3565,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                 S::Loop {
                     ref mut body,
                     ref mut continuing,
+                    break_if: _,
                 } => {
                     self.patch_statements(body, expressions, fun_parameter_sampling)?;
                     self.patch_statements(continuing, expressions, fun_parameter_sampling)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1439,11 +1439,23 @@ pub enum Statement {
     /// this loop. (It may have `Break` and `Continue` statements targeting
     /// loops or switches nested within the `continuing` block.)
     ///
+    /// If present, `break_if` is an expression which is evaluated after the
+    /// continuing block. If its value is true, control continues after the
+    /// `Loop` statement, rather than branching back to the top of body as
+    /// usual. The `break_if` expression corresponds to a "break if" statement
+    /// in WGSL, or a loop whose back edge is an `OpBranchConditional`
+    /// instruction in SPIR-V.
+    ///
     /// [`Break`]: Statement::Break
     /// [`Continue`]: Statement::Continue
     /// [`Kill`]: Statement::Kill
     /// [`Return`]: Statement::Return
-    Loop { body: Block, continuing: Block },
+    /// [`break if`]: Self::Loop::break_if
+    Loop {
+        body: Block,
+        continuing: Block,
+        break_if: Option<Handle<Expression>>,
+    },
 
     /// Exits the innermost enclosing [`Loop`] or [`Switch`].
     ///

--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -841,6 +841,7 @@ impl FunctionInfo {
                 S::Loop {
                     ref body,
                     ref continuing,
+                    break_if: _,
                 } => {
                     let body_uniformity =
                         self.process_block(body, other_functions, disruptor, expression_arena)?;

--- a/tests/in/break-if.wgsl
+++ b/tests/in/break-if.wgsl
@@ -1,0 +1,32 @@
+@compute @workgroup_size(1)
+fn main() {}
+
+fn breakIfEmpty() {
+    loop {
+        continuing {
+            break if true;
+        }
+    }
+}
+
+fn breakIfEmptyBody(a: bool) {
+    loop {
+        continuing {
+            var b = a;
+            var c = a != b;
+
+            break if a == c;
+        }
+    }
+}
+
+fn breakIf(a: bool) {
+    loop {
+        var d = a;
+        var e = a != d;
+
+        continuing {
+            break if a == e;
+        }
+    }
+}

--- a/tests/out/glsl/break-if.main.Compute.glsl
+++ b/tests/out/glsl/break-if.main.Compute.glsl
@@ -1,0 +1,65 @@
+#version 310 es
+
+precision highp float;
+precision highp int;
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+
+void breakIfEmpty() {
+    bool loop_init = true;
+    while(true) {
+        if (!loop_init) {
+            if (true) {
+                break;
+            }
+        }
+        loop_init = false;
+    }
+    return;
+}
+
+void breakIfEmptyBody(bool a) {
+    bool b = false;
+    bool c = false;
+    bool loop_init_1 = true;
+    while(true) {
+        if (!loop_init_1) {
+            b = a;
+            bool _e2 = b;
+            c = (a != _e2);
+            bool _e5 = c;
+            bool unnamed = (a == _e5);
+            if (unnamed) {
+                break;
+            }
+        }
+        loop_init_1 = false;
+    }
+    return;
+}
+
+void breakIf(bool a_1) {
+    bool d = false;
+    bool e = false;
+    bool loop_init_2 = true;
+    while(true) {
+        if (!loop_init_2) {
+            bool _e5 = e;
+            bool unnamed_1 = (a_1 == _e5);
+            if (unnamed_1) {
+                break;
+            }
+        }
+        loop_init_2 = false;
+        d = a_1;
+        bool _e2 = d;
+        e = (a_1 != _e2);
+    }
+    return;
+}
+
+void main() {
+    return;
+}
+

--- a/tests/out/hlsl/break-if.hlsl
+++ b/tests/out/hlsl/break-if.hlsl
@@ -1,0 +1,64 @@
+
+void breakIfEmpty()
+{
+    bool loop_init = true;
+    while(true) {
+        if (!loop_init) {
+            if (true) {
+                break;
+            }
+        }
+        loop_init = false;
+    }
+    return;
+}
+
+void breakIfEmptyBody(bool a)
+{
+    bool b = (bool)0;
+    bool c = (bool)0;
+
+    bool loop_init_1 = true;
+    while(true) {
+        if (!loop_init_1) {
+            b = a;
+            bool _expr2 = b;
+            c = (a != _expr2);
+            bool _expr5 = c;
+            bool unnamed = (a == _expr5);
+            if (unnamed) {
+                break;
+            }
+        }
+        loop_init_1 = false;
+    }
+    return;
+}
+
+void breakIf(bool a_1)
+{
+    bool d = (bool)0;
+    bool e = (bool)0;
+
+    bool loop_init_2 = true;
+    while(true) {
+        if (!loop_init_2) {
+            bool _expr5 = e;
+            bool unnamed_1 = (a_1 == _expr5);
+            if (unnamed_1) {
+                break;
+            }
+        }
+        loop_init_2 = false;
+        d = a_1;
+        bool _expr2 = d;
+        e = (a_1 != _expr2);
+    }
+    return;
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    return;
+}

--- a/tests/out/hlsl/break-if.hlsl.config
+++ b/tests/out/hlsl/break-if.hlsl.config
@@ -1,0 +1,3 @@
+vertex=()
+fragment=()
+compute=(main:cs_5_1 )

--- a/tests/out/ir/collatz.ron
+++ b/tests/out/ir/collatz.ron
@@ -261,6 +261,7 @@
                         ),
                     ],
                     continuing: [],
+                    break_if: None,
                 ),
                 Emit((
                     start: 24,

--- a/tests/out/ir/shadow.ron
+++ b/tests/out/ir/shadow.ron
@@ -1320,6 +1320,7 @@
                             value: 120,
                         ),
                     ],
+                    break_if: None,
                 ),
                 Emit((
                     start: 120,

--- a/tests/out/msl/break-if.msl
+++ b/tests/out/msl/break-if.msl
@@ -1,0 +1,69 @@
+// language: metal2.0
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+
+void breakIfEmpty(
+) {
+    bool loop_init = true;
+    while(true) {
+        if (!loop_init) {
+            if (true) {
+                break;
+            }
+        }
+        loop_init = false;
+    }
+    return;
+}
+
+void breakIfEmptyBody(
+    bool a
+) {
+    bool b = {};
+    bool c = {};
+    bool loop_init_1 = true;
+    while(true) {
+        if (!loop_init_1) {
+            b = a;
+            bool _e2 = b;
+            c = a != _e2;
+            bool _e5 = c;
+            bool unnamed = a == _e5;
+            if (a == c) {
+                break;
+            }
+        }
+        loop_init_1 = false;
+    }
+    return;
+}
+
+void breakIf(
+    bool a_1
+) {
+    bool d = {};
+    bool e = {};
+    bool loop_init_2 = true;
+    while(true) {
+        if (!loop_init_2) {
+            bool _e5 = e;
+            bool unnamed_1 = a_1 == _e5;
+            if (a_1 == e) {
+                break;
+            }
+        }
+        loop_init_2 = false;
+        d = a_1;
+        bool _e2 = d;
+        e = a_1 != _e2;
+    }
+    return;
+}
+
+kernel void main_(
+) {
+    return;
+}

--- a/tests/out/spv/break-if.spvasm
+++ b/tests/out/spv/break-if.spvasm
@@ -1,0 +1,88 @@
+; SPIR-V
+; Version: 1.1
+; Generator: rspirv
+; Bound: 50
+OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %48 "main"
+OpExecutionMode %48 LocalSize 1 1 1
+%2 = OpTypeVoid
+%4 = OpTypeBool
+%3 = OpConstantTrue  %4
+%7 = OpTypeFunction %2
+%14 = OpTypePointer Function %4
+%15 = OpConstantNull  %4
+%17 = OpConstantNull  %4
+%21 = OpTypeFunction %2 %4
+%32 = OpConstantNull  %4
+%34 = OpConstantNull  %4
+%6 = OpFunction  %2  None %7
+%5 = OpLabel
+OpBranch %8
+%8 = OpLabel
+OpBranch %9
+%9 = OpLabel
+OpLoopMerge %10 %12 None
+OpBranch %11
+%11 = OpLabel
+OpBranch %12
+%12 = OpLabel
+OpBranchConditional %3 %10 %9
+%10 = OpLabel
+OpReturn
+OpFunctionEnd
+%20 = OpFunction  %2  None %21
+%19 = OpFunctionParameter  %4
+%18 = OpLabel
+%13 = OpVariable  %14  Function %15
+%16 = OpVariable  %14  Function %17
+OpBranch %22
+%22 = OpLabel
+OpBranch %23
+%23 = OpLabel
+OpLoopMerge %24 %26 None
+OpBranch %25
+%25 = OpLabel
+OpBranch %26
+%26 = OpLabel
+OpStore %13 %19
+%27 = OpLoad  %4  %13
+%28 = OpLogicalNotEqual  %4  %19 %27
+OpStore %16 %28
+%29 = OpLoad  %4  %16
+%30 = OpLogicalEqual  %4  %19 %29
+OpBranchConditional %30 %24 %23
+%24 = OpLabel
+OpReturn
+OpFunctionEnd
+%37 = OpFunction  %2  None %21
+%36 = OpFunctionParameter  %4
+%35 = OpLabel
+%31 = OpVariable  %14  Function %32
+%33 = OpVariable  %14  Function %34
+OpBranch %38
+%38 = OpLabel
+OpBranch %39
+%39 = OpLabel
+OpLoopMerge %40 %42 None
+OpBranch %41
+%41 = OpLabel
+OpStore %31 %36
+%43 = OpLoad  %4  %31
+%44 = OpLogicalNotEqual  %4  %36 %43
+OpStore %33 %44
+OpBranch %42
+%42 = OpLabel
+%45 = OpLoad  %4  %33
+%46 = OpLogicalEqual  %4  %36 %45
+OpBranchConditional %46 %40 %39
+%40 = OpLabel
+OpReturn
+OpFunctionEnd
+%48 = OpFunction  %2  None %7
+%47 = OpLabel
+OpBranch %49
+%49 = OpLabel
+OpReturn
+OpFunctionEnd

--- a/tests/out/wgsl/break-if.wgsl
+++ b/tests/out/wgsl/break-if.wgsl
@@ -1,0 +1,47 @@
+fn breakIfEmpty() {
+    loop {
+        continuing {
+            break if true;
+        }
+    }
+    return;
+}
+
+fn breakIfEmptyBody(a: bool) {
+    var b: bool;
+    var c: bool;
+
+    loop {
+        continuing {
+            b = a;
+            let _e2 = b;
+            c = (a != _e2);
+            let _e5 = c;
+            _ = (a == _e5);
+            break if (a == _e5);
+        }
+    }
+    return;
+}
+
+fn breakIf(a_1: bool) {
+    var d: bool;
+    var e: bool;
+
+    loop {
+        d = a_1;
+        let _e2 = d;
+        e = (a_1 != _e2);
+        continuing {
+            let _e5 = e;
+            _ = (a_1 == _e5);
+            break if (a_1 == _e5);
+        }
+    }
+    return;
+}
+
+@compute @workgroup_size(1, 1, 1) 
+fn main() {
+    return;
+}

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -527,6 +527,10 @@ fn convert_wgsl() {
             "binding-arrays",
             Targets::WGSL | Targets::HLSL | Targets::METAL | Targets::SPIRV,
         ),
+        (
+            "break-if",
+            Targets::WGSL | Targets::GLSL | Targets::SPIRV | Targets::HLSL | Targets::METAL,
+        ),
     ];
 
     for &(name, targets) in inputs.iter() {

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -1556,3 +1556,44 @@ fn host_shareable_types() {
         }
     }
 }
+
+#[test]
+fn misplaced_break_if() {
+    check(
+        "
+        fn test_misplaced_break_if() {
+            loop {
+                break if true;
+            }
+        }
+        ",
+        r###"error: A break if is only allowed in a continuing block
+  ┌─ wgsl:4:17
+  │
+4 │                 break if true;
+  │                 ^^^^^^^^ not in a continuing block
+
+"###,
+    );
+}
+
+#[test]
+fn break_if_bad_condition() {
+    check_validation! {
+        "
+        fn test_break_if_bad_condition() {
+            loop {
+                continuing {
+                    break if 1;
+                }
+            }
+        }
+        ":
+        Err(
+            naga::valid::ValidationError::Function {
+                error: naga::valid::FunctionError::InvalidIfType(_),
+                ..
+            },
+        )
+    }
+}


### PR DESCRIPTION
Adds support for the `break if` statement that may appear in the `continuing` block of a loop.

Relevant part of the spec: https://gpuweb.github.io/gpuweb/wgsl/#break-if-statement

Implements parsing in the wgsl frontend, emission on all the backends and validation for it.

Uniformity analysis isn't implemented, following the same behavior as regular breaks (this will be fixed in the uniformity analysis v5 rewrite).

All commits can be reviewed individually and are fully tested

Closes #1831