### PR TITLE
Backport Simplify map_binding_to_attribute to always return an interpolate attribute to 0.12

### DIFF
--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -244,10 +244,7 @@ impl<W: Write> Writer<W> {
         for (index, arg) in func.arguments.iter().enumerate() {
             // Write argument attribute if a binding is present
             if let Some(ref binding) = arg.binding {
-                self.write_attributes(&map_binding_to_attribute(
-                    binding,
-                    module.types[arg.ty].inner.scalar_kind(),
-                ))?;
+                self.write_attributes(&map_binding_to_attribute(binding))?;
             }
             // Write argument name
             let argument_name = match func_ctx.ty {
@@ -274,10 +271,7 @@ impl<W: Write> Writer<W> {
         if let Some(ref result) = func.result {
             write!(self.out, " -> ")?;
             if let Some(ref binding) = result.binding {
-                self.write_attributes(&map_binding_to_attribute(
-                    binding,
-                    module.types[result.ty].inner.scalar_kind(),
-                ))?;
+                self.write_attributes(&map_binding_to_attribute(binding))?;
             }
             self.write_type(module, result.ty)?;
         }
@@ -401,10 +395,7 @@ impl<W: Write> Writer<W> {
             // The indentation is only for readability
             write!(self.out, "{}", back::INDENT)?;
             if let Some(ref binding) = member.binding {
-                self.write_attributes(&map_binding_to_attribute(
-                    binding,
-                    module.types[member.ty].inner.scalar_kind(),
-                ))?;
+                self.write_attributes(&map_binding_to_attribute(binding))?;
             }
             // Write struct member name and type
             let member_name = &self.names[&NameKey::StructMember(handle, index as u32)];
@@ -1941,10 +1932,7 @@ const fn address_space_str(
     )
 }
 
-fn map_binding_to_attribute(
-    binding: &crate::Binding,
-    scalar_kind: Option<crate::ScalarKind>,
-) -> Vec<Attribute> {
+fn map_binding_to_attribute(binding: &crate::Binding) -> Vec<Attribute> {
     match *binding {
         crate::Binding::BuiltIn(built_in) => {
             if let crate::BuiltIn::Position { invariant: true } = built_in {
@@ -1957,12 +1945,9 @@ fn map_binding_to_attribute(
             location,
             interpolation,
             sampling,
-        } => match scalar_kind {
-            Some(crate::ScalarKind::Float) => vec![
-                Attribute::Location(location),
-                Attribute::Interpolate(interpolation, sampling),
-            ],
-            _ => vec![Attribute::Location(location)],
-        },
+        } => vec![
+            Attribute::Location(location),
+            Attribute::Interpolate(interpolation, sampling),
+        ],
     }
 }

--- a/tests/out/wgsl/binding-arrays.wgsl
+++ b/tests/out/wgsl/binding-arrays.wgsl
@@ -3,7 +3,7 @@ struct UniformIndex {
 }
 
 struct FragmentIn {
-    @location(0) index: u32,
+    @location(0) @interpolate(flat) index: u32,
 }
 
 @group(0) @binding(0) 

--- a/tests/out/wgsl/binding-buffer-arrays.wgsl
+++ b/tests/out/wgsl/binding-buffer-arrays.wgsl
@@ -7,7 +7,7 @@ struct Foo {
 }
 
 struct FragmentIn {
-    @location(0) index: u32,
+    @location(0) @interpolate(flat) index: u32,
 }
 
 @group(0) @binding(0) 
@@ -16,7 +16,7 @@ var<storage> storage_array: binding_array<Foo,1>;
 var<uniform> uni: UniformIndex;
 
 @fragment 
-fn main(fragment_in: FragmentIn) -> @location(0) u32 {
+fn main(fragment_in: FragmentIn) -> @location(0) @interpolate(flat) u32 {
     var u1_: u32;
 
     let uniform_index = uni.index;

--- a/tests/out/wgsl/fragment-output.wgsl
+++ b/tests/out/wgsl/fragment-output.wgsl
@@ -1,19 +1,19 @@
 struct FragmentOutputVec4Vec3_ {
     @location(0) vec4f: vec4<f32>,
-    @location(1) vec4i: vec4<i32>,
-    @location(2) vec4u: vec4<u32>,
+    @location(1) @interpolate(flat) vec4i: vec4<i32>,
+    @location(2) @interpolate(flat) vec4u: vec4<u32>,
     @location(3) vec3f: vec3<f32>,
-    @location(4) vec3i: vec3<i32>,
-    @location(5) vec3u: vec3<u32>,
+    @location(4) @interpolate(flat) vec3i: vec3<i32>,
+    @location(5) @interpolate(flat) vec3u: vec3<u32>,
 }
 
 struct FragmentOutputVec2Scalar {
     @location(0) vec2f: vec2<f32>,
-    @location(1) vec2i: vec2<i32>,
-    @location(2) vec2u: vec2<u32>,
+    @location(1) @interpolate(flat) vec2i: vec2<i32>,
+    @location(2) @interpolate(flat) vec2u: vec2<u32>,
     @location(3) scalarf: f32,
-    @location(4) scalari: i32,
-    @location(5) scalaru: u32,
+    @location(4) @interpolate(flat) scalari: i32,
+    @location(5) @interpolate(flat) scalaru: u32,
 }
 
 @fragment 

--- a/tests/out/wgsl/interface.wgsl
+++ b/tests/out/wgsl/interface.wgsl
@@ -20,7 +20,7 @@ struct Input2_ {
 var<workgroup> output: array<u32,1>;
 
 @vertex 
-fn vertex(@builtin(vertex_index) vertex_index: u32, @builtin(instance_index) instance_index: u32, @location(10) color: u32) -> VertexOutput {
+fn vertex(@builtin(vertex_index) vertex_index: u32, @builtin(instance_index) instance_index: u32, @location(10) @interpolate(flat) color: u32) -> VertexOutput {
     let tmp: u32 = ((vertex_index + instance_index) + color);
     return VertexOutput(vec4<f32>(1.0), f32(tmp));
 }

--- a/tests/out/wgsl/interpolate.wgsl
+++ b/tests/out/wgsl/interpolate.wgsl
@@ -1,6 +1,6 @@
 struct FragmentInput {
     @builtin(position) position: vec4<f32>,
-    @location(0) _flat: u32,
+    @location(0) @interpolate(flat) _flat: u32,
     @location(1) @interpolate(linear) _linear: f32,
     @location(2) @interpolate(linear, centroid) linear_centroid: vec2<f32>,
     @location(3) @interpolate(linear, sample) linear_sample: vec3<f32>,

--- a/tests/out/wgsl/shadow.wgsl
+++ b/tests/out/wgsl/shadow.wgsl
@@ -48,7 +48,7 @@ fn fetch_shadow(light_id: u32, homogeneous_coords: vec4<f32>) -> f32 {
 }
 
 @vertex 
-fn vs_main(@location(0) position: vec4<i32>, @location(1) normal: vec4<i32>) -> VertexOutput {
+fn vs_main(@location(0) @interpolate(flat) position: vec4<i32>, @location(1) @interpolate(flat) normal: vec4<i32>) -> VertexOutput {
     var out: VertexOutput;
 
     let w = u_entity.world;


### PR DESCRIPTION
Backports #2318 to naga 0.12 because Bevy needs it for webgpu now that they adopted [naga_oil](https://github.com/bevyengine/naga_oil/).

Related: https://github.com/bevyengine/bevy/issues/9028