### PR TITLE
Ignore `unused_imports` in tests/snapshots.rs.

### DIFF
--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -1,6 +1,6 @@
 // A lot of the code can be unused based on configuration flags,
 // the corresponding warnings aren't helpful.
-#![allow(dead_code)]
+#![allow(dead_code, unused_imports)]
 
 use std::{
     fs,


### PR DESCRIPTION
This is for the same reason that we ignore `dead_code`:

    // A lot of the code can be unused based on configuration flags,
    // the corresponding warnings aren't helpful.