### PR TITLE
Revert "Error if the uniformity requirements for a barrier aren't met"

### DIFF
--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -139,8 +139,6 @@ pub enum FunctionError {
         Handle<crate::Expression>,
         UniformityDisruptor,
     ),
-    #[error("Required uniformity of barrier is not fulfilled because of {0:?}")]
-    NonUniformBarrier(UniformityDisruptor),
     #[error("Functions that are not entry points cannot have `@location` or `@builtin` attributes on their arguments: \"{name}\" has attributes")]
     PipelineInputRegularFunction { name: String },
     #[error("Functions that are not entry points cannot have `@location` or `@builtin` attributes on their return value types")]


### PR DESCRIPTION
This reverts commit e6e94d65 (#2115). That PR extends Naga's old uniformity analysis, adding a check for barriers that matches the existing checks on derivative operations. However, this breaks existing clients ([`Vello`](https://github.com/linebender/vello), for example), and extending the old uniformity analysis is not a priority, so it makes sense to back it out.