### PR TITLE
valid: Check regular functions don't have bindings

### DIFF
--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -143,6 +143,10 @@ pub enum FunctionError {
         Handle<crate::Expression>,
         UniformityDisruptor,
     ),
+    #[error("Functions that are not entry points cannot have `@location` or `@builtin` attributes on their arguments: \"{name}\" has attributes")]
+    PipelineInputRegularFunction { name: String },
+    #[error("Functions that are not entry points cannot have `@location` or `@builtin` attributes on their return value types")]
+    PipelineOutputRegularFunction,
 }
 
 bitflags::bitflags! {
@@ -859,6 +863,7 @@ impl super::Validator {
         fun: &crate::Function,
         module: &crate::Module,
         mod_info: &ModuleInfo,
+        entry_point: bool,
     ) -> Result<FunctionInfo, WithSpan<FunctionError>> {
         #[cfg_attr(not(feature = "validate"), allow(unused_mut))]
         let mut info = mod_info.process_function(fun, module, self.flags, self.capabilities)?;
@@ -909,6 +914,13 @@ impl super::Validator {
                 }
                 .with_span_handle(argument.ty, &module.types));
             }
+
+            if !entry_point && argument.binding.is_some() {
+                return Err(FunctionError::PipelineInputRegularFunction {
+                    name: argument.name.clone().unwrap_or_default(),
+                }
+                .with_span_handle(argument.ty, &module.types));
+            }
         }
 
         #[cfg(feature = "validate")]
@@ -918,6 +930,11 @@ impl super::Validator {
                 .contains(super::TypeFlags::CONSTRUCTIBLE)
             {
                 return Err(FunctionError::NonConstructibleReturnType
+                    .with_span_handle(result.ty, &module.types));
+            }
+
+            if !entry_point && result.binding.is_some() {
+                return Err(FunctionError::PipelineOutputRegularFunction
                     .with_span_handle(result.ty, &module.types));
             }
         }

--- a/src/valid/interface.rs
+++ b/src/valid/interface.rs
@@ -472,7 +472,7 @@ impl super::Validator {
         }
 
         let info = self
-            .validate_function(&ep.function, module, mod_info)
+            .validate_function(&ep.function, module, mod_info, true)
             .map_err(WithSpan::into_other)?;
 
         #[cfg(feature = "validate")]

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -373,7 +373,7 @@ impl Validator {
         };
 
         for (handle, fun) in module.functions.iter() {
-            match self.validate_function(fun, module, &mod_info) {
+            match self.validate_function(fun, module, &mod_info, false) {
                 Ok(info) => mod_info.functions.push(info),
                 Err(error) => {
                     return Err(error.and_then(|error| {


### PR DESCRIPTION
Checks that all arguments and return types have no bindings in regular functions.

Closes #2037