### PR TITLE
hlsl-out: Add support for push constants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ validate-wgsl: $(SNAPSHOTS_BASE_OUT)/wgsl/*.wgsl
 		cargo run $${file}; \
 	done
 
-validate-hlsl-dxc: SHELL:=/bin/bash # required because config files uses arrays
+validate-hlsl-dxc: SHELL:=/usr/bin/env bash # required because config files uses arrays
 validate-hlsl-dxc: $(SNAPSHOTS_BASE_OUT)/hlsl/*.hlsl
 	@set -e && for file in $^ ; do \
 		DXC_PARAMS="-Wno-parentheses-equality -Zi -Qembed_debug -Od"; \
@@ -94,7 +94,7 @@ validate-hlsl-dxc: $(SNAPSHOTS_BASE_OUT)/hlsl/*.hlsl
 		echo "======================"; \
 	done
 
-validate-hlsl-fxc: SHELL:=/bin/bash # required because config files uses arrays
+validate-hlsl-fxc: SHELL:=/usr/bin/env bash # required because config files uses arrays
 validate-hlsl-fxc: $(SNAPSHOTS_BASE_OUT)/hlsl/*.hlsl
 	@set -e && for file in $^ ; do \
 		FXC_PARAMS="-Zi -Od"; \

--- a/src/back/hlsl/mod.rs
+++ b/src/back/hlsl/mod.rs
@@ -189,6 +189,8 @@ pub struct Options {
     /// Add special constants to `SV_VertexIndex` and `SV_InstanceIndex`,
     /// to make them work like in Vulkan/Metal, with help of the host.
     pub special_constants_binding: Option<BindTarget>,
+    /// Bind target of the push constant buffer
+    pub push_constants_target: Option<BindTarget>,
 }
 
 impl Default for Options {
@@ -198,6 +200,7 @@ impl Default for Options {
             binding_map: BindingMap::default(),
             fake_missing_bindings: true,
             special_constants_binding: None,
+            push_constants_target: None,
         }
     }
 }

--- a/tests/in/push-constants.param.ron
+++ b/tests/in/push-constants.param.ron
@@ -12,7 +12,7 @@
 		shader_model: V5_1,
 		binding_map: {},
 		fake_missing_bindings: true,
-		special_constants_binding: None,
+		special_constants_binding: Some((space: 1, register: 0)),
 		push_constants_target: Some((space: 0, register: 0)),
 	),
 )

--- a/tests/in/push-constants.param.ron
+++ b/tests/in/push-constants.param.ron
@@ -8,4 +8,11 @@
 		writer_flags: (bits: 0),
 		binding_map: {},
 	),
+	hlsl: (
+		shader_model: V5_1,
+		binding_map: {},
+		fake_missing_bindings: true,
+		special_constants_binding: None,
+		push_constants_target: Some((space: 0, register: 0)),
+	),
 )

--- a/tests/in/push-constants.wgsl
+++ b/tests/in/push-constants.wgsl
@@ -7,6 +7,14 @@ struct FragmentIn {
     @location(0) color: vec4<f32>
 }
 
+@vertex
+fn vert_main(
+  @location(0) pos : vec2<f32>,
+  @builtin(vertex_index) vi: u32,
+) -> @builtin(position) vec4<f32> {
+    return vec4<f32>(f32(vi) * pc.multiplier * pos, 0.0, 1.0);
+}
+
 @fragment
 fn main(in: FragmentIn) -> @location(0) vec4<f32> {
     return in.color * pc.multiplier;

--- a/tests/out/glsl/push-constants.vert_main.Vertex.glsl
+++ b/tests/out/glsl/push-constants.vert_main.Vertex.glsl
@@ -1,0 +1,23 @@
+#version 320 es
+
+precision highp float;
+precision highp int;
+
+struct PushConstants {
+    float multiplier;
+};
+struct FragmentIn {
+    vec4 color;
+};
+uniform PushConstants pc;
+
+layout(location = 0) in vec2 _p2vs_location0;
+
+void main() {
+    vec2 pos = _p2vs_location0;
+    uint vi = uint(gl_VertexID);
+    float _e5 = pc.multiplier;
+    gl_Position = vec4(((float(vi) * _e5) * pos), 0.0, 1.0);
+    return;
+}
+

--- a/tests/out/hlsl/push-constants.hlsl
+++ b/tests/out/hlsl/push-constants.hlsl
@@ -1,3 +1,9 @@
+struct NagaConstants {
+    int base_vertex;
+    int base_instance;
+    uint other;
+};
+ConstantBuffer<NagaConstants> _NagaConstants: register(b0, space1);
 
 struct PushConstants {
     float multiplier;
@@ -12,6 +18,12 @@ ConstantBuffer<PushConstants> pc: register(b0);
 struct FragmentInput_main {
     float4 color : LOC0;
 };
+
+float4 vert_main(float2 pos : LOC0, uint vi : SV_VertexID) : SV_Position
+{
+    float _expr5 = pc.multiplier;
+    return float4(((float((_NagaConstants.base_vertex + vi)) * _expr5) * pos), 0.0, 1.0);
+}
 
 float4 main(FragmentInput_main fragmentinput_main) : SV_Target0
 {

--- a/tests/out/hlsl/push-constants.hlsl
+++ b/tests/out/hlsl/push-constants.hlsl
@@ -1,0 +1,21 @@
+
+struct PushConstants {
+    float multiplier;
+};
+
+struct FragmentIn {
+    float4 color : LOC0;
+};
+
+ConstantBuffer<PushConstants> pc: register(b0);
+
+struct FragmentInput_main {
+    float4 color : LOC0;
+};
+
+float4 main(FragmentInput_main fragmentinput_main) : SV_Target0
+{
+    FragmentIn in_ = { fragmentinput_main.color };
+    float _expr4 = pc.multiplier;
+    return (in_.color * _expr4);
+}

--- a/tests/out/hlsl/push-constants.hlsl.config
+++ b/tests/out/hlsl/push-constants.hlsl.config
@@ -1,0 +1,3 @@
+vertex=()
+fragment=(main:ps_5_1 )
+compute=()

--- a/tests/out/hlsl/push-constants.hlsl.config
+++ b/tests/out/hlsl/push-constants.hlsl.config
@@ -1,3 +1,3 @@
-vertex=()
+vertex=(vert_main:vs_5_1 )
 fragment=(main:ps_5_1 )
 compute=()

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -471,7 +471,7 @@ fn convert_wgsl() {
             Targets::SPIRV | Targets::METAL | Targets::HLSL | Targets::WGSL | Targets::GLSL,
         ),
         ("extra", Targets::SPIRV | Targets::METAL | Targets::WGSL),
-        ("push-constants", Targets::GLSL),
+        ("push-constants", Targets::GLSL | Targets::HLSL),
         (
             "operators",
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,


### PR DESCRIPTION
Push constants need to be configured by the consumer which must pass the
bind target of the constant buffer used for the push constants.

Closes #1782