### PR TITLE
build: move to the Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "naga"
 version = "0.10.0"
 authors = ["Naga Developers"]
-edition = "2018"
+edition = "2021"
 description = "Shader translation infrastructure"
 homepage = "https://github.com/gfx-rs/naga"
 repository = "https://github.com/gfx-rs/naga"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "naga-cli"
 version = "0.10.0"
 authors = ["Naga Developers"]
-edition = "2018"
+edition = "2021"
 description = "Shader translation command line tool"
 homepage = "https://github.com/gfx-rs/naga"
 repository = "https://github.com/gfx-rs/naga"

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -96,8 +96,6 @@ impl<T> Handle<T> {
 
     /// Convert a `usize` index into a `Handle<T>`.
     fn from_usize(index: usize) -> Self {
-        use std::convert::TryFrom;
-
         let handle_index = u32::try_from(index + 1)
             .ok()
             .and_then(Index::new)

--- a/src/front/wgsl/number.rs
+++ b/src/front/wgsl/number.rs
@@ -24,12 +24,9 @@ impl Number {
     /// lossy, return an error.
     fn abstract_to_concrete(self) -> Result<Number, NumberError> {
         match self {
-            Number::AbstractInt(num) => {
-                use std::convert::TryFrom;
-                i32::try_from(num)
-                    .map(Number::I32)
-                    .map_err(|_| NumberError::NotRepresentable)
-            }
+            Number::AbstractInt(num) => i32::try_from(num)
+                .map(Number::I32)
+                .map_err(|_| NumberError::NotRepresentable),
             Number::AbstractFloat(num) => {
                 let num = num as f32;
                 if num.is_finite() {
@@ -94,7 +91,7 @@ fn parse(input: &str) -> (Result<Number, NumberError>, &str) {
     /// returns `true` and consumes `X` bytes from the given byte buffer
     /// if the given `X` nr of patterns are found at the start of the buffer
     macro_rules! consume {
-        ($bytes:ident, $($($pattern:pat)|*),*) => {
+        ($bytes:ident, $($($pattern:pat_param)|*),*) => {
             match $bytes {
                 &[$($($pattern)|*),*, ref rest @ ..] => { $bytes = rest; true },
                 _ => false,
@@ -106,7 +103,7 @@ fn parse(input: &str) -> (Result<Number, NumberError>, &str) {
     /// if one of the given patterns are found at the start of the buffer
     /// returning the corresponding expr for the matched pattern
     macro_rules! consume_map {
-        ($bytes:ident, [$($($pattern:pat)|* => $to:expr),*]) => {
+        ($bytes:ident, [$($($pattern:pat_param)|* => $to:expr),*]) => {
             match $bytes {
                 $( &[$($pattern)|*, ref rest @ ..] => { $bytes = rest; Some($to) }, )*
                 _ => None,

--- a/src/front/wgsl/number.rs
+++ b/src/front/wgsl/number.rs
@@ -91,9 +91,9 @@ fn parse(input: &str) -> (Result<Number, NumberError>, &str) {
     /// returns `true` and consumes `X` bytes from the given byte buffer
     /// if the given `X` nr of patterns are found at the start of the buffer
     macro_rules! consume {
-        ($bytes:ident, $($($pattern:pat_param)|*),*) => {
+        ($bytes:ident, $($pattern:pat),*) => {
             match $bytes {
-                &[$($($pattern)|*),*, ref rest @ ..] => { $bytes = rest; true },
+                &[$($pattern),*, ref rest @ ..] => { $bytes = rest; true },
                 _ => false,
             }
         };
@@ -103,9 +103,9 @@ fn parse(input: &str) -> (Result<Number, NumberError>, &str) {
     /// if one of the given patterns are found at the start of the buffer
     /// returning the corresponding expr for the matched pattern
     macro_rules! consume_map {
-        ($bytes:ident, [$($($pattern:pat_param)|* => $to:expr),*]) => {
+        ($bytes:ident, [$($pattern:pat_param => $to:expr),*]) => {
             match $bytes {
-                $( &[$($pattern)|*, ref rest @ ..] => { $bytes = rest; Some($to) }, )*
+                $( &[$pattern, ref rest @ ..] => { $bytes = rest; Some($to) }, )*
                 _ => None,
             }
         };

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -389,7 +389,6 @@ impl crate::Constant {
     /// `OpArrayType` referring to an inappropriate `OpConstant`). So we return
     /// `Option` and let the caller sort things out.
     pub(crate) fn to_array_length(&self) -> Option<u32> {
-        use std::convert::TryInto;
         match self.inner {
             crate::ConstantInner::Scalar { value, width: _ } => match value {
                 crate::ScalarValue::Uint(value) => value.try_into().ok(),


### PR DESCRIPTION
Since the MSRV of `naga` [is currently 1.56][msrv], I don't think there's a strong reason to stay with the 2018 edition, and there _are_ a [few good reasons][edition-guide] to move to the 2021 edition.

I did this migration mostly automatically, per [official Rust guidelines]:

```sh
$ cargo fix --edition --all-targets
$ sed -i Cargo.toml 's/2018/2021'
$ cargo fix --edition-idioms --allow-dirty # doesn't change anything
```

The only manual edit needed to stymie a new warning introduced was the removal of the `TryFrom` import from several modules, since it's now in the 2021 prelude.

[msrv]: https://github.com/gfx-rs/naga/blob/a7193d652e49180661a6ca047889e0685667acdb/.github/workflows/pipeline.yml#L14
[edition-guide]: https://doc.rust-lang.org/edition-guide/rust-2021/index.html
[official Rust guidelines]: https://doc.rust-lang.org/cargo/commands/cargo-fix.html#edition-migration
