### PR TITLE
Require LF for snapshots

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/out/**/* text eol=lf


### PR DESCRIPTION
Depending on how you have your gitconfig set up, running the snapshot tests can cause a diff across every snapshot on Windows where line endings might switch between LF and CRLF. Instead we can force LF for everything in the `tests/out` directory which should avoid this problem.