### PR TITLE
[glsl-in] Use std430 layout when validating arrays within structs

### DIFF
--- a/src/front/glsl/parser/types.rs
+++ b/src/front/glsl/parser/types.rs
@@ -86,7 +86,7 @@ impl<'source> ParsingContext<'source> {
                 self.expect(parser, TokenValue::LeftBrace)?;
                 let mut members = Vec::new();
                 let span =
-                    self.parse_struct_declaration_list(parser, &mut members, StructLayout::Std140)?;
+                    self.parse_struct_declaration_list(parser, &mut members, StructLayout::Std430)?;
                 let end_meta = self.expect(parser, TokenValue::RightBrace)?.meta;
                 meta.subsume(end_meta);
                 let ty = parser.module.types.insert(


### PR DESCRIPTION
Fixes #2211. However I don't know whether this change has broader consequences