### PR TITLE
Fix incorrect atomic bounds check on metal back-end

### DIFF
--- a/tests/in/bounds-check-zero-atomic.wgsl
+++ b/tests/in/bounds-check-zero-atomic.wgsl
@@ -23,3 +23,16 @@ fn fetch_add_atomic_static_sized_array(i: i32) -> u32 {
 fn fetch_add_atomic_dynamic_sized_array(i: i32) -> u32 {
    return atomicAdd(&globals.c[i], 1u);
 }
+
+fn exchange_atomic() -> u32 {
+   return atomicExchange(&globals.a, 1u);
+}
+
+fn exchange_atomic_static_sized_array(i: i32) -> u32 {
+   return atomicExchange(&globals.b[i], 1u);
+}
+
+fn exchange_atomic_dynamic_sized_array(i: i32) -> u32 {
+   return atomicExchange(&globals.c[i], 1u);
+}
+

--- a/tests/out/msl/bounds-check-zero-atomic.msl
+++ b/tests/out/msl/bounds-check-zero-atomic.msl
@@ -49,3 +49,29 @@ uint fetch_add_atomic_dynamic_sized_array(
     uint _e5 = uint(i_1) < 1 + (_buffer_sizes.size0 - 44 - 4) / 4 ? metal::atomic_fetch_add_explicit(&globals.c[i_1], 1u, metal::memory_order_relaxed) : DefaultConstructible();
     return _e5;
 }
+
+uint exchange_atomic(
+    device Globals& globals,
+    constant _mslBufferSizes& _buffer_sizes
+) {
+    uint _e3 = metal::atomic_exchange_explicit(&globals.a, 1u, metal::memory_order_relaxed);
+    return _e3;
+}
+
+uint exchange_atomic_static_sized_array(
+    int i_2,
+    device Globals& globals,
+    constant _mslBufferSizes& _buffer_sizes
+) {
+    uint _e5 = uint(i_2) < 10 ? metal::atomic_exchange_explicit(&globals.b.inner[i_2], 1u, metal::memory_order_relaxed) : DefaultConstructible();
+    return _e5;
+}
+
+uint exchange_atomic_dynamic_sized_array(
+    int i_3,
+    device Globals& globals,
+    constant _mslBufferSizes& _buffer_sizes
+) {
+    uint _e5 = uint(i_3) < 1 + (_buffer_sizes.size0 - 44 - 4) / 4 ? metal::atomic_exchange_explicit(&globals.c[i_3], 1u, metal::memory_order_relaxed) : DefaultConstructible();
+    return _e5;
+}


### PR DESCRIPTION
Generalize put_atomic_fetch to handle `exchange` as well, rather than special-cased code which didn't do the bounds check (the check handling as fixed in #1703 but only for the fetch cases, exchange was skipped).

Fixes #1848