### PR TITLE
msl: handle the case of missing binding

### DIFF
--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -156,8 +156,10 @@ pub enum Error {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub enum EntryPointError {
+    #[error("global '{0}' doesn't have a binding")]
+    MissingBinding(String),
     #[error("mapping of {0:?} is missing")]
-    MissingBinding(crate::ResourceBinding),
+    MissingBindTarget(crate::ResourceBinding),
     #[error("mapping for push constants is missing")]
     MissingPushConstants,
     #[error("mapping for sizes buffer is missing")]
@@ -303,7 +305,7 @@ impl Options {
                 index: 0,
                 interpolation: None,
             }),
-            None => Err(EntryPointError::MissingBinding(res_binding.clone())),
+            None => Err(EntryPointError::MissingBindTarget(res_binding.clone())),
         }
     }
 


### PR DESCRIPTION
The purpose of this code is to detect if a global variable can or can't be used legally by a given entry point. It assumes the resource binding is present and just checks if the override is set. I find it also useful to check if there is a binding at all. Hence the new error type.

Note that, technically speaking, all backends assume the module is valid. And this validity includes having a binding decoration on all resource globals. And now this code makes MSL backend *also* work correctly for a subset of modules that are valid except for the bindings part. So it's a tricky case, and it's not directly hit by WebGPU paths.