### PR TITLE
[glsl-out] Version check countLeadingZeros

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -2995,7 +2995,7 @@ impl<'a, W: Write> Writer<'a, W> {
                                     } else {
                                         write!(self.out, "(")?;
                                         self.write_expr(arg, ctx)?;
-                                        write!(self.out, " <= 0 ? 0 : int(")?;
+                                        write!(self.out, " < 0 ? 0 : int(")?;
                                         write!(self.out, "31.0 - floor(log2(float(")?;
                                         self.write_expr(arg, ctx)?;
                                         write!(self.out, ") + 0.5))))")?;

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -2982,7 +2982,7 @@ impl<'a, W: Write> Writer<'a, W> {
                                         write!(self.out, "mix(vec{s}(31.0) - floor(log2(vec{s}(")?;
                                         self.write_expr(arg, ctx)?;
                                         write!(self.out, ") + 0.5)), ")?;
-                                        write!(self.out, "vec{s}(0.0), lessThanEqual(")?;
+                                        write!(self.out, "vec{s}(0.0), lessThan(")?;
                                         self.write_expr(arg, ctx)?;
                                         write!(self.out, ", ivec{s}(0u))))")?;
                                     }

--- a/tests/out/glsl/math-functions.main.Vertex.glsl
+++ b/tests/out/glsl/math-functions.main.Vertex.glsl
@@ -14,10 +14,10 @@ void main() {
     vec4 g = refract(v, v, 1.0);
     int const_dot = ( + ivec2(0, 0).x * ivec2(0, 0).x + ivec2(0, 0).y * ivec2(0, 0).y);
     uint first_leading_bit_abs = uint(findMSB(uint(abs(int(0u)))));
-    int clz_a = (-1 < 0 ? 0 : 31 - findMSB(-1));
-    uint clz_b = uint(31 - findMSB(1u));
+    int clz_a = (-1 <= 0 ? 0 : int(31.0 - floor(log2(float(-1)))));
+    uint clz_b = uint(31.0 - floor(log2(float(1u))));
     ivec2 _e20 = ivec2(-1);
-    ivec2 clz_c = mix(ivec2(31) - findMSB(_e20), ivec2(0), lessThan(_e20, ivec2(0)));
-    uvec2 clz_d = uvec2(ivec2(31) - findMSB(uvec2(1u)));
+    ivec2 clz_c = ivec2(mix(vec2(31.0) - floor(log2(vec2(_e20) + 0.5)), vec2(0.0), lessThanEqual(_e20, ivec2(0u))));
+    uvec2 clz_d = uvec2(vec2(31.0) - floor(log2(vec2(uvec2(1u)) + 0.5)));
 }
 

--- a/tests/out/glsl/math-functions.main.Vertex.glsl
+++ b/tests/out/glsl/math-functions.main.Vertex.glsl
@@ -18,7 +18,6 @@ void main() {
     uint clz_b = uint(31 - findMSB(1u));
     ivec2 _e20 = ivec2(-1);
     ivec2 clz_c = mix(ivec2(31) - findMSB(_e20), ivec2(0), lessThan(_e20, ivec2(0)));
-    uvec2 _e23 = uvec2(1u);
-    uvec2 clz_d = uvec2(ivec2(31) - findMSB(_e23));
+    uvec2 clz_d = uvec2(ivec2(31) - findMSB(uvec2(1u)));
 }
 

--- a/tests/out/glsl/math-functions.main.Vertex.glsl
+++ b/tests/out/glsl/math-functions.main.Vertex.glsl
@@ -14,10 +14,10 @@ void main() {
     vec4 g = refract(v, v, 1.0);
     int const_dot = ( + ivec2(0, 0).x * ivec2(0, 0).x + ivec2(0, 0).y * ivec2(0, 0).y);
     uint first_leading_bit_abs = uint(findMSB(uint(abs(int(0u)))));
-    int clz_a = (-1 <= 0 ? 0 : int(31.0 - floor(log2(float(-1)))));
-    uint clz_b = uint(31.0 - floor(log2(float(1u))));
+    int clz_a = (-1 < 0 ? 0 : 31 - findMSB(-1));
+    uint clz_b = uint(31 - findMSB(1u));
     ivec2 _e20 = ivec2(-1);
-    ivec2 clz_c = ivec2(mix(vec2(31.0) - floor(log2(vec2(_e20) + 0.5)), vec2(0.0), lessThanEqual(_e20, ivec2(0u))));
-    uvec2 clz_d = uvec2(vec2(31.0) - floor(log2(vec2(uvec2(1u)) + 0.5)));
+    ivec2 clz_c = mix(ivec2(31) - findMSB(_e20), ivec2(0), lessThan(_e20, ivec2(0)));
+    uvec2 clz_d = uvec2(ivec2(31) - findMSB(uvec2(1u)));
 }
 

--- a/tests/out/glsl/math-functions.main.Vertex.glsl
+++ b/tests/out/glsl/math-functions.main.Vertex.glsl
@@ -14,11 +14,11 @@ void main() {
     vec4 g = refract(v, v, 1.0);
     int const_dot = ( + ivec2(0, 0).x * ivec2(0, 0).x + ivec2(0, 0).y * ivec2(0, 0).y);
     uint first_leading_bit_abs = uint(findMSB(uint(abs(int(0u)))));
-    int clz_a = (-1 <= 0 ? (-1 == 0 ? 32 : 0) : int(31.0 - floor(log2(float(-1) + 0.5))));
-    uint clz_b = (1u == 0u ? 32u : uint(31.0 - floor(log2(float(1u) + 0.5))));
+    int clz_a = (-1 < 0 ? 0 : 31 - findMSB(-1));
+    uint clz_b = uint(31 - findMSB(1u));
     ivec2 _e20 = ivec2(-1);
-    ivec2 clz_c = ivec2(mix(vec2(31.0) - floor(log2(vec2(_e20) + 0.5)), mix(vec2(0.0), vec2(32.0), equal(_e20, ivec2(0))), lessThanEqual(_e20, ivec2(0))));
+    ivec2 clz_c = mix(ivec2(31) - findMSB(_e20), ivec2(0), lessThan(_e20, ivec2(0)));
     uvec2 _e23 = uvec2(1u);
-    uvec2 clz_d = uvec2(mix(vec2(31.0) - floor(log2(vec2(_e23) + 0.5)), vec2(32.0), lessThanEqual(_e23, uvec2(0u))));
+    uvec2 clz_d = uvec2(ivec2(31) - findMSB(_e23));
 }
 


### PR DESCRIPTION
Update `countLeadingZeros` to use `findMSB` in `400+` and `es 310+`.

As a side note, all of the integer functions categorized under `// bit` have the same [version requirements](https://docs.gl/sl4/bitCount).