### PR TITLE
Differentiate between i32 and u32 in switch

### DIFF
--- a/src/back/dot/mod.rs
+++ b/src/back/dot/mod.rs
@@ -157,8 +157,8 @@ impl StatementGraph {
                     for case in cases {
                         let (case_id, case_last) = self.add(&case.body, targets);
                         let label = match case.value {
-                            crate::SwitchValue::Integer(_) => "case",
                             crate::SwitchValue::Default => "default",
+                            _ => "case",
                         };
                         self.flow.push((id, case_id, label));
                         // Link the last node of the branch to the merge node

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -1906,21 +1906,13 @@ impl<'a, W: Write> Writer<'a, W> {
                 write!(self.out, "switch(")?;
                 self.write_expr(selector, ctx)?;
                 writeln!(self.out, ") {{")?;
-                let type_postfix = match *ctx.info[selector].ty.inner_with(&self.module.types) {
-                    crate::TypeInner::Scalar {
-                        kind: crate::ScalarKind::Uint,
-                        ..
-                    } => "u",
-                    _ => "",
-                };
 
                 // Write all cases
                 let l2 = level.next();
                 for case in cases {
                     match case.value {
-                        crate::SwitchValue::Integer(value) => {
-                            write!(self.out, "{l2}case {value}{type_postfix}:")?
-                        }
+                        crate::SwitchValue::I32(value) => write!(self.out, "{l2}case {value}:")?,
+                        crate::SwitchValue::U32(value) => write!(self.out, "{l2}case {value}u:")?,
                         crate::SwitchValue::Default => write!(self.out, "{l2}default:")?,
                     }
 

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -1883,13 +1883,6 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 write!(self.out, "switch(")?;
                 self.write_expr(module, selector, func_ctx)?;
                 writeln!(self.out, ") {{")?;
-                let type_postfix = match *func_ctx.info[selector].ty.inner_with(&module.types) {
-                    crate::TypeInner::Scalar {
-                        kind: crate::ScalarKind::Uint,
-                        ..
-                    } => "u",
-                    _ => "",
-                };
 
                 // Write all cases
                 let indent_level_1 = level.next();
@@ -1897,8 +1890,11 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
 
                 for (i, case) in cases.iter().enumerate() {
                     match case.value {
-                        crate::SwitchValue::Integer(value) => {
-                            write!(self.out, "{indent_level_1}case {value}{type_postfix}:")?
+                        crate::SwitchValue::I32(value) => {
+                            write!(self.out, "{indent_level_1}case {value}:")?
+                        }
+                        crate::SwitchValue::U32(value) => {
+                            write!(self.out, "{indent_level_1}case {value}u:")?
                         }
                         crate::SwitchValue::Default => {
                             write!(self.out, "{indent_level_1}default:")?

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -2551,19 +2551,15 @@ impl<W: Write> Writer<W> {
                 } => {
                     write!(self.out, "{level}switch(")?;
                     self.put_expression(selector, &context.expression, true)?;
-                    let type_postfix = match *context.expression.resolve_type(selector) {
-                        crate::TypeInner::Scalar {
-                            kind: crate::ScalarKind::Uint,
-                            ..
-                        } => "u",
-                        _ => "",
-                    };
                     writeln!(self.out, ") {{")?;
                     let lcase = level.next();
                     for case in cases.iter() {
                         match case.value {
-                            crate::SwitchValue::Integer(value) => {
-                                write!(self.out, "{lcase}case {value}{type_postfix}:")?;
+                            crate::SwitchValue::I32(value) => {
+                                write!(self.out, "{lcase}case {value}:")?;
+                            }
+                            crate::SwitchValue::U32(value) => {
+                                write!(self.out, "{lcase}case {value}u:")?;
                             }
                             crate::SwitchValue::Default => {
                                 write!(self.out, "{lcase}default:")?;

--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -1770,11 +1770,14 @@ impl<'w> BlockContext<'w> {
                         case_ids.push(label_id);
 
                         match case.value {
-                            crate::SwitchValue::Integer(value) => {
+                            crate::SwitchValue::I32(value) => {
                                 raw_cases.push(super::instructions::Case {
                                     value: value as Word,
                                     label_id,
                                 });
+                            }
+                            crate::SwitchValue::U32(value) => {
+                                raw_cases.push(super::instructions::Case { value, label_id });
                             }
                             crate::SwitchValue::Default => {
                                 default_id = Some(label_id);

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -865,14 +865,6 @@ impl<W: Write> Writer<W> {
                 self.write_expr(module, selector, func_ctx)?;
                 writeln!(self.out, " {{")?;
 
-                let type_postfix = match *func_ctx.info[selector].ty.inner_with(&module.types) {
-                    crate::TypeInner::Scalar {
-                        kind: crate::ScalarKind::Uint,
-                        ..
-                    } => "u",
-                    _ => "",
-                };
-
                 let l2 = level.next();
                 let mut new_case = true;
                 for case in cases {
@@ -884,11 +876,17 @@ impl<W: Write> Writer<W> {
                     }
 
                     match case.value {
-                        crate::SwitchValue::Integer(value) => {
+                        crate::SwitchValue::I32(value) => {
                             if new_case {
                                 write!(self.out, "{l2}case ")?;
                             }
-                            write!(self.out, "{value}{type_postfix}")?;
+                            write!(self.out, "{value}")?;
+                        }
+                        crate::SwitchValue::U32(value) => {
+                            if new_case {
+                                write!(self.out, "{l2}case ")?;
+                            }
+                            write!(self.out, "{value}u")?;
                         }
                         crate::SwitchValue::Default => {
                             if new_case {

--- a/src/front/spv/function.rs
+++ b/src/front/spv/function.rs
@@ -596,7 +596,7 @@ impl<'function> BlockContext<'function> {
                                 let fall_through = body.last().map_or(true, |s| !s.is_terminator());
 
                                 crate::SwitchCase {
-                                    value: crate::SwitchValue::Integer(value),
+                                    value: crate::SwitchValue::I32(value),
                                     body,
                                     fall_through,
                                 }

--- a/src/front/wgsl/lower/mod.rs
+++ b/src/front/wgsl/lower/mod.rs
@@ -1006,11 +1006,11 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     .map(|case| {
                         Ok(crate::SwitchCase {
                             value: match case.value {
-                                ast::SwitchValue::I32(num) if !uint => {
-                                    crate::SwitchValue::Integer(num)
+                                ast::SwitchValue::I32(value) if !uint => {
+                                    crate::SwitchValue::I32(value)
                                 }
-                                ast::SwitchValue::U32(num) if uint => {
-                                    crate::SwitchValue::Integer(num as i32)
+                                ast::SwitchValue::U32(value) if uint => {
+                                    crate::SwitchValue::U32(value)
                                 }
                                 ast::SwitchValue::Default => crate::SwitchValue::Default,
                                 _ => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1429,7 +1429,7 @@ pub use block::Block;
 
 /// The value of the switch case.
 // Clone is used only for error reporting and is not intended for end users
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1434,7 +1434,8 @@ pub use block::Block;
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub enum SwitchValue {
-    Integer(i32),
+    I32(i32),
+    U32(u32),
     Default,
 }
 

--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -463,7 +463,7 @@ impl super::Validator {
                                         .span_iter()
                                         .next()
                                         .map_or(Default::default(), |(_, s)| *s),
-                                    "invalid switch arm here",
+                                    "conflicting switch arm here",
                                 ));
                             }
                         };

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -154,6 +154,13 @@ impl ops::Index<Handle<crate::Function>> for ModuleInfo {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum SwitchValue {
+    I32(i32),
+    U32(u32),
+    Default,
+}
+
 #[derive(Debug)]
 pub struct Validator {
     flags: ValidationFlags,
@@ -163,7 +170,7 @@ pub struct Validator {
     location_mask: BitSet,
     bind_group_masks: Vec<BitSet>,
     #[allow(dead_code)]
-    select_cases: FastHashSet<i32>,
+    switch_values: FastHashSet<SwitchValue>,
     valid_expression_list: Vec<Handle<crate::Expression>>,
     valid_expression_set: BitSet,
 }
@@ -275,7 +282,7 @@ impl Validator {
             layouter: Layouter::default(),
             location_mask: BitSet::new(),
             bind_group_masks: Vec::new(),
-            select_cases: FastHashSet::default(),
+            switch_values: FastHashSet::default(),
             valid_expression_list: Vec::new(),
             valid_expression_set: BitSet::new(),
         }
@@ -287,7 +294,7 @@ impl Validator {
         self.layouter.clear();
         self.location_mask.clear();
         self.bind_group_masks.clear();
-        self.select_cases.clear();
+        self.switch_values.clear();
         self.valid_expression_list.clear();
         self.valid_expression_set.clear();
     }

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -154,13 +154,6 @@ impl ops::Index<Handle<crate::Function>> for ModuleInfo {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum SwitchValue {
-    I32(i32),
-    U32(u32),
-    Default,
-}
-
 #[derive(Debug)]
 pub struct Validator {
     flags: ValidationFlags,
@@ -170,7 +163,7 @@ pub struct Validator {
     location_mask: BitSet,
     bind_group_masks: Vec<BitSet>,
     #[allow(dead_code)]
-    switch_values: FastHashSet<SwitchValue>,
+    switch_values: FastHashSet<crate::SwitchValue>,
     valid_expression_list: Vec<Handle<crate::Expression>>,
     valid_expression_set: BitSet,
 }


### PR DESCRIPTION
Fixes https://github.com/gfx-rs/naga/issues/1960.

Updated all instances of `SwitchValue::Integer` to include uints.

Renamed `select_cases` to `switch_values` since it did not appear to be used for anything other than switch values.

Added a check to validate all cases had similar types. That's just how I interpreted [this bit](https://www.w3.org/TR/WGSL/#ref-for-type-rule-preconditions%E2%91%A1)  from the spec.

Added a duplicate `SwitchValue` enum to validation since I wasn't sure if adding additional derives to `lib` was appropriate or not. This adds a tiny bit of redundancy that I can remove if needed.