### PR TITLE
Remove overly restrictive array stride check

### DIFF
--- a/src/valid/type.rs
+++ b/src/valid/type.rs
@@ -380,14 +380,6 @@ impl super::Validator {
                 }
 
                 let base_layout = self.layouter[base];
-                let expected_stride = base_layout.to_stride();
-                if stride != expected_stride {
-                    return Err(TypeError::InvalidArrayStride {
-                        stride,
-                        expected: expected_stride,
-                    });
-                }
-
                 let general_alignment = base_layout.alignment;
                 let uniform_layout = match base_info.uniform_layout {
                     Ok(base_alignment) => {


### PR DESCRIPTION
Fixes #2211 by removing the stride check, as suggested in https://github.com/gfx-rs/naga/pull/2212#issuecomment-1386177626. The alignments when used in uniforms and storage buffers are both validated below in the same function.