### PR TITLE
Workaround FXC Bug in Matrix Indexing

### DIFF
--- a/tests/out/hlsl/access.hlsl
+++ b/tests/out/hlsl/access.hlsl
@@ -147,11 +147,11 @@ void test_matrix_within_struct_accesses()
     float2 unnamed_1 = GetMatmOnBaz(baz)[0];
     int _expr16 = idx;
     float2 unnamed_2 = GetMatmOnBaz(baz)[_expr16];
-    float unnamed_3 = GetMatmOnBaz(baz)[0][1];
+    float unnamed_3 = GetMatmOnBaz(baz)[0].y;
     int _expr28 = idx;
     float unnamed_4 = GetMatmOnBaz(baz)[0][_expr28];
     int _expr32 = idx;
-    float unnamed_5 = GetMatmOnBaz(baz)[_expr32][1];
+    float unnamed_5 = GetMatmOnBaz(baz)[_expr32].y;
     int _expr38 = idx;
     int _expr40 = idx;
     float unnamed_6 = GetMatmOnBaz(baz)[_expr38][_expr40];
@@ -191,11 +191,11 @@ void test_matrix_within_array_within_struct_accesses()
     float2 unnamed_9 = nested_mat_cx2_.am[0]._0;
     int _expr25 = idx_1;
     float2 unnamed_10 = __get_col_of_mat4x2(nested_mat_cx2_.am[0], _expr25);
-    float unnamed_11 = nested_mat_cx2_.am[0]._0[1];
+    float unnamed_11 = nested_mat_cx2_.am[0]._0.y;
     int _expr41 = idx_1;
     float unnamed_12 = nested_mat_cx2_.am[0]._0[_expr41];
     int _expr47 = idx_1;
-    float unnamed_13 = __get_col_of_mat4x2(nested_mat_cx2_.am[0], _expr47)[1];
+    float unnamed_13 = __get_col_of_mat4x2(nested_mat_cx2_.am[0], _expr47).y;
     int _expr55 = idx_1;
     int _expr57 = idx_1;
     float unnamed_14 = __get_col_of_mat4x2(nested_mat_cx2_.am[0], _expr55)[_expr57];
@@ -207,7 +207,7 @@ void test_matrix_within_array_within_struct_accesses()
     t_1.am[0]._0 = (9.0).xx;
     int _expr90 = idx_1;
     __set_col_of_mat4x2(t_1.am[0], _expr90, (90.0).xx);
-    t_1.am[0]._0[1] = 10.0;
+    t_1.am[0]._0.y = 10.0;
     int _expr107 = idx_1;
     t_1.am[0]._0[_expr107] = 20.0;
     int _expr113 = idx_1;


### PR DESCRIPTION
Fixes #2095 by using more conventional `.x` indexing instead of "unconventional" `[0]`.