### PR TITLE
[spv-out] Properly combine the fixes for #2035 and #2038.

### DIFF
--- a/tests/out/spv/access.spvasm
+++ b/tests/out/spv/access.spvasm
@@ -98,7 +98,6 @@ OpDecorate %78 Binding 3
 OpDecorate %79 Block
 OpMemberDecorate %79 0 Offset 0
 OpDecorate %228 BuiltIn VertexIndex
-OpDecorate %228 Flat
 OpDecorate %231 BuiltIn Position
 OpDecorate %273 Location 0
 %2 = OpTypeVoid

--- a/tests/out/spv/boids.spvasm
+++ b/tests/out/spv/boids.spvasm
@@ -61,7 +61,6 @@ OpDecorate %26 DescriptorSet 0
 OpDecorate %26 Binding 2
 OpDecorate %19 Block
 OpDecorate %48 BuiltIn GlobalInvocationId
-OpDecorate %48 Flat
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 0
 %3 = OpConstant  %4  1500

--- a/tests/out/spv/collatz.spvasm
+++ b/tests/out/spv/collatz.spvasm
@@ -24,7 +24,6 @@ OpDecorate %11 DescriptorSet 0
 OpDecorate %11 Binding 0
 OpDecorate %9 Block
 OpDecorate %46 BuiltIn GlobalInvocationId
-OpDecorate %46 Flat
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 0
 %3 = OpConstant  %4  0

--- a/tests/out/spv/control-flow.spvasm
+++ b/tests/out/spv/control-flow.spvasm
@@ -8,7 +8,6 @@ OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %44 "main" %41
 OpExecutionMode %44 LocalSize 1 1 1
 OpDecorate %41 BuiltIn GlobalInvocationId
-OpDecorate %41 Flat
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 1
 %3 = OpConstant  %4  1

--- a/tests/out/spv/image.spvasm
+++ b/tests/out/spv/image.spvasm
@@ -95,9 +95,7 @@ OpDecorate %68 Binding 2
 OpDecorate %70 DescriptorSet 1
 OpDecorate %70 Binding 3
 OpDecorate %73 BuiltIn LocalInvocationId
-OpDecorate %73 Flat
 OpDecorate %119 BuiltIn LocalInvocationId
-OpDecorate %119 Flat
 OpDecorate %140 BuiltIn Position
 OpDecorate %193 BuiltIn Position
 OpDecorate %222 Location 0

--- a/tests/out/spv/interface.compute.spvasm
+++ b/tests/out/spv/interface.compute.spvasm
@@ -16,15 +16,10 @@ OpDecorate %16 ArrayStride 4
 OpMemberDecorate %18 0 Offset 0
 OpMemberDecorate %19 0 Offset 0
 OpDecorate %23 BuiltIn GlobalInvocationId
-OpDecorate %23 Flat
 OpDecorate %26 BuiltIn LocalInvocationId
-OpDecorate %26 Flat
 OpDecorate %28 BuiltIn LocalInvocationIndex
-OpDecorate %28 Flat
 OpDecorate %31 BuiltIn WorkgroupId
-OpDecorate %31 Flat
 OpDecorate %33 BuiltIn NumWorkgroups
-OpDecorate %33 Flat
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpConstant  %4  1.0

--- a/tests/out/spv/interface.fragment.spvasm
+++ b/tests/out/spv/interface.fragment.spvasm
@@ -28,7 +28,6 @@ OpDecorate %34 BuiltIn SampleMask
 OpDecorate %34 Flat
 OpDecorate %36 BuiltIn FragDepth
 OpDecorate %38 BuiltIn SampleMask
-OpDecorate %38 Flat
 OpDecorate %40 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32

--- a/tests/out/spv/interface.vertex.spvasm
+++ b/tests/out/spv/interface.vertex.spvasm
@@ -15,9 +15,7 @@ OpDecorate %16 ArrayStride 4
 OpMemberDecorate %18 0 Offset 0
 OpMemberDecorate %19 0 Offset 0
 OpDecorate %21 BuiltIn VertexIndex
-OpDecorate %21 Flat
 OpDecorate %24 BuiltIn InstanceIndex
-OpDecorate %24 Flat
 OpDecorate %26 Location 10
 OpDecorate %28 Invariant
 OpDecorate %28 BuiltIn Position

--- a/tests/out/spv/interface.vertex_two_structs.spvasm
+++ b/tests/out/spv/interface.vertex_two_structs.spvasm
@@ -15,9 +15,7 @@ OpDecorate %16 ArrayStride 4
 OpMemberDecorate %18 0 Offset 0
 OpMemberDecorate %19 0 Offset 0
 OpDecorate %24 BuiltIn VertexIndex
-OpDecorate %24 Flat
 OpDecorate %28 BuiltIn InstanceIndex
-OpDecorate %28 Flat
 OpDecorate %30 Invariant
 OpDecorate %30 BuiltIn Position
 OpDecorate %32 BuiltIn PointSize

--- a/tests/out/spv/multiview.spvasm
+++ b/tests/out/spv/multiview.spvasm
@@ -9,7 +9,6 @@ OpExtension "SPV_KHR_multiview"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Vertex %8 "main" %5
 OpDecorate %5 BuiltIn ViewIndex
-OpDecorate %5 Flat
 %2 = OpTypeVoid
 %3 = OpTypeInt 32 1
 %6 = OpTypePointer Input %3

--- a/tests/out/spv/skybox.spvasm
+++ b/tests/out/spv/skybox.spvasm
@@ -25,7 +25,6 @@ OpDecorate %22 Binding 1
 OpDecorate %24 DescriptorSet 0
 OpDecorate %24 Binding 2
 OpDecorate %32 BuiltIn VertexIndex
-OpDecorate %32 Flat
 OpDecorate %35 BuiltIn Position
 OpDecorate %37 Location 0
 OpDecorate %83 BuiltIn FragCoord


### PR DESCRIPTION
The Vulkan decoration rules require us to distinguish vertex shader
inputs, fragment shader inputs, and everything else, so just pass the
stage to `Writer::write_varying`. Together with the SPIRV storage
class, this is sufficient to distinguish all the cases in a way that
closely follows the spec language.