### PR TITLE
Fix textureGather compatibility on macOS 10.13

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1440,7 +1440,7 @@ impl<W: Write> Writer<W> {
                         // Offset always comes before the gather, except
                         // in cube maps where it's not applicable
                         if offset.is_none() && !is_cube_map {
-                            write!(self.out, ", int2(0)")?;
+                            write!(self.out, ", metal::int2(0)")?;
                         }
                         let letter = ['x', 'y', 'z', 'w'][component as usize];
                         write!(self.out, ", {}::component::{}", NAMESPACE, letter)?;

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1440,7 +1440,7 @@ impl<W: Write> Writer<W> {
                         // Offset always comes before the gather, except
                         // in cube maps where it's not applicable
                         if offset.is_none() && !is_cube_map {
-                            write!(self.out, ", metal::int2(0)")?;
+                            write!(self.out, ", {}::int2(0)", NAMESPACE)?;
                         }
                         let letter = ['x', 'y', 'z', 'w'][component as usize];
                         write!(self.out, ", {}::component::{}", NAMESPACE, letter)?;

--- a/tests/out/msl/image.msl
+++ b/tests/out/msl/image.msl
@@ -144,7 +144,7 @@ fragment gatherOutput gather(
 , metal::depth2d<float, metal::access::sample> image_2d_depth [[user(fake0)]]
 ) {
     metal::float2 tc_2 = metal::float2(0.5);
-    metal::float4 s2d_1 = image_2d.gather(sampler_reg, tc_2, int2(0), metal::component::y);
+    metal::float4 s2d_1 = image_2d.gather(sampler_reg, tc_2, metal::int2(0), metal::component::y);
     metal::float4 s2d_offset_1 = image_2d.gather(sampler_reg, tc_2, const_type_9_, metal::component::w);
     metal::float4 s2d_depth_1 = image_2d_depth.gather_compare(sampler_cmp, tc_2, 0.5);
     metal::float4 s2d_depth_offset = image_2d_depth.gather_compare(sampler_cmp, tc_2, 0.5, const_type_9_);


### PR DESCRIPTION
```
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_render_pipeline
    Internal error in VERTEX shader: Metal: Compilation failed: 

program_source:90:65: error: use of undeclared identifier 'int2'; did you mean 'int'?
            metal::float4 _e4 = image.gather(samp, tex_coord_1, int2(0), metal::component::y);
                                                                ^
program_source:94:65: error: use of undeclared identifier 'int2'; did you mean 'int'?
            metal::float4 _e5 = image.gather(samp, tex_coord_1, int2(0), metal::component::z);
                                                                ^
program_source:98:65: error: use of undeclared identifier 'int2'; did you mean 'int'?
            metal::float4 _e6 = image.gather(samp, tex_coord_1, int2(0), metal::component::w);
                                                                ^
program_source:196:98: warning: suggest braces around initialization of subobject
                fitting_lanczos_weight(weight_color_1, weight_sum_1, _e74, point_ori_1, type_10 {metal::float2(gather_center.x - 0.5, gather_center.y + 0.5), metal::float2(gather_center.x + 0.5, gather_center.y + 0.5), metal::float2(gather_center.x + 0.5, gather_center.y - 0.5), metal::float2(gather_center.x - 0.5, gather_center.y - 0.5)}, fitting_scale);
                                                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                                 {                                                                                                                                                                                                                                                 }


', /Users/admin/.cargo/git/checkouts/wgpu-53e70f8674b08dd4/754a4ba/wgpu/src/backend/[direct.rs:2418](http://direct.rs:2418/):5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```