### PR TITLE
Explicitely enable std for indexmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ termcolor = { version = "1.0.4", optional = true }
 # https://github.com/brendanzab/codespan/commit/e99c867339a877731437e7ee6a903a3d03b5439e
 codespan-reporting = { version = "0.11.0", optional = true }
 rustc-hash = "1.1.0"
-indexmap = "1.6"
+indexmap = { version = "1.6", features = ["std"] }
 log = "0.4"
 num-traits = "0.2"
 spirv = { version = "0.2", optional = true }


### PR DESCRIPTION
I noticed that depending on the environment the std check by the autocfg crate may fail. This enables std like recommended here: https://github.com/bluss/indexmap/issues/184