### PR TITLE
[spv-out] Fix invalid spirv being generated from integer dot products

### DIFF
--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -1627,12 +1627,7 @@ impl<'w> BlockContext<'w> {
         size: u32,
         block: &mut Block,
     ) {
-        let const_null = self.gen_id();
-        block
-            .body
-            .push(Instruction::constant_null(result_type_id, const_null));
-
-        let mut partial_sum = const_null;
+        let mut partial_sum = self.writer.write_constant_null(result_type_id);
         let last_component = size - 1;
         for index in 0..=last_component {
             // compute the product of the current components

--- a/tests/out/spv/functions.spvasm
+++ b/tests/out/spv/functions.spvasm
@@ -23,10 +23,10 @@ OpExecutionMode %74 LocalSize 1 1 1
 %15 = OpTypeVector %7 4
 %18 = OpTypeFunction %12
 %26 = OpTypeFunction %7
-%75 = OpTypeFunction %2
 %31 = OpConstantNull  %7
 %42 = OpConstantNull  %9
 %57 = OpConstantNull  %7
+%75 = OpTypeFunction %2
 %17 = OpFunction  %12  None %18
 %16 = OpLabel
 OpBranch %19

--- a/tests/out/spv/math-functions.spvasm
+++ b/tests/out/spv/math-functions.spvasm
@@ -24,12 +24,12 @@ OpEntryPoint Vertex %18 "main"
 %19 = OpTypeFunction %2
 %27 = OpConstantComposite  %14  %5 %5 %5 %5
 %28 = OpConstantComposite  %14  %3 %3 %3 %3
+%31 = OpConstantNull  %7
 %42 = OpConstant  %9  32
 %50 = OpTypeVector %9 2
 %53 = OpConstantComposite  %50  %42 %42
 %65 = OpConstant  %7  31
 %71 = OpConstantComposite  %15  %65 %65
-%31 = OpConstantNull  %7
 %18 = OpFunction  %2  None %19
 %17 = OpLabel
 OpBranch %20


### PR DESCRIPTION
Short: this fixes integer dot product SPIR-V generation by moving a constant declaration to the right place.

Longer:
The code generation for integer dot products would (only sometimes, I am not sure why the tests do not catch this) produce SPIR-V that is technically invalid because it tries to declare constant null/0 inside of a function:

```
; Function 21
%21 = OpFunction %void None %22
%17 = OpLabel
// [...]
// vvv generated integer dot product
%38 = OpConstantNull %uint
%39 = OpCompositeExtract %uint %33 0
%40 = OpCompositeExtract %uint %36 0
%41 = OpIMul %uint %39 %40
%42 = OpIAdd %uint %38 %41
// [...]
```

Running against the SPIR-V validator (or a sufficiently pedantic driver like those for the Intel Arc Alchemist) causes a validation failure along the lines of:
```
error: line 55: ConstantNull cannot appear in a function declaration
  %38 = OpConstantNull %uint
```

Mysterious crashes from this had been noticed before on some hardware (e.g., https://github.com/gfx-rs/wgpu/issues/2694).

The fix is to use the already-provided helper function for declaring constant null/0.