### PR TITLE
add Range::new_from_bounds

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -153,6 +153,15 @@ impl<T> Iterator for Range<T> {
     }
 }
 
+impl<T> Range<T> {
+    pub fn new_from_bounds(first: Handle<T>, last: Handle<T>) -> Self {
+        Self {
+            inner: (first.index() as u32)..(last.index() as u32 + 1),
+            marker: Default::default(),
+        }
+    }
+}
+
 /// An arena holding some kind of component (e.g., type, constant,
 /// instruction, etc.) that can be referenced.
 ///


### PR DESCRIPTION
when working with naga IR i've found i need to be able to construct `Range`s (specifically for `Statement::Emit` which can't be constructed otherwise). it is possible currently, but only via serde hacking.

i added a `Range::new_from_bounds` method to allow construction.

first PR, apologies if i missed any standard process.