### PR TITLE
Error if the uniformity requirements for a barrier aren't met

### DIFF
--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -780,13 +780,25 @@ impl FunctionInfo {
                         ExitFlags::empty()
                     },
                 },
-                S::Barrier(_) => FunctionUniformity {
-                    result: Uniformity {
-                        non_uniform_result: None,
-                        requirements: UniformityRequirements::WORK_GROUP_BARRIER,
-                    },
-                    exit: ExitFlags::empty(),
-                },
+                S::Barrier(_) => {
+                    #[cfg(feature = "validate")]
+                    if self
+                        .flags
+                        .contains(super::ValidationFlags::CONTROL_FLOW_UNIFORMITY)
+                    {
+                        if let Some(cause) = disruptor {
+                            return Err(FunctionError::NonUniformBarrier(cause)
+                                .with_span_static(span, "Barrier creation"));
+                        }
+                    }
+                    FunctionUniformity {
+                        result: Uniformity {
+                            non_uniform_result: None,
+                            requirements: UniformityRequirements::WORK_GROUP_BARRIER,
+                        },
+                        exit: ExitFlags::empty(),
+                    }
+                }
                 S::Block(ref b) => {
                     self.process_block(b, other_functions, disruptor, expression_arena)?
                 }
@@ -1159,7 +1171,7 @@ fn uniform_control_flow() {
     assert_eq!(info[derivative_expr].ref_count, 1);
     assert_eq!(info[non_uniform_global], GlobalUse::READ);
 
-    let stmt_emit3 = S::Emit(emit_range_globals);
+    let stmt_emit3 = S::Emit(emit_range_globals.clone());
     let stmt_return_non_uniform = S::Return {
         value: Some(non_uniform_global_expr),
     };
@@ -1206,4 +1218,25 @@ fn uniform_control_flow() {
         }),
     );
     assert_eq!(info[non_uniform_global], GlobalUse::READ | GlobalUse::WRITE);
+
+    let stmt_emit5 = S::Emit(emit_range_globals.clone());
+    let stmt_if_non_uniform = S::If {
+        condition: non_uniform_global_expr,
+        accept: vec![S::Barrier(crate::Barrier::empty())].into(),
+        reject: crate::Block::new(),
+    };
+    assert_eq!(
+        info.process_block(
+            &vec![stmt_emit5, stmt_if_non_uniform].into(),
+            &[],
+            None,
+            &expressions
+        ),
+        Err(
+            FunctionError::NonUniformBarrier(UniformityDisruptor::Expression(
+                non_uniform_global_expr
+            ))
+            .with_span()
+        ),
+    );
 }

--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -140,6 +140,8 @@ pub enum FunctionError {
         Handle<crate::Expression>,
         UniformityDisruptor,
     ),
+    #[error("Required uniformity of barrier is not fulfilled because of {0:?}")]
+    NonUniformBarrier(UniformityDisruptor),
     #[error("Functions that are not entry points cannot have `@location` or `@builtin` attributes on their arguments: \"{name}\" has attributes")]
     PipelineInputRegularFunction { name: String },
     #[error("Functions that are not entry points cannot have `@location` or `@builtin` attributes on their return value types")]


### PR DESCRIPTION
I think this is the only other case in `process_block` where a uniformity requirement can be created without being validated.