### PR TITLE
valid: Improve forward declaration validation

### DIFF
--- a/src/valid/handles.rs
+++ b/src/valid/handles.rs
@@ -532,8 +532,8 @@ pub enum InvalidHandleError {
 
 #[derive(Clone, Debug, thiserror::Error)]
 #[error(
-    "{subject:?} of kind depends on {depends_on:?} of kind {depends_on_kind}, which has not been \
-    processed yet"
+    "{subject:?} of kind {subject_kind:?} depends on {depends_on:?} of kind {depends_on_kind}, \
+    which has not been processed yet"
 )]
 pub struct FwdDepError {
     // This error is used for many `Handle` types, but there's no point in making this generic, so
@@ -580,7 +580,7 @@ impl<T> Handle<T> {
             Ok(self)
         } else {
             let erase_handle_type = |handle: Handle<_>| {
-                Handle::new(NonZeroU32::new(handle.index().try_into().unwrap()).unwrap())
+                Handle::new(NonZeroU32::new((handle.index() + 1).try_into().unwrap()).unwrap())
             };
             Err(FwdDepError {
                 subject: erase_handle_type(self),


### PR DESCRIPTION
This PR fixes an issue with the dependency code and adds dependency validation to function calls.

The handle validator had an issue that caused it to try to build a handle with a zero based index while type erasing handles, this would crash because the index must be a `NonZeroU32` and it would also not be correct since the handle would be off by one from the original handle.

It also fixes the error message for the forward dependency not containing the subject's kind.

Lastly it adds a dependency check for function calls, to prevent forward declarations to pass to further stages and cause crashes (mitigates #2225)