### PR TITLE
wgsl-in: Fix bad span in assignment lhs error

### DIFF
--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -237,6 +237,22 @@ impl<'a> Lexer<'a> {
         }
     }
 
+    /// Consumes [`Trivia`] tokens until another token is encountered, returns
+    /// the byte offset after consuming the tokens.
+    ///
+    /// [`Trivia`]: Token::Trivia
+    #[must_use]
+    pub(super) fn consume_blankspace(&mut self) -> usize {
+        loop {
+            let (token, rest) = consume_token(self.input, false);
+            if let Token::Trivia = token {
+                self.input = rest;
+            } else {
+                return self.current_byte_offset();
+            }
+        }
+    }
+
     #[must_use]
     pub(super) fn peek(&mut self) -> TokenSpan<'a> {
         let (token, _) = self.peek_token_and_rest();

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -3290,7 +3290,7 @@ impl Parser {
     ) -> Result<(), Error<'a>> {
         use crate::BinaryOperator as Bo;
 
-        let span_start = lexer.current_byte_offset();
+        let span_start = lexer.consume_blankspace();
         context.emitter.start(context.expressions);
         let reference = self.parse_unary_expression(lexer, context.reborrow())?;
         // The left hand side of an assignment must be a reference.


### PR DESCRIPTION
The wgsl frontend was emiting errors for lhs expressions on assignments that weren't references using a span that didn't skip blankspaces causing the span to look weird (like starting at the end of the previous line)

This is fixed by consuming the blankspace before constructing the span

Related to #2053