### PR TITLE
spv-out: Decorate integer builtins as Flat in the spirv writer

### DIFF
--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1225,6 +1225,26 @@ impl Writer {
                 };
 
                 self.decorate(id, Decoration::BuiltIn, &[built_in as u32]);
+
+                use crate::ScalarKind as Sk;
+
+                // Per the Vulkan spec, `VUID-StandaloneSpirv-Flat-04744`:
+                //
+                // > Any variable with integer or double-precision floating-
+                // > point type and with Input storage class in a fragment
+                // > shader, must be decorated Flat
+                let is_flat = match ir_module.types[ty].inner {
+                    crate::TypeInner::Scalar { kind, .. }
+                    | crate::TypeInner::Vector { kind, .. } => match kind {
+                        Sk::Uint | Sk::Sint | Sk::Bool => true,
+                        Sk::Float => false,
+                    },
+                    _ => false,
+                };
+
+                if is_flat {
+                    self.decorate(id, Decoration::Flat, &[]);
+                }
             }
         }
 

--- a/tests/out/spv/access.spvasm
+++ b/tests/out/spv/access.spvasm
@@ -98,6 +98,7 @@ OpDecorate %78 Binding 3
 OpDecorate %79 Block
 OpMemberDecorate %79 0 Offset 0
 OpDecorate %228 BuiltIn VertexIndex
+OpDecorate %228 Flat
 OpDecorate %231 BuiltIn Position
 OpDecorate %273 Location 0
 %2 = OpTypeVoid

--- a/tests/out/spv/boids.spvasm
+++ b/tests/out/spv/boids.spvasm
@@ -61,6 +61,7 @@ OpDecorate %26 DescriptorSet 0
 OpDecorate %26 Binding 2
 OpDecorate %19 Block
 OpDecorate %48 BuiltIn GlobalInvocationId
+OpDecorate %48 Flat
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 0
 %3 = OpConstant  %4  1500

--- a/tests/out/spv/collatz.spvasm
+++ b/tests/out/spv/collatz.spvasm
@@ -24,6 +24,7 @@ OpDecorate %11 DescriptorSet 0
 OpDecorate %11 Binding 0
 OpDecorate %9 Block
 OpDecorate %46 BuiltIn GlobalInvocationId
+OpDecorate %46 Flat
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 0
 %3 = OpConstant  %4  0

--- a/tests/out/spv/control-flow.spvasm
+++ b/tests/out/spv/control-flow.spvasm
@@ -8,6 +8,7 @@ OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %44 "main" %41
 OpExecutionMode %44 LocalSize 1 1 1
 OpDecorate %41 BuiltIn GlobalInvocationId
+OpDecorate %41 Flat
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 1
 %3 = OpConstant  %4  1

--- a/tests/out/spv/extra.spvasm
+++ b/tests/out/spv/extra.spvasm
@@ -17,6 +17,7 @@ OpDecorate %12 Block
 OpMemberDecorate %12 0 Offset 0
 OpDecorate %16 Location 0
 OpDecorate %19 BuiltIn PrimitiveId
+OpDecorate %19 Flat
 OpDecorate %22 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32

--- a/tests/out/spv/image.spvasm
+++ b/tests/out/spv/image.spvasm
@@ -95,7 +95,9 @@ OpDecorate %68 Binding 2
 OpDecorate %70 DescriptorSet 1
 OpDecorate %70 Binding 3
 OpDecorate %73 BuiltIn LocalInvocationId
+OpDecorate %73 Flat
 OpDecorate %119 BuiltIn LocalInvocationId
+OpDecorate %119 Flat
 OpDecorate %140 BuiltIn Position
 OpDecorate %193 BuiltIn Position
 OpDecorate %222 Location 0

--- a/tests/out/spv/interface.compute.spvasm
+++ b/tests/out/spv/interface.compute.spvasm
@@ -16,10 +16,15 @@ OpDecorate %16 ArrayStride 4
 OpMemberDecorate %18 0 Offset 0
 OpMemberDecorate %19 0 Offset 0
 OpDecorate %23 BuiltIn GlobalInvocationId
+OpDecorate %23 Flat
 OpDecorate %26 BuiltIn LocalInvocationId
+OpDecorate %26 Flat
 OpDecorate %28 BuiltIn LocalInvocationIndex
+OpDecorate %28 Flat
 OpDecorate %31 BuiltIn WorkgroupId
+OpDecorate %31 Flat
 OpDecorate %33 BuiltIn NumWorkgroups
+OpDecorate %33 Flat
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpConstant  %4  1.0

--- a/tests/out/spv/interface.fragment.spvasm
+++ b/tests/out/spv/interface.fragment.spvasm
@@ -21,10 +21,14 @@ OpDecorate %22 Invariant
 OpDecorate %22 BuiltIn FragCoord
 OpDecorate %25 Location 1
 OpDecorate %28 BuiltIn FrontFacing
+OpDecorate %28 Flat
 OpDecorate %31 BuiltIn SampleId
+OpDecorate %31 Flat
 OpDecorate %34 BuiltIn SampleMask
+OpDecorate %34 Flat
 OpDecorate %36 BuiltIn FragDepth
 OpDecorate %38 BuiltIn SampleMask
+OpDecorate %38 Flat
 OpDecorate %40 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32

--- a/tests/out/spv/interface.vertex.spvasm
+++ b/tests/out/spv/interface.vertex.spvasm
@@ -15,7 +15,9 @@ OpDecorate %16 ArrayStride 4
 OpMemberDecorate %18 0 Offset 0
 OpMemberDecorate %19 0 Offset 0
 OpDecorate %21 BuiltIn VertexIndex
+OpDecorate %21 Flat
 OpDecorate %24 BuiltIn InstanceIndex
+OpDecorate %24 Flat
 OpDecorate %26 Location 10
 OpDecorate %26 Flat
 OpDecorate %28 Invariant

--- a/tests/out/spv/interface.vertex_two_structs.spvasm
+++ b/tests/out/spv/interface.vertex_two_structs.spvasm
@@ -15,7 +15,9 @@ OpDecorate %16 ArrayStride 4
 OpMemberDecorate %18 0 Offset 0
 OpMemberDecorate %19 0 Offset 0
 OpDecorate %24 BuiltIn VertexIndex
+OpDecorate %24 Flat
 OpDecorate %28 BuiltIn InstanceIndex
+OpDecorate %28 Flat
 OpDecorate %30 Invariant
 OpDecorate %30 BuiltIn Position
 OpDecorate %32 BuiltIn PointSize

--- a/tests/out/spv/multiview.spvasm
+++ b/tests/out/spv/multiview.spvasm
@@ -9,6 +9,7 @@ OpExtension "SPV_KHR_multiview"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Vertex %8 "main" %5
 OpDecorate %5 BuiltIn ViewIndex
+OpDecorate %5 Flat
 %2 = OpTypeVoid
 %3 = OpTypeInt 32 1
 %6 = OpTypePointer Input %3

--- a/tests/out/spv/skybox.spvasm
+++ b/tests/out/spv/skybox.spvasm
@@ -25,6 +25,7 @@ OpDecorate %22 Binding 1
 OpDecorate %24 DescriptorSet 0
 OpDecorate %24 Binding 2
 OpDecorate %32 BuiltIn VertexIndex
+OpDecorate %32 Flat
 OpDecorate %35 BuiltIn Position
 OpDecorate %37 Location 0
 OpDecorate %83 BuiltIn FragCoord


### PR DESCRIPTION
Fixes #2032

Take what I write in this PR with a whole handful off salt, I'm new enough to naga and spirv that there's a decent chance I am jumping to conclusions.

See the investigation in #2032. My uneducated guess is that spirv wants the integer input builtins such as `primitive_index` to have the flat decoration. So I added that in fairly naive way.

This PR fixes the `primitive_index.wgsl` test case and doesn't appear to cause regressions as far as `cargo test --all` can tell.