### PR TITLE
[hlsl-out] clear `named_expressions` inserted by duplicated blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ glsl-out = []
 msl-out = []
 serialize = ["serde", "indexmap/serde-1"]
 deserialize = ["serde", "indexmap/serde-1"]
+arbitrary = ["dep:arbitrary", "indexmap/arbitrary"]
 spv-in = ["petgraph", "spirv"]
 spv-out = ["spirv"]
 wgsl-in = ["codespan-reporting", "hexf-parse", "termcolor", "unicode-xid"]
@@ -52,7 +53,7 @@ termcolor = { version = "1.0.4", optional = true }
 # https://github.com/brendanzab/codespan/commit/e99c867339a877731437e7ee6a903a3d03b5439e
 codespan-reporting = { version = "0.11.0", optional = true }
 rustc-hash = "1.1.0"
-indexmap = { version = "1.6", features = ["std"] }
+indexmap = { version = "1.9.2", features = ["std"] }
 log = "0.4"
 num-traits = "0.2"
 spirv = { version = "0.2", optional = true }

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -1908,9 +1908,12 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                         let indent_level_3 = indent_level_2.next();
                         for case in &cases[i..=end_case_idx] {
                             writeln!(self.out, "{indent_level_2}{{")?;
+                            let prev_len = self.named_expressions.len();
                             for sta in case.body.iter() {
                                 self.write_stmt(module, sta, func_ctx, indent_level_3)?;
                             }
+                            // Clear all named expressions that were previously inserted by the statements in the block
+                            self.named_expressions.truncate(prev_len);
                             writeln!(self.out, "{indent_level_2}}}")?;
                         }
 

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -8,9 +8,8 @@ use super::{
 };
 use crate::{
     front::glsl::types::type_power, proc::ensure_block_returns, AddressSpace, Arena, Block,
-    Constant, ConstantInner, EntryPoint, Expression, FastHashMap, Function, FunctionArgument,
-    FunctionResult, Handle, LocalVariable, ScalarKind, ScalarValue, Span, Statement, StructMember,
-    Type, TypeInner,
+    Constant, ConstantInner, EntryPoint, Expression, Function, FunctionArgument, FunctionResult,
+    Handle, LocalVariable, ScalarKind, ScalarValue, Span, Statement, StructMember, Type, TypeInner,
 };
 use std::iter;
 
@@ -1064,7 +1063,7 @@ impl Frontend {
             result,
             local_variables: locals,
             expressions,
-            named_expressions: FastHashMap::default(),
+            named_expressions: crate::NamedExpressions::default(),
             body,
         };
 

--- a/src/front/spv/function.rs
+++ b/src/front/spv/function.rs
@@ -61,7 +61,7 @@ impl<I: Iterator<Item = u32>> super::Frontend<I> {
                 local_variables: Arena::new(),
                 expressions: self
                     .make_expression_storage(&module.global_variables, &module.constants),
-                named_expressions: crate::FastHashMap::default(),
+                named_expressions: crate::NamedExpressions::default(),
                 body: crate::Block::new(),
             }
         };
@@ -298,7 +298,7 @@ impl<I: Iterator<Item = u32>> super::Frontend<I> {
                 result: None,
                 local_variables: Arena::new(),
                 expressions: Arena::new(),
-                named_expressions: crate::FastHashMap::default(),
+                named_expressions: crate::NamedExpressions::default(),
                 body: crate::Block::new(),
             };
 

--- a/src/front/wgsl/lower/mod.rs
+++ b/src/front/wgsl/lower/mod.rs
@@ -74,7 +74,7 @@ pub struct StatementContext<'source, 'temp, 'out> {
     typifier: &'temp mut Typifier,
     variables: &'out mut Arena<crate::LocalVariable>,
     naga_expressions: &'out mut Arena<crate::Expression>,
-    named_expressions: &'out mut FastHashMap<Handle<crate::Expression>, String>,
+    named_expressions: &'out mut crate::NamedExpressions,
     arguments: &'out [crate::FunctionArgument],
     module: &'out mut crate::Module,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,11 @@ pub type FastHashMap<K, T> = rustc_hash::FxHashMap<K, T>;
 pub type FastHashSet<K> = rustc_hash::FxHashSet<K>;
 
 /// Map of expressions that have associated variable names
-pub(crate) type NamedExpressions = FastHashMap<Handle<Expression>, String>;
+pub(crate) type NamedExpressions = indexmap::IndexMap<
+    Handle<Expression>,
+    String,
+    std::hash::BuildHasherDefault<rustc_hash::FxHasher>,
+>;
 
 /// Early fragment tests.
 ///

--- a/tests/out/ir/access.ron
+++ b/tests/out/ir/access.ron
@@ -2149,17 +2149,17 @@
                     ),
                 ],
                 named_expressions: {
-                    29: "c",
-                    4: "baz",
-                    17: "b",
                     1: "vi",
-                    27: "a",
+                    4: "baz",
                     8: "_matrix",
                     11: "arr",
-                    34: "data_pointer",
-                    47: "value",
                     12: "index",
+                    17: "b",
+                    27: "a",
+                    29: "c",
+                    34: "data_pointer",
                     35: "foo_value",
+                    47: "value",
                 },
                 body: [
                     Store(


### PR DESCRIPTION
fixes #1972