### PR TITLE
[wgsl-in] Error on param redefinition

### DIFF
--- a/tests/in/lexical-scopes.wgsl
+++ b/tests/in/lexical-scopes.wgsl
@@ -1,45 +1,41 @@
 fn blockLexicalScope(a: bool) {
-    let a = 1.0;
     {
         let a = 2;
         {
-            let a = true;
+            let a = 2.0;
         }
-        let test = a == 3;
+        let test: i32 = a;
     }
-    let test = a == 2.0;
+    let test: bool = a;
 }
 
 fn ifLexicalScope(a: bool) {
-    let a = 1.0;
-    if (a == 1.0) {
-        let a = true;
+    if (a) {
+        let a = 2.0;
     }
-    let test = a == 2.0;
+    let test: bool = a;
 }
 
 
 fn loopLexicalScope(a: bool) {
-    let a = 1.0;
     loop {
-        let a = true;
+        let a = 2.0;
     }
-    let test = a == 2.0;
+    let test: bool = a;
 }
 
 fn forLexicalScope(a: f32) {
-    let a = false;
     for (var a = 0; a < 1; a++) {
-        let a = 3.0;
+        let a = true;
     }
-    let test = a == true;
+    let test: f32 = a;
 }
 
 fn whileLexicalScope(a: i32) {
     while (a > 2) {
         let a = false;
     }
-    let test = a == 1;
+    let test: i32 = a;
 }
 
 fn switchLexicalScope(a: i32) {

--- a/tests/out/wgsl/lexical-scopes.wgsl
+++ b/tests/out/wgsl/lexical-scopes.wgsl
@@ -1,22 +1,23 @@
 fn blockLexicalScope(a: bool) {
     {
         {
+            return;
         }
-        let test = (2 == 3);
     }
-    let test_1 = (1.0 == 2.0);
 }
 
 fn ifLexicalScope(a_1: bool) {
-    if (1.0 == 1.0) {
+    if a_1 {
+        return;
+    } else {
+        return;
     }
-    let test_2 = (1.0 == 2.0);
 }
 
 fn loopLexicalScope(a_2: bool) {
     loop {
     }
-    let test_3 = (1.0 == 2.0);
+    return;
 }
 
 fn forLexicalScope(a_3: f32) {
@@ -24,19 +25,19 @@ fn forLexicalScope(a_3: f32) {
 
     a_4 = 0;
     loop {
-        let _e4 = a_4;
-        if (_e4 < 1) {
+        let _e3 = a_4;
+        if (_e3 < 1) {
         } else {
             break;
         }
         {
         }
         continuing {
-            let _e8 = a_4;
-            a_4 = (_e8 + 1);
+            let _e7 = a_4;
+            a_4 = (_e7 + 1);
         }
     }
-    let test_4 = (false == true);
+    return;
 }
 
 fn whileLexicalScope(a_5: i32) {
@@ -48,7 +49,7 @@ fn whileLexicalScope(a_5: i32) {
         {
         }
     }
-    let test_5 = (a_5 == 1);
+    return;
 }
 
 fn switchLexicalScope(a_6: i32) {
@@ -60,6 +61,6 @@ fn switchLexicalScope(a_6: i32) {
         default: {
         }
     }
-    let test_6 = (a_6 == 2);
+    let test = (a_6 == 2);
 }
 

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -1884,7 +1884,7 @@ fn function_returns_void() {
 }
 
 #[test]
-fn function_param_redefinition() {
+fn function_param_redefinition_as_param() {
     check(
         "
         fn x(a: f32, a: vec2<f32>) {}
@@ -1896,6 +1896,26 @@ fn function_param_redefinition() {
   │              ^       ^ redefinition of `a`
   │              │        
   │              previous definition of `a`
+
+"###,
+    )
+}
+
+#[test]
+fn function_param_redefinition_as_local() {
+    check(
+        "
+        fn x(a: f32) {
+			let a = 0.0;
+		}
+    ",
+        r###"error: redefinition of `a`
+  ┌─ wgsl:2:14
+  │
+2 │         fn x(a: f32) {
+  │              ^ previous definition of `a`
+3 │             let a = 0.0;
+  │                 ^ redefinition of `a`
 
 "###,
     )

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -1884,6 +1884,24 @@ fn function_returns_void() {
 }
 
 #[test]
+fn function_param_redefinition() {
+    check(
+        "
+        fn x(a: f32, a: vec2<f32>) {}
+    ",
+        r###"error: redefinition of `a`
+  ┌─ wgsl:2:14
+  │
+2 │         fn x(a: f32, a: vec2<f32>) {}
+  │              ^       ^ redefinition of `a`
+  │              │        
+  │              previous definition of `a`
+
+"###,
+    )
+}
+
+#[test]
 fn binding_array_local() {
     check_validation! {
         "fn f() { var x: binding_array<sampler, 4>; }":


### PR DESCRIPTION
Previously,
```rs
fn x(a: f32, a: vec2<f32>) {}
```
was silently accepted by naga, binding the second parameter to `a`.

Now, it errors with
```rs
error: redefinition of `a`
  ┌─ ..\naga tests\wgsl.wgsl:1:6
  │
1 │ fn x(a: f32, a: vec2<f32>) {}
  │      ^       ^ redefinition of `a`
  │      │
  │      previous definition of `a`
```