### PR TITLE
Expose early depth test field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,7 +289,7 @@ pub(crate) type NamedExpressions = indexmap::IndexMap<
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct EarlyDepthTest {
-    conservative: Option<ConservativeDepth>,
+    pub conservative: Option<ConservativeDepth>,
 }
 /// Enables adjusting depth without disabling early Z.
 ///


### PR DESCRIPTION
For my use case, I need to be able to access the `conservative` field of the `EarlyDepthTest` struct. Every other top-level public struct has every field accessible, so this just brings `EarlyDepthTest` in line with the other components of a module. 