### PR TITLE
Satisfy latest `clippy` lints (up to Rust 1.64)

### DIFF
--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -10,7 +10,7 @@ fn gather_inputs(folder: &str, extension: &str) -> Vec<Box<[u8]>> {
     for file_entry in read_dir {
         match file_entry {
             Ok(entry) => match entry.path().extension() {
-                Some(ostr) if &*ostr == extension => {
+                Some(ostr) if ostr == extension => {
                     let input = fs::read(entry.path()).unwrap_or_default();
                     list.push(input.into_boxed_slice());
                 }

--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -250,21 +250,20 @@ fn backends(c: &mut Criterion) {
                         entry_point: ep.name.clone(),
                         multiview: None,
                     };
-                    match naga::back::glsl::Writer::new(
+                    let _ = naga::back::glsl::Writer::new(
                         &mut string,
                         module,
                         info,
                         &options,
                         &pipeline_options,
                         naga::proc::BoundsCheckPolicies::default(),
-                    ) {
-                        Ok(mut writer) => {
-                            let _ = writer.write(); // can error if unsupported
-                        }
-                        Err(_) => {
-                            // missing features
-                        }
-                    };
+                    )
+                    .map(|mut writer| {
+                        // might be `Err` if unsupported
+                        writer.write()
+                    });
+                    // might be `Err` if missing features
+
                     string.clear();
                 }
             }

--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -250,19 +250,18 @@ fn backends(c: &mut Criterion) {
                         entry_point: ep.name.clone(),
                         multiview: None,
                     };
-                    let _ = naga::back::glsl::Writer::new(
+
+                    // might be `Err` if missing features
+                    if let Ok(mut writer) = naga::back::glsl::Writer::new(
                         &mut string,
                         module,
                         info,
                         &options,
                         &pipeline_options,
                         naga::proc::BoundsCheckPolicies::default(),
-                    )
-                    .map(|mut writer| {
-                        // might be `Err` if unsupported
-                        writer.write()
-                    });
-                    // might be `Err` if missing features
+                    ) {
+                        let _ = writer.write(); // might be `Err` if unsupported
+                    }
 
                     string.clear();
                 }

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -3955,12 +3955,13 @@ fn test_stack_size() {
 
     {
         // check expression stack
-        let mut addresses = usize::MAX..0usize;
+        let mut addresses_start = usize::MAX;
+        let mut addresses_end = 0usize;
         for pointer in writer.put_expression_stack_pointers {
-            addresses.start = addresses.start.min(pointer as usize);
-            addresses.end = addresses.end.max(pointer as usize);
+            addresses_start = addresses_start.min(pointer as usize);
+            addresses_end = addresses_end.max(pointer as usize);
         }
-        let stack_size = addresses.end - addresses.start;
+        let stack_size = addresses_end - addresses_start;
         // check the size (in debug only)
         // last observed macOS value: 20528 (CI)
         if !(11000..=25000).contains(&stack_size) {
@@ -3970,12 +3971,13 @@ fn test_stack_size() {
 
     {
         // check block stack
-        let mut addresses = usize::MAX..0usize;
+        let mut addresses_start = usize::MAX;
+        let mut addresses_end = 0usize;
         for pointer in writer.put_block_stack_pointers {
-            addresses.start = addresses.start.min(pointer as usize);
-            addresses.end = addresses.end.max(pointer as usize);
+            addresses_start = addresses_start.min(pointer as usize);
+            addresses_end = addresses_end.max(pointer as usize);
         }
-        let stack_size = addresses.end - addresses.start;
+        let stack_size = addresses_end - addresses_start;
         // check the size (in debug only)
         // last observed macOS value: 19152 (CI)
         if !(9500..=20000).contains(&stack_size) {

--- a/src/front/glsl/constants.rs
+++ b/src/front/glsl/constants.rs
@@ -739,8 +739,8 @@ mod tests {
 
         let res3_inner = &constants[res3].inner;
 
-        match res3_inner {
-            &ConstantInner::Composite {
+        match *res3_inner {
+            ConstantInner::Composite {
                 ref ty,
                 ref components,
             } => {
@@ -936,8 +936,8 @@ mod tests {
 
         let res1_inner = &constants[res1].inner;
 
-        match res1_inner {
-            &ConstantInner::Composite {
+        match *res1_inner {
+            ConstantInner::Composite {
                 ref ty,
                 ref components,
             } => {

--- a/src/front/glsl/constants.rs
+++ b/src/front/glsl/constants.rs
@@ -740,7 +740,10 @@ mod tests {
         let res3_inner = &constants[res3].inner;
 
         match res3_inner {
-            ConstantInner::Composite { ty, components } => {
+            &ConstantInner::Composite {
+                ref ty,
+                ref components,
+            } => {
                 assert_eq!(*ty, vec_ty);
                 let mut components_iter = components.iter().copied();
                 assert_eq!(
@@ -934,7 +937,10 @@ mod tests {
         let res1_inner = &constants[res1].inner;
 
         match res1_inner {
-            ConstantInner::Composite { ty, components } => {
+            &ConstantInner::Composite {
+                ref ty,
+                ref components,
+            } => {
                 assert_eq!(*ty, vec_ty);
                 let mut components_iter = components.iter().copied();
                 assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ tree.
     clippy::pattern_type_mismatch,
     clippy::missing_const_for_fn
 )]
-#![deny(clippy::panic)]
+#![cfg_attr(not(test), deny(clippy::panic))]
 
 mod arena;
 pub mod back;

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -2,7 +2,10 @@
 // the corresponding warnings aren't helpful.
 #![allow(dead_code)]
 
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 const BASE_DIR_IN: &str = "tests/in";
 const BASE_DIR_OUT: &str = "tests/out";
@@ -195,7 +198,7 @@ fn check_targets(module: &naga::Module, name: &str, targets: Targets) {
 fn write_output_spv(
     module: &naga::Module,
     info: &naga::valid::ModuleInfo,
-    destination: &PathBuf,
+    destination: &Path,
     file_name: &str,
     params: &SpirvOutParameters,
     bounds_check_policies: naga::proc::BoundsCheckPolicies,
@@ -253,7 +256,7 @@ fn write_output_spv(
 fn write_output_msl(
     module: &naga::Module,
     info: &naga::valid::ModuleInfo,
-    destination: &PathBuf,
+    destination: &Path,
     file_name: &str,
     options: &naga::back::msl::Options,
     pipeline_options: &naga::back::msl::PipelineOptions,
@@ -281,7 +284,7 @@ fn write_output_msl(
 fn write_output_glsl(
     module: &naga::Module,
     info: &naga::valid::ModuleInfo,
-    destination: &PathBuf,
+    destination: &Path,
     file_name: &str,
     stage: naga::ShaderStage,
     ep_name: &str,
@@ -322,7 +325,7 @@ fn write_output_glsl(
 fn write_output_hlsl(
     module: &naga::Module,
     info: &naga::valid::ModuleInfo,
-    destination: &PathBuf,
+    destination: &Path,
     file_name: &str,
     options: &naga::back::hlsl::Options,
 ) {
@@ -401,7 +404,7 @@ fn write_output_hlsl(
 fn write_output_wgsl(
     module: &naga::Module,
     info: &naga::valid::ModuleInfo,
-    destination: &PathBuf,
+    destination: &Path,
     file_name: &str,
     params: &WgslOutParameters,
 ) {

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -280,6 +280,7 @@ fn write_output_msl(
 }
 
 #[cfg(feature = "glsl-out")]
+#[allow(clippy::too_many_arguments)]
 fn write_output_glsl(
     module: &naga::Module,
     info: &naga::valid::ModuleInfo,

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -227,7 +227,6 @@ fn write_output_spv(
         },
         bounds_check_policies,
         binding_map: params.binding_map.clone(),
-        ..spv::Options::default()
     };
 
     if params.separate_entry_points {

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -679,7 +679,7 @@ fn convert_glsl_folder() {
                 &module,
                 &info,
                 &dest,
-                &file_name.replace(".", "-"),
+                &file_name.replace('.', "-"),
                 &WgslOutParameters::default(),
             );
         }


### PR DESCRIPTION
Just some quick `clippy` lint updates; I'm currently using Rust 1.64 for this PR. 😊 Recommended review experience: commit by commit. I've tried to note in specific commits where I felt some thought was required with the decision to silence or change code significantly.

Open questions:

- [ ] Why is CI not currently failing this? @ErichDonGubler sees that `pipeline.yml` describes a `clippy` job running `clippy --all-features --workspace` on the latest `stable` channel of Rust...🤔 which is what he used to find these lints locally with Rust 1.63:

    https://github.com/gfx-rs/naga/blob/41ebe1320d246f7db8645a4c8baa4f7e42267529/.github/workflows/pipeline.yml#L56-L70