### PR TITLE
[front/spir-v] Obey the `is_depth` field of `OpTypeImage`

### DIFF
--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -4708,7 +4708,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
         let id = self.next()?;
         let sample_type_id = self.next()?;
         let dim = self.next()?;
-        let _is_depth = self.next()?;
+        let is_depth = self.next()?;
         let is_array = self.next()? != 0;
         let is_msaa = self.next()? != 0;
         let _is_sampled = self.next()?;
@@ -4740,7 +4740,9 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
             .ok_or(Error::InvalidImageBaseType(base_handle))?;
 
         let inner = crate::TypeInner::Image {
-            class: if format != 0 {
+            class: if is_depth == 1 {
+                crate::ImageClass::Depth { multi: is_msaa }
+            } else if format != 0 {
                 crate::ImageClass::Storage {
                     format: map_image_format(format)?,
                     access: crate::StorageAccess::default(),


### PR DESCRIPTION
From https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpTypeImage:
```
Depth is whether or not this image is a depth image. (Note that whether or not depth comparisons are actually done is a property of the sampling opcode, not of this type declaration.)
0 indicates not a depth image
1 indicates a depth image
2 means no indication as to whether this is a depth or non-depth image
```

I've been trying to get a SPIR-V shader to work in wgpu where I sample normally from a depth texture. To my knowledge I should be able to do this without 'casting' it to R32Float or anything first (but of course let me know if I'm barking up the wrong tree!)

At first I got the error
```
Caused by:
    In Device::create_bind_group
    Texture binding 0 expects sample type = Float { filterable: true }, but given a view with format = Depth32Float
```

When I changed the bind group layout to take a Depth texture I got this error related to naga: 

```
Caused by:
    In Device::create_compute_pipeline
      note: label = `out.spv`
    Error matching shader requirements against the pipeline
    Shader global ResourceBinding { group: 0, binding: 0 } is not available in the layout pipeline layout
    Texture class Depth { multi: false } doesn't match the shader Sampled { kind: Float, multi: false }
```
I then thought I'd try changing the `%type_2d_image = OpTypeImage %float 2D --2-- 0 0 1 Unknown` in the shader to `%type_2d_image = OpTypeImage %float 2D ++1++ 0 0 1 Unknown` in order to force the texture to be set as depth. This didn't change anything so I then checked naga to see how the depth param was handled and realized that it was not, so now we're here ;).

There are some validations happening with this so far I believe.
 