### PR TITLE
Handle case insensitive FXC HLSL keywords.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ petgraph = { version ="0.6", optional = true }
 pp-rs = { version = "0.2.1", optional = true }
 hexf-parse = { version = "0.2.1", optional = true }
 unicode-xid = { version = "0.2.3", optional = true }
+unicase = "2"
 
 [dev-dependencies]
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ petgraph = { version ="0.6", optional = true }
 pp-rs = { version = "0.2.1", optional = true }
 hexf-parse = { version = "0.2.1", optional = true }
 unicode-xid = { version = "0.2.3", optional = true }
-unicase = "2"
 
 [dev-dependencies]
 bincode = "1"

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -484,7 +484,13 @@ impl<'a, W: Write> Writer<'a, W> {
         // Generate a map with names required to write the module
         let mut names = crate::FastHashMap::default();
         let mut namer = proc::Namer::default();
-        namer.reset(module, keywords::RESERVED_KEYWORDS, &["gl_"], &mut names);
+        namer.reset(
+            module,
+            keywords::RESERVED_KEYWORDS,
+            &[],
+            &["gl_"],
+            &mut names,
+        );
 
         // Build the instance
         let mut this = Self {

--- a/src/back/hlsl/keywords.rs
+++ b/src/back/hlsl/keywords.rs
@@ -4,9 +4,23 @@ HLSL Reserved Words
 - <https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-appendix-reserved-words>
 */
 
+// When compiling with FXC without strict mode, these keywords are actually case insensitive.
+// If you compile with strict mode and specify a different casing like "Pass" instead in an identifier, FXC will give this error:
+// "error X3086: alternate cases for 'pass' are deprecated in strict mode"
+// This behavior is not documented anywhere, but as far as I can tell this is the full list.
+pub const RESERVED_CASE_INSENSITIVE: &[&str] = &[
+    "asm",
+    "decl",
+    "pass",
+    "technique",
+    "Texture1D",
+    "Texture2D",
+    "Texture3D",
+    "TextureCube",
+];
+
 pub const RESERVED: &[&str] = &[
     "AppendStructuredBuffer",
-    "asm",
     "asm_fragment",
     "BlendState",
     "bool",
@@ -68,7 +82,6 @@ pub const RESERVED: &[&str] = &[
     "out",
     "OutputPatch",
     "packoffset",
-    "pass",
     "pixelfragment",
     "PixelShader",
     "point",
@@ -101,17 +114,13 @@ pub const RESERVED: &[&str] = &[
     "switch",
     "StructuredBuffer",
     "tbuffer",
-    "technique",
     "technique10",
     "technique11",
     "texture",
-    "Texture1D",
     "Texture1DArray",
-    "Texture2D",
     "Texture2DArray",
     "Texture2DMS",
     "Texture2DMSArray",
-    "Texture3D",
     "TextureCube",
     "TextureCubeArray",
     "true",

--- a/src/back/hlsl/keywords.rs
+++ b/src/back/hlsl/keywords.rs
@@ -121,7 +121,6 @@ pub const RESERVED: &[&str] = &[
     "Texture2DArray",
     "Texture2DMS",
     "Texture2DMSArray",
-    "TextureCube",
     "TextureCubeArray",
     "true",
     "typedef",

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -89,8 +89,13 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
 
     fn reset(&mut self, module: &Module) {
         self.names.clear();
-        self.namer
-            .reset(module, super::keywords::RESERVED, &[], &mut self.names);
+        self.namer.reset(
+            module,
+            super::keywords::RESERVED,
+            super::keywords::RESERVED_CASE_INSENSITIVE,
+            &[],
+            &mut self.names,
+        );
         self.entry_point_io.clear();
         self.named_expressions.clear();
         self.wrapped.clear();

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -3020,7 +3020,7 @@ impl<W: Write> Writer<W> {
     ) -> Result<TranslationInfo, Error> {
         self.names.clear();
         self.namer
-            .reset(module, super::keywords::RESERVED, &[], &mut self.names);
+            .reset(module, super::keywords::RESERVED, &[], &[], &mut self.names);
         self.struct_member_pads.clear();
 
         writeln!(

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -86,6 +86,7 @@ impl<W: Write> Writer<W> {
             module,
             crate::keywords::wgsl::RESERVED,
             // an identifier must not start with two underscore
+            &[],
             &["__"],
             &mut self.names,
         );

--- a/src/proc/namer.rs
+++ b/src/proc/namer.rs
@@ -26,7 +26,7 @@ pub struct Namer {
     /// The last numeric suffix used for each base name. Zero means "no suffix".
     unique: FastHashMap<String, u32>,
     keywords: FastHashSet<String>,
-    keywords_case_insensitive: FastHashSet<AsciiUniCase<String>>,
+    keywords_case_insensitive: FastHashSet<AsciiUniCase<&'static str>>,
     reserved_prefixes: Vec<String>,
 }
 
@@ -108,7 +108,7 @@ impl Namer {
                     || self.keywords.contains(base.as_ref())
                     || self
                         .keywords_case_insensitive
-                        .contains(&AsciiUniCase(base.to_owned().into_owned()))
+                        .contains(&AsciiUniCase(base.as_ref()))
                 {
                     suffixed.push(SEPARATOR);
                 }
@@ -144,7 +144,7 @@ impl Namer {
         &mut self,
         module: &crate::Module,
         reserved_keywords: &[&str],
-        reserved_keywords_case_insensitive: &[&str],
+        reserved_keywords_case_insensitive: &[&'static str],
         reserved_prefixes: &[&str],
         output: &mut FastHashMap<NameKey, String>,
     ) {
@@ -164,7 +164,7 @@ impl Namer {
         self.keywords_case_insensitive.extend(
             reserved_keywords_case_insensitive
                 .iter()
-                .map(|string| (AsciiUniCase(string.to_string()))),
+                .map(|string| (AsciiUniCase(*string))),
         );
 
         let mut temp = String::new();

--- a/tests/in/hlsl-keyword.wgsl
+++ b/tests/in/hlsl-keyword.wgsl
@@ -1,0 +1,6 @@
+@fragment
+fn fs_main() -> @location(0) vec4f {
+    // Make sure case-insensitive keywords are escaped in HLSL.
+    var Pass = vec4(1.0,1.0,1.0,1.0);
+    return Pass;
+}

--- a/tests/out/hlsl/hlsl-keyword.hlsl
+++ b/tests/out/hlsl/hlsl-keyword.hlsl
@@ -1,0 +1,9 @@
+
+float4 fs_main() : SV_Target0
+{
+    float4 Pass_ = (float4)0;
+
+    Pass_ = float4(1.0, 1.0, 1.0, 1.0);
+    float4 _expr6 = Pass_;
+    return _expr6;
+}

--- a/tests/out/hlsl/hlsl-keyword.hlsl.config
+++ b/tests/out/hlsl/hlsl-keyword.hlsl.config
@@ -1,0 +1,3 @@
+vertex=()
+fragment=(fs_main:ps_5_1 )
+compute=()

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -580,6 +580,7 @@ fn convert_wgsl() {
         ("force_point_size_vertex_shader_webgl", Targets::GLSL),
         ("invariant", Targets::GLSL),
         ("ray-query", Targets::SPIRV | Targets::METAL),
+        ("hlsl-keyword", Targets::HLSL),
     ];
 
     for &(name, targets) in inputs.iter() {


### PR DESCRIPTION
Honestly I realized while almost done with this that maybe trying to put maintenance effort into FXC rather than DXC wouldn't be worth it, but OH WELL. Feel free to deny this PR if we don't want to add bugfixes for FXC.

There are a few keywords like "pass" in HLSL that are actually case-insensitive for FXC. This can be disabled with strict mode, but even if you do that FXC will continue to give an error if you try to use them in identifiers (at all, with any casing).

This changes the namer code to escape these keywords even if the casing is different.

If you're wondering where I got the list from: I looked at the list of strings in D3DCompiler_47.dll. None of this is documented.