### PR TITLE
[msl-out] Replace `per_stage_map` with `per_entry_point_map`

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -3368,7 +3368,7 @@ impl<W: Write> Writer<W> {
                                     break;
                                 }
                             };
-                            let target = options.get_resource_binding_target(&ep, &br);
+                            let target = options.get_resource_binding_target(ep, br);
                             let good = match target {
                                 Some(target) => {
                                     let binding_ty = match module.types[var.ty].inner {

--- a/tests/in/access.param.ron
+++ b/tests/in/access.param.ron
@@ -6,8 +6,8 @@
 	),
 	msl: (
 		lang_version: (2, 0),
-		per_stage_map: (
-			vs: (
+		per_entry_point_map: {
+			"foo_vert": (
 				resources: {
 					(group: 0, binding: 0): (buffer: Some(0), mutable: false),
 					(group: 0, binding: 1): (buffer: Some(1), mutable: false),
@@ -16,20 +16,20 @@
 				},
 				sizes_buffer: Some(24),
 			),
-			fs: (
+			"foo_frag": (
 				resources: {
 					(group: 0, binding: 0): (buffer: Some(0), mutable: true),
 					(group: 0, binding: 2): (buffer: Some(2), mutable: true),
 				},
 				sizes_buffer: Some(24),
 			),
-			cs: (
+			"atomics": (
 				resources: {
 					(group: 0, binding: 0): (buffer: Some(0), mutable: true),
 				},
 				sizes_buffer: Some(24),
 			),
-		),
+		},
 		inline_samplers: [],
 		spirv_cross_compatibility: false,
 		fake_missing_bindings: false,

--- a/tests/in/binding-arrays.param.ron
+++ b/tests/in/binding-arrays.param.ron
@@ -19,14 +19,14 @@
 	),
 	msl: (
 		lang_version: (2, 0),
-		per_stage_map: (
-			fs: (
+		per_entry_point_map: {
+			"main": (
 				resources: {
 					(group: 0, binding: 0): (texture: Some(0), binding_array_size: Some(10), mutable: false),
 				},
 				sizes_buffer: None,
 			)
-		),
+		},
 		inline_samplers: [],
 		spirv_cross_compatibility: false,
 		fake_missing_bindings: true,

--- a/tests/in/bitcast.params.ron
+++ b/tests/in/bitcast.params.ron
@@ -1,13 +1,13 @@
 (
 	msl: (
 		lang_version: (1, 2),
-		per_stage_map: (
-			cs: (
+		per_entry_point_map: {
+			"main": (
 				resources: {
 				},
 				sizes_buffer: Some(0),
 			)
-		),
+		},
 		inline_samplers: [],
 		spirv_cross_compatibility: false,
 		fake_missing_bindings: false,

--- a/tests/in/bits.param.ron
+++ b/tests/in/bits.param.ron
@@ -1,13 +1,13 @@
 (
 	msl: (
 		lang_version: (1, 2),
-		per_stage_map: (
-			cs: (
+		per_entry_point_map: {
+			"main": (
 				resources: {
 				},
 				sizes_buffer: Some(0),
 			)
-		),
+		},
 		inline_samplers: [],
 		spirv_cross_compatibility: false,
 		fake_missing_bindings: false,

--- a/tests/in/boids.param.ron
+++ b/tests/in/boids.param.ron
@@ -6,8 +6,8 @@
 	),
 	msl: (
 		lang_version: (2, 0),
-		per_stage_map: (
-			cs: (
+		per_entry_point_map: {
+			"main": (
 				resources: {
 					(group: 0, binding: 0): (buffer: Some(0), mutable: false),
 					(group: 0, binding: 1): (buffer: Some(1), mutable: true),
@@ -15,7 +15,7 @@
 				},
 				sizes_buffer: Some(3),
 			)
-		),
+		},
 		inline_samplers: [],
 		spirv_cross_compatibility: false,
 		fake_missing_bindings: false,

--- a/tests/in/extra.param.ron
+++ b/tests/in/extra.param.ron
@@ -5,11 +5,11 @@
 	),
 	msl: (
 		lang_version: (2, 2),
-		per_stage_map: (
-			fs: (
+		per_entry_point_map: {
+			"main": (
 				push_constant_buffer: Some(1),
 			),
-		),
+		},
 		inline_samplers: [],
 		spirv_cross_compatibility: false,
 		fake_missing_bindings: false,

--- a/tests/in/interface.param.ron
+++ b/tests/in/interface.param.ron
@@ -19,7 +19,7 @@
 	),
 	msl: (
 		lang_version: (2, 1),
-		per_stage_map: (),
+		per_entry_point_map: {},
 		inline_samplers: [],
 		spirv_cross_compatibility: false,
 		fake_missing_bindings: false,

--- a/tests/in/padding.param.ron
+++ b/tests/in/padding.param.ron
@@ -6,15 +6,15 @@
 	),
 	msl: (
 		lang_version: (2, 0),
-		per_stage_map: (
-			vs: (
+		per_entry_point_map: {
+			"vertex": (
 				resources: {
 					(group: 0, binding: 0): (buffer: Some(0), mutable: false),
                     (group: 0, binding: 1): (buffer: Some(1), mutable: false),
                     (group: 0, binding: 2): (buffer: Some(2), mutable: false),
 				},
 			),
-		),
+		},
 		inline_samplers: [],
 		spirv_cross_compatibility: false,
 		fake_missing_bindings: false,

--- a/tests/in/resource-binding-map.param.ron
+++ b/tests/in/resource-binding-map.param.ron
@@ -1,0 +1,53 @@
+(
+	god_mode: true,
+	msl: (
+		lang_version: (2, 0),
+		per_entry_point_map: {
+			"entry_point_one": (
+				resources: {
+					(group: 0, binding: 0): (texture: Some(0)),
+					(group: 0, binding: 2): (sampler: Some(Inline(0))),
+					(group: 0, binding: 4): (buffer: Some(0)),
+				}
+			),
+			"entry_point_two": (
+				resources: {
+					(group: 0, binding: 0): (texture: Some(0)),
+					(group: 0, binding: 2): (sampler: Some(Resource(0))),
+					(group: 0, binding: 4): (buffer: Some(0)),
+				}
+			),
+			"entry_point_three": (
+				resources: {
+					(group: 0, binding: 0): (texture: Some(0)),
+					(group: 0, binding: 1): (texture: Some(1)),
+					(group: 0, binding: 2): (sampler: Some(Inline(0))),
+					(group: 0, binding: 3): (sampler: Some(Resource(1))),
+					(group: 0, binding: 4): (buffer: Some(0)),
+					(group: 1, binding: 0): (buffer: Some(1)),
+				}
+			)
+		},
+		inline_samplers: [
+			(
+				coord: Normalized,
+				address: (ClampToEdge, ClampToEdge, ClampToEdge),
+				mag_filter: Linear,
+				min_filter: Linear,
+				mip_filter: None,
+				border_color: TransparentBlack,
+				compare_func: Never,
+				lod_clamp: Some((start: 0.5, end: 10.0)),
+				max_anisotropy: Some(8),
+			),
+		],
+		spirv_cross_compatibility: false,
+		fake_missing_bindings: false,
+		zero_initialize_workgroup_memory: true,
+	),
+	bounds_check_policies: (
+		index: ReadZeroSkipWrite,
+		buffer: ReadZeroSkipWrite,
+		image: ReadZeroSkipWrite,
+	)
+)

--- a/tests/in/resource-binding-map.wgsl
+++ b/tests/in/resource-binding-map.wgsl
@@ -1,0 +1,23 @@
+@group(0) @binding(0) var t1: texture_2d<f32>;
+@group(0) @binding(1) var t2: texture_2d<f32>;
+@group(0) @binding(2) var s1: sampler;
+@group(0) @binding(3) var s2: sampler;
+
+@group(0) @binding(4) var<uniform> uniformOne: vec2<f32>;
+@group(1) @binding(0) var<uniform> uniformTwo: vec2<f32>;
+
+@fragment
+fn entry_point_one(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
+    return textureSample(t1, s1, pos.xy);
+}
+
+@fragment
+fn entry_point_two() -> @location(0) vec4<f32> {
+    return textureSample(t1, s1, uniformOne);
+}
+
+@fragment
+fn entry_point_three() -> @location(0) vec4<f32> {
+    return textureSample(t1, s1, uniformTwo + uniformOne) +
+           textureSample(t2, s2, uniformOne);
+}

--- a/tests/in/skybox.param.ron
+++ b/tests/in/skybox.param.ron
@@ -7,19 +7,19 @@
 	),
 	msl: (
 		lang_version: (2, 1),
-		per_stage_map: (
-			vs: (
+		per_entry_point_map: {
+			"vs_main": (
 				resources: {
 					(group: 0, binding: 0): (buffer: Some(0)),
 				},
 			),
-			fs: (
+			"fs_main": (
 				resources: {
 					(group: 0, binding: 1): (texture: Some(0)),
 					(group: 0, binding: 2): (sampler: Some(Inline(0))),
 				},
 			),
-		),
+		},
 		inline_samplers: [
 			(
 				coord: Normalized,

--- a/tests/in/workgroup-var-init.param.ron
+++ b/tests/in/workgroup-var-init.param.ron
@@ -6,14 +6,14 @@
 	),
 	msl: (
 		lang_version: (2, 0),
-		per_stage_map: (
-			cs: (
+		per_entry_point_map: {
+			"main": (
 				resources: {
 					(group: 0, binding: 0): (buffer: Some(0), mutable: true),
 				},
 				sizes_buffer: None,
 			),
-		),
+		},
 		inline_samplers: [],
 		spirv_cross_compatibility: false,
 		fake_missing_bindings: false,

--- a/tests/out/msl/resource-binding-map.msl
+++ b/tests/out/msl/resource-binding-map.msl
@@ -1,0 +1,74 @@
+// language: metal2.0
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+struct DefaultConstructible {
+    template<typename T>
+    operator T() && {
+        return T {};
+    }
+};
+
+struct entry_point_oneInput {
+};
+struct entry_point_oneOutput {
+    metal::float4 member [[color(0)]];
+};
+fragment entry_point_oneOutput entry_point_one(
+  metal::float4 pos [[position]]
+, metal::texture2d<float, metal::access::sample> t1_ [[texture(0)]]
+) {
+    constexpr metal::sampler s1_(
+        metal::s_address::clamp_to_edge,
+        metal::t_address::clamp_to_edge,
+        metal::r_address::clamp_to_edge,
+        metal::mag_filter::linear,
+        metal::min_filter::linear,
+        metal::coord::normalized
+    );
+    metal::float4 _e4 = t1_.sample(s1_, pos.xy);
+    return entry_point_oneOutput { _e4 };
+}
+
+
+struct entry_point_twoOutput {
+    metal::float4 member_1 [[color(0)]];
+};
+fragment entry_point_twoOutput entry_point_two(
+  metal::texture2d<float, metal::access::sample> t1_ [[texture(0)]]
+, metal::sampler s1_ [[sampler(0)]]
+, constant metal::float2& uniformOne [[buffer(0)]]
+) {
+    metal::float2 _e3 = uniformOne;
+    metal::float4 _e4 = t1_.sample(s1_, _e3);
+    return entry_point_twoOutput { _e4 };
+}
+
+
+struct entry_point_threeOutput {
+    metal::float4 member_2 [[color(0)]];
+};
+fragment entry_point_threeOutput entry_point_three(
+  metal::texture2d<float, metal::access::sample> t1_ [[texture(0)]]
+, metal::texture2d<float, metal::access::sample> t2_ [[texture(1)]]
+, metal::sampler s2_ [[sampler(1)]]
+, constant metal::float2& uniformOne [[buffer(0)]]
+, constant metal::float2& uniformTwo [[buffer(1)]]
+) {
+    constexpr metal::sampler s1_(
+        metal::s_address::clamp_to_edge,
+        metal::t_address::clamp_to_edge,
+        metal::r_address::clamp_to_edge,
+        metal::mag_filter::linear,
+        metal::min_filter::linear,
+        metal::coord::normalized
+    );
+    metal::float2 _e3 = uniformTwo;
+    metal::float2 _e5 = uniformOne;
+    metal::float4 _e7 = t1_.sample(s1_, _e3 + _e5);
+    metal::float2 _e11 = uniformOne;
+    metal::float4 _e12 = t2_.sample(s2_, _e11);
+    return entry_point_threeOutput { _e7 + _e12 };
+}

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -90,8 +90,11 @@ struct Parameters {
 #[allow(unused_variables)]
 fn check_targets(module: &naga::Module, name: &str, targets: Targets) {
     let root = env!("CARGO_MANIFEST_DIR");
-    let params = match fs::read_to_string(format!("{root}/{BASE_DIR_IN}/{name}.param.ron")) {
-        Ok(string) => ron::de::from_str(&string).expect("Couldn't parse param file"),
+    let filepath = format!("{root}/{BASE_DIR_IN}/{name}.param.ron");
+    let params = match fs::read_to_string(&filepath) {
+        Ok(string) => {
+            ron::de::from_str(&string).expect(&format!("Couldn't parse param file: {}", filepath))
+        }
         Err(_) => Parameters::default(),
     };
 
@@ -543,6 +546,7 @@ fn convert_wgsl() {
             "binding-arrays",
             Targets::WGSL | Targets::HLSL | Targets::METAL | Targets::SPIRV,
         ),
+        ("resource-binding-map", Targets::METAL),
         ("multiview", Targets::SPIRV | Targets::GLSL | Targets::WGSL),
         ("multiview_webgl", Targets::GLSL),
         (


### PR DESCRIPTION
The existing `per_stage_map` field of MSL backend options specifies resource binding maps that apply to all entry points of each stage type. It is useful to have the ability to provide a separate binding index map for each entry point, especially when the same shader module defines multiple entry points of the same stage kind.

This patch introduces a new `per_entry_point_map` option. When fields are missing in the per-entry-point map, the code falls back to the existing `per_stage_map` option as before.
