### PR TITLE
Split image bounds check policy

### DIFF
--- a/cli/src/bin/naga.rs
+++ b/cli/src/bin/naga.rs
@@ -30,12 +30,19 @@ struct Args {
     #[argh(option)]
     buffer_bounds_check_policy: Option<BoundsCheckPolicyArg>,
 
-    /// what policy to use for texture bounds checking.
+    /// what policy to use for texture loads bounds checking.
     ///
     /// Possible values are the same as for `index-bounds-check-policy`. If
     /// omitted, defaults to the index bounds check policy.
     #[argh(option)]
-    image_bounds_check_policy: Option<BoundsCheckPolicyArg>,
+    image_load_bounds_check_policy: Option<BoundsCheckPolicyArg>,
+
+    /// what policy to use for texture stores bounds checking.
+    ///
+    /// Possible values are the same as for `index-bounds-check-policy`. If
+    /// omitted, defaults to the index bounds check policy.
+    #[argh(option)]
+    image_store_bounds_check_policy: Option<BoundsCheckPolicyArg>,
 
     /// directory to dump the SPIR-V block context dump to
     #[argh(option)]
@@ -244,7 +251,11 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         Some(arg) => arg.0,
         None => params.bounds_check_policies.index,
     };
-    params.bounds_check_policies.image = match args.image_bounds_check_policy {
+    params.bounds_check_policies.image_load = match args.image_load_bounds_check_policy {
+        Some(arg) => arg.0,
+        None => params.bounds_check_policies.index,
+    };
+    params.bounds_check_policies.image_store = match args.image_store_bounds_check_policy {
         Some(arg) => arg.0,
         None => params.bounds_check_policies.index,
     };

--- a/src/back/glsl/features.rs
+++ b/src/back/glsl/features.rs
@@ -444,7 +444,7 @@ impl<'a, W> Writer<'a, W> {
                 Expression::ImageLoad {
                     sample, level, ..
                 } => {
-                    if policies.image != crate::proc::BoundsCheckPolicy::Unchecked {
+                    if policies.image_load != crate::proc::BoundsCheckPolicy::Unchecked {
                         if sample.is_some() {
                             features.request(Features::TEXTURE_SAMPLES)
                         }

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1820,7 +1820,7 @@ impl<'a, W: Write> Writer<'a, W> {
                             ..
                         } = *ctx.info[image].ty.inner_with(&self.module.types)
                         {
-                            if let proc::BoundsCheckPolicy::Restrict = self.policies.image {
+                            if let proc::BoundsCheckPolicy::Restrict = self.policies.image_load {
                                 write!(self.out, "{level}")?;
                                 self.write_clamped_lod(ctx, handle, image, level_expr)?
                             }
@@ -3500,11 +3500,22 @@ impl<'a, W: Write> Writer<'a, W> {
         // and the policy to be used with it.
         let (fun_name, policy) = match class {
             // Sampled images inherit the policy from the user passed policies
-            crate::ImageClass::Sampled { .. } => ("texelFetch", self.policies.image),
+            crate::ImageClass::Sampled { .. } => ("texelFetch", self.policies.image_load),
             crate::ImageClass::Storage { .. } => {
-                // OpenGL 4.2 Core §3.9.20 defines that out of bounds texels in `imageLoad`s
-                // always return zero values so we don't need to generate bounds checks
-                ("imageLoad", proc::BoundsCheckPolicy::Unchecked)
+                // OpenGL ES 3.1 mentiones in Chapter "8.22 Texture Image Loads and Stores" that:
+                // "Invalid image loads will return a vector where the value of R, G, and B components
+                // is 0 and the value of the A component is undefined."
+                //
+                // OpenGL 4.2 Core mentiones in Chapter "3.9.20 Texture Image Loads and Stores" that:
+                // "Invalid image loads will return zero."
+                //
+                // So, we only inject bounds checks for ES
+                let policy = if self.options.version.is_es() {
+                    self.policies.image_load
+                } else {
+                    proc::BoundsCheckPolicy::Unchecked
+                };
+                ("imageLoad", policy)
             }
             // TODO: Is there even a function for this?
             crate::ImageClass::Depth { multi: _ } => {

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -944,7 +944,7 @@ impl<W: Write> Writer<W> {
         mut address: TexelAddress,
         context: &ExpressionContext,
     ) -> BackendResult {
-        match context.policies.image {
+        match context.policies.image_load {
             proc::BoundsCheckPolicy::Restrict => {
                 // Use the cached restricted level of detail, if any. Omit the
                 // level altogether for 1D textures.
@@ -1013,7 +1013,7 @@ impl<W: Write> Writer<W> {
         value: Handle<crate::Expression>,
         context: &StatementContext,
     ) -> BackendResult {
-        match context.expression.policies.image {
+        match context.expression.policies.image_store {
             proc::BoundsCheckPolicy::Restrict => {
                 // We don't have a restricted level value, because we don't
                 // support writes to mipmapped textures.
@@ -2420,7 +2420,7 @@ impl<W: Write> Writer<W> {
             None => return Ok(()),
         };
 
-        if context.expression.policies.image != index::BoundsCheckPolicy::Restrict
+        if context.expression.policies.image_load != index::BoundsCheckPolicy::Restrict
             || !context.expression.image_needs_lod(image)
         {
             return Ok(());

--- a/src/back/spv/image.rs
+++ b/src/back/spv/image.rs
@@ -753,7 +753,7 @@ impl<'w> BlockContext<'w> {
         let sample_id = sample.map(|expr| self.cached[expr]);
 
         // Perform the access, according to the bounds check policy.
-        let access_id = match self.writer.bounds_check_policies.image {
+        let access_id = match self.writer.bounds_check_policies.image_load {
             crate::proc::BoundsCheckPolicy::Restrict => {
                 let (coords, level_id, sample_id) = self.write_restricted_coordinates(
                     image_id,
@@ -1231,7 +1231,7 @@ impl<'w> BlockContext<'w> {
 
         let write = Store { image_id, value_id };
 
-        match self.writer.bounds_check_policies.image {
+        match self.writer.bounds_check_policies.image_store {
             crate::proc::BoundsCheckPolicy::Restrict => {
                 let (coords, _, _) =
                     self.write_restricted_coordinates(image_id, coordinates, None, None, block)?;

--- a/src/proc/index.rs
+++ b/src/proc/index.rs
@@ -109,14 +109,24 @@ pub struct BoundsCheckPolicies {
     /// How should the generated code handle image texel references that are out
     /// of range?
     ///
-    /// This controls the behavior of [`ImageLoad`] expressions and
-    /// [`ImageStore`] statements when a coordinate, texture array index, level
-    /// of detail, or multisampled sample number is out of range.
+    /// This controls the behavior of [`ImageLoad`] expressions when a coordinate,
+    /// texture array index, level of detail, or multisampled sample number is out of range.
     ///
     /// [`ImageLoad`]: crate::Expression::ImageLoad
+    #[cfg_attr(feature = "deserialize", serde(default))]
+    pub image_load: BoundsCheckPolicy,
+
+    /// How should the generated code handle image texel references that are out
+    /// of range?
+    ///
+    /// This controls the behavior of [`ImageStore`] statements when a coordinate,
+    /// texture array index, level of detail, or multisampled sample number is out of range.
+    ///
+    /// This policy should't be needed since all backends should ignore OOB writes.
+    ///
     /// [`ImageStore`]: crate::Statement::ImageStore
     #[cfg_attr(feature = "deserialize", serde(default))]
-    pub image: BoundsCheckPolicy,
+    pub image_store: BoundsCheckPolicy,
 
     /// How should the generated code handle binding array indexes that are out of bounds.
     #[cfg_attr(feature = "deserialize", serde(default))]
@@ -163,7 +173,10 @@ impl BoundsCheckPolicies {
 
     /// Return `true` if any of `self`'s policies are `policy`.
     pub fn contains(&self, policy: BoundsCheckPolicy) -> bool {
-        self.index == policy || self.buffer == policy || self.image == policy
+        self.index == policy
+            || self.buffer == policy
+            || self.image_load == policy
+            || self.image_store == policy
     }
 }
 
@@ -261,7 +274,7 @@ pub fn find_checked_indexes(
                     level,
                     ..
                 } => {
-                    if policies.image == BoundsCheckPolicy::ReadZeroSkipWrite {
+                    if policies.image_load == BoundsCheckPolicy::ReadZeroSkipWrite {
                         guarded_indices.insert(coordinate.index());
                         if let Some(array_index) = array_index {
                             guarded_indices.insert(array_index.index());

--- a/tests/in/binding-arrays.param.ron
+++ b/tests/in/binding-arrays.param.ron
@@ -41,6 +41,7 @@
 	bounds_check_policies: (
 		index: ReadZeroSkipWrite,
 		buffer: ReadZeroSkipWrite,
-		image: ReadZeroSkipWrite,
+		image_load: ReadZeroSkipWrite,
+		image_store: ReadZeroSkipWrite,
 	)
 )

--- a/tests/in/bounds-check-image-restrict.param.ron
+++ b/tests/in/bounds-check-image-restrict.param.ron
@@ -1,6 +1,7 @@
 (
 	bounds_check_policies: (
-		image: Restrict,
+		image_load: Restrict,
+		image_store: Restrict,
 	),
 	spv: (
 		version: (1, 1),

--- a/tests/in/bounds-check-image-rzsw.param.ron
+++ b/tests/in/bounds-check-image-rzsw.param.ron
@@ -1,6 +1,7 @@
 (
 	bounds_check_policies: (
-		image: ReadZeroSkipWrite,
+		image_load: ReadZeroSkipWrite,
+		image_store: ReadZeroSkipWrite,
 	),
 	spv: (
 		version: (1, 1),

--- a/tests/in/pointers.param.ron
+++ b/tests/in/pointers.param.ron
@@ -1,6 +1,7 @@
 (
 	bounds_check_policies: (
-		image: ReadZeroSkipWrite,
+		image_load: ReadZeroSkipWrite,
+		image_store: ReadZeroSkipWrite,
 	),
 	spv: (
 		version: (1, 2),

--- a/tests/in/policy-mix.param.ron
+++ b/tests/in/policy-mix.param.ron
@@ -2,7 +2,8 @@
 	bounds_check_policies: (
 		index: Restrict,
 		buffer: Unchecked,
-		image: ReadZeroSkipWrite,
+		image_load: ReadZeroSkipWrite,
+		image_store: ReadZeroSkipWrite,
 	),
 	spv: (
 		version: (1, 1),

--- a/tests/in/resource-binding-map.param.ron
+++ b/tests/in/resource-binding-map.param.ron
@@ -48,6 +48,7 @@
 	bounds_check_policies: (
 		index: ReadZeroSkipWrite,
 		buffer: ReadZeroSkipWrite,
-		image: ReadZeroSkipWrite,
+		image_load: ReadZeroSkipWrite,
+		image_store: ReadZeroSkipWrite,
 	)
 )


### PR DESCRIPTION
Split image bounds check policy since we shouldn't need bounds checks for writes.
See https://github.com/gpuweb/gpuweb/issues/3893#issuecomment-1453847182.