### PR TITLE
Add ValidationFlags::BINDINGS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,7 @@ tree.
     clippy::unneeded_field_pattern,
     clippy::match_like_matches_macro,
     clippy::if_same_then_else,
+    clippy::collapsible_if,
     clippy::derive_partial_eq_without_eq
 )]
 #![warn(

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -66,6 +66,9 @@ bitflags::bitflags! {
         /// Constants.
         #[cfg(feature = "validate")]
         const CONSTANTS = 0x10;
+        /// Group, binding, and location attributes.
+        #[cfg(feature = "validate")]
+        const BINDINGS = 0x20;
     }
 }
 

--- a/tests/out/analysis/collatz.info.ron
+++ b/tests/out/analysis/collatz.info.ron
@@ -2,7 +2,7 @@
     functions: [
         (
             flags: (
-                bits: 31,
+                bits: 63,
             ),
             available_stages: (
                 bits: 7,
@@ -346,7 +346,7 @@
     entry_points: [
         (
             flags: (
-                bits: 31,
+                bits: 63,
             ),
             available_stages: (
                 bits: 7,

--- a/tests/out/analysis/shadow.info.ron
+++ b/tests/out/analysis/shadow.info.ron
@@ -2,7 +2,7 @@
     functions: [
         (
             flags: (
-                bits: 31,
+                bits: 63,
             ),
             available_stages: (
                 bits: 7,
@@ -1068,7 +1068,7 @@
         ),
         (
             flags: (
-                bits: 31,
+                bits: 63,
             ),
             available_stages: (
                 bits: 7,
@@ -2871,7 +2871,7 @@
     entry_points: [
         (
             flags: (
-                bits: 31,
+                bits: 63,
             ),
             available_stages: (
                 bits: 7,


### PR DESCRIPTION
Part of #2154

A few things to think about here:
  1. Is the scope of the flag chosen soundly? I was considering `INTERFACE` first, but it could be considered too wide of a scope.
  2. Can this be released as a patch? I.e. is adding a bitflag a breaking change?