### PR TITLE
glsl-in: Migrate to `SymbolTable`

### DIFF
--- a/src/front/glsl/parser/functions.rs
+++ b/src/front/glsl/parser/functions.rs
@@ -422,7 +422,7 @@ impl<'source> ParsingContext<'source> {
             TokenValue::For => {
                 let mut meta = self.bump(parser)?.meta;
 
-                ctx.push_scope();
+                ctx.symbol_table.push_scope();
                 self.expect(parser, TokenValue::LeftParen)?;
 
                 if self.bump_if(parser, TokenValue::Semicolon).is_none() {
@@ -520,7 +520,7 @@ impl<'source> ParsingContext<'source> {
                     meta,
                 );
 
-                ctx.remove_current_scope();
+                ctx.symbol_table.pop_scope();
 
                 meta
             }
@@ -528,7 +528,6 @@ impl<'source> ParsingContext<'source> {
                 let meta = self.bump(parser)?.meta;
 
                 let mut block = Block::new();
-                ctx.push_scope();
 
                 let mut block_terminator = None;
                 let meta = self.parse_compound_statement(
@@ -538,8 +537,6 @@ impl<'source> ParsingContext<'source> {
                     &mut block,
                     &mut block_terminator,
                 )?;
-
-                ctx.remove_current_scope();
 
                 body.push(Statement::Block(block), meta);
                 if block_terminator.is_some() {
@@ -572,6 +569,8 @@ impl<'source> ParsingContext<'source> {
         body: &mut Block,
         terminator: &mut Option<usize>,
     ) -> Result<Span> {
+        ctx.symbol_table.push_scope();
+
         loop {
             if let Some(Token {
                 meta: brace_meta, ..
@@ -591,6 +590,8 @@ impl<'source> ParsingContext<'source> {
         if let Some(idx) = *terminator {
             body.cull(idx..)
         }
+
+        ctx.symbol_table.pop_scope();
 
         Ok(meta)
     }


### PR DESCRIPTION
Moves the glsl frontend from it's custom solution for lexical scopes to the new `SymbolTable`.

Adds an `add_root` method to `SymbolTable` that's needed for glsl builtins and implement `Debug`.