### PR TITLE
spv-in: Don't apply interpolation to fragment shaders outputs

### DIFF
--- a/src/front/spv/function.rs
+++ b/src/front/spv/function.rs
@@ -387,7 +387,18 @@ impl<I: Iterator<Item = u32>> super::Frontend<I> {
                                     None => continue,
                                     _ => {}
                                 }
-                                members.push(sm.clone());
+                                let mut sm = sm.clone();
+
+                                if let Some(ref mut binding) = sm.binding {
+                                    if ep.stage == crate::ShaderStage::Vertex {
+                                        binding.apply_default_interpolation(
+                                            &module.types[sm.ty].inner,
+                                        );
+                                    }
+                                }
+
+                                members.push(sm);
+
                                 components.push(function.expressions.append(
                                     crate::Expression::AccessIndex {
                                         base: expr_handle,
@@ -397,11 +408,18 @@ impl<I: Iterator<Item = u32>> super::Frontend<I> {
                                 ));
                             }
                         }
-                        _ => {
+                        ref inner => {
+                            let mut binding = result.binding.clone();
+                            if let Some(ref mut binding) = binding {
+                                if ep.stage == crate::ShaderStage::Vertex {
+                                    binding.apply_default_interpolation(inner);
+                                }
+                            }
+
                             members.push(crate::StructMember {
                                 name: None,
                                 ty: result.ty,
-                                binding: result.binding.clone(),
+                                binding,
                                 offset: 0,
                             });
                             // populate just the globals first, then do `Load` in a

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -4479,7 +4479,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
             span = member_alignment.round_up(span);
             alignment = member_alignment.max(alignment);
 
-            let mut binding = decor.io_binding().ok();
+            let binding = decor.io_binding().ok();
             if let Some(offset) = decor.offset {
                 span = offset;
             }
@@ -4507,9 +4507,6 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                 }
             }
 
-            if let Some(ref mut binding) = binding {
-                binding.apply_default_interpolation(inner);
-            }
             members.push(crate::StructMember {
                 name: decor.name,
                 ty,
@@ -4943,7 +4940,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                 (Variable::Global, var)
             }
             ExtendedClass::Input => {
-                let mut binding = dec.io_binding()?;
+                let binding = dec.io_binding()?;
                 let mut unsigned_ty = ty;
                 if let crate::Binding::BuiltIn(built_in) = binding {
                     let needs_inner_uint = match built_in {
@@ -4984,8 +4981,6 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                     init: None,
                 };
 
-                binding.apply_default_interpolation(&module.types[unsigned_ty].inner);
-
                 let inner = Variable::Input(crate::FunctionArgument {
                     name: dec.name,
                     ty: unsigned_ty,
@@ -4995,7 +4990,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
             }
             ExtendedClass::Output => {
                 // For output interface blocks, this would be a structure.
-                let mut binding = dec.io_binding().ok();
+                let binding = dec.io_binding().ok();
                 let init = match binding {
                     Some(crate::Binding::BuiltIn(built_in)) => {
                         match null::generate_default_built_in(
@@ -5058,9 +5053,6 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                     ty,
                     init,
                 };
-                if let Some(ref mut binding) = binding {
-                    binding.apply_default_interpolation(&module.types[ty].inner);
-                }
                 let inner = Variable::Output(crate::FunctionResult { ty, binding });
                 (inner, var)
             }

--- a/tests/out/ir/shadow.ron
+++ b/tests/out/ir/shadow.ron
@@ -1368,8 +1368,8 @@
                     ty: 4,
                     binding: Some(Location(
                         location: 0,
-                        interpolation: Some(Perspective),
-                        sampling: Some(Center),
+                        interpolation: None,
+                        sampling: None,
                     )),
                 )),
                 local_variables: [],


### PR DESCRIPTION
SPIR-V doesn't allow the `Flat`, `NoPerspective`, `Sample` or `Centroid` decorations on fragment shaders outputs ([VUID-StandaloneSpirv-Flat-06201](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-StandaloneSpirv-Flat-06201)), but the spirv frontend was applying default interpolation to all outputs unconditionally.

This wasn't an issue for most shaders since they output floats and the default values for them don't interfere with SPIR-V semantics, but if the shader returned a uint or int the interpolation would be set to `Flat` which as stated above is disallowed.

This commit fixes the issue by only running the default interpolation code when constructing the entry point and if the stage/IO allow it.