### PR TITLE
Address Clippy 1.67 lints.

### DIFF
--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_borrowed_reference)]
+
 use criterion::*;
 use std::{fs, path::PathBuf, slice};
 

--- a/cli/src/bin/naga.rs
+++ b/cli/src/bin/naga.rs
@@ -99,8 +99,7 @@ impl FromStr for BoundsCheckPolicyArg {
             "unchecked" => BoundsCheckPolicy::Unchecked,
             _ => {
                 return Err(format!(
-                    "Invalid value for --index-bounds-check-policy: {}",
-                    s
+                    "Invalid value for --index-bounds-check-policy: {s}"
                 ))
             }
         }))
@@ -120,7 +119,7 @@ impl FromStr for ShaderModelArg {
             "50" => ShaderModel::V5_0,
             "51" => ShaderModel::V5_1,
             "60" => ShaderModel::V6_0,
-            _ => return Err(format!("Invalid value for --shader-model: {}", s)),
+            _ => return Err(format!("Invalid value for --shader-model: {s}")),
         }))
     }
 }
@@ -139,7 +138,7 @@ impl FromStr for GlslProfileArg {
         } else if s.starts_with("es") {
             Version::new_gles(s[2..].parse().unwrap_or(310))
         } else {
-            return Err(format!("Unknown profile: {}", s));
+            return Err(format!("Unknown profile: {s}"));
         }))
     }
 }
@@ -163,7 +162,7 @@ trait PrettyResult {
 }
 
 fn print_err(error: &dyn Error) {
-    eprint!("{}", error);
+    eprint!("{error}");
 
     let mut e = error.source();
     if e.is_some() {
@@ -173,7 +172,7 @@ fn print_err(error: &dyn Error) {
     }
 
     while let Some(source) = e {
-        eprintln!("\t{}", source);
+        eprintln!("\t{source}");
         e = source.source();
     }
 }
@@ -366,10 +365,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 use std::io::Write;
 
                 let mut file = fs::File::create(output_path)?;
-                writeln!(file, "{:#?}", module)?;
+                writeln!(file, "{module:#?}")?;
                 if let Some(ref info) = info {
                     writeln!(file)?;
-                    writeln!(file, "{:#?}", info)?;
+                    writeln!(file, "{info:#?}")?;
                 }
             }
             "bin" => {
@@ -515,7 +514,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 fs::write(output_path, wgsl)?;
             }
             other => {
-                println!("Unknown output extension: {}", other);
+                println!("Unknown output extension: {other}");
             }
         }
     }

--- a/src/back/dot/mod.rs
+++ b/src/back/dot/mod.rs
@@ -304,15 +304,13 @@ fn write_fun(
     for (index, label) in sg.nodes.into_iter().enumerate() {
         writeln!(
             output,
-            "\t\t{}_s{} [ shape=square label=\"{}\" ]",
-            prefix, index, label,
+            "\t\t{prefix}_s{index} [ shape=square label=\"{label}\" ]",
         )?;
     }
     for (from, to, label) in sg.flow {
         writeln!(
             output,
-            "\t\t{}_s{} -> {}_s{} [ arrowhead=tee label=\"{}\" ]",
-            prefix, from, prefix, to, label,
+            "\t\t{prefix}_s{from} -> {prefix}_s{to} [ arrowhead=tee label=\"{label}\" ]",
         )?;
     }
     for (from, to, label, color_id) in sg.jumps {
@@ -384,12 +382,12 @@ fn write_function_expressions(
             }
             E::AccessIndex { base, index } => {
                 edges.insert("base", base);
-                (format!("AccessIndex[{}]", index).into(), 1)
+                (format!("AccessIndex[{index}]").into(), 1)
             }
             E::Constant(_) => ("Constant".into(), 2),
             E::Splat { size, value } => {
                 edges.insert("value", value);
-                (format!("Splat{:?}", size).into(), 3)
+                (format!("Splat{size:?}").into(), 3)
             }
             E::Swizzle {
                 size,
@@ -403,7 +401,7 @@ fn write_function_expressions(
                 payload = Some(Payload::Arguments(components));
                 ("Compose".into(), 3)
             }
-            E::FunctionArgument(index) => (format!("Argument[{}]", index).into(), 1),
+            E::FunctionArgument(index) => (format!("Argument[{index}]").into(), 1),
             E::GlobalVariable(h) => {
                 payload = Some(Payload::Global(h));
                 ("Global".into(), 2)
@@ -450,7 +448,7 @@ fn write_function_expressions(
                     edges.insert("depth_ref", expr);
                 }
                 let string = match gather {
-                    Some(component) => Cow::Owned(format!("ImageGather{:?}", component)),
+                    Some(component) => Cow::Owned(format!("ImageGather{component:?}")),
                     _ => Cow::Borrowed("ImageSample"),
                 };
                 (string, 5)
@@ -484,18 +482,18 @@ fn write_function_expressions(
                         }
                         Cow::from("ImageSize")
                     }
-                    _ => Cow::Owned(format!("{:?}", query)),
+                    _ => Cow::Owned(format!("{query:?}")),
                 };
                 (args, 7)
             }
             E::Unary { op, expr } => {
                 edges.insert("expr", expr);
-                (format!("{:?}", op).into(), 6)
+                (format!("{op:?}").into(), 6)
             }
             E::Binary { op, left, right } => {
                 edges.insert("left", left);
                 edges.insert("right", right);
-                (format!("{:?}", op).into(), 6)
+                (format!("{op:?}").into(), 6)
             }
             E::Select {
                 condition,
@@ -509,11 +507,11 @@ fn write_function_expressions(
             }
             E::Derivative { axis, expr } => {
                 edges.insert("", expr);
-                (format!("d{:?}", axis).into(), 8)
+                (format!("d{axis:?}").into(), 8)
             }
             E::Relational { fun, argument } => {
                 edges.insert("arg", argument);
-                (format!("{:?}", fun).into(), 6)
+                (format!("{fun:?}").into(), 6)
             }
             E::Math {
                 fun,
@@ -532,7 +530,7 @@ fn write_function_expressions(
                 if let Some(expr) = arg3 {
                     edges.insert("arg3", expr);
                 }
-                (format!("{:?}", fun).into(), 7)
+                (format!("{fun:?}").into(), 7)
             }
             E::As {
                 kind,
@@ -541,8 +539,8 @@ fn write_function_expressions(
             } => {
                 edges.insert("", expr);
                 let string = match convert {
-                    Some(width) => format!("Convert<{:?},{}>", kind, width),
-                    None => format!("Bitcast<{:?}>", kind),
+                    Some(width) => format!("Convert<{kind:?},{width}>"),
+                    None => format!("Bitcast<{kind:?}>"),
                 };
                 (string.into(), 3)
             }
@@ -644,7 +642,7 @@ pub fn write(
 
     for (handle, fun) in module.functions.iter() {
         let prefix = format!("f{}", handle.index());
-        writeln!(output, "\tsubgraph cluster_{} {{", prefix)?;
+        writeln!(output, "\tsubgraph cluster_{prefix} {{")?;
         writeln!(
             output,
             "\t\tlabel=\"Function{:?}/'{}'\"",
@@ -656,8 +654,8 @@ pub fn write(
         writeln!(output, "\t}}")?;
     }
     for (ep_index, ep) in module.entry_points.iter().enumerate() {
-        let prefix = format!("ep{}", ep_index);
-        writeln!(output, "\tsubgraph cluster_{} {{", prefix)?;
+        let prefix = format!("ep{ep_index}");
+        writeln!(output, "\tsubgraph cluster_{prefix} {{")?;
         writeln!(output, "\t\tlabel=\"{:?}/'{}'\"", ep.stage, ep.name)?;
         let info = mod_info.map(|a| a.get_entry_point(ep_index));
         write_fun(&mut output, prefix, &ep.function, info, &options)?;

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -198,8 +198,8 @@ impl PartialOrd for Version {
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Version::Desktop(v) => write!(f, "{} core", v),
-            Version::Embedded { version: v, .. } => write!(f, "{} es", v),
+            Version::Desktop(v) => write!(f, "{v} core"),
+            Version::Embedded { version: v, .. } => write!(f, "{v} es"),
         }
     }
 }
@@ -327,7 +327,7 @@ impl fmt::Display for VaryingName<'_> {
                     // fragment to pipeline
                     (ShaderStage::Fragment, true) => "fs2p",
                 };
-                write!(f, "_{}_location{}", prefix, location,)
+                write!(f, "_{prefix}_location{location}",)
             }
             crate::Binding::BuiltIn(built_in) => {
                 write!(
@@ -563,7 +563,7 @@ impl<'a, W: Write> Writer<'a, W> {
                         Cd::LessEqual => "less",
                         Cd::Unchanged => "unchanged",
                     };
-                    writeln!(self.out, "layout (depth_{}) out float gl_FragDepth;", depth)?;
+                    writeln!(self.out, "layout (depth_{depth}) out float gl_FragDepth;")?;
                 }
                 writeln!(self.out)?;
             } else {
@@ -576,7 +576,7 @@ impl<'a, W: Write> Writer<'a, W> {
 
         if self.entry_point.stage == ShaderStage::Vertex && self.options.version.is_webgl() {
             if let Some(multiview) = self.multiview.as_ref() {
-                writeln!(self.out, "layout(num_views = {}) in;", multiview)?;
+                writeln!(self.out, "layout(num_views = {multiview}) in;")?;
                 writeln!(self.out)?;
             }
         }
@@ -597,7 +597,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     .is_dynamically_sized(&self.module.types)
                 {
                     let name = &self.names[&NameKey::Type(handle)];
-                    write!(self.out, "struct {} ", name)?;
+                    write!(self.out, "struct {name} ")?;
                     self.write_struct_body(handle, members)?;
                     writeln!(self.out, ";")?;
                 }
@@ -653,7 +653,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     if layout_binding.is_some() || storage_format_access.is_some() {
                         write!(self.out, "layout(")?;
                         if let Some(binding) = layout_binding {
-                            write!(self.out, "binding = {}", binding)?;
+                            write!(self.out, "binding = {binding}")?;
                         }
                         if let Some((format, _)) = storage_format_access {
                             let format_str = glsl_storage_format(format);
@@ -661,7 +661,7 @@ impl<'a, W: Write> Writer<'a, W> {
                                 Some(_) => ",",
                                 None => "",
                             };
-                            write!(self.out, "{}{}", separator, format_str)?;
+                            write!(self.out, "{separator}{format_str}")?;
                         }
                         write!(self.out, ") ")?;
                     }
@@ -683,7 +683,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     // Finally write the name and end the global with a `;`
                     // The leading space is important
                     let global_name = self.get_global_name(handle, global);
-                    writeln!(self.out, " {};", global_name)?;
+                    writeln!(self.out, " {global_name};")?;
                     writeln!(self.out)?;
 
                     self.reflection_names_globals.insert(handle, global_name);
@@ -717,7 +717,7 @@ impl<'a, W: Write> Writer<'a, W> {
                             self.write_type(ty)?;
                         }
                     };
-                    write!(self.out, " {} = ", name)?;
+                    write!(self.out, " {name} = ")?;
                     self.write_constant(handle)?;
                     writeln!(self.out, ";")?;
                 }
@@ -777,11 +777,11 @@ impl<'a, W: Write> Writer<'a, W> {
                     crate::ConstantInner::Scalar {
                         width: _,
                         value: crate::ScalarValue::Uint(size),
-                    } => write!(self.out, "{}", size)?,
+                    } => write!(self.out, "{size}")?,
                     crate::ConstantInner::Scalar {
                         width: _,
                         value: crate::ScalarValue::Sint(size),
-                    } => write!(self.out, "{}", size)?,
+                    } => write!(self.out, "{size}")?,
                     _ => unreachable!(),
                 }
             }
@@ -865,7 +865,7 @@ impl<'a, W: Write> Writer<'a, W> {
             | TypeInner::Image { .. }
             | TypeInner::Sampler { .. }
             | TypeInner::BindingArray { .. } => {
-                return Err(Error::Custom(format!("Unable to write type {:?}", inner)))
+                return Err(Error::Custom(format!("Unable to write type {inner:?}")))
             }
         }
 
@@ -890,7 +890,7 @@ impl<'a, W: Write> Writer<'a, W> {
             TypeInner::Struct { .. } => {
                 // Get the struct name
                 let name = &self.names[&NameKey::Type(ty)];
-                write!(self.out, "{}", name)?;
+                write!(self.out, "{name}")?;
                 Ok(())
             }
             // glsl array has the size separated from the base type
@@ -972,7 +972,7 @@ impl<'a, W: Write> Writer<'a, W> {
                             crate::AddressSpace::Uniform => "std140, ",
                             _ => "",
                         };
-                        write!(self.out, "layout({}binding = {}) ", layout, binding)?
+                        write!(self.out, "layout({layout}binding = {binding}) ")?
                     }
                     None => {
                         log::debug!("unassigned binding for {:?}", global.name);
@@ -991,7 +991,7 @@ impl<'a, W: Write> Writer<'a, W> {
         }
 
         if let Some(storage_qualifier) = glsl_storage_qualifier(global.space) {
-            write!(self.out, "{} ", storage_qualifier)?;
+            write!(self.out, "{storage_qualifier} ")?;
         }
 
         match global.space {
@@ -1071,7 +1071,7 @@ impl<'a, W: Write> Writer<'a, W> {
             self.block_id.generate(),
             self.entry_point.stage,
         );
-        write!(self.out, "{} ", block_name)?;
+        write!(self.out, "{block_name} ")?;
         self.reflection_names_globals.insert(handle, block_name);
 
         match self.module.types[global.ty].inner {
@@ -1272,7 +1272,7 @@ impl<'a, W: Write> Writer<'a, W> {
 
         // Write the I/O locations, if allowed
         if self.options.version.supports_explicit_locations() || !emit_interpolation_and_auxiliary {
-            write!(self.out, "layout(location = {}) ", location)?;
+            write!(self.out, "layout(location = {location}) ")?;
         }
 
         // Write the interpolation qualifier.
@@ -1290,7 +1290,7 @@ impl<'a, W: Write> Writer<'a, W> {
         if let Some(sampling) = sampling {
             if emit_interpolation_and_auxiliary {
                 if let Some(qualifier) = glsl_sampling(sampling) {
-                    write!(self.out, "{} ", qualifier)?;
+                    write!(self.out, "{qualifier} ")?;
                 }
             }
         }
@@ -1314,7 +1314,7 @@ impl<'a, W: Write> Writer<'a, W> {
             output,
             targetting_webgl: self.options.version.is_webgl(),
         };
-        writeln!(self.out, " {};", vname)?;
+        writeln!(self.out, " {vname};")?;
 
         Ok(())
     }
@@ -1366,7 +1366,7 @@ impl<'a, W: Write> Writer<'a, W> {
             back::FunctionType::Function(handle) => &self.names[&NameKey::Function(handle)],
             back::FunctionType::EntryPoint(_) => "main",
         };
-        write!(self.out, " {}(", function_name)?;
+        write!(self.out, " {function_name}(")?;
 
         // Write the comma separated argument list
         //
@@ -1448,7 +1448,7 @@ impl<'a, W: Write> Writer<'a, W> {
                 write!(self.out, "{}", back::INDENT)?;
                 self.write_type(arg.ty)?;
                 let name = &self.names[&NameKey::EntryPointArgument(ep_index, index as u32)];
-                write!(self.out, " {}", name)?;
+                write!(self.out, " {name}")?;
                 write!(self.out, " = ")?;
                 match self.module.types[arg.ty].inner {
                     crate::TypeInner::Struct { ref members, .. } => {
@@ -1464,7 +1464,7 @@ impl<'a, W: Write> Writer<'a, W> {
                             if index != 0 {
                                 write!(self.out, ", ")?;
                             }
-                            write!(self.out, "{}", varying_name)?;
+                            write!(self.out, "{varying_name}")?;
                         }
                         writeln!(self.out, ");")?;
                     }
@@ -1475,7 +1475,7 @@ impl<'a, W: Write> Writer<'a, W> {
                             output: false,
                             targetting_webgl: self.options.version.is_webgl(),
                         };
-                        writeln!(self.out, "{};", varying_name)?;
+                        writeln!(self.out, "{varying_name};")?;
                     }
                 }
             }
@@ -1547,8 +1547,7 @@ impl<'a, W: Write> Writer<'a, W> {
 
             writeln!(
                 self.out,
-                "{}if (gl_GlobalInvocationID == uvec3(0u)) {{",
-                level
+                "{level}if (gl_GlobalInvocationID == uvec3(0u)) {{"
             )?;
 
             for (handle, var) in vars {
@@ -1558,7 +1557,7 @@ impl<'a, W: Write> Writer<'a, W> {
                 writeln!(self.out, ";")?;
             }
 
-            writeln!(self.out, "{}}}", level)?;
+            writeln!(self.out, "{level}}}")?;
             self.write_barrier(crate::Barrier::WORK_GROUP, level)?;
         }
 
@@ -1607,17 +1606,17 @@ impl<'a, W: Write> Writer<'a, W> {
                 ref value,
             } => match *value {
                 // Signed integers don't need anything special
-                Sv::Sint(int) => write!(self.out, "{}", int)?,
+                Sv::Sint(int) => write!(self.out, "{int}")?,
                 // Unsigned integers need a `u` at the end
                 //
                 // While `core` doesn't necessarily need it, it's allowed and since `es` needs it we
                 // always write it as the extra branch wouldn't have any benefit in readability
-                Sv::Uint(int) => write!(self.out, "{}u", int)?,
+                Sv::Uint(int) => write!(self.out, "{int}u")?,
                 // Floats are written using `Debug` instead of `Display` because it always appends the
                 // decimal part even it's zero which is needed for a valid glsl float constant
-                Sv::Float(float) => write!(self.out, "{:?}", float)?,
+                Sv::Float(float) => write!(self.out, "{float:?}")?,
                 // Booleans are either `true` or `false` so nothing special needs to be done
-                Sv::Bool(boolean) => write!(self.out, "{}", boolean)?,
+                Sv::Bool(boolean) => write!(self.out, "{boolean}")?,
             },
             // Composite constant are created using the same syntax as compose
             // `type(components)` where `components` is a comma separated list of constants
@@ -1662,13 +1661,13 @@ impl<'a, W: Write> Writer<'a, W> {
             // it shouldn't produce large expressions.
             self.write_expr(arg, ctx)?;
             // Access the current component on the first vector
-            write!(self.out, ".{} * ", component)?;
+            write!(self.out, ".{component} * ")?;
             // Write the second vector expression, this expression is marked to be
             // cached so unless it can't be cached (for example, it's a Constant)
             // it shouldn't produce large expressions.
             self.write_expr(arg1, ctx)?;
             // Access the current component on the second vector
-            write!(self.out, ".{}", component)?;
+            write!(self.out, ".{component}")?;
         }
 
         write!(self.out, ")")?;
@@ -1787,14 +1786,14 @@ impl<'a, W: Write> Writer<'a, W> {
                         } = *ctx.info[image].ty.inner_with(&self.module.types)
                         {
                             if let proc::BoundsCheckPolicy::Restrict = self.policies.image {
-                                write!(self.out, "{}", level)?;
+                                write!(self.out, "{level}")?;
                                 self.write_clamped_lod(ctx, handle, image, level_expr)?
                             }
                         }
                     }
 
                     if let Some(name) = expr_name {
-                        write!(self.out, "{}", level)?;
+                        write!(self.out, "{level}")?;
                         self.write_named_expr(handle, name, ctx)?;
                     }
                 }
@@ -1803,13 +1802,13 @@ impl<'a, W: Write> Writer<'a, W> {
             // We could also just print the statements but this is more readable and maps more
             // closely to the IR
             Statement::Block(ref block) => {
-                write!(self.out, "{}", level)?;
+                write!(self.out, "{level}")?;
                 writeln!(self.out, "{{")?;
                 for sta in block.iter() {
                     // Increase the indentation to help with readability
                     self.write_stmt(sta, ctx, level.next())?
                 }
-                writeln!(self.out, "{}}}", level)?
+                writeln!(self.out, "{level}}}")?
             }
             // Ifs are written as in C:
             // ```
@@ -1824,7 +1823,7 @@ impl<'a, W: Write> Writer<'a, W> {
                 ref accept,
                 ref reject,
             } => {
-                write!(self.out, "{}", level)?;
+                write!(self.out, "{level}")?;
                 write!(self.out, "if (")?;
                 self.write_expr(condition, ctx)?;
                 writeln!(self.out, ") {{")?;
@@ -1837,7 +1836,7 @@ impl<'a, W: Write> Writer<'a, W> {
                 // If there are no statements in the reject block we skip writing it
                 // This is only for readability
                 if !reject.is_empty() {
-                    writeln!(self.out, "{}}} else {{", level)?;
+                    writeln!(self.out, "{level}}} else {{")?;
 
                     for sta in reject {
                         // Increase indentation to help with readability
@@ -1845,7 +1844,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     }
                 }
 
-                writeln!(self.out, "{}}}", level)?
+                writeln!(self.out, "{level}}}")?
             }
             // Switch are written as in C:
             // ```
@@ -1868,7 +1867,7 @@ impl<'a, W: Write> Writer<'a, W> {
                 ref cases,
             } => {
                 // Start the switch
-                write!(self.out, "{}", level)?;
+                write!(self.out, "{level}")?;
                 write!(self.out, "switch(")?;
                 self.write_expr(selector, ctx)?;
                 writeln!(self.out, ") {{")?;
@@ -1885,9 +1884,9 @@ impl<'a, W: Write> Writer<'a, W> {
                 for case in cases {
                     match case.value {
                         crate::SwitchValue::Integer(value) => {
-                            write!(self.out, "{}case {}{}:", l2, value, type_postfix)?
+                            write!(self.out, "{l2}case {value}{type_postfix}:")?
                         }
-                        crate::SwitchValue::Default => write!(self.out, "{}default:", l2)?,
+                        crate::SwitchValue::Default => write!(self.out, "{l2}default:")?,
                     }
 
                     let write_block_braces = !(case.fall_through && case.body.is_empty());
@@ -1906,11 +1905,11 @@ impl<'a, W: Write> Writer<'a, W> {
                     }
 
                     if write_block_braces {
-                        writeln!(self.out, "{}}}", l2)?;
+                        writeln!(self.out, "{l2}}}")?;
                     }
                 }
 
-                writeln!(self.out, "{}}}", level)?
+                writeln!(self.out, "{level}}}")?
             }
             // Loops in naga IR are based on wgsl loops, glsl can emulate the behaviour by using a
             // while true loop and appending the continuing block to the body resulting on:
@@ -1929,45 +1928,45 @@ impl<'a, W: Write> Writer<'a, W> {
             } => {
                 if !continuing.is_empty() || break_if.is_some() {
                     let gate_name = self.namer.call("loop_init");
-                    writeln!(self.out, "{}bool {} = true;", level, gate_name)?;
-                    writeln!(self.out, "{}while(true) {{", level)?;
+                    writeln!(self.out, "{level}bool {gate_name} = true;")?;
+                    writeln!(self.out, "{level}while(true) {{")?;
                     let l2 = level.next();
                     let l3 = l2.next();
-                    writeln!(self.out, "{}if (!{}) {{", l2, gate_name)?;
+                    writeln!(self.out, "{l2}if (!{gate_name}) {{")?;
                     for sta in continuing {
                         self.write_stmt(sta, ctx, l3)?;
                     }
                     if let Some(condition) = break_if {
-                        write!(self.out, "{}if (", l3)?;
+                        write!(self.out, "{l3}if (")?;
                         self.write_expr(condition, ctx)?;
                         writeln!(self.out, ") {{")?;
                         writeln!(self.out, "{}break;", l3.next())?;
-                        writeln!(self.out, "{}}}", l3)?;
+                        writeln!(self.out, "{l3}}}")?;
                     }
-                    writeln!(self.out, "{}}}", l2)?;
+                    writeln!(self.out, "{l2}}}")?;
                     writeln!(self.out, "{}{} = false;", level.next(), gate_name)?;
                 } else {
-                    writeln!(self.out, "{}while(true) {{", level)?;
+                    writeln!(self.out, "{level}while(true) {{")?;
                 }
                 for sta in body {
                     self.write_stmt(sta, ctx, level.next())?;
                 }
-                writeln!(self.out, "{}}}", level)?
+                writeln!(self.out, "{level}}}")?
             }
             // Break, continue and return as written as in C
             // `break;`
             Statement::Break => {
-                write!(self.out, "{}", level)?;
+                write!(self.out, "{level}")?;
                 writeln!(self.out, "break;")?
             }
             // `continue;`
             Statement::Continue => {
-                write!(self.out, "{}", level)?;
+                write!(self.out, "{level}")?;
                 writeln!(self.out, "continue;")?
             }
             // `return expr;`, `expr` is optional
             Statement::Return { value } => {
-                write!(self.out, "{}", level)?;
+                write!(self.out, "{level}")?;
                 match ctx.ty {
                     back::FunctionType::Function(_) => {
                         write!(self.out, "return")?;
@@ -1995,7 +1994,7 @@ impl<'a, W: Write> Writer<'a, W> {
                                             )?;
                                             self.write_expr(value, ctx)?;
                                             writeln!(self.out, ";")?;
-                                            write!(self.out, "{}", level)?;
+                                            write!(self.out, "{level}")?;
                                             Some(return_struct)
                                         }
                                         _ => None,
@@ -2024,10 +2023,10 @@ impl<'a, W: Write> Writer<'a, W> {
                                             output: true,
                                             targetting_webgl: self.options.version.is_webgl(),
                                         };
-                                        write!(self.out, "{} = ", varying_name)?;
+                                        write!(self.out, "{varying_name} = ")?;
 
                                         if let Some(struct_name) = temp_struct_name {
-                                            write!(self.out, "{}", struct_name)?;
+                                            write!(self.out, "{struct_name}")?;
                                         } else {
                                             self.write_expr(value, ctx)?;
                                         }
@@ -2039,7 +2038,7 @@ impl<'a, W: Write> Writer<'a, W> {
                                             &self.names
                                                 [&NameKey::StructMember(result.ty, index as u32)]
                                         )?;
-                                        write!(self.out, "{}", level)?;
+                                        write!(self.out, "{level}")?;
                                     }
                                 }
                                 _ => {
@@ -2049,10 +2048,10 @@ impl<'a, W: Write> Writer<'a, W> {
                                         output: true,
                                         targetting_webgl: self.options.version.is_webgl(),
                                     };
-                                    write!(self.out, "{} = ", name)?;
+                                    write!(self.out, "{name} = ")?;
                                     self.write_expr(value, ctx)?;
                                     writeln!(self.out, ";")?;
-                                    write!(self.out, "{}", level)?;
+                                    write!(self.out, "{level}")?;
                                 }
                             }
                         }
@@ -2069,7 +2068,7 @@ impl<'a, W: Write> Writer<'a, W> {
                                     self.out,
                                     "gl_Position.yz = vec2(-gl_Position.y, gl_Position.z * 2.0 - gl_Position.w);",
                                 )?;
-                                write!(self.out, "{}", level)?;
+                                write!(self.out, "{level}")?;
                             }
                         }
                         writeln!(self.out, "return;")?;
@@ -2079,13 +2078,13 @@ impl<'a, W: Write> Writer<'a, W> {
             // This is one of the places were glsl adds to the syntax of C in this case the discard
             // keyword which ceases all further processing in a fragment shader, it's called OpKill
             // in spir-v that's why it's called `Statement::Kill`
-            Statement::Kill => writeln!(self.out, "{}discard;", level)?,
+            Statement::Kill => writeln!(self.out, "{level}discard;")?,
             Statement::Barrier(flags) => {
                 self.write_barrier(flags, level)?;
             }
             // Stores in glsl are just variable assignments written as `pointer = value;`
             Statement::Store { pointer, value } => {
-                write!(self.out, "{}", level)?;
+                write!(self.out, "{level}")?;
                 self.write_expr(pointer, ctx)?;
                 write!(self.out, " = ")?;
                 self.write_expr(value, ctx)?;
@@ -2098,7 +2097,7 @@ impl<'a, W: Write> Writer<'a, W> {
                 array_index,
                 value,
             } => {
-                write!(self.out, "{}", level)?;
+                write!(self.out, "{level}")?;
                 self.write_image_store(ctx, image, coordinate, array_index, value)?
             }
             // A `Call` is written `name(arguments)` where `arguments` is a comma separated expressions list
@@ -2107,12 +2106,12 @@ impl<'a, W: Write> Writer<'a, W> {
                 ref arguments,
                 result,
             } => {
-                write!(self.out, "{}", level)?;
+                write!(self.out, "{level}")?;
                 if let Some(expr) = result {
                     let name = format!("{}{}", back::BAKE_PREFIX, expr.index());
                     let result = self.module.functions[function].result.as_ref().unwrap();
                     self.write_type(result.ty)?;
-                    write!(self.out, " {} = ", name)?;
+                    write!(self.out, " {name} = ")?;
                     self.named_expressions.insert(expr, name);
                 }
                 write!(self.out, "{}(", &self.names[&NameKey::Function(function)])?;
@@ -2136,15 +2135,15 @@ impl<'a, W: Write> Writer<'a, W> {
                 value,
                 result,
             } => {
-                write!(self.out, "{}", level)?;
+                write!(self.out, "{level}")?;
                 let res_name = format!("{}{}", back::BAKE_PREFIX, result.index());
                 let res_ty = ctx.info[result].ty.inner_with(&self.module.types);
                 self.write_value_type(res_ty)?;
-                write!(self.out, " {} = ", res_name)?;
+                write!(self.out, " {res_name} = ")?;
                 self.named_expressions.insert(result, res_name);
 
                 let fun_str = fun.to_glsl();
-                write!(self.out, "atomic{}(", fun_str)?;
+                write!(self.out, "atomic{fun_str}(")?;
                 self.write_expr(pointer, ctx)?;
                 write!(self.out, ", ")?;
                 // handle the special cases
@@ -2180,7 +2179,7 @@ impl<'a, W: Write> Writer<'a, W> {
         use crate::Expression;
 
         if let Some(name) = self.named_expressions.get(&expr) {
-            write!(self.out, "{}", name)?;
+            write!(self.out, "{name}")?;
             return Ok(());
         }
 
@@ -2215,7 +2214,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     }
                     TypeInner::Matrix { .. }
                     | TypeInner::Array { .. }
-                    | TypeInner::ValuePointer { .. } => write!(self.out, "[{}]", index)?,
+                    | TypeInner::ValuePointer { .. } => write!(self.out, "[{index}]")?,
                     TypeInner::Struct { .. } => {
                         // This will never panic in case the type is a `Struct`, this is not true
                         // for other types so we can only check while inside this match arm
@@ -2227,7 +2226,7 @@ impl<'a, W: Write> Writer<'a, W> {
                             &self.names[&NameKey::StructMember(ty, index)]
                         )?
                     }
-                    ref other => return Err(Error::Custom(format!("Cannot index {:?}", other))),
+                    ref other => return Err(Error::Custom(format!("Cannot index {other:?}"))),
                 }
             }
             // Constants are delegated to `write_constant`
@@ -2353,7 +2352,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     None => "",
                 };
 
-                write!(self.out, "{}{}(", fun_name, offset_name)?;
+                write!(self.out, "{fun_name}{offset_name}(")?;
 
                 // Write the image that will be used
                 self.write_expr(image, ctx)?;
@@ -2413,7 +2412,7 @@ impl<'a, W: Write> Writer<'a, W> {
                                 crate::ImageDimension::Cube => 3,
                                 _ => 2,
                             };
-                            write!(self.out, ", vec{}(0.0), vec{}(0.0)", vec_dim, vec_dim)?;
+                            write!(self.out, ", vec{vec_dim}(0.0), vec{vec_dim}(0.0)")?;
                         } else if gather.is_none() {
                             write!(self.out, ", 0.0")?;
                         }
@@ -2538,7 +2537,7 @@ impl<'a, W: Write> Writer<'a, W> {
                             ImageClass::Sampled { .. } | ImageClass::Depth { .. } => "textureSize",
                             ImageClass::Storage { .. } => "imageSize",
                         };
-                        write!(self.out, "{}(", fun_name)?;
+                        write!(self.out, "{fun_name}(")?;
                         self.write_expr(image, ctx)?;
                         // All textureSize calls requires an lod argument
                         // except for multisampled samplers
@@ -2557,7 +2556,7 @@ impl<'a, W: Write> Writer<'a, W> {
                             }
                             ImageClass::Storage { .. } => "imageSamples",
                         };
-                        write!(self.out, "{}(", fun_name)?;
+                        write!(self.out, "{fun_name}(")?;
                         self.write_expr(image, ctx)?;
                         write!(self.out, ")",)?;
                     }
@@ -2586,14 +2585,13 @@ impl<'a, W: Write> Writer<'a, W> {
                                 Some(Sk::Bool) => "!",
                                 ref other => {
                                     return Err(Error::Custom(format!(
-                                        "Cannot apply not to type {:?}",
-                                        other
+                                        "Cannot apply not to type {other:?}"
                                     )))
                                 }
                             },
                         };
 
-                        write!(self.out, "{}(", operator)?;
+                        write!(self.out, "{operator}(")?;
                     }
                 }
 
@@ -2667,7 +2665,7 @@ impl<'a, W: Write> Writer<'a, W> {
                             Bo::NotEqual => "notEqual(",
                             _ => unreachable!(),
                         };
-                        write!(self.out, "{}", op_str)?;
+                        write!(self.out, "{op_str}")?;
                         self.write_expr(left, ctx)?;
                         write!(self.out, ", ")?;
                         self.write_expr(right, ctx)?;
@@ -2802,7 +2800,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     Rf::All => "all",
                     Rf::Any => "any",
                 };
-                write!(self.out, "{}(", fun_name)?;
+                write!(self.out, "{fun_name}(")?;
 
                 self.write_expr(argument, ctx)?;
 
@@ -2987,7 +2985,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     }
                 }
 
-                write!(self.out, "{}(", fun_name)?;
+                write!(self.out, "{fun_name}(")?;
 
                 // Cast to int if the function needs it
                 if arg_might_need_uint_to_int {
@@ -3199,7 +3197,7 @@ impl<'a, W: Write> Writer<'a, W> {
             // constructor notation (NOTE: the inner `ivec` can also be a scalar, this
             // is important for 1D arrayed images).
             Some(layer_expr) => {
-                write!(self.out, "ivec{}(", vector_size)?;
+                write!(self.out, "ivec{vector_size}(")?;
                 self.write_expr(coordinate, ctx)?;
                 write!(self.out, ", ")?;
                 // If we are replacing sampler1D with sampler2D we also need
@@ -3229,7 +3227,7 @@ impl<'a, W: Write> Writer<'a, W> {
                 } else if uvec_size.is_some() {
                     match uvec_size {
                         Some(None) => write!(self.out, "int(")?,
-                        Some(Some(size)) => write!(self.out, "ivec{}(", size)?,
+                        Some(Some(size)) => write!(self.out, "ivec{size}(")?,
                         _ => {}
                     }
                 }
@@ -3442,7 +3440,7 @@ impl<'a, W: Write> Writer<'a, W> {
         }
 
         // Begin the call to the function used to load the texel
-        write!(self.out, "{}(", fun_name)?;
+        write!(self.out, "{fun_name}(")?;
         self.write_expr(image, ctx)?;
         write!(self.out, ", ")?;
 
@@ -3463,7 +3461,7 @@ impl<'a, W: Write> Writer<'a, W> {
             if vector_size == 1 {
                 write!(self.out, ", 0")?;
             } else {
-                write!(self.out, ", ivec{}(0)", vector_size)?;
+                write!(self.out, ", ivec{vector_size}(0)")?;
             }
             // Start the `textureSize` call to use as the max value.
             write!(self.out, ", textureSize(")?;
@@ -3487,7 +3485,7 @@ impl<'a, W: Write> Writer<'a, W> {
             if vector_size == 1 {
                 write!(self.out, " - 1")?;
             } else {
-                write!(self.out, " - ivec{}(1)", vector_size)?;
+                write!(self.out, " - ivec{vector_size}(1)")?;
             }
 
             // Close the `clamp` call
@@ -3563,7 +3561,7 @@ impl<'a, W: Write> Writer<'a, W> {
             proc::TypeResolution::Handle(ty_handle) => match self.module.types[ty_handle].inner {
                 TypeInner::Struct { .. } => {
                     let ty_name = &self.names[&NameKey::Type(ty_handle)];
-                    write!(self.out, "{}", ty_name)?;
+                    write!(self.out, "{ty_name}")?;
                 }
                 _ => {
                     self.write_type(ty_handle)?;
@@ -3577,7 +3575,7 @@ impl<'a, W: Write> Writer<'a, W> {
         let base_ty_res = &ctx.info[handle].ty;
         let resolved = base_ty_res.inner_with(&self.module.types);
 
-        write!(self.out, " {}", name)?;
+        write!(self.out, " {name}")?;
         if let TypeInner::Array { base, size, .. } = *resolved {
             self.write_array_size(base, size)?;
         }
@@ -3629,7 +3627,7 @@ impl<'a, W: Write> Writer<'a, W> {
             }
             TypeInner::Struct { ref members, .. } => {
                 let name = &self.names[&NameKey::Type(ty)];
-                write!(self.out, "{}(", name)?;
+                write!(self.out, "{name}(")?;
                 for (i, member) in members.iter().enumerate() {
                     self.write_zero_init_value(member.ty)?;
                     if i != members.len().saturating_sub(1) {
@@ -3660,12 +3658,12 @@ impl<'a, W: Write> Writer<'a, W> {
     /// OpenGL always requires a call to the `barrier()` function after a `memoryBarrier*()`
     fn write_barrier(&mut self, flags: crate::Barrier, level: back::Level) -> BackendResult {
         if flags.contains(crate::Barrier::STORAGE) {
-            writeln!(self.out, "{}memoryBarrierBuffer();", level)?;
+            writeln!(self.out, "{level}memoryBarrierBuffer();")?;
         }
         if flags.contains(crate::Barrier::WORK_GROUP) {
-            writeln!(self.out, "{}memoryBarrierShared();", level)?;
+            writeln!(self.out, "{level}memoryBarrierShared();")?;
         }
-        writeln!(self.out, "{}barrier();", level)?;
+        writeln!(self.out, "{level}barrier();")?;
         Ok(())
     }
 

--- a/src/back/hlsl/conv.rs
+++ b/src/back/hlsl/conv.rs
@@ -175,10 +175,10 @@ impl crate::BuiltIn {
             // in `Writer::write_expr`.
             Self::NumWorkGroups => "SV_GroupID",
             Self::BaseInstance | Self::BaseVertex | Self::WorkGroupSize => {
-                return Err(Error::Unimplemented(format!("builtin {:?}", self)))
+                return Err(Error::Unimplemented(format!("builtin {self:?}")))
             }
             Self::ViewIndex | Self::PointCoord => {
-                return Err(Error::Custom(format!("Unsupported builtin {:?}", self)))
+                return Err(Error::Custom(format!("Unsupported builtin {self:?}")))
             }
         })
     }

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -412,16 +412,16 @@ impl ResolvedBinding {
                         return Err(Error::UnsupportedBuiltIn(built_in))
                     }
                 };
-                write!(out, "{}", name)?;
+                write!(out, "{name}")?;
             }
-            Self::Attribute(index) => write!(out, "attribute({})", index)?,
-            Self::Color(index) => write!(out, "color({})", index)?,
+            Self::Attribute(index) => write!(out, "attribute({index})")?,
+            Self::Color(index) => write!(out, "color({index})")?,
             Self::User {
                 prefix,
                 index,
                 interpolation,
             } => {
-                write!(out, "user({}{})", prefix, index)?;
+                write!(out, "user({prefix}{index})")?;
                 if let Some(interpolation) = interpolation {
                     write!(out, ", ")?;
                     interpolation.try_fmt(out)?;
@@ -429,11 +429,11 @@ impl ResolvedBinding {
             }
             Self::Resource(ref target) => {
                 if let Some(id) = target.buffer {
-                    write!(out, "buffer({})", id)?;
+                    write!(out, "buffer({id})")?;
                 } else if let Some(id) = target.texture {
-                    write!(out, "texture({})", id)?;
+                    write!(out, "texture({id})")?;
                 } else if let Some(BindSamplerTarget::Resource(id)) = target.sampler {
-                    write!(out, "sampler({})", id)?;
+                    write!(out, "sampler({id})")?;
                 } else {
                     return Err(Error::UnimplementedBindTarget(target.clone()));
                 }

--- a/src/front/glsl/constants.rs
+++ b/src/front/glsl/constants.rs
@@ -241,8 +241,7 @@ impl<'a> ConstantSolver<'a> {
                             ),
                             _ => {
                                 return Err(ConstantSolvingError::NotImplemented(format!(
-                                    "{:?} applied to vector values",
-                                    fun
+                                    "{fun:?} applied to vector values"
                                 )))
                             }
                         };
@@ -250,7 +249,7 @@ impl<'a> ConstantSolver<'a> {
                         let inner = ConstantInner::Scalar { width, value };
                         Ok(self.register_constant(inner, span))
                     }
-                    _ => Err(ConstantSolvingError::NotImplemented(format!("{:?}", fun))),
+                    _ => Err(ConstantSolvingError::NotImplemented(format!("{fun:?}"))),
                 }
             }
             Expression::As {

--- a/src/front/glsl/context.rs
+++ b/src/front/glsl/context.rs
@@ -591,8 +591,7 @@ impl Context {
                             parser.errors.push(Error {
                                 kind: ErrorKind::SemanticError(
                                     format!(
-                                        "Cannot apply operation to {:?} and {:?}",
-                                        left_inner, right_inner
+                                        "Cannot apply operation to {left_inner:?} and {right_inner:?}"
                                     )
                                     .into(),
                                 ),
@@ -823,8 +822,7 @@ impl Context {
                             parser.errors.push(Error {
                                 kind: ErrorKind::SemanticError(
                                     format!(
-                                        "Cannot apply operation to {:?} and {:?}",
-                                        left_inner, right_inner
+                                        "Cannot apply operation to {left_inner:?} and {right_inner:?}"
                                     )
                                     .into(),
                                 ),
@@ -914,8 +912,7 @@ impl Context {
                             parser.errors.push(Error {
                                 kind: ErrorKind::SemanticError(
                                     format!(
-                                        "Cannot apply operation to {:?} and {:?}",
-                                        left_inner, right_inner
+                                        "Cannot apply operation to {left_inner:?} and {right_inner:?}"
                                     )
                                     .into(),
                                 ),
@@ -1383,7 +1380,7 @@ impl Context {
                     _ => {
                         return Err(Error {
                             kind: ErrorKind::SemanticError(
-                                format!("unknown method '{}'", name).into(),
+                                format!("unknown method '{name}'").into(),
                             ),
                             meta,
                         });

--- a/src/front/glsl/error.rs
+++ b/src/front/glsl/error.rs
@@ -43,7 +43,7 @@ impl From<TokenValue> for ExpectedToken {
 impl std::fmt::Display for ExpectedToken {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
-            ExpectedToken::Token(ref token) => write!(f, "{:?}", token),
+            ExpectedToken::Token(ref token) => write!(f, "{token:?}"),
             ExpectedToken::TypeName => write!(f, "a type"),
             ExpectedToken::Identifier => write!(f, "identifier"),
             ExpectedToken::IntLiteral => write!(f, "integer literal"),

--- a/src/front/glsl/functions.rs
+++ b/src/front/glsl/functions.rs
@@ -721,8 +721,7 @@ impl Parser {
                         self.errors.push(Error {
                             kind: ErrorKind::SemanticError(
                                 format!(
-                                    "'{}': image needs {:?} access but only {:?} was provided",
-                                    name, overload_access, call_access
+                                    "'{name}': image needs {overload_access:?} access but only {call_access:?} was provided"
                                 )
                                 .into(),
                             ),
@@ -829,14 +828,14 @@ impl Parser {
         if ambiguous {
             self.errors.push(Error {
                 kind: ErrorKind::SemanticError(
-                    format!("Ambiguous best function for '{}'", name).into(),
+                    format!("Ambiguous best function for '{name}'").into(),
                 ),
                 meta,
             })
         }
 
         let overload = maybe_overload.ok_or_else(|| Error {
-            kind: ErrorKind::SemanticError(format!("Unknown function '{}'", name).into()),
+            kind: ErrorKind::SemanticError(format!("Unknown function '{name}'").into()),
             meta,
         })?;
 

--- a/src/front/glsl/types.rs
+++ b/src/front/glsl/types.rs
@@ -256,7 +256,7 @@ impl Parser {
         ctx.typifier
             .grow(expr, &ctx.expressions, &resolve_ctx)
             .map_err(|error| Error {
-                kind: ErrorKind::SemanticError(format!("Can't resolve type: {:?}", error).into()),
+                kind: ErrorKind::SemanticError(format!("Can't resolve type: {error:?}").into()),
                 meta,
             })
     }
@@ -322,7 +322,7 @@ impl Parser {
         ctx.typifier
             .invalidate(expr, &ctx.expressions, &resolve_ctx)
             .map_err(|error| Error {
-                kind: ErrorKind::SemanticError(format!("Can't resolve type: {:?}", error).into()),
+                kind: ErrorKind::SemanticError(format!("Can't resolve type: {error:?}").into()),
                 meta,
             })
     }

--- a/src/front/glsl/variables.rs
+++ b/src/front/glsl/variables.rs
@@ -317,8 +317,7 @@ impl Parser {
                                 kind:
                                 ErrorKind::SemanticError(
                                 format!(
-                                    "swizzle cannot have duplicate components in left-hand-side expression for \"{:?}\"",
-                                    name
+                                    "swizzle cannot have duplicate components in left-hand-side expression for \"{name:?}\""
                                 )
                                 .into(),
                             ),
@@ -379,7 +378,7 @@ impl Parser {
                         _ => {
                             self.errors.push(Error {
                                 kind: ErrorKind::SemanticError(
-                                    format!("Bad swizzle size for \"{:?}\"", name).into(),
+                                    format!("Bad swizzle size for \"{name:?}\"").into(),
                                 ),
                                 meta,
                             });
@@ -413,7 +412,7 @@ impl Parser {
                 } else {
                     Err(Error {
                         kind: ErrorKind::SemanticError(
-                            format!("Invalid swizzle for vector \"{}\"", name).into(),
+                            format!("Invalid swizzle for vector \"{name}\"").into(),
                         ),
                         meta,
                     })
@@ -421,7 +420,7 @@ impl Parser {
             }
             _ => Err(Error {
                 kind: ErrorKind::SemanticError(
-                    format!("Can't lookup field on this type \"{}\"", name).into(),
+                    format!("Can't lookup field on this type \"{name}\"").into(),
                 ),
                 meta,
             }),

--- a/src/front/spv/function.rs
+++ b/src/front/spv/function.rs
@@ -170,7 +170,7 @@ impl<I: Iterator<Item = u32>> super::Parser<I> {
                 None => format!("block_ctx.Fun-{}.txt", module.functions.len()),
             };
             let dest = prefix.join(dump_suffix);
-            let dump = format!("{:#?}", block_ctx);
+            let dump = format!("{block_ctx:#?}");
             if let Err(e) = std::fs::write(&dest, dump) {
                 log::error!("Unable to dump the block context into {:?}: {}", dest, e);
             }

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -1378,7 +1378,7 @@ impl<I: Iterator<Item = u32>> Parser<I> {
                     let result_type_id = self.next()?;
                     let result_id = self.next()?;
 
-                    let name = format!("phi_{}", result_id);
+                    let name = format!("phi_{result_id}");
                     let local = ctx.local_arena.append(
                         crate::LocalVariable {
                             name: Some(name),

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -218,20 +218,20 @@ impl<'a> Error<'a> {
                 let expected_str = match expected {
                         ExpectedToken::Token(token) => {
                             match token {
-                                Token::Separator(c) => format!("'{}'", c),
-                                Token::Paren(c) => format!("'{}'", c),
+                                Token::Separator(c) => format!("'{c}'"),
+                                Token::Paren(c) => format!("'{c}'"),
                                 Token::Attribute => "@".to_string(),
                                 Token::Number(_) => "number".to_string(),
                                 Token::Word(s) => s.to_string(),
-                                Token::Operation(c) => format!("operation ('{}')", c),
-                                Token::LogicalOperation(c) => format!("logical operation ('{}')", c),
-                                Token::ShiftOperation(c) => format!("bitshift ('{}{}')", c, c),
-                                Token::AssignmentOperation(c) if c=='<' || c=='>' => format!("bitshift ('{}{}=')", c, c),
-                                Token::AssignmentOperation(c) => format!("operation ('{}=')", c),
+                                Token::Operation(c) => format!("operation ('{c}')"),
+                                Token::LogicalOperation(c) => format!("logical operation ('{c}')"),
+                                Token::ShiftOperation(c) => format!("bitshift ('{c}{c}')"),
+                                Token::AssignmentOperation(c) if c=='<' || c=='>' => format!("bitshift ('{c}{c}=')"),
+                                Token::AssignmentOperation(c) => format!("operation ('{c}=')"),
                                 Token::IncrementOperation => "increment operation".to_string(),
                                 Token::DecrementOperation => "decrement operation".to_string(),
                                 Token::Arrow => "->".to_string(),
-                                Token::Unknown(c) => format!("unknown ('{}')", c),
+                                Token::Unknown(c) => format!("unknown ('{c}')"),
                                 Token::Trivia => "trivia".to_string(),
                                 Token::End => "end".to_string(),
                             }
@@ -261,7 +261,7 @@ impl<'a> Error<'a> {
                         "expected {}, found '{}'",
                         expected_str, &source[unexpected_span],
                     ),
-                    labels: vec![(unexpected_span, format!("expected {}", expected_str).into())],
+                    labels: vec![(unexpected_span, format!("expected {expected_str}").into())],
                     notes: vec![],
                 }
             }
@@ -305,7 +305,7 @@ impl<'a> Error<'a> {
                 notes: vec![],
             },
             Error::UnknownIdent(ident_span, ident) => ParseError {
-                message: format!("no definition in scope for identifier: '{}'", ident),
+                message: format!("no definition in scope for identifier: '{ident}'"),
                 labels: vec![(ident_span, "unknown identifier".into())],
                 notes: vec![],
             },
@@ -342,7 +342,7 @@ impl<'a> Error<'a> {
                 ref from_type,
                 ref to_type,
             } => {
-                let msg = format!("cannot cast a {} to a {}", from_type, to_type);
+                let msg = format!("cannot cast a {from_type} to a {to_type}");
                 ParseError {
                     message: msg.clone(),
                     labels: vec![(span, msg.into())],
@@ -376,10 +376,7 @@ impl<'a> Error<'a> {
                 notes: vec![],
             },
             Error::InvalidConstructorComponentType(bad_span, component) => ParseError {
-                message: format!(
-                    "invalid type for constructor component at index [{}]",
-                    component
-                ),
+                message: format!("invalid type for constructor component at index [{component}]"),
                 labels: vec![(bad_span, "invalid component type".into())],
                 notes: vec![],
             },
@@ -435,13 +432,13 @@ impl<'a> Error<'a> {
                 notes: vec![],
             },
             Error::SizeAttributeTooLow(bad_span, min_size) => ParseError {
-                message: format!("struct member size must be at least {}", min_size),
-                labels: vec![(bad_span, format!("must be at least {}", min_size).into())],
+                message: format!("struct member size must be at least {min_size}"),
+                labels: vec![(bad_span, format!("must be at least {min_size}").into())],
                 notes: vec![],
             },
             Error::AlignAttributeTooLow(bad_span, min_align) => ParseError {
-                message: format!("struct member alignment must be at least {}", min_align),
-                labels: vec![(bad_span, format!("must be at least {}", min_align).into())],
+                message: format!("struct member alignment must be at least {min_align}"),
+                labels: vec![(bad_span, format!("must be at least {min_align}").into())],
                 notes: vec![],
             },
             Error::NonPowerOfTwoAlignAttribute(bad_span) => ParseError {
@@ -512,7 +509,7 @@ impl<'a> Error<'a> {
                 notes: vec![],
             },
             Error::NotReference(what, span) => ParseError {
-                message: format!("{} must be a reference", what),
+                message: format!("{what} must be a reference"),
                 labels: vec![(span, "expression is not a reference".into())],
                 notes: vec![],
             },
@@ -532,7 +529,7 @@ impl<'a> Error<'a> {
                 },
             },
             Error::Pointer(what, span) => ParseError {
-                message: format!("{} must not be a pointer", what),
+                message: format!("{what} must not be a pointer"),
                 labels: vec![(span, "expression is a pointer".into())],
                 notes: vec![],
             },
@@ -733,7 +730,7 @@ impl crate::TypeInner {
             Ti::Pointer { base, .. } => {
                 let base = &types[base];
                 let name = base.name.as_deref().unwrap_or("unknown");
-                format!("ptr<{}>", name)
+                format!("ptr<{name}>")
             }
             Ti::ValuePointer { kind, width, .. } => {
                 format!("ptr<{}>", kind.to_wgsl(width))
@@ -758,9 +755,9 @@ impl crate::TypeInner {
                                 } => size.to_string(),
                                 _ => "?".to_string(),
                             });
-                        format!("array<{}, {}>", base, size)
+                        format!("array<{base}, {size}>")
                     }
-                    crate::ArraySize::Dynamic => format!("array<{}>", base),
+                    crate::ArraySize::Dynamic => format!("array<{base}>"),
                 }
             }
             Ti::Struct { .. } => {
@@ -794,7 +791,7 @@ impl crate::TypeInner {
                         // The lexer has already verified this, so we can safely assume it here.
                         // https://gpuweb.github.io/gpuweb/wgsl/#sampled-texture-type
                         let element_type = kind.to_wgsl(4);
-                        format!("<{}>", element_type)
+                        format!("<{element_type}>")
                     }
                     crate::ImageClass::Depth { multi: _ } => String::new(),
                     crate::ImageClass::Storage { format, access } => {
@@ -806,10 +803,7 @@ impl crate::TypeInner {
                     }
                 };
 
-                format!(
-                    "texture{}{}{}{}",
-                    class_suffix, dim_suffix, array_suffix, type_in_brackets
-                )
+                format!("texture{class_suffix}{dim_suffix}{array_suffix}{type_in_brackets}")
             }
             Ti::Sampler { .. } => "sampler".to_string(),
             Ti::BindingArray { base, size, .. } => {
@@ -818,9 +812,9 @@ impl crate::TypeInner {
                 match size {
                     crate::ArraySize::Constant(size) => {
                         let size = constants[size].name.as_deref().unwrap_or("unknown");
-                        format!("binding_array<{}, {}>", base, size)
+                        format!("binding_array<{base}, {size}>")
                     }
-                    crate::ArraySize::Dynamic => format!("binding_array<{}>", base),
+                    crate::ArraySize::Dynamic => format!("binding_array<{base}>"),
                 }
             }
         }
@@ -1681,7 +1675,7 @@ impl ParseError {
             .with_notes(
                 self.notes
                     .iter()
-                    .map(|note| format!("note: {}", note))
+                    .map(|note| format!("note: {note}"))
                     .collect(),
             );
         diagnostic

--- a/src/front/wgsl/number.rs
+++ b/src/front/wgsl/number.rs
@@ -317,7 +317,7 @@ fn parse_hex_float_missing_period(
     exponent: &str,
     kind: Option<FloatKind>,
 ) -> Result<Number, NumberError> {
-    let hexf_input = format!("{}.{}", significand, exponent);
+    let hexf_input = format!("{significand}.{exponent}");
     parse_hex_float(&hexf_input, kind)
 }
 
@@ -328,7 +328,7 @@ fn parse_hex_int(
     kind: Option<IntKind>,
 ) -> Result<Number, NumberError> {
     let digits_with_sign = if is_negative {
-        Cow::Owned(format!("-{}", digits))
+        Cow::Owned(format!("-{digits}"))
     } else {
         Cow::Borrowed(digits)
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,8 @@ tree.
     clippy::match_like_matches_macro,
     clippy::if_same_then_else,
     clippy::collapsible_if,
-    clippy::derive_partial_eq_without_eq
+    clippy::derive_partial_eq_without_eq,
+    clippy::needless_borrowed_reference
 )]
 #![warn(
     trivial_casts,

--- a/src/proc/namer.rs
+++ b/src/proc/namer.rs
@@ -64,7 +64,7 @@ impl Namer {
 
         for prefix in &self.reserved_prefixes {
             if base.starts_with(prefix) {
-                return format!("gen_{}", base).into();
+                return format!("gen_{base}").into();
             }
         }
 
@@ -210,11 +210,11 @@ impl Namer {
                         crate::ConstantInner::Scalar {
                             width: _,
                             value: crate::ScalarValue::Sint(v),
-                        } => write!(temp, "const_{}i", v),
+                        } => write!(temp, "const_{v}i"),
                         crate::ConstantInner::Scalar {
                             width: _,
                             value: crate::ScalarValue::Uint(v),
-                        } => write!(temp, "const_{}u", v),
+                        } => write!(temp, "const_{v}u"),
                         crate::ConstantInner::Scalar {
                             width: _,
                             value: crate::ScalarValue::Float(v),
@@ -237,7 +237,7 @@ impl Namer {
                         crate::ConstantInner::Scalar {
                             width: _,
                             value: crate::ScalarValue::Bool(v),
-                        } => write!(temp, "const_{}", v),
+                        } => write!(temp, "const_{v}"),
                         crate::ConstantInner::Composite { ty, components: _ } => {
                             write!(temp, "const_{}", output[&NameKey::Type(ty)])
                         }

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -601,8 +601,7 @@ impl<'a> ResolveContext<'a> {
                         (&Ti::Vector { .. }, &Ti::Vector { .. }) => res_left.clone(),
                         (tl, tr) => {
                             return Err(ResolveError::IncompatibleOperands(format!(
-                                "{:?} * {:?}",
-                                tl, tr
+                                "{tl:?} * {tr:?}"
                             )))
                         }
                     }
@@ -622,8 +621,7 @@ impl<'a> ResolveContext<'a> {
                         Ti::Vector { size, .. } => Ti::Vector { size, kind, width },
                         ref other => {
                             return Err(ResolveError::IncompatibleOperands(format!(
-                                "{:?}({:?}, _)",
-                                op, other
+                                "{op:?}({other:?}, _)"
                             )))
                         }
                     };
@@ -660,8 +658,7 @@ impl<'a> ResolveContext<'a> {
                     }),
                     ref other => {
                         return Err(ResolveError::IncompatibleOperands(format!(
-                            "{:?}({:?})",
-                            fun, other
+                            "{fun:?}({other:?})"
                         )))
                     }
                 },
@@ -722,18 +719,18 @@ impl<'a> ResolveContext<'a> {
                         } => TypeResolution::Value(Ti::Scalar { kind, width }),
                         ref other =>
                             return Err(ResolveError::IncompatibleOperands(
-                                format!("{:?}({:?}, _)", fun, other)
+                                format!("{fun:?}({other:?}, _)")
                             )),
                     },
                     Mf::Outer => {
                         let arg1 = arg1.ok_or_else(|| ResolveError::IncompatibleOperands(
-                            format!("{:?}(_, None)", fun)
+                            format!("{fun:?}(_, None)")
                         ))?;
                         match (res_arg.inner_with(types), past(arg1)?.inner_with(types)) {
                             (&Ti::Vector {kind: _, size: columns,width}, &Ti::Vector{ size: rows, .. }) => TypeResolution::Value(Ti::Matrix { columns, rows, width }),
                             (left, right) =>
                                 return Err(ResolveError::IncompatibleOperands(
-                                    format!("{:?}({:?}, {:?})", fun, left, right)
+                                    format!("{fun:?}({left:?}, {right:?})")
                                 )),
                         }
                     },
@@ -743,7 +740,7 @@ impl<'a> ResolveContext<'a> {
                         Ti::Scalar {width,kind} |
                         Ti::Vector {width,kind,size:_} => TypeResolution::Value(Ti::Scalar { kind, width }),
                         ref other => return Err(ResolveError::IncompatibleOperands(
-                                format!("{:?}({:?})", fun, other)
+                                format!("{fun:?}({other:?})")
                             )),
                     },
                     Mf::Normalize |
@@ -769,7 +766,7 @@ impl<'a> ResolveContext<'a> {
                             width,
                         }),
                         ref other => return Err(ResolveError::IncompatibleOperands(
-                            format!("{:?}({:?})", fun, other)
+                            format!("{fun:?}({other:?})")
                         )),
                     },
                     Mf::Inverse => match *res_arg.inner_with(types) {
@@ -783,7 +780,7 @@ impl<'a> ResolveContext<'a> {
                             width,
                         }),
                         ref other => return Err(ResolveError::IncompatibleOperands(
-                            format!("{:?}({:?})", fun, other)
+                            format!("{fun:?}({other:?})")
                         )),
                     },
                     Mf::Determinant => match *res_arg.inner_with(types) {
@@ -792,7 +789,7 @@ impl<'a> ResolveContext<'a> {
                             ..
                         } => TypeResolution::Value(Ti::Scalar { kind: crate::ScalarKind::Float, width }),
                         ref other => return Err(ResolveError::IncompatibleOperands(
-                            format!("{:?}({:?})", fun, other)
+                            format!("{fun:?}({other:?})")
                         )),
                     },
                     // bits
@@ -807,7 +804,7 @@ impl<'a> ResolveContext<'a> {
                         Ti::Vector { size, kind: kind @ (crate::ScalarKind::Sint | crate::ScalarKind::Uint), width } =>
                             TypeResolution::Value(Ti::Vector { size, kind, width }),
                         ref other => return Err(ResolveError::IncompatibleOperands(
-                                format!("{:?}({:?})", fun, other)
+                                format!("{fun:?}({other:?})")
                             )),
                     },
                     // data packing
@@ -853,8 +850,7 @@ impl<'a> ResolveContext<'a> {
                 }),
                 ref other => {
                     return Err(ResolveError::IncompatibleOperands(format!(
-                        "{:?} as {:?}",
-                        other, kind
+                        "{other:?} as {kind:?}"
                     )))
                 }
             },

--- a/tests/spirv-capabilities.rs
+++ b/tests/spirv-capabilities.rs
@@ -40,10 +40,7 @@ fn require_and_forbid(required: &[Ca], forbidden: &[Ca], source: &str) {
         .cloned()
         .collect();
     if !missing_caps.is_empty() {
-        panic!(
-            "shader code should have requested these caps: {:?}\n\n{}",
-            missing_caps, source
-        );
+        panic!("shader code should have requested these caps: {missing_caps:?}\n\n{source}");
     }
 
     let forbidden_caps: Vec<_> = forbidden
@@ -52,10 +49,7 @@ fn require_and_forbid(required: &[Ca], forbidden: &[Ca], source: &str) {
         .cloned()
         .collect();
     if !forbidden_caps.is_empty() {
-        panic!(
-            "shader code should not have requested these caps: {:?}\n\n{}",
-            forbidden_caps, source
-        );
+        panic!("shader code should not have requested these caps: {forbidden_caps:?}\n\n{source}");
     }
 }
 

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -10,9 +10,9 @@ fn check(input: &str, snapshot: &str) {
     if output != snapshot {
         for diff in diff::lines(&output, snapshot) {
             match diff {
-                diff::Result::Left(l) => println!("-{}", l),
-                diff::Result::Both(l, _) => println!(" {}", l),
-                diff::Result::Right(r) => println!("+{}", r),
+                diff::Result::Left(l) => println!("-{l}"),
+                diff::Result::Both(l, _) => println!(" {l}"),
+                diff::Result::Right(r) => println!("+{r}"),
             }
         }
         panic!("Error snapshot failed");
@@ -1419,16 +1419,12 @@ fn wrong_access_mode() {
 #[test]
 fn io_shareable_types() {
     for numeric in "i32 u32 f32".split_whitespace() {
-        let types = format!(
-            "{} vec2<{}> vec3<{}> vec4<{}>",
-            numeric, numeric, numeric, numeric
-        );
+        let types = format!("{numeric} vec2<{numeric}> vec3<{numeric}> vec4<{numeric}>");
         for ty in types.split_whitespace() {
             check_one_validation! {
                 &format!("@vertex
-                          fn f(@location(0) arg: {}) -> @builtin(position) vec4<f32>
-                          {{ return vec4<f32>(0.0); }}",
-                         ty),
+                          fn f(@location(0) arg: {ty}) -> @builtin(position) vec4<f32>
+                          {{ return vec4<f32>(0.0); }}"),
                 Ok(_module)
             }
         }
@@ -1443,9 +1439,8 @@ fn io_shareable_types() {
     {
         check_one_validation! {
             &format!("@vertex
-                          fn f(@location(0) arg: {}) -> @builtin(position) vec4<f32>
-                          {{ return vec4<f32>(0.0); }}",
-                     ty),
+                          fn f(@location(0) arg: {ty}) -> @builtin(position) vec4<f32>
+                          {{ return vec4<f32>(0.0); }}"),
             Err(
                 naga::valid::ValidationError::EntryPoint {
                     stage: naga::ShaderStage::Vertex,
@@ -1474,9 +1469,8 @@ fn host_shareable_types() {
     for ty in types.split_whitespace() {
         check_one_validation! {
             &format!("struct AStruct {{ member: array<mat4x4<f32>, 8> }};
-                      @group(0) @binding(0) var<uniform> ubuf: {};
-                      @group(0) @binding(1) var<storage> sbuf: {};",
-                     ty, ty),
+                      @group(0) @binding(0) var<uniform> ubuf: {ty};
+                      @group(0) @binding(1) var<storage> sbuf: {ty};"),
             Ok(_module)
         }
     }
@@ -1489,8 +1483,7 @@ fn host_shareable_types() {
     for ty in types.split_whitespace() {
         check_one_validation! {
             &format!("struct AStruct {{ member: array<atomic<u32>, 8> }};
-                      @group(0) @binding(1) var<storage> sbuf: {};",
-                     ty),
+                      @group(0) @binding(1) var<storage> sbuf: {ty};"),
             Ok(_module)
         }
     }
@@ -1498,7 +1491,7 @@ fn host_shareable_types() {
     // Types that are neither host-shareable nor constructible.
     for ty in "bool ptr<storage,i32>".split_whitespace() {
         check_one_validation! {
-            &format!("@group(0) @binding(0) var<storage> sbuf: {};", ty),
+            &format!("@group(0) @binding(0) var<storage> sbuf: {ty};"),
             Err(
                 naga::valid::ValidationError::GlobalVariable {
                     name,
@@ -1510,7 +1503,7 @@ fn host_shareable_types() {
         }
 
         check_one_validation! {
-            &format!("@group(0) @binding(0) var<uniform> ubuf: {};", ty),
+            &format!("@group(0) @binding(0) var<uniform> ubuf: {ty};"),
             Err(naga::valid::ValidationError::GlobalVariable {
                     name,
                     handle: _,


### PR DESCRIPTION
* Inline identifiers into format strings.

[Since Rust 1.58], Rust format strings have been able to "capture
arguments simply by writing {ident} in the string." Clippy 1.67 made
the corresponding warning, `uninlined_format_args`, warn-by-default.
Inlined arguments seem more readable, so Naga should adopt them.

[Since Rust 1.58]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1580-2022-01-13

* Allow `clippy::needless_borrowed_reference`.

In Clippy 1.67, the `needless_borrowed_reference` lint [was enhanced]
to look into struct and tuple patterns, so that a line like this:

    for &(ref module, ref info) in inputs.iter()

where `inputs.iter()` is yielding `&(Module, ModuleInfo)` pairs,
elicits a warning. Clippy suggests, instead:

    for (module, info) in inputs.iter()

but this is at odds with Naga's preference that `match` patterns
should have the same type as the expression being matched, for which
we have enabled the `pattern_type_mismatch` lint since
9e5cc4c9 (2021-3-12).

[was enhanced]: https://github.com/rust-lang/rust-clippy/pull/9855

