### PR TITLE
Makefile: validate-spv: update spirv-as and spirv-val invocations.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ validate-spv: $(SNAPSHOTS_BASE_OUT)/spv/*.spvasm
 		echo "Validating" $${file#"$(SNAPSHOTS_BASE_OUT)/"};	\
 		version_line=$$(head -2 $${file} | tail -1);	\
 		version=$${version_line#"; Version: "};\
-		cat $${file} | spirv-as --target-env spv$${version} -o - | spirv-val; \
+		cat $${file} | spirv-as --target-env spv$${version} - -o - | spirv-val -; \
 	done
 
 validate-msl: $(SNAPSHOTS_BASE_OUT)/msl/*.msl


### PR DESCRIPTION
Newer versions of these programs require `-` as a filename argument to read from standard input.