### PR TITLE
enforce discard only in fragment

### DIFF
--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -595,6 +595,7 @@ impl super::Validator {
                     finished = true;
                 }
                 S::Kill => {
+                    stages &= super::ShaderStages::FRAGMENT;
                     finished = true;
                 }
                 S::Barrier(_) => {

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -944,6 +944,35 @@ fn invalid_arrays() {
 }
 
 #[test]
+fn discard_in_wrong_stage() {
+    check_validation! {
+        "@compute @workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    if global_id.x == 3u {
+        discard;
+    }
+}":
+        Err(naga::valid::ValidationError::EntryPoint {
+            stage: naga::ShaderStage::Compute,
+            source: naga::valid::EntryPointError::ForbiddenStageOperations,
+            ..
+        })
+    }
+
+    check_validation! {
+        "@vertex
+fn main() {
+    discard;
+}":
+        Err(naga::valid::ValidationError::EntryPoint {
+            stage: naga::ShaderStage::Vertex,
+            source: naga::valid::EntryPointError::ForbiddenStageOperations,
+            ..
+        })
+    }
+}
+
+#[test]
 fn invalid_structs() {
     check_validation! {
         "struct Bad { data: sampler }",


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/naga/issues/2263

as per [wgsl spec](https://www.w3.org/TR/WGSL/#discard-statement) "The discard statement must only be used in a fragment shader stage."