### PR TITLE
spv-out: Don't decorate varyings with interpolation modes at pipeline start/end

### DIFF
--- a/tests/out/spv/interface.vertex.spvasm
+++ b/tests/out/spv/interface.vertex.spvasm
@@ -17,7 +17,6 @@ OpMemberDecorate %19 0 Offset 0
 OpDecorate %21 BuiltIn VertexIndex
 OpDecorate %24 BuiltIn InstanceIndex
 OpDecorate %26 Location 10
-OpDecorate %26 Flat
 OpDecorate %28 Invariant
 OpDecorate %28 BuiltIn Position
 OpDecorate %30 Location 1

--- a/tests/out/spv/shadow.spvasm
+++ b/tests/out/spv/shadow.spvasm
@@ -96,9 +96,7 @@ OpDecorate %43 Binding 2
 OpDecorate %45 DescriptorSet 0
 OpDecorate %45 Binding 3
 OpDecorate %84 Location 0
-OpDecorate %84 Flat
 OpDecorate %87 Location 1
-OpDecorate %87 Flat
 OpDecorate %89 BuiltIn Position
 OpDecorate %91 Location 0
 OpDecorate %93 Location 1


### PR DESCRIPTION
Fixes #2036.