### PR TITLE
glsl-in: Fix position propagation in lowering

### DIFF
--- a/tests/in/glsl/expressions.frag
+++ b/tests/in/glsl/expressions.frag
@@ -144,6 +144,13 @@ void testConstantLength(float a[4u]) {
     int len = a.length();
 }
 
+struct TestStruct { uvec4 array[2]; };
+const TestStruct strct = { { uvec4(0), uvec4(1) } };
+
+void indexConstantNonConstantIndex(int i) {
+    const uvec4 a = strct.array[i];
+}
+
 out vec4 o_color;
 void main() {
     privatePointer(global);

--- a/tests/out/wgsl/bevy-pbr-frag.wgsl
+++ b/tests/out/wgsl/bevy-pbr-frag.wgsl
@@ -737,25 +737,25 @@ fn point_light(light: PointLight, roughness_8: f32, NdotV: f32, N: vec3<f32>, V_
     R_1 = R;
     F0_1 = F0_;
     diffuseColor_1 = diffuseColor;
-    let _e57 = light_1.pos;
+    let _e56 = light_1;
     let _e59 = v_WorldPosition_1;
-    light_to_frag = (_e57.xyz - _e59.xyz);
+    light_to_frag = (_e56.pos.xyz - _e59.xyz);
     _ = light_to_frag;
     _ = light_to_frag;
     let _e65 = light_to_frag;
     let _e66 = light_to_frag;
     distance_square = dot(_e65, _e66);
     _ = distance_square;
-    let _e71 = light_1.lightParams;
-    _ = _e71.x;
+    let _e70 = light_1;
+    _ = _e70.lightParams.x;
     let _e73 = distance_square;
-    let _e75 = light_1.lightParams;
-    let _e77 = getDistanceAttenuation(_e73, _e75.x);
+    let _e74 = light_1;
+    let _e77 = getDistanceAttenuation(_e73, _e74.lightParams.x);
     rangeAttenuation = _e77;
     let _e79 = roughness_9;
     a_1 = _e79;
-    let _e82 = light_1.lightParams;
-    radius = _e82.y;
+    let _e81 = light_1;
+    radius = _e81.lightParams.y;
     _ = light_to_frag;
     _ = R_1;
     let _e87 = light_to_frag;
@@ -918,10 +918,10 @@ fn point_light(light: PointLight, roughness_8: f32, NdotV: f32, N: vec3<f32>, V_
     diffuse = (_e302 * _e311);
     let _e314 = diffuse;
     let _e315 = specular_1;
-    let _e318 = light_1.color;
+    let _e317 = light_1;
     let _e321 = rangeAttenuation;
     let _e322 = NoL_6;
-    return (((_e314 + _e315) * _e318.xyz) * (_e321 * _e322));
+    return (((_e314 + _e315) * _e317.color.xyz) * (_e321 * _e322));
 }
 
 fn dir_light(light_2: DirectionalLight, roughness_10: f32, NdotV_2: f32, normal: vec3<f32>, view: vec3<f32>, R_2: vec3<f32>, F0_2: vec3<f32>, diffuseColor_2: vec3<f32>) -> vec3<f32> {
@@ -961,8 +961,8 @@ fn dir_light(light_2: DirectionalLight, roughness_10: f32, NdotV_2: f32, normal:
     R_3 = R_2;
     F0_3 = F0_2;
     diffuseColor_3 = diffuseColor_2;
-    let _e57 = light_3.direction;
-    incident_light = _e57.xyz;
+    let _e56 = light_3;
+    incident_light = _e56.direction.xyz;
     let _e60 = incident_light;
     let _e61 = view_1;
     _ = (_e60 + _e61);
@@ -1031,9 +1031,9 @@ fn dir_light(light_2: DirectionalLight, roughness_10: f32, NdotV_2: f32, normal:
     specular_2 = _e146;
     let _e148 = specular_2;
     let _e149 = diffuse_1;
-    let _e152 = light_3.color;
+    let _e151 = light_3;
     let _e155 = NoL_7;
-    return (((_e148 + _e149) * _e152.xyz) * _e155);
+    return (((_e148 + _e149) * _e151.color.xyz) * _e155);
 }
 
 fn main_1() {

--- a/tests/out/wgsl/expressions-frag.wgsl
+++ b/tests/out/wgsl/expressions-frag.wgsl
@@ -6,6 +6,10 @@ struct a_buf {
     a: array<f32>,
 }
 
+struct TestStruct {
+    array_: array<vec4<u32>,2u>,
+}
+
 struct FragmentOutput {
     @location(0) o_color: vec4<f32>,
 }
@@ -396,30 +400,44 @@ fn testConstantLength(a_24: array<f32,4u>) {
     return;
 }
 
+fn indexConstantNonConstantIndex(i: i32) {
+    var i_1: i32;
+    var local_5: TestStruct = TestStruct(array<vec4<u32>,2u>(vec4<u32>(0u, 0u, 0u, 0u), vec4<u32>(1u, 1u, 1u, 1u)));
+    var a_26: vec4<u32>;
+
+    _ = (&global_1.a);
+    i_1 = i;
+    let _e6 = i_1;
+    let _e10 = local_5.array_[_e6];
+    a_26 = _e10;
+    return;
+}
+
 fn main_1() {
-    var local_5: f32;
+    var local_6: f32;
 
     _ = (&global_1.a);
     _ = global;
-    let _e5 = global;
-    local_5 = _e5;
-    privatePointer((&local_5));
-    let _e7 = local_5;
-    global = _e7;
-    let _e8 = o_color;
-    _ = _e8.xyzw;
-    let _e11 = vec4<f32>(1.0);
-    o_color.x = _e11.x;
-    o_color.y = _e11.y;
-    o_color.z = _e11.z;
-    o_color.w = _e11.w;
+    let _e6 = global;
+    local_6 = _e6;
+    privatePointer((&local_6));
+    let _e8 = local_6;
+    global = _e8;
+    let _e9 = o_color;
+    _ = _e9.xyzw;
+    let _e12 = vec4<f32>(1.0);
+    o_color.x = _e12.x;
+    o_color.y = _e12.y;
+    o_color.z = _e12.z;
+    o_color.w = _e12.w;
     return;
 }
 
 @fragment 
 fn main() -> FragmentOutput {
     _ = (&global_1.a);
+    _ = TestStruct(array<vec4<u32>,2u>(vec4<u32>(u32(0)), vec4<u32>(u32(1))));
     main_1();
-    let _e7 = o_color;
-    return FragmentOutput(_e7);
+    let _e17 = o_color;
+    return FragmentOutput(_e17);
 }

--- a/tests/out/wgsl/fma-frag.wgsl
+++ b/tests/out/wgsl/fma-frag.wgsl
@@ -16,18 +16,18 @@ fn Fma(d: ptr<function, Mat4x3_>, m: Mat4x3_, s: f32) {
 
     m_1 = m;
     s_1 = s;
-    let _e7 = (*d).mx;
-    let _e9 = m_1.mx;
+    let _e6 = (*d);
+    let _e8 = m_1;
     let _e10 = s_1;
-    (*d).mx = (_e7 + (_e9 * _e10));
-    let _e15 = (*d).my;
-    let _e17 = m_1.my;
+    (*d).mx = (_e6.mx + (_e8.mx * _e10));
+    let _e14 = (*d);
+    let _e16 = m_1;
     let _e18 = s_1;
-    (*d).my = (_e15 + (_e17 * _e18));
-    let _e23 = (*d).mz;
-    let _e25 = m_1.mz;
+    (*d).my = (_e14.my + (_e16.my * _e18));
+    let _e22 = (*d);
+    let _e24 = m_1;
     let _e26 = s_1;
-    (*d).mz = (_e23 + (_e25 * _e26));
+    (*d).mz = (_e22.mz + (_e24.mz * _e26));
     return;
 }
 


### PR DESCRIPTION
When lowering `Select` expressions the position could be wrongfully updated from `AccessBase { constant_index: false }` to `AccessBase { constant_index: true }` this caused dynamic indexing in an array behind a structure to fail if it was stored in a constant.

Furthermore the position could also be updated from `Rhs` to `AccessBase`, this could cause issues because `AccessBase` doesn't load variables (which `Rhs` does), so accessing a member from a structure behind a pointer would return the wrong result.