### PR TITLE
Add 'function' to the list of reserved wgsl keywords

### DIFF
--- a/src/keywords/wgsl.rs
+++ b/src/keywords/wgsl.rs
@@ -130,6 +130,7 @@ pub const RESERVED: &[&str] = &[
     "friend",
     "from",
     "fxgroup",
+    "function",
     "get",
     "goto",
     "groupshared",


### PR DESCRIPTION
Prior to this change I was getting this wgpu error on shaders converted at build-time from spir-v to wgsl:
```
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_shader_module
      note: label = `../../compiled-shaders/single_view_vertex.wgsl`
    
Shader '../../compiled-shaders/single_view_vertex.wgsl' parsing error: name `function` is a reserved keyword
   ┌─ wgsl:79:4
   │
79 │ fn function() {
   │    ^^^^^^^^ definition of `function`


    name `function` is a reserved keyword

', /home/ashley/.cargo/git/checkouts/wgpu-c9d051493be6af69/4cf0d03/wgpu/src/backend/direct.rs:2962:5
```