### PR TITLE
[glsl-out] use `fma` polyfill for versions below gles 320

### DIFF
--- a/src/back/glsl/features.rs
+++ b/src/back/glsl/features.rs
@@ -1,7 +1,7 @@
 use super::{BackendResult, Error, Version, Writer};
 use crate::{
     AddressSpace, Binding, Bytes, Expression, Handle, ImageClass, ImageDimension, Interpolation,
-    MathFunction, Sampling, ScalarKind, ShaderStage, StorageFormat, Type, TypeInner,
+    Sampling, ScalarKind, ShaderStage, StorageFormat, Type, TypeInner,
 };
 use std::fmt::Write;
 
@@ -34,14 +34,12 @@ bitflags::bitflags! {
         /// Arrays with a dynamic length.
         const DYNAMIC_ARRAY_SIZE = 1 << 16;
         const MULTI_VIEW = 1 << 17;
-        /// Fused multiply-add.
-        const FMA = 1 << 18;
         /// Texture samples query
-        const TEXTURE_SAMPLES = 1 << 19;
+        const TEXTURE_SAMPLES = 1 << 18;
         /// Texture levels query
-        const TEXTURE_LEVELS = 1 << 20;
+        const TEXTURE_LEVELS = 1 << 19;
         /// Image size query
-        const IMAGE_SIZE = 1 << 21;
+        const IMAGE_SIZE = 1 << 20;
     }
 }
 
@@ -222,11 +220,6 @@ impl FeaturesManager {
                 // https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GL_EXT_multiview.txt
                 writeln!(out, "#extension GL_EXT_multiview : require")?;
             }
-        }
-
-        if self.0.contains(Features::FMA) && version >= Version::new_gles(310) {
-            // https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_gpu_shader5.txt
-            writeln!(out, "#extension GL_EXT_gpu_shader5 : require")?;
         }
 
         if self.0.contains(Features::TEXTURE_SAMPLES) {
@@ -425,10 +418,6 @@ impl<'a, W> Writer<'a, W> {
         {
             for (_, expr) in expressions.iter() {
                 match *expr {
-                // Check for fused multiply add use
-                Expression::Math { fun, .. } if fun == MathFunction::Fma => {
-                    features.request(Features::FMA)
-                }
                 // Check for queries that neeed aditonal features
                 Expression::ImageQuery {
                     image,

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -179,7 +179,7 @@ impl Version {
     }
 
     fn supports_fma_function(&self) -> bool {
-        *self >= Version::Desktop(400) || *self >= Version::new_gles(310)
+        *self >= Version::Desktop(400) || *self >= Version::new_gles(320)
     }
 }
 

--- a/tests/in/functions-webgl.param.ron
+++ b/tests/in/functions-webgl.param.ron
@@ -1,7 +1,7 @@
 (
 	glsl: (
 		version: Embedded(
-			version: 300,
+			version: 320,
 			is_webgl: false
 		),
 		writer_flags: (bits: 0),

--- a/tests/out/glsl/functions-webgl.main.Vertex.glsl
+++ b/tests/out/glsl/functions-webgl.main.Vertex.glsl
@@ -1,4 +1,4 @@
-#version 300 es
+#version 320 es
 
 precision highp float;
 precision highp int;
@@ -8,7 +8,7 @@ vec2 test_fma() {
     vec2 a = vec2(2.0, 2.0);
     vec2 b = vec2(0.5, 0.5);
     vec2 c = vec2(0.5, 0.5);
-    return (a * b + c);
+    return fma(a, b, c);
 }
 
 void main() {

--- a/tests/out/glsl/functions.main.Compute.glsl
+++ b/tests/out/glsl/functions.main.Compute.glsl
@@ -1,5 +1,4 @@
 #version 310 es
-#extension GL_EXT_gpu_shader5 : require
 
 precision highp float;
 precision highp int;
@@ -11,7 +10,7 @@ vec2 test_fma() {
     vec2 a = vec2(2.0, 2.0);
     vec2 b = vec2(0.5, 0.5);
     vec2 c = vec2(0.5, 0.5);
-    return fma(a, b, c);
+    return (a * b + c);
 }
 
 int test_integer_dot_product() {


### PR DESCRIPTION
The issue was that we were effectively requiring GLSL 310 + `GL_EXT_gpu_shader5` when we could have instead used the polyfill.

Was previously brought up in https://github.com/gfx-rs/naga/pull/1580#discussion_r772578184.
Closes #2196.