### PR TITLE
Don't `use std::opsIndex`, used only when `"validate"` is on.

### DIFF
--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -1,5 +1,3 @@
-use std::ops::Index;
-
 #[cfg(feature = "validate")]
 use super::{
     compose::validate_compose, validate_atomic_compare_exchange_struct, FunctionInfo, ShaderStages,
@@ -134,7 +132,7 @@ struct ExpressionTypeResolver<'a> {
 }
 
 #[cfg(feature = "validate")]
-impl<'a> Index<Handle<crate::Expression>> for ExpressionTypeResolver<'a> {
+impl<'a> std::ops::Index<Handle<crate::Expression>> for ExpressionTypeResolver<'a> {
     type Output = crate::TypeInner;
 
     #[allow(clippy::panic)]


### PR DESCRIPTION
In `src/valid/expresion.rs`, use the full path `std::ops::Index` when implementing the trait on `ExpressionTypeResolver`. This implementation is `#[cfg(feature = "validate")]`, so the `use` directive becomes unnecessary when that feature is not enabled, triggering warnings.