### PR TITLE
wgsl-in: Improve assignment diagnostics

### DIFF
--- a/src/front/wgsl/lexer.rs
+++ b/src/front/wgsl/lexer.rs
@@ -273,7 +273,7 @@ impl<'a> Lexer<'a> {
         if next.0 == expected {
             Ok(next.1)
         } else {
-            Err(Error::Unexpected(next, ExpectedToken::Token(expected)))
+            Err(Error::Unexpected(next.1, ExpectedToken::Token(expected)))
         }
     }
 
@@ -288,7 +288,7 @@ impl<'a> Lexer<'a> {
             Ok(())
         } else {
             Err(Error::Unexpected(
-                next,
+                next.1,
                 ExpectedToken::Token(Token::Paren(expected)),
             ))
         }
@@ -314,7 +314,7 @@ impl<'a> Lexer<'a> {
                 Err(Error::ReservedIdentifierPrefix(span))
             }
             (Token::Word(word), span) => Ok((word, span)),
-            other => Err(Error::Unexpected(other, ExpectedToken::Identifier)),
+            other => Err(Error::Unexpected(other.1, ExpectedToken::Identifier)),
         }
     }
 

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -3349,7 +3349,7 @@ impl Parser {
                 ty: if context.named_expressions.contains_key(&reference.handle) {
                     InvalidAssignmentType::ImmutableBinding
                 } else {
-                    match context.expressions.get_mut(reference.handle) {
+                    match *context.expressions.get_mut(reference.handle) {
                         crate::Expression::Swizzle { .. } => InvalidAssignmentType::Swizzle,
                         _ => InvalidAssignmentType::Other,
                     }

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -1597,3 +1597,83 @@ fn break_if_bad_condition() {
         )
     }
 }
+
+#[test]
+fn swizzle_assignment() {
+    check(
+        "
+        fn f() {
+            var v = vec2(0);
+            v.xy = vec2(1);
+        }
+    ",
+        r###"error: invalid left-hand side of assignment
+  ┌─ wgsl:4:13
+  │
+4 │             v.xy = vec2(1);
+  │             ^^^^ cannot assign to this expression
+  │
+  = note: WGSL does not support assignments to swizzles
+  = note: consider assigning each component individually
+
+"###,
+    );
+}
+
+#[test]
+fn binary_statement() {
+    check(
+        "
+        fn f() {
+            3 + 5;
+        }
+    ",
+        r###"error: expected assignment or increment/decrement, found '3 + 5'
+  ┌─ wgsl:3:13
+  │
+3 │             3 + 5;
+  │             ^^^^^ expected assignment or increment/decrement
+
+"###,
+    );
+}
+
+#[test]
+fn assign_to_expr() {
+    check(
+        "
+        fn f() {
+            3 + 5 = 10;
+        }
+        ",
+        r###"error: invalid left-hand side of assignment
+  ┌─ wgsl:3:13
+  │
+3 │             3 + 5 = 10;
+  │             ^^^^^ cannot assign to this expression
+
+"###,
+    );
+}
+
+#[test]
+fn assign_to_let() {
+    check(
+        "
+        fn f() {
+            let a = 10;
+	        a = 20;
+        }
+        ",
+        r###"error: invalid left-hand side of assignment
+  ┌─ wgsl:4:10
+  │
+4 │             a = 20;
+  │             ^ cannot assign to this expression
+  │
+  = note: 'a' is an immutable binding
+  = note: consider declaring it with `var` instead of `let`
+
+"###,
+    );
+}


### PR DESCRIPTION
This improves the diagnostics on invalid assignment statements.
Fixes #2052.

Given:
```wgsl
fn f() {
    var v = vec2(0);
    v.xy = vec2(1);
}
```
Naga used to error with:
```
error: the left-hand side of an assignment must be a reference
  ┌─ test.wgsl:3:5
  │
3 │     v.xy = vec2(1);
  │     ^^^^ expression is not a reference
```
Now:
```
error: invalid left-hand side of assignment
  ┌─ test.wgsl:3:5
  │
3 │     v.xy = vec2(1);
  │     ^^^^ cannot assign to this expression
  │
  = note: WGSL does not support assignments to swizzles
  = note: consider assigning each component individually
```

Given:
```wgsl
fn f() {
    3 + 5;
}
```
Naga used to error with:
```
error: the left-hand side of an assignment must be a reference
  ┌─ test.wgsl:2:5
  │
2 │     3 + 5;
  │     ^ expression is not a reference
```
Now:
```
error: expected assignment or increment/decrement, found '3 + 5'
  ┌─ test.wgsl:2:5
  │
2 │     3 + 5;
  │     ^^^^^ expected assignment or increment/decrement
```

Given:
```wgsl
fn f() {
    3 + 5 = 10;
}
```
Naga used to error with:
```
error: the left-hand side of an assignment must be a reference
  ┌─ test.wgsl:2:5
  │
2 │     3 + 5 = 10;
  │     ^ expression is not a reference
```
Now:
```
error: invalid left-hand side of assignment
  ┌─ test.wgsl:2:5
  │
2 │     3 + 5 = 10;
  │     ^^^^^ cannot assign to this expression
```

Given:
```
fn f() {
    let a = 10;
	a = 20;
}
```
Naga used to error with:
```
error: invalid left-hand side of assignment
  ┌─ test.wgsl:3:2
  │
3 │     a = 20;
  │     ^ cannot assign to this expression
```
Now:
```
error: invalid left-hand side of assignment
  ┌─ test.wgsl:3:2
  │
3 │     a = 20;
  │     ^ cannot assign to this expression
  │
  = note: 'a' is an immutable binding
  = note: consider declaring it with `var` instead of `let`
```

`Error` has breaking changes made to it.