### PR TITLE
Skip `invariant` for `gl_FragCoord` on WebGL2

### DIFF
--- a/tests/in/invariant.param.ron
+++ b/tests/in/invariant.param.ron
@@ -1,0 +1,11 @@
+(
+    glsl: (
+        version: Embedded (
+            version: 300,
+            is_webgl: true
+        ),
+        writer_flags: (bits: 0),
+        binding_map: {},
+        zero_initialize_workgroup_memory: true,
+    ),
+)

--- a/tests/in/invariant.wgsl
+++ b/tests/in/invariant.wgsl
@@ -1,0 +1,7 @@
+@vertex
+fn vs() -> @builtin(position) @invariant vec4<f32> {
+    return vec4<f32>(0.0);
+}
+
+@fragment
+fn fs(@builtin(position) @invariant position: vec4<f32>) { }

--- a/tests/out/glsl/invariant.frag_main.Fragment.glsl
+++ b/tests/out/glsl/invariant.frag_main.Fragment.glsl
@@ -1,0 +1,11 @@
+#version 300 es
+
+precision highp float;
+precision highp int;
+
+
+void main() {
+    vec4 position = gl_FragCoord;
+    return;
+}
+

--- a/tests/out/glsl/invariant.fs.Fragment.glsl
+++ b/tests/out/glsl/invariant.fs.Fragment.glsl
@@ -1,0 +1,11 @@
+#version 300 es
+
+precision highp float;
+precision highp int;
+
+
+void main() {
+    vec4 position = gl_FragCoord;
+    return;
+}
+

--- a/tests/out/glsl/invariant.vs.Vertex.glsl
+++ b/tests/out/glsl/invariant.vs.Vertex.glsl
@@ -1,0 +1,12 @@
+#version 300 es
+
+precision highp float;
+precision highp int;
+
+invariant gl_Position;
+
+void main() {
+    gl_Position = vec4(0.0);
+    return;
+}
+

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -558,6 +558,7 @@ fn convert_wgsl() {
         ),
         ("sprite", Targets::SPIRV),
         ("force_point_size_vertex_shader_webgl", Targets::GLSL),
+        ("invariant", Targets::GLSL),
     ];
 
     for &(name, targets) in inputs.iter() {


### PR DESCRIPTION
Fixes #2252

If the browser behavior changes here we can restore it later on, but for now at least ANGLE (maybe others) reject `invariant gl_FragCoord` as described in #2252