### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
-# Regular testing.
-name: pipeline
+name: CI
 on: [push, pull_request]
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,18 +32,15 @@ jobs:
         run: cargo +$MSRV check --all-features --workspace
 
   test:
-    name: Test Nightly
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install nightly toolchain
-        run: rustup toolchain install nightly --no-self-update --profile=minimal
-
-      - name: Install cargo-nextest
+      - name: Install cargo-nextest and cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-nextest
+          tool: cargo-nextest,cargo-llvm-cov
 
       - name: Default test
         # Our intention here is to test `naga` with no features enabled. But
@@ -51,10 +48,15 @@ jobs:
         # `naga` with the features requested in `cli/Cargo.toml`. Passing
         # `--package naga` causes us to use the default features in the
         # top-level `Cargo.toml` instead.
-        run: cargo +nightly nextest run --package naga
+        run: cargo nextest run --package naga
 
       - name: Test all features
-        run: cargo +nightly nextest run --all-features --workspace
+        run: cargo llvm-cov --lcov --output-path lcov.info nextest --all-features --workspace
+
+      - name: Upload coverage report to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info
 
       - name: Check snapshots
         run: git diff --exit-code -- tests/out

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -10,34 +10,6 @@ env:
   RUST_BACKTRACE: full
 
 jobs:
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install binstall
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-binstall
-
-      - name: Install cargo-tarpaulin
-        run: cargo binstall --no-confirm cargo-tarpaulin
-
-      - name: Generate report
-        run: cargo tarpaulin --tests --all-features --workspace --out Xml
-
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v3
-        with:
-          name: code-coverage-report
-          path: cobertura.xml
-
   parse-dota2:
     name: Parse Dota2 shaders
     runs-on: ubuntu-latest

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: code-coverage-report
           path: cobertura.xml

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -15,18 +15,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Install binstall
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-binstall
+
       - name: Install cargo-tarpaulin
         run: cargo binstall --no-confirm cargo-tarpaulin
+
       - name: Generate report
         run: cargo tarpaulin --tests --all-features --workspace --out Xml
+
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3
         with:
@@ -38,13 +43,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - run: mkdir data
+
       - name: Download shaders
         run: curl https://user.fm/files/v2-5573e18b9f03f42c6ae53c392083da35/dota2-shaders.zip -o data/all.zip
+
       - name: Unpack shaders
         run: cd data && unzip all.zip
+
       - name: Build Naga
         run: cargo build --release --bin naga
+
       - name: Convert shaders
         run: for file in data/*.spv ; do echo "Translating" ${file} && target/release/naga --validate 27 ${file} ${file}.metal; done
 
@@ -53,10 +63,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Download shaders
         run: git clone https://github.com/SaschaWillems/Vulkan.git
+
       - name: Build Naga
         run: cargo build --release --bin naga
+
       - name: Convert metal shaders
         run: |
           # No needed to stop workflow if we can't validate one file
@@ -82,15 +95,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Download shaders
         run: git clone https://github.com/dneto0/spirv-samples.git
+
       - name: Build Naga
         run: cargo build --release --bin naga
+
       - name: Install spirv-tools
         run: |
            wget -q https://storage.googleapis.com/spirv-tools/artifacts/prod/graphics_shader_compiler/spirv-tools/linux-clang-release/continuous/1489/20210629-121459/install.tgz
            tar zxf install.tgz
            ./install/bin/spirv-as --version
+
       - name: Compile spv from spvasm
         run: |
            cd spirv-samples
@@ -101,6 +118,7 @@ jobs:
                echo "Convert to spv with spirv-as: $fname"
                ../install/bin/spirv-as --target-env spv1.3 $(realpath ${fname}) -o ./spv/$(basename ${fname}).spv
            done;
+
       - name: Validate spv and generate wgsl
         run: |
            set +e
@@ -125,6 +143,7 @@ jobs:
                echo "Result: $(expr $FILE_COUNT - $SUCCESS_RESULT_COUNT) / $FILE_COUNT" > counter
            done
            cat counter
+
       - name: Validate output wgsl
         run: |
            set +e
@@ -152,13 +171,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
+
       - name: Test minimal (without span)
         run: cargo nextest run --features validate -p naga
+
       - name: Test all (without validation)
         run: cargo nextest run --features wgsl-in,wgsl-out,glsl-in,glsl-out,spv-in,spv-out,msl-out,hlsl-out,dot-out --workspace
+
       - name: Check snapshots (without validation)
         run: git diff --exit-code -- tests/out

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -9,7 +9,7 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -35,7 +35,7 @@ jobs:
     name: Parse Dota2 shaders
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -54,7 +54,7 @@ jobs:
     name: Parse Sascha Willems Vulkan tutorial shaders
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -87,7 +87,7 @@ jobs:
     name: Parse dneto0 spirv-samples
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -161,7 +161,7 @@ jobs:
     name: Check snapshots (validated or not)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -152,9 +152,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - name: Test minimal (without span)
-        run: cargo test --features validate -p naga
+        run: cargo nextest run --features validate -p naga
       - name: Test all (without validation)
-        run: cargo test --features wgsl-in,wgsl-out,glsl-in,glsl-out,spv-in,spv-out,msl-out,hlsl-out,dot-out --workspace
+        run: cargo nextest run --features wgsl-in,wgsl-out,glsl-in,glsl-out,spv-in,spv-out,msl-out,hlsl-out,dot-out --workspace
       - name: Check snapshots (without validation)
         run: git diff --exit-code -- tests/out

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [master]
 
+env:
+  CARGO_INCREMENTAL: false
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+
 jobs:
   coverage:
     name: Coverage

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Generate report
         run: cargo tarpaulin --tests --all-features --workspace --out Xml
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Archive code coverage results

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -10,9 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
       - name: Install binstall
         uses: taiki-e/install-action@v2
         with:
@@ -36,10 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
       - run: mkdir data
       - name: Download shaders
         run: curl https://user.fm/files/v2-5573e18b9f03f42c6ae53c392083da35/dota2-shaders.zip -o data/all.zip
@@ -55,10 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
       - name: Download shaders
         run: git clone https://github.com/SaschaWillems/Vulkan.git
       - name: Build Naga
@@ -88,10 +77,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
       - name: Download shaders
         run: git clone https://github.com/dneto0/spirv-samples.git
       - name: Build Naga
@@ -162,19 +147,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        name: Test minimal (without span)
-        with:
-          command: test
-          args: --features validate -p naga
-      - uses: actions-rs/cargo@v1
-        name: Test all (without validation)
-        with:
-          command: test
-          args: --features wgsl-in,wgsl-out,glsl-in,glsl-out,spv-in,spv-out,msl-out,hlsl-out,dot-out --workspace
+      - name: Test minimal (without span)
+        run: cargo test --features validate -p naga
+      - name: Test all (without validation)
+        run: cargo test --features wgsl-in,wgsl-out,glsl-in,glsl-out,spv-in,spv-out,msl-out,hlsl-out,dot-out --workspace
       - name: Check snapshots (without validation)
         run: git diff --exit-code -- tests/out

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -50,8 +50,17 @@ jobs:
         run: cargo +nightly nextest run --all-features --workspace
       - name: Check snapshots
         run: git diff --exit-code -- tests/out
+  check:
+    name: Check benchmarks and naga-fuzz
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
       - name: Check benchmarks
-        run: cargo +nightly check --benches
+        run: cargo check --benches
+      - name: Check naga-fuzz
+        run: |
+          cd fuzz
+          cargo check
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -14,29 +14,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Install MSRV toolchain
         run: rustup toolchain install $MSRV --no-self-update --profile=minimal
+
       - name: Install nightly toolchain
         run: rustup toolchain install nightly --no-self-update --profile=minimal
+
       - name: Install cargo-hack
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack
+
       # -Z avoid-dev-deps doesn't work
       - run: cargo +nightly hack generate-lockfile --remove-dev-deps -Z minimal-versions --offline
+
       - name: Test all features
         run: cargo +$MSRV check --all-features --workspace
+
   test:
     name: Test Nightly
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Install nightly toolchain
         run: rustup toolchain install nightly --no-self-update --profile=minimal
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
+
       - name: Default test
         # Our intention here is to test `naga` with no features enabled. But
         # since `cli` is the default package, a plain `cargo test` will build
@@ -44,28 +53,37 @@ jobs:
         # `--package naga` causes us to use the default features in the
         # top-level `Cargo.toml` instead.
         run: cargo +nightly nextest run --package naga
+
       - name: Test all features
         run: cargo +nightly nextest run --all-features --workspace
+
       - name: Check snapshots
         run: git diff --exit-code -- tests/out
+
   check:
     name: Check benchmarks and naga-fuzz
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Check benchmarks
         run: cargo check --benches
+
       - name: Check naga-fuzz
         run: |
           cd fuzz
           cargo check
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - run: rustup component add clippy
+
       - run: cargo clippy --all-features --workspace -- -D warnings
+
   documentation:
     name: Documentation
     runs-on: ubuntu-latest
@@ -73,10 +91,13 @@ jobs:
       RUSTDOCFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v3
+
       - run: cargo doc -p naga --all-features --document-private-items
+
   fmt:
     name: Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - run: cargo fmt -- --check

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -7,7 +7,7 @@ jobs:
     name: Test MSRV and dependencies minimal-versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -25,7 +25,7 @@ jobs:
     name: Test Nightly
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -57,7 +57,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -74,7 +74,7 @@ jobs:
     env:
       RUSTDOCFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -88,7 +88,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -18,14 +18,14 @@ jobs:
         run: rustup toolchain install $MSRV --no-self-update --profile=minimal
       - name: Install nightly toolchain
         run: rustup toolchain install nightly --no-self-update --profile=minimal
-      - name: Install cargo-hack
+      - name: Install cargo-hack and cargo-nextest
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-hack
+          tool: cargo-hack,cargo-nextest
       # -Z avoid-dev-deps doesn't work
       - run: cargo +nightly hack generate-lockfile --remove-dev-deps -Z minimal-versions --offline
       - name: Test all features
-        run: cargo +$MSRV test --all-features --workspace
+        run: cargo +$MSRV nextest run --all-features --workspace
       - name: Check snapshots
         run: git diff --exit-code -- tests/out
   test:
@@ -35,15 +35,19 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install nightly toolchain
         run: rustup toolchain install nightly --no-self-update --profile=minimal
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - name: Default test
         # Our intention here is to test `naga` with no features enabled. But
         # since `cli` is the default package, a plain `cargo test` will build
         # `naga` with the features requested in `cli/Cargo.toml`. Passing
         # `--package naga` causes us to use the default features in the
         # top-level `Cargo.toml` instead.
-        run: cargo +nightly test --package naga
+        run: cargo +nightly nextest run --package naga
       - name: Test all features
-        run: cargo +nightly test --all-features --workspace
+        run: cargo +nightly nextest run --all-features --workspace
       - name: Check snapshots
         run: git diff --exit-code -- tests/out
       - name: Check benchmarks

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -3,6 +3,9 @@ name: pipeline
 on: [push, pull_request]
 
 env:
+  CARGO_INCREMENTAL: false
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
   MSRV: 1.63
 
 jobs:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,23 +2,27 @@
 name: pipeline
 on: [push, pull_request]
 
+env:
+  MSRV: 1.63
+
 jobs:
   test-msrv:
     name: Test MSRV and dependencies minimal-versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - name: Install MSRV toolchain
+        run: rustup toolchain install $MSRV --no-self-update --profile=minimal
+      - name: Install nightly toolchain
+        run: rustup toolchain install nightly --no-self-update --profile=minimal
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@v2
         with:
-          profile: minimal
-          toolchain: "1.63.0"
-          override: true
-      - uses: taiki-e/install-action@cargo-hack
-      - uses: taiki-e/install-action@cargo-minimal-versions
-      # nightly is only used by cargo-minimal-versions to regenerate the lock file
-      - run: rustup toolchain add nightly --no-self-update
+          tool: cargo-hack
+      # -Z avoid-dev-deps doesn't work
+      - run: cargo +nightly hack generate-lockfile --remove-dev-deps -Z minimal-versions --offline
       - name: Test all features
-        run: cargo minimal-versions test --all-features --workspace
+        run: cargo +$MSRV test --all-features --workspace
       - name: Check snapshots
         run: git diff --exit-code -- tests/out
   test:
@@ -26,48 +30,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/cargo@v1
-        name: Default test
-        with:
-          # Our intention here is to test `naga` with no features enabled. But
-          # since `cli` is the default package, a plain `cargo test` will build
-          # `naga` with the features requested in `cli/Cargo.toml`. Passing
-          # `--package naga` causes us to use the default features in the
-          # top-level `Cargo.toml` instead.
-          command: test
-          args: --package naga
-      - uses: actions-rs/cargo@v1
-        name: Test all features
-        with:
-          command: test
-          args: --all-features --workspace
+      - name: Install nightly toolchain
+        run: rustup toolchain install nightly --no-self-update --profile=minimal
+      - name: Default test
+        # Our intention here is to test `naga` with no features enabled. But
+        # since `cli` is the default package, a plain `cargo test` will build
+        # `naga` with the features requested in `cli/Cargo.toml`. Passing
+        # `--package naga` causes us to use the default features in the
+        # top-level `Cargo.toml` instead.
+        run: cargo +nightly test --package naga
+      - name: Test all features
+        run: cargo +nightly test --all-features --workspace
       - name: Check snapshots
         run: git diff --exit-code -- tests/out
-      - uses: actions-rs/cargo@v1
-        name: Check benchmarks
-        with:
-          command: check
-          args: --benches
+      - name: Check benchmarks
+        run: cargo +nightly check --benches
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
       - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --workspace -- -D warnings
+      - run: cargo clippy --all-features --workspace -- -D warnings
   documentation:
     name: Documentation
     runs-on: ubuntu-latest
@@ -75,26 +59,10 @@ jobs:
       RUSTDOCFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: -p naga --all-features --document-private-items
+      - run: cargo doc -p naga --all-features --document-private-items
   fmt:
     name: Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt
-      - name: run rustfmt
-        run: |
-          cargo fmt -- --check
+      - run: cargo fmt -- --check

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -9,8 +9,8 @@ env:
   MSRV: 1.63
 
 jobs:
-  test-msrv:
-    name: Test MSRV and dependencies minimal-versions
+  check-msrv:
+    name: Check MSRV and minimal-versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -18,16 +18,14 @@ jobs:
         run: rustup toolchain install $MSRV --no-self-update --profile=minimal
       - name: Install nightly toolchain
         run: rustup toolchain install nightly --no-self-update --profile=minimal
-      - name: Install cargo-hack and cargo-nextest
+      - name: Install cargo-hack
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-hack,cargo-nextest
+          tool: cargo-hack
       # -Z avoid-dev-deps doesn't work
       - run: cargo +nightly hack generate-lockfile --remove-dev-deps -Z minimal-versions --offline
       - name: Test all features
-        run: cargo +$MSRV nextest run --all-features --workspace
-      - name: Check snapshots
-        run: git diff --exit-code -- tests/out
+        run: cargo +$MSRV check --all-features --workspace
   test:
     name: Test Nightly
     runs-on: ubuntu-latest

--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -13,7 +13,7 @@ jobs:
     name: SPIR-V + GLSL
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install tools
         run: sudo apt-get install spirv-tools glslang-tools graphviz
       - run: make validate-spv

--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -14,9 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Install tools
         run: sudo apt-get install spirv-tools glslang-tools graphviz
+
       - run: make validate-spv
+
       - run: make validate-glsl
+
       - run: make validate-dot
+
       - run: make validate-wgsl

--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   validate-linux:
     name: SPIR-V + GLSL
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install tools

--- a/.github/workflows/validation-macos.yml
+++ b/.github/workflows/validation-macos.yml
@@ -10,4 +10,5 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
+
       - run: make validate-msl

--- a/.github/workflows/validation-macos.yml
+++ b/.github/workflows/validation-macos.yml
@@ -9,5 +9,5 @@ jobs:
     name: MSL
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: make validate-msl

--- a/.github/workflows/validation-windows.yml
+++ b/.github/workflows/validation-windows.yml
@@ -9,7 +9,7 @@ jobs:
     name: HLSL via DXC
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Add DirectXShaderCompiler
         uses: napokue/setup-dxc@v1.1.0
       - run: make validate-hlsl-dxc
@@ -19,7 +19,7 @@ jobs:
     name: HLSL via FXC
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Add fxc bin to PATH
         run: |
           Get-Childitem -Path "C:\Program Files (x86)\Windows Kits\10\bin\**\x64\fxc.exe" `

--- a/.github/workflows/validation-windows.yml
+++ b/.github/workflows/validation-windows.yml
@@ -10,8 +10,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Add DirectXShaderCompiler
         uses: napokue/setup-dxc@v1.1
+
       - run: make validate-hlsl-dxc
         shell: sh
 
@@ -20,6 +22,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Add fxc bin to PATH
         run: |
           Get-Childitem -Path "C:\Program Files (x86)\Windows Kits\10\bin\**\x64\fxc.exe" `
@@ -28,5 +31,6 @@ jobs:
           | Split-Path -Parent `
           | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
         shell: powershell
+
       - run: make validate-hlsl-fxc
         shell: sh

--- a/.github/workflows/validation-windows.yml
+++ b/.github/workflows/validation-windows.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Add DirectXShaderCompiler
-        uses: napokue/setup-dxc@v1.1.0
+        uses: napokue/setup-dxc@v1.1
       - run: make validate-hlsl-dxc
         shell: sh
 


### PR DESCRIPTION
- update actions
- check `naga-fuzz`
- use `cargo-nextest`
- remove unmaintained `actions-rs` actions
- only check on MSRV and minimal-versions (dev deps might bump up the version of deps)
- enable colors in the CI terminal
- use `cargo-llvm-cov` (improves accuracy of reports 69% -> 82%, wgpu also uses it)
- compute and upload coverage to codecov for PRs as well

(should resolve all CI warnings; ex. scroll down to "Annotations" section https://github.com/gfx-rs/naga/actions/runs/4085172347)