### PR TITLE
Add several `clippy` lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,17 @@ tree.
     clippy::rest_pat_in_fully_bound_structs,
     clippy::match_wildcard_for_single_variants
 )]
-#![cfg_attr(not(test), deny(clippy::panic))]
+#![deny(clippy::exit)]
+#![cfg_attr(
+    not(test),
+    warn(
+        clippy::dbg_macro,
+        clippy::panic,
+        clippy::print_stderr,
+        clippy::print_stdout,
+        clippy::todo
+    )
+)]
 
 mod arena;
 pub mod back;


### PR DESCRIPTION
I noticed that I had let `dbg!(…)` sneak into commits in #2294 by accident. Clippy can help us with this! Set `deny(clippy::dbg_macro)`, so CI catches this for future contributions.

---

We do this for `panic`king, but I'm not sure if `deny` or `warn` is more appropriate for a debugging tool like `dbg!(…)`.