### PR TITLE
Correctness and diagnostic fixes

### DIFF
--- a/src/front/wgsl/lower/mod.rs
+++ b/src/front/wgsl/lower/mod.rs
@@ -352,10 +352,10 @@ impl<'a> ExpressionContext<'a, '_, '_> {
             }
             crate::TypeInner::Vector { size, kind, width } => {
                 let scalar_ty = self.ensure_type_exists(crate::TypeInner::Scalar { width, kind });
-                let component = self.create_zero_value_constant(scalar_ty);
+                let component = self.create_zero_value_constant(scalar_ty)?;
                 crate::ConstantInner::Composite {
                     ty,
-                    components: (0..size as u8).map(|_| component).collect::<Option<_>>()?,
+                    components: (0..size as u8).map(|_| component).collect(),
                 }
             }
             crate::TypeInner::Matrix {
@@ -368,12 +368,10 @@ impl<'a> ExpressionContext<'a, '_, '_> {
                     kind: crate::ScalarKind::Float,
                     size: rows,
                 });
-                let component = self.create_zero_value_constant(vec_ty);
+                let component = self.create_zero_value_constant(vec_ty)?;
                 crate::ConstantInner::Composite {
                     ty,
-                    components: (0..columns as u8)
-                        .map(|_| component)
-                        .collect::<Option<_>>()?,
+                    components: (0..columns as u8).map(|_| component).collect(),
                 }
             }
             crate::TypeInner::Array {
@@ -381,12 +379,11 @@ impl<'a> ExpressionContext<'a, '_, '_> {
                 size: crate::ArraySize::Constant(size),
                 ..
             } => {
-                let component = self.create_zero_value_constant(base);
+                let size = self.module.constants[size].to_array_length()?;
+                let component = self.create_zero_value_constant(base)?;
                 crate::ConstantInner::Composite {
                     ty,
-                    components: (0..self.module.constants[size].to_array_length().unwrap())
-                        .map(|_| component)
-                        .collect::<Option<_>>()?,
+                    components: (0..size).map(|_| component).collect(),
                 }
             }
             crate::TypeInner::Struct { ref members, .. } => {

--- a/src/front/wgsl/parse/mod.rs
+++ b/src/front/wgsl/parse/mod.rs
@@ -1661,14 +1661,17 @@ impl Parser {
                             let span = span.until(&peeked_span);
                             return Err(Error::InvalidBreakIf(span));
                         }
+                        lexer.expect(Token::Separator(';'))?;
                         ast::StatementKind::Break
                     }
                     "continue" => {
                         let _ = lexer.next();
+                        lexer.expect(Token::Separator(';'))?;
                         ast::StatementKind::Continue
                     }
                     "discard" => {
                         let _ = lexer.next();
+                        lexer.expect(Token::Separator(';'))?;
                         ast::StatementKind::Kill
                     }
                     // assignment or a function call
@@ -1685,6 +1688,7 @@ impl Parser {
             }
             _ => {
                 self.assignment_statement(lexer, ctx.reborrow(), block)?;
+                lexer.expect(Token::Separator(';'))?;
                 self.pop_rule_span(lexer);
             }
         }

--- a/src/front/wgsl/parse/mod.rs
+++ b/src/front/wgsl/parse/mod.rs
@@ -1776,7 +1776,7 @@ impl Parser {
 
         ctx.local_table.push_scope();
 
-        let _ = lexer.next();
+        lexer.expect(Token::Paren('{'))?;
         let mut statements = ast::Block::default();
         while !lexer.skip(Token::Paren('}')) {
             self.statement(lexer, ctx.reborrow(), &mut statements)?;

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -1624,13 +1624,56 @@ fn assign_to_let() {
         }
         ",
         r###"error: invalid left-hand side of assignment
-  ┌─ wgsl:4:10
+  ┌─ wgsl:3:17
   │
+3 │             let a = 10;
+  │                 ^ this is an immutable binding
 4 │             a = 20;
   │             ^ cannot assign to this expression
   │
-  = note: 'a' is an immutable binding
-  = note: consider declaring it with `var` instead of `let`
+  = note: consider declaring 'a' with `var` instead of `let`
+
+"###,
+    );
+
+    check(
+        "
+        fn f() {
+            let a = array(1, 2);
+			a[0] = 1;
+        }
+        ",
+        r###"error: invalid left-hand side of assignment
+  ┌─ wgsl:3:17
+  │
+3 │             let a = array(1, 2);
+  │                 ^ this is an immutable binding
+4 │             a[0] = 1;
+  │             ^^^^ cannot assign to this expression
+  │
+  = note: consider declaring 'a' with `var` instead of `let`
+
+"###,
+    );
+
+    check(
+        "
+        struct S { a: i32 }
+
+        fn f() {
+            let a = S(10);
+	        a.a = 20;
+        }
+        ",
+        r###"error: invalid left-hand side of assignment
+  ┌─ wgsl:5:17
+  │
+5 │             let a = S(10);
+  │                 ^ this is an immutable binding
+6 │             a.a = 20;
+  │             ^^^ cannot assign to this expression
+  │
+  = note: consider declaring 'a' with `var` instead of `let`
 
 "###,
     );


### PR DESCRIPTION
- fixes #2216 
- fixes #2209 
- fixes #2169 

Also checks for the `;` after `break`, `continue`, and `discard`, as per the spec.

The diagnostic for #2209 is a bit weird:
```
error: type `array<f32, 0f>` is not constructible
  ┌─ wgsl:2:6
  │
2 │     -array<f32, 0f>() = v;
  │      ^^^^^^^^^^^^^^ type is not constructible
```
But it does point the user to where the problem is and doesn't crash.

The invalid assignment diagnostic is also improved overall:
```
error: invalid left-hand side of assignment
  ┌─ wgsl:2:9
  │
2 │     let a = array(1, 2);
  │         ^ this is an immutable binding
3 │     a[0] = 2;
  │     ^^^^ cannot assign to this expression
  │
  = note: consider declaring 'a' with `var` instead of `let`
```