### PR TITLE
[glsl-in] add support for .length()

### DIFF
--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -159,10 +159,14 @@ pub enum HirExprKind {
         /// The target expression
         expr: Handle<HirExpr>,
     },
-    /// a .length() on an array
-    GetLength {
-        /// the array
-        array: Handle<HirExpr>,
+    /// a `what.something(a, b, c)`
+    Method {
+        /// the object the method is being called on (`what` in the example)
+        object: Handle<HirExpr>,
+        /// the method name (`something` in the example)
+        name: String,
+        /// the arguments to the method (`a`, `b`, and `c` in the example)
+        args: Vec<Handle<HirExpr>>,
     },
 }
 

--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -159,10 +159,10 @@ pub enum HirExprKind {
         /// The target expression
         expr: Handle<HirExpr>,
     },
-    /// a `what.something(a, b, c)`
+    /// A method call like `what.something(a, b, c)`
     Method {
-        /// the object the method is being called on (`what` in the example)
-        object: Handle<HirExpr>,
+        /// expression the method call applies to (`what` in the example)
+        expr: Handle<HirExpr>,
         /// the method name (`something` in the example)
         name: String,
         /// the arguments to the method (`a`, `b`, and `c` in the example)

--- a/src/front/glsl/ast.rs
+++ b/src/front/glsl/ast.rs
@@ -159,6 +159,11 @@ pub enum HirExprKind {
         /// The target expression
         expr: Handle<HirExpr>,
     },
+    /// a .length() on an array
+    GetLength {
+        /// the array
+        array: Handle<HirExpr>,
+    },
 }
 
 #[derive(Debug, Hash, PartialEq, Eq)]

--- a/src/front/glsl/context.rs
+++ b/src/front/glsl/context.rs
@@ -1412,13 +1412,7 @@ impl Context {
                                     meta,
                                     body,
                                 );
-                                self.forced_conversion(
-                                    parser,
-                                    &mut array_length,
-                                    meta,
-                                    ScalarKind::Sint,
-                                    4,
-                                )?;
+                                self.conversion(&mut array_length, meta, ScalarKind::Sint, 4)?;
                                 array_length
                             }
                         }

--- a/src/front/glsl/context.rs
+++ b/src/front/glsl/context.rs
@@ -1399,16 +1399,21 @@ impl Context {
                             let t = &parser.module.types[t];
                             match t.inner {
                                 TypeInner::Array {
-                                    base: _,
                                     size: crate::ArraySize::Constant(size),
-                                    stride: _,
+                                    ..
                                 } => {
                                     let mut array_length =
                                         this.add_expression(Expression::Constant(size), meta, body);
-                                    this.conversion(&mut array_length, meta, ScalarKind::Sint, 4)?;
+                                    this.forced_conversion(
+                                        parser,
+                                        &mut array_length,
+                                        meta,
+                                        ScalarKind::Sint,
+                                        4,
+                                    )?;
                                     Ok(array_length)
                                 }
-                                TypeInner::Pointer { base, space: _ } => {
+                                TypeInner::Pointer { base, .. } => {
                                     handle_type(this, base, array, meta, body, parser)
                                 }
                                 // let the error be handled in type checking if it's not a dynamic array
@@ -1418,7 +1423,13 @@ impl Context {
                                         meta,
                                         body,
                                     );
-                                    this.conversion(&mut array_length, meta, ScalarKind::Sint, 4)?;
+                                    this.forced_conversion(
+                                        parser,
+                                        &mut array_length,
+                                        meta,
+                                        ScalarKind::Sint,
+                                        4,
+                                    )?;
                                     Ok(array_length)
                                 }
                             }

--- a/src/front/glsl/context.rs
+++ b/src/front/glsl/context.rs
@@ -1387,32 +1387,50 @@ impl Context {
                         }
                         let lowered_array =
                             self.lower_expect_inner(stmt, parser, object, pos, body)?.0;
-                        let array_type = parser.resolve_type(self, lowered_array, meta)?;
-                        match array_type {
-                            &TypeInner::Array {
-                                base: _,
-                                size: crate::ArraySize::Constant(size),
-                                stride: _,
-                            } => {
-                                let mut array_length = self.add_expression(
-                                    Expression::Constant(size),
-                                    stmt.hir_exprs[expr].meta,
-                                    body,
-                                );
-                                self.conversion(&mut array_length, meta, ScalarKind::Sint, 4)?;
-                                array_length
-                            }
-                            // let the error be handeled in type checking if it's not a dynamic array
-                            _ => {
-                                let mut array_length = self.add_expression(
-                                    Expression::ArrayLength(lowered_array),
-                                    stmt.hir_exprs[expr].meta,
-                                    body,
-                                );
-                                self.conversion(&mut array_length, meta, ScalarKind::Sint, 4)?;
-                                array_length
+                        let array_type = parser.resolve_type_handle(self, lowered_array, meta)?;
+                        fn handle_type(
+                            this: &mut Context,
+                            t: Handle<Type>,
+                            array: Handle<Expression>,
+                            meta: Span,
+                            body: &mut Block,
+                            parser: &Parser,
+                        ) -> Result<Handle<Expression>> {
+                            let t = &parser.module.types[t];
+                            match t.inner {
+                                TypeInner::Array {
+                                    base: _,
+                                    size: crate::ArraySize::Constant(size),
+                                    stride: _,
+                                } => {
+                                    let mut array_length =
+                                        this.add_expression(Expression::Constant(size), meta, body);
+                                    this.conversion(&mut array_length, meta, ScalarKind::Sint, 4)?;
+                                    Ok(array_length)
+                                }
+                                TypeInner::Pointer { base, space: _ } => {
+                                    handle_type(this, base, array, meta, body, parser)
+                                }
+                                // let the error be handled in type checking if it's not a dynamic array
+                                _ => {
+                                    let mut array_length = this.add_expression(
+                                        Expression::ArrayLength(array),
+                                        meta,
+                                        body,
+                                    );
+                                    this.conversion(&mut array_length, meta, ScalarKind::Sint, 4)?;
+                                    Ok(array_length)
+                                }
                             }
                         }
+                        handle_type(
+                            self,
+                            array_type,
+                            lowered_array,
+                            stmt.hir_exprs[expr].meta,
+                            body,
+                            parser,
+                        )?
                     }
                     _ => {
                         return Err(Error {

--- a/src/front/glsl/context.rs
+++ b/src/front/glsl/context.rs
@@ -1366,6 +1366,14 @@ impl Context {
                     value
                 }
             }
+            HirExprKind::GetLength { array } if ExprPos::Lhs != pos => {
+                let lowered_array = self.lower_expect_inner(stmt, parser, array, pos, body)?.0;
+                self.add_expression(
+                    Expression::ArrayLength(lowered_array),
+                    stmt.hir_exprs[expr].meta,
+                    body,
+                )
+            }
             _ => {
                 return Err(Error {
                     kind: ErrorKind::SemanticError(

--- a/src/front/glsl/parser/expressions.rs
+++ b/src/front/glsl/parser/expressions.rs
@@ -231,6 +231,23 @@ impl<'source> ParsingContext<'source> {
                 TokenValue::Dot => {
                     let (field, end_meta) = self.expect_ident(parser)?;
 
+                    if let Some(tok) = self.peek(parser) {
+                        if tok.value == TokenValue::LeftParen && field == "length" {
+                            let _l_paren = self.expect(parser, TokenValue::LeftParen)?;
+                            let r_paren = self.expect(parser, TokenValue::RightParen)?;
+                            // can be sure we are trying to access .length() now
+                            meta.subsume(r_paren.meta);
+                            base = stmt.hir_exprs.append(
+                                HirExpr {
+                                    kind: HirExprKind::GetLength { array: base },
+                                    meta,
+                                },
+                                Default::default(),
+                            );
+                            continue;
+                        }
+                    }
+
                     meta.subsume(end_meta);
                     base = stmt.hir_exprs.append(
                         HirExpr {

--- a/tests/in/glsl/expressions.frag
+++ b/tests/in/glsl/expressions.frag
@@ -132,6 +132,14 @@ void testMatrixMultiplication(mat4x3 a, mat4x4 b) {
     mat4x3 c = a * b;
 }
 
+layout(std430, binding = 0) buffer a_buf {
+    float a[];
+};
+
+void testLength() {
+    int len = a.length();
+}
+
 out vec4 o_color;
 void main() {
     privatePointer(global);

--- a/tests/in/glsl/expressions.frag
+++ b/tests/in/glsl/expressions.frag
@@ -140,6 +140,10 @@ void testLength() {
     int len = a.length();
 }
 
+void testConstantLength(float a[4u]) {
+    int len = a.length();
+}
+
 out vec4 o_color;
 void main() {
     privatePointer(global);

--- a/tests/out/wgsl/expressions-frag.wgsl
+++ b/tests/out/wgsl/expressions-frag.wgsl
@@ -2,11 +2,17 @@ struct BST {
     data: i32,
 }
 
+struct a_buf {
+    a: array<f32>,
+}
+
 struct FragmentOutput {
     @location(0) o_color: vec4<f32>,
 }
 
 var<private> global: f32;
+@group(0) @binding(0) 
+var<storage, read_write> global_1: a_buf;
 var<private> o_color: vec4<f32>;
 
 fn testBinOpVecFloat(a: vec4<f32>, b: f32) {
@@ -369,28 +375,37 @@ fn testMatrixMultiplication(a_22: mat4x3<f32>, b_18: mat4x4<f32>) {
     return;
 }
 
+fn testLength() {
+    var len: i32;
+
+    len = i32(arrayLength((&global_1.a)));
+    return;
+}
+
 fn main_1() {
     var local_5: f32;
 
+    _ = (&global_1.a);
     _ = global;
-    let _e3 = global;
-    local_5 = _e3;
+    let _e5 = global;
+    local_5 = _e5;
     privatePointer((&local_5));
-    let _e5 = local_5;
-    global = _e5;
-    let _e6 = o_color;
-    _ = _e6.xyzw;
-    let _e9 = vec4<f32>(1.0);
-    o_color.x = _e9.x;
-    o_color.y = _e9.y;
-    o_color.z = _e9.z;
-    o_color.w = _e9.w;
+    let _e7 = local_5;
+    global = _e7;
+    let _e8 = o_color;
+    _ = _e8.xyzw;
+    let _e11 = vec4<f32>(1.0);
+    o_color.x = _e11.x;
+    o_color.y = _e11.y;
+    o_color.z = _e11.z;
+    o_color.w = _e11.w;
     return;
 }
 
 @fragment 
 fn main() -> FragmentOutput {
+    _ = (&global_1.a);
     main_1();
-    let _e5 = o_color;
-    return FragmentOutput(_e5);
+    let _e7 = o_color;
+    return FragmentOutput(_e7);
 }

--- a/tests/out/wgsl/expressions-frag.wgsl
+++ b/tests/out/wgsl/expressions-frag.wgsl
@@ -382,6 +382,16 @@ fn testLength() {
     return;
 }
 
+fn testConstantLength(a_24: array<f32,4u>) {
+    var a_25: array<f32,4u>;
+    var len_1: i32 = 4;
+
+    _ = (&global_1.a);
+    a_25 = a_24;
+    _ = a_25;
+    _ = i32(4u);
+}
+
 fn main_1() {
     var local_5: f32;
 


### PR DESCRIPTION
this fixes #2016

i see two reasons you may not want to merge this
1. this assumes that .length() is only valid on arrays and never has any other meaning
2. this assumes that .length() has the same semantics as `Expression::ArrayLength`, which it may not have

other than that there should be no problems, other than that this was done in a hasty way