### PR TITLE
[wgsl-in] Remove non-32bit integers

### DIFF
--- a/src/front/wgsl/conv.rs
+++ b/src/front/wgsl/conv.rs
@@ -97,17 +97,11 @@ pub fn map_storage_format(word: &str, span: Span) -> Result<crate::StorageFormat
 
 pub fn get_scalar_type(word: &str) -> Option<(crate::ScalarKind, crate::Bytes)> {
     match word {
-        "f16" => Some((crate::ScalarKind::Float, 2)),
+        // "f16" => Some((crate::ScalarKind::Float, 2)),
         "f32" => Some((crate::ScalarKind::Float, 4)),
         "f64" => Some((crate::ScalarKind::Float, 8)),
-        "i8" => Some((crate::ScalarKind::Sint, 1)),
-        "i16" => Some((crate::ScalarKind::Sint, 2)),
         "i32" => Some((crate::ScalarKind::Sint, 4)),
-        "i64" => Some((crate::ScalarKind::Sint, 8)),
-        "u8" => Some((crate::ScalarKind::Uint, 1)),
-        "u16" => Some((crate::ScalarKind::Uint, 2)),
         "u32" => Some((crate::ScalarKind::Uint, 4)),
-        "u64" => Some((crate::ScalarKind::Uint, 8)),
         "bool" => Some((crate::ScalarKind::Bool, crate::BOOL_WIDTH)),
         _ => None,
     }

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -279,9 +279,7 @@ impl<'a> Error<'a> {
             Error::UnknownScalarType(ref bad_span) => ParseError {
                 message: format!("unknown scalar type: '{}'", &source[bad_span.clone()]),
                 labels: vec![(bad_span.clone(), "unknown scalar type".into())],
-                notes: vec!["Valid scalar types are f16, f32, f64, \
-                             i8, i16, i32, i64, \
-                             u8, u16, u32, u64, bool"
+                notes: vec!["Valid scalar types are f32, f64, i32, u32, bool"
                     .into()],
             },
             Error::BadTextureSampleType {

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -279,8 +279,7 @@ impl<'a> Error<'a> {
             Error::UnknownScalarType(ref bad_span) => ParseError {
                 message: format!("unknown scalar type: '{}'", &source[bad_span.clone()]),
                 labels: vec![(bad_span.clone(), "unknown scalar type".into())],
-                notes: vec!["Valid scalar types are f32, f64, i32, u32, bool"
-                    .into()],
+                notes: vec!["Valid scalar types are f32, f64, i32, u32, bool".into()],
             },
             Error::BadTextureSampleType {
                 ref span,

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -78,12 +78,12 @@ fn invalid_float() {
 #[test]
 fn invalid_texture_sample_type() {
     check(
-        "let x: texture_2d<f16>;",
-        r###"error: texture sample type must be one of f32, i32 or u32, but found f16
+        "let x: texture_2d<bool>;",
+        r###"error: texture sample type must be one of f32, i32 or u32, but found bool
   ┌─ wgsl:1:19
   │
-1 │ let x: texture_2d<f16>;
-  │                   ^^^ must be one of f32, i32 or u32
+1 │ let x: texture_2d<bool>;
+  │                   ^^^^ must be one of f32, i32 or u32
 
 "###,
     );
@@ -373,7 +373,7 @@ fn unknown_scalar_type() {
 2 │             let a: vec2<something>;
   │                         ^^^^^^^^^ unknown scalar type
   │
-  = note: Valid scalar types are f16, f32, f64, i8, i16, i32, i64, u8, u16, u32, u64, bool
+  = note: Valid scalar types are f32, f64, i32, u32, bool
 
 "#,
     );


### PR DESCRIPTION
Validation already fails on any non-32bit integers but this change makes it clearer what the frontend actually supports.

Also commented out `f16`, we can uncomment it once we implement the extension.
