### PR TITLE
[spv-out] Use `IndexSet` instead of `HashSet` for iterated sets (capabilities/extensions).

### DIFF
--- a/src/back/spv/mod.rs
+++ b/src/back/spv/mod.rs
@@ -595,10 +595,10 @@ pub struct Writer {
     ///
     /// If `capabilities_available` is `Some`, then this is always a subset of
     /// that.
-    capabilities_used: crate::FastHashSet<Capability>,
+    capabilities_used: crate::FastIndexSet<Capability>,
 
     /// The set of spirv extensions used.
-    extensions_used: crate::FastHashSet<&'static str>,
+    extensions_used: crate::FastIndexSet<&'static str>,
 
     debugs: Vec<Instruction>,
     annotations: Vec<Instruction>,

--- a/src/back/spv/recyclable.rs
+++ b/src/back/spv/recyclable.rs
@@ -52,6 +52,13 @@ impl<K, S: Clone> Recyclable for std::collections::HashSet<K, S> {
     }
 }
 
+impl<K, S: Clone> Recyclable for indexmap::IndexSet<K, S> {
+    fn recycle(mut self) -> Self {
+        self.clear();
+        self
+    }
+}
+
 impl<K: Ord, V> Recyclable for std::collections::BTreeMap<K, V> {
     fn recycle(mut self) -> Self {
         self.clear();

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -47,7 +47,7 @@ impl Writer {
         }
         let raw_version = ((major as u32) << 16) | ((minor as u32) << 8);
 
-        let mut capabilities_used = crate::FastHashSet::default();
+        let mut capabilities_used = crate::FastIndexSet::default();
         capabilities_used.insert(spirv::Capability::Shader);
 
         let mut id_gen = IdGenerator::default();
@@ -60,7 +60,7 @@ impl Writer {
             id_gen,
             capabilities_available: options.capabilities.clone(),
             capabilities_used,
-            extensions_used: crate::FastHashSet::default(),
+            extensions_used: crate::FastIndexSet::default(),
             debugs: vec![],
             annotations: vec![],
             flags: options.flags,
@@ -1936,7 +1936,7 @@ impl Writer {
     }
 
     /// Return the set of capabilities the last module written used.
-    pub const fn get_capabilities_used(&self) -> &crate::FastHashSet<spirv::Capability> {
+    pub const fn get_capabilities_used(&self) -> &crate::FastIndexSet<spirv::Capability> {
         &self.capabilities_used
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,6 +254,11 @@ pub type FastHashMap<K, T> = rustc_hash::FxHashMap<K, T>;
 /// Hash set that is faster but not resilient to DoS attacks.
 pub type FastHashSet<K> = rustc_hash::FxHashSet<K>;
 
+/// Insertion-order-preserving hash set (`IndexSet<K>`), but with the same
+/// hasher as `FastHashSet<K>` (faster but not resilient to DoS attacks).
+pub type FastIndexSet<K> =
+    indexmap::IndexSet<K, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
+
 /// Map of expressions that have associated variable names
 pub(crate) type NamedExpressions = indexmap::IndexMap<
     Handle<Expression>,

--- a/tests/out/spv/bounds-check-image-restrict.spvasm
+++ b/tests/out/spv/bounds-check-image-restrict.spvasm
@@ -2,10 +2,10 @@
 ; Version: 1.1
 ; Generator: rspirv
 ; Bound: 310
-OpCapability ImageQuery
-OpCapability Image1D
 OpCapability Shader
 OpCapability Sampled1D
+OpCapability Image1D
+OpCapability ImageQuery
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %269 "fragment_shader" %267

--- a/tests/out/spv/bounds-check-image-rzsw.spvasm
+++ b/tests/out/spv/bounds-check-image-rzsw.spvasm
@@ -2,10 +2,10 @@
 ; Version: 1.1
 ; Generator: rspirv
 ; Bound: 347
-OpCapability ImageQuery
-OpCapability Image1D
 OpCapability Shader
 OpCapability Sampled1D
+OpCapability Image1D
+OpCapability ImageQuery
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %306 "fragment_shader" %304

--- a/tests/out/spv/image.spvasm
+++ b/tests/out/spv/image.spvasm
@@ -2,11 +2,11 @@
 ; Version: 1.1
 ; Generator: rspirv
 ; Bound: 546
+OpCapability Shader
+OpCapability Image1D
+OpCapability Sampled1D
 OpCapability SampledCubeArray
 OpCapability ImageQuery
-OpCapability Image1D
-OpCapability Shader
-OpCapability Sampled1D
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %82 "main" %79

--- a/tests/out/spv/ray-query.spvasm
+++ b/tests/out/spv/ray-query.spvasm
@@ -2,8 +2,8 @@
 ; Version: 1.4
 ; Generator: rspirv
 ; Bound: 95
-OpCapability RayQueryKHR
 OpCapability Shader
+OpCapability RayQueryKHR
 OpExtension "SPV_KHR_ray_query"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450

--- a/tests/spirv-capabilities.rs
+++ b/tests/spirv-capabilities.rs
@@ -6,7 +6,7 @@ Test SPIR-V backend capability checks.
 
 use spirv::Capability as Ca;
 
-fn capabilities_used(source: &str) -> naga::FastHashSet<Ca> {
+fn capabilities_used(source: &str) -> naga::FastIndexSet<Ca> {
     use naga::back::spv;
     use naga::valid;
 
@@ -36,7 +36,7 @@ fn require_and_forbid(required: &[Ca], forbidden: &[Ca], source: &str) {
 
     let missing_caps: Vec<_> = required
         .iter()
-        .filter(|cap| !caps_used.contains(cap))
+        .filter(|&cap| !caps_used.contains(cap))
         .cloned()
         .collect();
     if !missing_caps.is_empty() {
@@ -45,7 +45,7 @@ fn require_and_forbid(required: &[Ca], forbidden: &[Ca], source: &str) {
 
     let forbidden_caps: Vec<_> = forbidden
         .iter()
-        .filter(|cap| caps_used.contains(cap))
+        .filter(|&cap| caps_used.contains(cap))
         .cloned()
         .collect();
     if !forbidden_caps.is_empty() {


### PR DESCRIPTION
Naga currently doesn't pass its own CI because its tests hardcode a specific `hashbrown`+`fx` iteration order.

And then upstream upgraded `hashbrown` in `nightly-2023-06-16` which changed the order:
* https://github.com/rust-lang/rust/pull/104455

What's worse is I'm hitting this on a `v0.10` backport, where I would prefer not to backport this PR too:
* https://github.com/gfx-rs/naga/pull/2387