### PR TITLE
Update setup-dxc to v1.1.0

### DIFF
--- a/.github/workflows/validation-windows.yml
+++ b/.github/workflows/validation-windows.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Add DirectXShaderCompiler
-        uses: napokue/setup-dxc@v1.0.0
+        uses: napokue/setup-dxc@v1.1.0
       - run: make validate-hlsl-dxc
         shell: sh
 


### PR DESCRIPTION
I saw the "[validation-windows](https://github.com/gfx-rs/naga/actions/workflows/validation-windows.yml)" jobs were giving a warning due to [setup-dxc](https://github.com/Napokue/setup-dxc) not being updated to NodeJs16. Updated it and released it under v1.1.0.

This PR updates the action to use v1.1.0 instead of version v1.0.0.