### PR TITLE
Document `EarlyDepthTest` and `ConservativeDepth` syntax in WGSL

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,7 @@ pub(crate) type NamedExpressions = FastHashMap<Handle<Expression>, String>;
 ///   - GLSL: `layout(early_fragment_tests) in;`
 ///   - HLSL: `Attribute earlydepthstencil`
 ///   - SPIR-V: `ExecutionMode EarlyFragmentTests`
+///   - WGSL: `@early_depth_test`
 ///
 /// For more, see:
 ///   - <https://www.khronos.org/opengl/wiki/Early_Fragment_Test#Explicit_specification>
@@ -265,6 +266,7 @@ pub struct EarlyDepthTest {
 ///     - `depth_any` option behaves as if the layout qualifier was not present.
 ///   - HLSL: `SV_DepthGreaterEqual`/`SV_DepthLessEqual`/`SV_Depth`
 ///   - SPIR-V: `ExecutionMode Depth<Greater/Less/Unchanged>`
+///   - WGSL: `@early_depth_test(greater_equal/less_equal/unchanged)`
 ///
 /// For more, see:
 ///   - <https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_conservative_depth.txt>


### PR DESCRIPTION
👋 Hey there,

Was trying to figure out how to explicitly enable early depth tests in WebGPU/WGSL shaders, and noticed there was documentation on the syntax for `EarlyDepthTest` and `ConservativeDepth` options for GLSL/HLSL/SPIR-V, but not for WGSL. 

Had to do some digging through the parser code to figure out how to do it, so this PR adds documentation, so that hopefully others can find it more easily in the future.

```wgsl
@fragment
@early_depth_test
fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
  // ....
}
```

_OR_

```wgsl
@fragment
@early_depth_test(greater_equal/less_equal/unchanged) // pick one mode
fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
  // ....
}
```
