### PR TITLE
Fix for incorrect GLSL validation on witeonly image uniforms

### DIFF
--- a/src/front/glsl/parser_tests.rs
+++ b/src/front/glsl/parser_tests.rs
@@ -320,6 +320,20 @@ fn declarations() {
         "#,
         )
         .unwrap();
+
+    parser
+        .parse(
+            &Options::from(ShaderStage::Compute),
+            r#"
+        #version 450
+        precision highp float;
+        
+        layout(binding = 0) uniform writeonly image2D image;
+
+        void main() {}
+        "#,
+        )
+        .unwrap();
 }
 
 #[test]

--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -6,8 +6,8 @@ use super::{
 };
 use crate::{
     AddressSpace, Binding, Block, BuiltIn, Constant, Expression, GlobalVariable, Handle,
-    Interpolation, LocalVariable, ResourceBinding, ScalarKind, ShaderStage, SwizzleComponent, Type,
-    TypeInner, VectorSize,
+    Interpolation, LocalVariable, ResourceBinding, ScalarKind, ShaderStage, StorageAccess,
+    SwizzleComponent, Type, TypeInner, VectorSize,
 };
 
 pub struct VarDeclaration<'a, 'key> {
@@ -518,14 +518,17 @@ impl Parser {
 
                                 match qualifiers.layout_qualifiers.remove(&QualifierKey::Format) {
                                     Some((QualifierValue::Format(f), _)) => format = f,
-                                    // TODO: glsl supports images without format qualifier
-                                    // if they are `writeonly`
-                                    None => self.errors.push(Error {
-                                        kind: ErrorKind::SemanticError(
-                                            "image types require a format layout qualifier".into(),
-                                        ),
-                                        meta,
-                                    }),
+                                    None => {
+                                        if access.contains(StorageAccess::LOAD) {
+                                            self.errors.push(Error {
+                                                kind: ErrorKind::SemanticError(
+                                                    "image types require a format layout qualifier"
+                                                        .into(),
+                                                ),
+                                                meta,
+                                            })
+                                        }
+                                    }
                                     _ => unreachable!(),
                                 }
 


### PR DESCRIPTION
Related to this issue: https://github.com/gfx-rs/wgpu/issues/4530

I noticed the validation on layout qualifiers for writeonly image uniforms was not working according to the GLSL spec.

I saw there was already a TODO in the code, and the fix seemed straightforward so I made a PR for this.