### PR TITLE
[hlsl-out] Use the namer to sanitise entrypoint input/output struct names

### DIFF
--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -199,8 +199,9 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
         }
 
         // Write all entry points wrapped structs
-        for ep in module.entry_points.iter() {
-            let ep_io = self.write_ep_interface(module, &ep.function, ep.stage, &ep.name)?;
+        for (index, ep) in module.entry_points.iter().enumerate() {
+            let ep_name = self.names[&NameKey::EntryPoint(index as u16)].clone();
+            let ep_io = self.write_ep_interface(module, &ep.function, ep.stage, &ep_name)?;
             self.entry_point_io.push(ep_io);
         }
 


### PR DESCRIPTION
This is especially relevant for shaders generated by rust-gpu.

Before:

```hlsl
struct VertexOutput_single_view::vertex_skybox_mirrored {
    float3 member_1 : LOC0;
    float4 member : SV_Position;
};
```

After:

```hlsl
struct VertexOutput_single_viewvertex_skybox_mirrored {
    float3 member_1 : LOC0;
    float4 member : SV_Position;
};
```