### PR TITLE
[spv] Fix OpImageQueries to allow Uints

### DIFF
--- a/src/back/spv/image.rs
+++ b/src/back/spv/image.rs
@@ -1101,15 +1101,7 @@ impl<'w> BlockContext<'w> {
                 let query_id = self.gen_id();
                 block.body.push(Instruction::image_query(
                     spirv::Op::ImageQueryLevels,
-                    self.get_type_id(
-                        LocalType::Value {
-                            vector_size: None,
-                            kind: crate::ScalarKind::Uint,
-                            width: 4,
-                            pointer_space: None,
-                        }
-                        .into(),
-                    ),
+                    result_type_id,
                     query_id,
                     image_id,
                 ));
@@ -1140,15 +1132,7 @@ impl<'w> BlockContext<'w> {
 
                 let extract_id = self.gen_id();
                 block.body.push(Instruction::composite_extract(
-                    self.get_type_id(
-                        LocalType::Value {
-                            vector_size: None,
-                            kind: crate::ScalarKind::Uint,
-                            width: 4,
-                            pointer_space: None,
-                        }
-                        .into(),
-                    ),
+                    result_type_id,
                     extract_id,
                     id_extended,
                     &[vec_size as u32 - 1],
@@ -1160,15 +1144,7 @@ impl<'w> BlockContext<'w> {
                 let query_id = self.gen_id();
                 block.body.push(Instruction::image_query(
                     spirv::Op::ImageQuerySamples,
-                    self.get_type_id(
-                        LocalType::Value {
-                            vector_size: None,
-                            kind: crate::ScalarKind::Uint,
-                            width: 4,
-                            pointer_space: None,
-                        }
-                        .into(),
-                    ),
+                    result_type_id,
                     query_id,
                     image_id,
                 ));

--- a/src/back/spv/image.rs
+++ b/src/back/spv/image.rs
@@ -1045,7 +1045,7 @@ impl<'w> BlockContext<'w> {
                 };
                 let extended_size_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
                     vector_size,
-                    kind: crate::ScalarKind::Sint,
+                    kind: crate::ScalarKind::Uint,
                     width: 4,
                     pointer_space: None,
                 }));
@@ -1077,24 +1077,7 @@ impl<'w> BlockContext<'w> {
                 }
                 block.body.push(inst);
 
-                let bitcast_type_id = self.get_type_id(
-                    LocalType::Value {
-                        vector_size,
-                        kind: crate::ScalarKind::Uint,
-                        width: 4,
-                        pointer_space: None,
-                    }
-                    .into(),
-                );
-                let bitcast_id = self.gen_id();
-                block.body.push(Instruction::unary(
-                    spirv::Op::Bitcast,
-                    bitcast_type_id,
-                    bitcast_id,
-                    id_extended,
-                ));
-
-                if result_type_id != bitcast_type_id {
+                if result_type_id != extended_size_type_id {
                     let id = self.gen_id();
                     let components = match dim {
                         // always pick the first component, and duplicate it for all 3 dimensions
@@ -1104,14 +1087,14 @@ impl<'w> BlockContext<'w> {
                     block.body.push(Instruction::vector_shuffle(
                         result_type_id,
                         id,
-                        bitcast_id,
-                        bitcast_id,
+                        id_extended,
+                        id_extended,
                         components,
                     ));
 
                     id
                 } else {
-                    bitcast_id
+                    id_extended
                 }
             }
             Iq::NumLevels => {
@@ -1121,7 +1104,7 @@ impl<'w> BlockContext<'w> {
                     self.get_type_id(
                         LocalType::Value {
                             vector_size: None,
-                            kind: crate::ScalarKind::Sint,
+                            kind: crate::ScalarKind::Uint,
                             width: 4,
                             pointer_space: None,
                         }
@@ -1131,15 +1114,7 @@ impl<'w> BlockContext<'w> {
                     image_id,
                 ));
 
-                let id = self.gen_id();
-                block.body.push(Instruction::unary(
-                    spirv::Op::Bitcast,
-                    result_type_id,
-                    id,
-                    query_id,
-                ));
-
-                id
+                query_id
             }
             Iq::NumLayers => {
                 let vec_size = match dim {
@@ -1149,7 +1124,7 @@ impl<'w> BlockContext<'w> {
                 };
                 let extended_size_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
                     vector_size: Some(vec_size),
-                    kind: crate::ScalarKind::Sint,
+                    kind: crate::ScalarKind::Uint,
                     width: 4,
                     pointer_space: None,
                 }));
@@ -1168,7 +1143,7 @@ impl<'w> BlockContext<'w> {
                     self.get_type_id(
                         LocalType::Value {
                             vector_size: None,
-                            kind: crate::ScalarKind::Sint,
+                            kind: crate::ScalarKind::Uint,
                             width: 4,
                             pointer_space: None,
                         }
@@ -1179,15 +1154,7 @@ impl<'w> BlockContext<'w> {
                     &[vec_size as u32 - 1],
                 ));
 
-                let id = self.gen_id();
-                block.body.push(Instruction::unary(
-                    spirv::Op::Bitcast,
-                    result_type_id,
-                    id,
-                    extract_id,
-                ));
-
-                id
+                extract_id
             }
             Iq::NumSamples => {
                 let query_id = self.gen_id();
@@ -1196,7 +1163,7 @@ impl<'w> BlockContext<'w> {
                     self.get_type_id(
                         LocalType::Value {
                             vector_size: None,
-                            kind: crate::ScalarKind::Sint,
+                            kind: crate::ScalarKind::Uint,
                             width: 4,
                             pointer_space: None,
                         }
@@ -1206,15 +1173,7 @@ impl<'w> BlockContext<'w> {
                     image_id,
                 ));
 
-                let id = self.gen_id();
-                block.body.push(Instruction::unary(
-                    spirv::Op::Bitcast,
-                    result_type_id,
-                    id,
-                    query_id,
-                ));
-
-                id
+                query_id
             }
         };
 

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -2695,19 +2695,11 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                 }
                 Op::ImageQueryLevels => {
                     inst.expect(4)?;
-                    self.parse_image_query_other(
-                        crate::ImageQuery::NumLevels,
-                        ctx.expressions,
-                        block_id,
-                    )?;
+                    self.parse_image_query_other(crate::ImageQuery::NumLevels, ctx, block_id)?;
                 }
                 Op::ImageQuerySamples => {
                     inst.expect(4)?;
-                    self.parse_image_query_other(
-                        crate::ImageQuery::NumSamples,
-                        ctx.expressions,
-                        block_id,
-                    )?;
+                    self.parse_image_query_other(crate::ImageQuery::NumSamples, ctx, block_id)?;
                 }
                 // other ops
                 Op::Select => {

--- a/tests/out/spv/binding-arrays.spvasm
+++ b/tests/out/spv/binding-arrays.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 447
+; Bound: 435
 OpCapability Shader
 OpCapability ImageQuery
 OpCapability ShaderNonUniform
@@ -35,28 +35,28 @@ OpMemberDecorate %47 0 Offset 0
 OpDecorate %63 Location 0
 OpDecorate %63 Flat
 OpDecorate %66 Location 0
-OpDecorate %97 NonUniform
-OpDecorate %121 NonUniform
-OpDecorate %123 NonUniform
-OpDecorate %148 NonUniform
-OpDecorate %150 NonUniform
-OpDecorate %188 NonUniform
-OpDecorate %219 NonUniform
-OpDecorate %238 NonUniform
-OpDecorate %257 NonUniform
-OpDecorate %279 NonUniform
-OpDecorate %281 NonUniform
-OpDecorate %303 NonUniform
-OpDecorate %305 NonUniform
-OpDecorate %327 NonUniform
-OpDecorate %329 NonUniform
-OpDecorate %351 NonUniform
-OpDecorate %353 NonUniform
-OpDecorate %375 NonUniform
-OpDecorate %377 NonUniform
-OpDecorate %399 NonUniform
-OpDecorate %401 NonUniform
-OpDecorate %424 NonUniform
+OpDecorate %95 NonUniform
+OpDecorate %118 NonUniform
+OpDecorate %120 NonUniform
+OpDecorate %145 NonUniform
+OpDecorate %147 NonUniform
+OpDecorate %185 NonUniform
+OpDecorate %214 NonUniform
+OpDecorate %230 NonUniform
+OpDecorate %246 NonUniform
+OpDecorate %267 NonUniform
+OpDecorate %269 NonUniform
+OpDecorate %291 NonUniform
+OpDecorate %293 NonUniform
+OpDecorate %315 NonUniform
+OpDecorate %317 NonUniform
+OpDecorate %339 NonUniform
+OpDecorate %341 NonUniform
+OpDecorate %363 NonUniform
+OpDecorate %365 NonUniform
+OpDecorate %387 NonUniform
+OpDecorate %389 NonUniform
+OpDecorate %412 NonUniform
 %2 = OpTypeVoid
 %3 = OpTypeInt 32 0
 %4 = OpTypeStruct %3
@@ -123,20 +123,20 @@ OpDecorate %424 NonUniform
 %74 = OpConstant  %26  0
 %76 = OpTypePointer Uniform %3
 %84 = OpTypePointer UniformConstant %5
-%105 = OpTypePointer UniformConstant %18
-%108 = OpTypeSampledImage %5
-%129 = OpTypePointer UniformConstant %14
-%132 = OpTypePointer UniformConstant %18
-%135 = OpTypeSampledImage %14
-%158 = OpTypeBool
-%159 = OpConstantNull  %22
-%165 = OpTypeVector %158 2
-%175 = OpConstantNull  %22
-%190 = OpConstantNull  %22
-%203 = OpTypePointer UniformConstant %10
-%206 = OpTypeVector %26 3
-%244 = OpTypePointer UniformConstant %12
-%407 = OpTypePointer UniformConstant %16
+%102 = OpTypePointer UniformConstant %18
+%105 = OpTypeSampledImage %5
+%126 = OpTypePointer UniformConstant %14
+%129 = OpTypePointer UniformConstant %18
+%132 = OpTypeSampledImage %14
+%155 = OpTypeBool
+%156 = OpConstantNull  %22
+%162 = OpTypeVector %155 2
+%172 = OpConstantNull  %22
+%187 = OpConstantNull  %22
+%200 = OpTypePointer UniformConstant %10
+%203 = OpTypeVector %3 3
+%235 = OpTypePointer UniformConstant %12
+%395 = OpTypePointer UniformConstant %16
 %68 = OpFunction  %2  None %69
 %61 = OpLabel
 %52 = OpVariable  %53  Function %54
@@ -161,415 +161,403 @@ OpStore %58 %81
 %83 = OpCompositeConstruct  %25  %74 %74
 %85 = OpAccessChain  %84  %28 %71
 %86 = OpLoad  %5  %85
-%87 = OpImageQuerySizeLod  %25  %86 %71
-%88 = OpBitcast  %23  %87
-%89 = OpLoad  %23  %52
-%90 = OpIAdd  %23  %89 %88
-OpStore %52 %90
-%91 = OpAccessChain  %84  %28 %78
-%92 = OpLoad  %5  %91
-%93 = OpImageQuerySizeLod  %25  %92 %71
-%94 = OpBitcast  %23  %93
-%95 = OpLoad  %23  %52
-%96 = OpIAdd  %23  %95 %94
-OpStore %52 %96
-%97 = OpAccessChain  %84  %28 %79
-%98 = OpLoad  %5  %97
-%99 = OpImageQuerySizeLod  %25  %98 %71
-%100 = OpBitcast  %23  %99
-%101 = OpLoad  %23  %52
-%102 = OpIAdd  %23  %101 %100
-OpStore %52 %102
-%103 = OpAccessChain  %84  %32 %71
-%104 = OpLoad  %5  %103
-%106 = OpAccessChain  %105  %42 %71
-%107 = OpLoad  %18  %106
-%109 = OpSampledImage  %108  %104 %107
-%110 = OpImageGather  %22  %109 %82 %71
-%111 = OpLoad  %22  %58
-%112 = OpFAdd  %22  %111 %110
-OpStore %58 %112
-%113 = OpAccessChain  %84  %32 %78
-%114 = OpLoad  %5  %113
-%115 = OpAccessChain  %105  %42 %78
-%116 = OpLoad  %18  %115
-%117 = OpSampledImage  %108  %114 %116
-%118 = OpImageGather  %22  %117 %82 %71
-%119 = OpLoad  %22  %58
-%120 = OpFAdd  %22  %119 %118
-OpStore %58 %120
-%121 = OpAccessChain  %84  %32 %79
-%122 = OpLoad  %5  %121
-%123 = OpAccessChain  %105  %42 %79
-%124 = OpLoad  %18  %123
-%125 = OpSampledImage  %108  %122 %124
-%126 = OpImageGather  %22  %125 %82 %71
-%127 = OpLoad  %22  %58
-%128 = OpFAdd  %22  %127 %126
-OpStore %58 %128
-%130 = OpAccessChain  %129  %38 %71
-%131 = OpLoad  %14  %130
-%133 = OpAccessChain  %132  %44 %71
-%134 = OpLoad  %18  %133
-%136 = OpSampledImage  %135  %131 %134
-%137 = OpImageDrefGather  %22  %136 %82 %73
-%138 = OpLoad  %22  %58
-%139 = OpFAdd  %22  %138 %137
-OpStore %58 %139
-%140 = OpAccessChain  %129  %38 %78
-%141 = OpLoad  %14  %140
-%142 = OpAccessChain  %132  %44 %78
-%143 = OpLoad  %18  %142
-%144 = OpSampledImage  %135  %141 %143
-%145 = OpImageDrefGather  %22  %144 %82 %73
-%146 = OpLoad  %22  %58
-%147 = OpFAdd  %22  %146 %145
-OpStore %58 %147
-%148 = OpAccessChain  %129  %38 %79
-%149 = OpLoad  %14  %148
-%150 = OpAccessChain  %132  %44 %79
-%151 = OpLoad  %18  %150
-%152 = OpSampledImage  %135  %149 %151
-%153 = OpImageDrefGather  %22  %152 %82 %73
-%154 = OpLoad  %22  %58
-%155 = OpFAdd  %22  %154 %153
-OpStore %58 %155
-%156 = OpAccessChain  %84  %28 %71
-%157 = OpLoad  %5  %156
-%160 = OpImageQueryLevels  %26  %157
-%161 = OpULessThan  %158  %74 %160
-OpSelectionMerge %162 None
-OpBranchConditional %161 %163 %162
-%163 = OpLabel
-%164 = OpImageQuerySizeLod  %25  %157 %74
-%166 = OpULessThan  %165  %83 %164
-%167 = OpAll  %158  %166
-OpBranchConditional %167 %168 %162
-%168 = OpLabel
-%169 = OpImageFetch  %22  %157 %83 Lod %74
-OpBranch %162
-%162 = OpLabel
-%170 = OpPhi  %22  %159 %75 %159 %163 %169 %168
-%171 = OpLoad  %22  %58
-%172 = OpFAdd  %22  %171 %170
-OpStore %58 %172
-%173 = OpAccessChain  %84  %28 %78
-%174 = OpLoad  %5  %173
-%176 = OpImageQueryLevels  %26  %174
-%177 = OpULessThan  %158  %74 %176
-OpSelectionMerge %178 None
-OpBranchConditional %177 %179 %178
-%179 = OpLabel
-%180 = OpImageQuerySizeLod  %25  %174 %74
-%181 = OpULessThan  %165  %83 %180
-%182 = OpAll  %158  %181
-OpBranchConditional %182 %183 %178
-%183 = OpLabel
-%184 = OpImageFetch  %22  %174 %83 Lod %74
-OpBranch %178
-%178 = OpLabel
-%185 = OpPhi  %22  %175 %162 %175 %179 %184 %183
-%186 = OpLoad  %22  %58
-%187 = OpFAdd  %22  %186 %185
-OpStore %58 %187
-%188 = OpAccessChain  %84  %28 %79
-%189 = OpLoad  %5  %188
-%191 = OpImageQueryLevels  %26  %189
-%192 = OpULessThan  %158  %74 %191
-OpSelectionMerge %193 None
-OpBranchConditional %192 %194 %193
-%194 = OpLabel
-%195 = OpImageQuerySizeLod  %25  %189 %74
-%196 = OpULessThan  %165  %83 %195
-%197 = OpAll  %158  %196
-OpBranchConditional %197 %198 %193
-%198 = OpLabel
-%199 = OpImageFetch  %22  %189 %83 Lod %74
-OpBranch %193
-%193 = OpLabel
-%200 = OpPhi  %22  %190 %178 %190 %194 %199 %198
-%201 = OpLoad  %22  %58
-%202 = OpFAdd  %22  %201 %200
-OpStore %58 %202
-%204 = OpAccessChain  %203  %34 %71
-%205 = OpLoad  %10  %204
-%207 = OpImageQuerySizeLod  %206  %205 %71
-%208 = OpCompositeExtract  %26  %207 2
-%209 = OpBitcast  %3  %208
-%210 = OpLoad  %3  %49
-%211 = OpIAdd  %3  %210 %209
-OpStore %49 %211
-%212 = OpAccessChain  %203  %34 %78
-%213 = OpLoad  %10  %212
-%214 = OpImageQuerySizeLod  %206  %213 %71
-%215 = OpCompositeExtract  %26  %214 2
-%216 = OpBitcast  %3  %215
-%217 = OpLoad  %3  %49
-%218 = OpIAdd  %3  %217 %216
-OpStore %49 %218
-%219 = OpAccessChain  %203  %34 %79
-%220 = OpLoad  %10  %219
-%221 = OpImageQuerySizeLod  %206  %220 %71
-%222 = OpCompositeExtract  %26  %221 2
-%223 = OpBitcast  %3  %222
-%224 = OpLoad  %3  %49
-%225 = OpIAdd  %3  %224 %223
-OpStore %49 %225
-%226 = OpAccessChain  %84  %32 %71
-%227 = OpLoad  %5  %226
-%228 = OpImageQueryLevels  %26  %227
-%229 = OpBitcast  %3  %228
-%230 = OpLoad  %3  %49
-%231 = OpIAdd  %3  %230 %229
-OpStore %49 %231
-%232 = OpAccessChain  %84  %32 %78
-%233 = OpLoad  %5  %232
-%234 = OpImageQueryLevels  %26  %233
-%235 = OpBitcast  %3  %234
-%236 = OpLoad  %3  %49
-%237 = OpIAdd  %3  %236 %235
-OpStore %49 %237
-%238 = OpAccessChain  %84  %32 %79
-%239 = OpLoad  %5  %238
-%240 = OpImageQueryLevels  %26  %239
-%241 = OpBitcast  %3  %240
-%242 = OpLoad  %3  %49
-%243 = OpIAdd  %3  %242 %241
-OpStore %49 %243
-%245 = OpAccessChain  %244  %36 %71
-%246 = OpLoad  %12  %245
-%247 = OpImageQuerySamples  %26  %246
-%248 = OpBitcast  %3  %247
+%87 = OpImageQuerySizeLod  %23  %86 %71
+%88 = OpLoad  %23  %52
+%89 = OpIAdd  %23  %88 %87
+OpStore %52 %89
+%90 = OpAccessChain  %84  %28 %78
+%91 = OpLoad  %5  %90
+%92 = OpImageQuerySizeLod  %23  %91 %71
+%93 = OpLoad  %23  %52
+%94 = OpIAdd  %23  %93 %92
+OpStore %52 %94
+%95 = OpAccessChain  %84  %28 %79
+%96 = OpLoad  %5  %95
+%97 = OpImageQuerySizeLod  %23  %96 %71
+%98 = OpLoad  %23  %52
+%99 = OpIAdd  %23  %98 %97
+OpStore %52 %99
+%100 = OpAccessChain  %84  %32 %71
+%101 = OpLoad  %5  %100
+%103 = OpAccessChain  %102  %42 %71
+%104 = OpLoad  %18  %103
+%106 = OpSampledImage  %105  %101 %104
+%107 = OpImageGather  %22  %106 %82 %71
+%108 = OpLoad  %22  %58
+%109 = OpFAdd  %22  %108 %107
+OpStore %58 %109
+%110 = OpAccessChain  %84  %32 %78
+%111 = OpLoad  %5  %110
+%112 = OpAccessChain  %102  %42 %78
+%113 = OpLoad  %18  %112
+%114 = OpSampledImage  %105  %111 %113
+%115 = OpImageGather  %22  %114 %82 %71
+%116 = OpLoad  %22  %58
+%117 = OpFAdd  %22  %116 %115
+OpStore %58 %117
+%118 = OpAccessChain  %84  %32 %79
+%119 = OpLoad  %5  %118
+%120 = OpAccessChain  %102  %42 %79
+%121 = OpLoad  %18  %120
+%122 = OpSampledImage  %105  %119 %121
+%123 = OpImageGather  %22  %122 %82 %71
+%124 = OpLoad  %22  %58
+%125 = OpFAdd  %22  %124 %123
+OpStore %58 %125
+%127 = OpAccessChain  %126  %38 %71
+%128 = OpLoad  %14  %127
+%130 = OpAccessChain  %129  %44 %71
+%131 = OpLoad  %18  %130
+%133 = OpSampledImage  %132  %128 %131
+%134 = OpImageDrefGather  %22  %133 %82 %73
+%135 = OpLoad  %22  %58
+%136 = OpFAdd  %22  %135 %134
+OpStore %58 %136
+%137 = OpAccessChain  %126  %38 %78
+%138 = OpLoad  %14  %137
+%139 = OpAccessChain  %129  %44 %78
+%140 = OpLoad  %18  %139
+%141 = OpSampledImage  %132  %138 %140
+%142 = OpImageDrefGather  %22  %141 %82 %73
+%143 = OpLoad  %22  %58
+%144 = OpFAdd  %22  %143 %142
+OpStore %58 %144
+%145 = OpAccessChain  %126  %38 %79
+%146 = OpLoad  %14  %145
+%147 = OpAccessChain  %129  %44 %79
+%148 = OpLoad  %18  %147
+%149 = OpSampledImage  %132  %146 %148
+%150 = OpImageDrefGather  %22  %149 %82 %73
+%151 = OpLoad  %22  %58
+%152 = OpFAdd  %22  %151 %150
+OpStore %58 %152
+%153 = OpAccessChain  %84  %28 %71
+%154 = OpLoad  %5  %153
+%157 = OpImageQueryLevels  %26  %154
+%158 = OpULessThan  %155  %74 %157
+OpSelectionMerge %159 None
+OpBranchConditional %158 %160 %159
+%160 = OpLabel
+%161 = OpImageQuerySizeLod  %25  %154 %74
+%163 = OpULessThan  %162  %83 %161
+%164 = OpAll  %155  %163
+OpBranchConditional %164 %165 %159
+%165 = OpLabel
+%166 = OpImageFetch  %22  %154 %83 Lod %74
+OpBranch %159
+%159 = OpLabel
+%167 = OpPhi  %22  %156 %75 %156 %160 %166 %165
+%168 = OpLoad  %22  %58
+%169 = OpFAdd  %22  %168 %167
+OpStore %58 %169
+%170 = OpAccessChain  %84  %28 %78
+%171 = OpLoad  %5  %170
+%173 = OpImageQueryLevels  %26  %171
+%174 = OpULessThan  %155  %74 %173
+OpSelectionMerge %175 None
+OpBranchConditional %174 %176 %175
+%176 = OpLabel
+%177 = OpImageQuerySizeLod  %25  %171 %74
+%178 = OpULessThan  %162  %83 %177
+%179 = OpAll  %155  %178
+OpBranchConditional %179 %180 %175
+%180 = OpLabel
+%181 = OpImageFetch  %22  %171 %83 Lod %74
+OpBranch %175
+%175 = OpLabel
+%182 = OpPhi  %22  %172 %159 %172 %176 %181 %180
+%183 = OpLoad  %22  %58
+%184 = OpFAdd  %22  %183 %182
+OpStore %58 %184
+%185 = OpAccessChain  %84  %28 %79
+%186 = OpLoad  %5  %185
+%188 = OpImageQueryLevels  %26  %186
+%189 = OpULessThan  %155  %74 %188
+OpSelectionMerge %190 None
+OpBranchConditional %189 %191 %190
+%191 = OpLabel
+%192 = OpImageQuerySizeLod  %25  %186 %74
+%193 = OpULessThan  %162  %83 %192
+%194 = OpAll  %155  %193
+OpBranchConditional %194 %195 %190
+%195 = OpLabel
+%196 = OpImageFetch  %22  %186 %83 Lod %74
+OpBranch %190
+%190 = OpLabel
+%197 = OpPhi  %22  %187 %175 %187 %191 %196 %195
+%198 = OpLoad  %22  %58
+%199 = OpFAdd  %22  %198 %197
+OpStore %58 %199
+%201 = OpAccessChain  %200  %34 %71
+%202 = OpLoad  %10  %201
+%204 = OpImageQuerySizeLod  %203  %202 %71
+%205 = OpCompositeExtract  %3  %204 2
+%206 = OpLoad  %3  %49
+%207 = OpIAdd  %3  %206 %205
+OpStore %49 %207
+%208 = OpAccessChain  %200  %34 %78
+%209 = OpLoad  %10  %208
+%210 = OpImageQuerySizeLod  %203  %209 %71
+%211 = OpCompositeExtract  %3  %210 2
+%212 = OpLoad  %3  %49
+%213 = OpIAdd  %3  %212 %211
+OpStore %49 %213
+%214 = OpAccessChain  %200  %34 %79
+%215 = OpLoad  %10  %214
+%216 = OpImageQuerySizeLod  %203  %215 %71
+%217 = OpCompositeExtract  %3  %216 2
+%218 = OpLoad  %3  %49
+%219 = OpIAdd  %3  %218 %217
+OpStore %49 %219
+%220 = OpAccessChain  %84  %32 %71
+%221 = OpLoad  %5  %220
+%222 = OpImageQueryLevels  %3  %221
+%223 = OpLoad  %3  %49
+%224 = OpIAdd  %3  %223 %222
+OpStore %49 %224
+%225 = OpAccessChain  %84  %32 %78
+%226 = OpLoad  %5  %225
+%227 = OpImageQueryLevels  %3  %226
+%228 = OpLoad  %3  %49
+%229 = OpIAdd  %3  %228 %227
+OpStore %49 %229
+%230 = OpAccessChain  %84  %32 %79
+%231 = OpLoad  %5  %230
+%232 = OpImageQueryLevels  %3  %231
+%233 = OpLoad  %3  %49
+%234 = OpIAdd  %3  %233 %232
+OpStore %49 %234
+%236 = OpAccessChain  %235  %36 %71
+%237 = OpLoad  %12  %236
+%238 = OpImageQuerySamples  %3  %237
+%239 = OpLoad  %3  %49
+%240 = OpIAdd  %3  %239 %238
+OpStore %49 %240
+%241 = OpAccessChain  %235  %36 %78
+%242 = OpLoad  %12  %241
+%243 = OpImageQuerySamples  %3  %242
+%244 = OpLoad  %3  %49
+%245 = OpIAdd  %3  %244 %243
+OpStore %49 %245
+%246 = OpAccessChain  %235  %36 %79
+%247 = OpLoad  %12  %246
+%248 = OpImageQuerySamples  %3  %247
 %249 = OpLoad  %3  %49
 %250 = OpIAdd  %3  %249 %248
 OpStore %49 %250
-%251 = OpAccessChain  %244  %36 %78
-%252 = OpLoad  %12  %251
-%253 = OpImageQuerySamples  %26  %252
-%254 = OpBitcast  %3  %253
-%255 = OpLoad  %3  %49
-%256 = OpIAdd  %3  %255 %254
-OpStore %49 %256
-%257 = OpAccessChain  %244  %36 %79
-%258 = OpLoad  %12  %257
-%259 = OpImageQuerySamples  %26  %258
-%260 = OpBitcast  %3  %259
-%261 = OpLoad  %3  %49
-%262 = OpIAdd  %3  %261 %260
-OpStore %49 %262
-%263 = OpAccessChain  %84  %32 %71
-%264 = OpLoad  %5  %263
-%265 = OpAccessChain  %105  %42 %71
-%266 = OpLoad  %18  %265
-%267 = OpSampledImage  %108  %264 %266
-%268 = OpImageSampleImplicitLod  %22  %267 %82
-%269 = OpLoad  %22  %58
-%270 = OpFAdd  %22  %269 %268
-OpStore %58 %270
-%271 = OpAccessChain  %84  %32 %78
-%272 = OpLoad  %5  %271
-%273 = OpAccessChain  %105  %42 %78
-%274 = OpLoad  %18  %273
-%275 = OpSampledImage  %108  %272 %274
-%276 = OpImageSampleImplicitLod  %22  %275 %82
-%277 = OpLoad  %22  %58
-%278 = OpFAdd  %22  %277 %276
-OpStore %58 %278
-%279 = OpAccessChain  %84  %32 %79
-%280 = OpLoad  %5  %279
-%281 = OpAccessChain  %105  %42 %79
-%282 = OpLoad  %18  %281
-%283 = OpSampledImage  %108  %280 %282
-%284 = OpImageSampleImplicitLod  %22  %283 %82
-%285 = OpLoad  %22  %58
-%286 = OpFAdd  %22  %285 %284
-OpStore %58 %286
-%287 = OpAccessChain  %84  %32 %71
-%288 = OpLoad  %5  %287
-%289 = OpAccessChain  %105  %42 %71
-%290 = OpLoad  %18  %289
-%291 = OpSampledImage  %108  %288 %290
-%292 = OpImageSampleImplicitLod  %22  %291 %82 Bias %73
-%293 = OpLoad  %22  %58
-%294 = OpFAdd  %22  %293 %292
-OpStore %58 %294
-%295 = OpAccessChain  %84  %32 %78
-%296 = OpLoad  %5  %295
-%297 = OpAccessChain  %105  %42 %78
-%298 = OpLoad  %18  %297
-%299 = OpSampledImage  %108  %296 %298
-%300 = OpImageSampleImplicitLod  %22  %299 %82 Bias %73
-%301 = OpLoad  %22  %58
-%302 = OpFAdd  %22  %301 %300
-OpStore %58 %302
-%303 = OpAccessChain  %84  %32 %79
-%304 = OpLoad  %5  %303
-%305 = OpAccessChain  %105  %42 %79
-%306 = OpLoad  %18  %305
-%307 = OpSampledImage  %108  %304 %306
-%308 = OpImageSampleImplicitLod  %22  %307 %82 Bias %73
-%309 = OpLoad  %22  %58
-%310 = OpFAdd  %22  %309 %308
-OpStore %58 %310
-%311 = OpAccessChain  %129  %38 %71
-%312 = OpLoad  %14  %311
-%313 = OpAccessChain  %132  %44 %71
-%314 = OpLoad  %18  %313
-%315 = OpSampledImage  %135  %312 %314
-%316 = OpImageSampleDrefImplicitLod  %6  %315 %82 %73
-%317 = OpLoad  %6  %55
-%318 = OpFAdd  %6  %317 %316
-OpStore %55 %318
-%319 = OpAccessChain  %129  %38 %78
-%320 = OpLoad  %14  %319
-%321 = OpAccessChain  %132  %44 %78
-%322 = OpLoad  %18  %321
-%323 = OpSampledImage  %135  %320 %322
-%324 = OpImageSampleDrefImplicitLod  %6  %323 %82 %73
-%325 = OpLoad  %6  %55
-%326 = OpFAdd  %6  %325 %324
-OpStore %55 %326
-%327 = OpAccessChain  %129  %38 %79
-%328 = OpLoad  %14  %327
-%329 = OpAccessChain  %132  %44 %79
-%330 = OpLoad  %18  %329
-%331 = OpSampledImage  %135  %328 %330
-%332 = OpImageSampleDrefImplicitLod  %6  %331 %82 %73
-%333 = OpLoad  %6  %55
-%334 = OpFAdd  %6  %333 %332
-OpStore %55 %334
-%335 = OpAccessChain  %129  %38 %71
-%336 = OpLoad  %14  %335
-%337 = OpAccessChain  %132  %44 %71
-%338 = OpLoad  %18  %337
-%339 = OpSampledImage  %135  %336 %338
-%340 = OpImageSampleDrefExplicitLod  %6  %339 %82 %73 Lod %73
-%341 = OpLoad  %6  %55
-%342 = OpFAdd  %6  %341 %340
-OpStore %55 %342
-%343 = OpAccessChain  %129  %38 %78
-%344 = OpLoad  %14  %343
-%345 = OpAccessChain  %132  %44 %78
-%346 = OpLoad  %18  %345
-%347 = OpSampledImage  %135  %344 %346
-%348 = OpImageSampleDrefExplicitLod  %6  %347 %82 %73 Lod %73
-%349 = OpLoad  %6  %55
-%350 = OpFAdd  %6  %349 %348
-OpStore %55 %350
-%351 = OpAccessChain  %129  %38 %79
-%352 = OpLoad  %14  %351
-%353 = OpAccessChain  %132  %44 %79
-%354 = OpLoad  %18  %353
-%355 = OpSampledImage  %135  %352 %354
-%356 = OpImageSampleDrefExplicitLod  %6  %355 %82 %73 Lod %73
-%357 = OpLoad  %6  %55
-%358 = OpFAdd  %6  %357 %356
-OpStore %55 %358
-%359 = OpAccessChain  %84  %32 %71
-%360 = OpLoad  %5  %359
-%361 = OpAccessChain  %105  %42 %71
-%362 = OpLoad  %18  %361
-%363 = OpSampledImage  %108  %360 %362
-%364 = OpImageSampleExplicitLod  %22  %363 %82 Grad %82 %82
-%365 = OpLoad  %22  %58
-%366 = OpFAdd  %22  %365 %364
-OpStore %58 %366
-%367 = OpAccessChain  %84  %32 %78
-%368 = OpLoad  %5  %367
-%369 = OpAccessChain  %105  %42 %78
-%370 = OpLoad  %18  %369
-%371 = OpSampledImage  %108  %368 %370
-%372 = OpImageSampleExplicitLod  %22  %371 %82 Grad %82 %82
-%373 = OpLoad  %22  %58
-%374 = OpFAdd  %22  %373 %372
-OpStore %58 %374
-%375 = OpAccessChain  %84  %32 %79
-%376 = OpLoad  %5  %375
-%377 = OpAccessChain  %105  %42 %79
-%378 = OpLoad  %18  %377
-%379 = OpSampledImage  %108  %376 %378
-%380 = OpImageSampleExplicitLod  %22  %379 %82 Grad %82 %82
-%381 = OpLoad  %22  %58
-%382 = OpFAdd  %22  %381 %380
-OpStore %58 %382
-%383 = OpAccessChain  %84  %32 %71
-%384 = OpLoad  %5  %383
-%385 = OpAccessChain  %105  %42 %71
-%386 = OpLoad  %18  %385
-%387 = OpSampledImage  %108  %384 %386
-%388 = OpImageSampleExplicitLod  %22  %387 %82 Lod %73
-%389 = OpLoad  %22  %58
-%390 = OpFAdd  %22  %389 %388
-OpStore %58 %390
-%391 = OpAccessChain  %84  %32 %78
-%392 = OpLoad  %5  %391
-%393 = OpAccessChain  %105  %42 %78
-%394 = OpLoad  %18  %393
-%395 = OpSampledImage  %108  %392 %394
-%396 = OpImageSampleExplicitLod  %22  %395 %82 Lod %73
-%397 = OpLoad  %22  %58
-%398 = OpFAdd  %22  %397 %396
-OpStore %58 %398
-%399 = OpAccessChain  %84  %32 %79
-%400 = OpLoad  %5  %399
-%401 = OpAccessChain  %105  %42 %79
-%402 = OpLoad  %18  %401
-%403 = OpSampledImage  %108  %400 %402
-%404 = OpImageSampleExplicitLod  %22  %403 %82 Lod %73
-%405 = OpLoad  %22  %58
-%406 = OpFAdd  %22  %405 %404
-OpStore %58 %406
-%408 = OpAccessChain  %407  %40 %71
-%409 = OpLoad  %16  %408
-%410 = OpLoad  %22  %58
-%411 = OpImageQuerySize  %25  %409
-%412 = OpULessThan  %165  %83 %411
-%413 = OpAll  %158  %412
-OpSelectionMerge %414 None
-OpBranchConditional %413 %415 %414
-%415 = OpLabel
-OpImageWrite %409 %83 %410
-OpBranch %414
-%414 = OpLabel
-%416 = OpAccessChain  %407  %40 %78
-%417 = OpLoad  %16  %416
-%418 = OpLoad  %22  %58
-%419 = OpImageQuerySize  %25  %417
-%420 = OpULessThan  %165  %83 %419
-%421 = OpAll  %158  %420
-OpSelectionMerge %422 None
-OpBranchConditional %421 %423 %422
-%423 = OpLabel
-OpImageWrite %417 %83 %418
-OpBranch %422
-%422 = OpLabel
-%424 = OpAccessChain  %407  %40 %79
-%425 = OpLoad  %16  %424
-%426 = OpLoad  %22  %58
-%427 = OpImageQuerySize  %25  %425
-%428 = OpULessThan  %165  %83 %427
-%429 = OpAll  %158  %428
-OpSelectionMerge %430 None
-OpBranchConditional %429 %431 %430
-%431 = OpLabel
-OpImageWrite %425 %83 %426
-OpBranch %430
-%430 = OpLabel
-%432 = OpLoad  %23  %52
-%433 = OpLoad  %3  %49
-%434 = OpCompositeConstruct  %23  %433 %433
-%435 = OpIAdd  %23  %432 %434
-%436 = OpConvertUToF  %24  %435
-%437 = OpLoad  %22  %58
-%438 = OpCompositeExtract  %6  %436 0
-%439 = OpCompositeExtract  %6  %436 1
-%440 = OpCompositeExtract  %6  %436 0
-%441 = OpCompositeExtract  %6  %436 1
-%442 = OpCompositeConstruct  %22  %438 %439 %440 %441
-%443 = OpFAdd  %22  %437 %442
-%444 = OpLoad  %6  %55
-%445 = OpCompositeConstruct  %22  %444 %444 %444 %444
-%446 = OpFAdd  %22  %443 %445
-OpStore %66 %446
+%251 = OpAccessChain  %84  %32 %71
+%252 = OpLoad  %5  %251
+%253 = OpAccessChain  %102  %42 %71
+%254 = OpLoad  %18  %253
+%255 = OpSampledImage  %105  %252 %254
+%256 = OpImageSampleImplicitLod  %22  %255 %82
+%257 = OpLoad  %22  %58
+%258 = OpFAdd  %22  %257 %256
+OpStore %58 %258
+%259 = OpAccessChain  %84  %32 %78
+%260 = OpLoad  %5  %259
+%261 = OpAccessChain  %102  %42 %78
+%262 = OpLoad  %18  %261
+%263 = OpSampledImage  %105  %260 %262
+%264 = OpImageSampleImplicitLod  %22  %263 %82
+%265 = OpLoad  %22  %58
+%266 = OpFAdd  %22  %265 %264
+OpStore %58 %266
+%267 = OpAccessChain  %84  %32 %79
+%268 = OpLoad  %5  %267
+%269 = OpAccessChain  %102  %42 %79
+%270 = OpLoad  %18  %269
+%271 = OpSampledImage  %105  %268 %270
+%272 = OpImageSampleImplicitLod  %22  %271 %82
+%273 = OpLoad  %22  %58
+%274 = OpFAdd  %22  %273 %272
+OpStore %58 %274
+%275 = OpAccessChain  %84  %32 %71
+%276 = OpLoad  %5  %275
+%277 = OpAccessChain  %102  %42 %71
+%278 = OpLoad  %18  %277
+%279 = OpSampledImage  %105  %276 %278
+%280 = OpImageSampleImplicitLod  %22  %279 %82 Bias %73
+%281 = OpLoad  %22  %58
+%282 = OpFAdd  %22  %281 %280
+OpStore %58 %282
+%283 = OpAccessChain  %84  %32 %78
+%284 = OpLoad  %5  %283
+%285 = OpAccessChain  %102  %42 %78
+%286 = OpLoad  %18  %285
+%287 = OpSampledImage  %105  %284 %286
+%288 = OpImageSampleImplicitLod  %22  %287 %82 Bias %73
+%289 = OpLoad  %22  %58
+%290 = OpFAdd  %22  %289 %288
+OpStore %58 %290
+%291 = OpAccessChain  %84  %32 %79
+%292 = OpLoad  %5  %291
+%293 = OpAccessChain  %102  %42 %79
+%294 = OpLoad  %18  %293
+%295 = OpSampledImage  %105  %292 %294
+%296 = OpImageSampleImplicitLod  %22  %295 %82 Bias %73
+%297 = OpLoad  %22  %58
+%298 = OpFAdd  %22  %297 %296
+OpStore %58 %298
+%299 = OpAccessChain  %126  %38 %71
+%300 = OpLoad  %14  %299
+%301 = OpAccessChain  %129  %44 %71
+%302 = OpLoad  %18  %301
+%303 = OpSampledImage  %132  %300 %302
+%304 = OpImageSampleDrefImplicitLod  %6  %303 %82 %73
+%305 = OpLoad  %6  %55
+%306 = OpFAdd  %6  %305 %304
+OpStore %55 %306
+%307 = OpAccessChain  %126  %38 %78
+%308 = OpLoad  %14  %307
+%309 = OpAccessChain  %129  %44 %78
+%310 = OpLoad  %18  %309
+%311 = OpSampledImage  %132  %308 %310
+%312 = OpImageSampleDrefImplicitLod  %6  %311 %82 %73
+%313 = OpLoad  %6  %55
+%314 = OpFAdd  %6  %313 %312
+OpStore %55 %314
+%315 = OpAccessChain  %126  %38 %79
+%316 = OpLoad  %14  %315
+%317 = OpAccessChain  %129  %44 %79
+%318 = OpLoad  %18  %317
+%319 = OpSampledImage  %132  %316 %318
+%320 = OpImageSampleDrefImplicitLod  %6  %319 %82 %73
+%321 = OpLoad  %6  %55
+%322 = OpFAdd  %6  %321 %320
+OpStore %55 %322
+%323 = OpAccessChain  %126  %38 %71
+%324 = OpLoad  %14  %323
+%325 = OpAccessChain  %129  %44 %71
+%326 = OpLoad  %18  %325
+%327 = OpSampledImage  %132  %324 %326
+%328 = OpImageSampleDrefExplicitLod  %6  %327 %82 %73 Lod %73
+%329 = OpLoad  %6  %55
+%330 = OpFAdd  %6  %329 %328
+OpStore %55 %330
+%331 = OpAccessChain  %126  %38 %78
+%332 = OpLoad  %14  %331
+%333 = OpAccessChain  %129  %44 %78
+%334 = OpLoad  %18  %333
+%335 = OpSampledImage  %132  %332 %334
+%336 = OpImageSampleDrefExplicitLod  %6  %335 %82 %73 Lod %73
+%337 = OpLoad  %6  %55
+%338 = OpFAdd  %6  %337 %336
+OpStore %55 %338
+%339 = OpAccessChain  %126  %38 %79
+%340 = OpLoad  %14  %339
+%341 = OpAccessChain  %129  %44 %79
+%342 = OpLoad  %18  %341
+%343 = OpSampledImage  %132  %340 %342
+%344 = OpImageSampleDrefExplicitLod  %6  %343 %82 %73 Lod %73
+%345 = OpLoad  %6  %55
+%346 = OpFAdd  %6  %345 %344
+OpStore %55 %346
+%347 = OpAccessChain  %84  %32 %71
+%348 = OpLoad  %5  %347
+%349 = OpAccessChain  %102  %42 %71
+%350 = OpLoad  %18  %349
+%351 = OpSampledImage  %105  %348 %350
+%352 = OpImageSampleExplicitLod  %22  %351 %82 Grad %82 %82
+%353 = OpLoad  %22  %58
+%354 = OpFAdd  %22  %353 %352
+OpStore %58 %354
+%355 = OpAccessChain  %84  %32 %78
+%356 = OpLoad  %5  %355
+%357 = OpAccessChain  %102  %42 %78
+%358 = OpLoad  %18  %357
+%359 = OpSampledImage  %105  %356 %358
+%360 = OpImageSampleExplicitLod  %22  %359 %82 Grad %82 %82
+%361 = OpLoad  %22  %58
+%362 = OpFAdd  %22  %361 %360
+OpStore %58 %362
+%363 = OpAccessChain  %84  %32 %79
+%364 = OpLoad  %5  %363
+%365 = OpAccessChain  %102  %42 %79
+%366 = OpLoad  %18  %365
+%367 = OpSampledImage  %105  %364 %366
+%368 = OpImageSampleExplicitLod  %22  %367 %82 Grad %82 %82
+%369 = OpLoad  %22  %58
+%370 = OpFAdd  %22  %369 %368
+OpStore %58 %370
+%371 = OpAccessChain  %84  %32 %71
+%372 = OpLoad  %5  %371
+%373 = OpAccessChain  %102  %42 %71
+%374 = OpLoad  %18  %373
+%375 = OpSampledImage  %105  %372 %374
+%376 = OpImageSampleExplicitLod  %22  %375 %82 Lod %73
+%377 = OpLoad  %22  %58
+%378 = OpFAdd  %22  %377 %376
+OpStore %58 %378
+%379 = OpAccessChain  %84  %32 %78
+%380 = OpLoad  %5  %379
+%381 = OpAccessChain  %102  %42 %78
+%382 = OpLoad  %18  %381
+%383 = OpSampledImage  %105  %380 %382
+%384 = OpImageSampleExplicitLod  %22  %383 %82 Lod %73
+%385 = OpLoad  %22  %58
+%386 = OpFAdd  %22  %385 %384
+OpStore %58 %386
+%387 = OpAccessChain  %84  %32 %79
+%388 = OpLoad  %5  %387
+%389 = OpAccessChain  %102  %42 %79
+%390 = OpLoad  %18  %389
+%391 = OpSampledImage  %105  %388 %390
+%392 = OpImageSampleExplicitLod  %22  %391 %82 Lod %73
+%393 = OpLoad  %22  %58
+%394 = OpFAdd  %22  %393 %392
+OpStore %58 %394
+%396 = OpAccessChain  %395  %40 %71
+%397 = OpLoad  %16  %396
+%398 = OpLoad  %22  %58
+%399 = OpImageQuerySize  %25  %397
+%400 = OpULessThan  %162  %83 %399
+%401 = OpAll  %155  %400
+OpSelectionMerge %402 None
+OpBranchConditional %401 %403 %402
+%403 = OpLabel
+OpImageWrite %397 %83 %398
+OpBranch %402
+%402 = OpLabel
+%404 = OpAccessChain  %395  %40 %78
+%405 = OpLoad  %16  %404
+%406 = OpLoad  %22  %58
+%407 = OpImageQuerySize  %25  %405
+%408 = OpULessThan  %162  %83 %407
+%409 = OpAll  %155  %408
+OpSelectionMerge %410 None
+OpBranchConditional %409 %411 %410
+%411 = OpLabel
+OpImageWrite %405 %83 %406
+OpBranch %410
+%410 = OpLabel
+%412 = OpAccessChain  %395  %40 %79
+%413 = OpLoad  %16  %412
+%414 = OpLoad  %22  %58
+%415 = OpImageQuerySize  %25  %413
+%416 = OpULessThan  %162  %83 %415
+%417 = OpAll  %155  %416
+OpSelectionMerge %418 None
+OpBranchConditional %417 %419 %418
+%419 = OpLabel
+OpImageWrite %413 %83 %414
+OpBranch %418
+%418 = OpLabel
+%420 = OpLoad  %23  %52
+%421 = OpLoad  %3  %49
+%422 = OpCompositeConstruct  %23  %421 %421
+%423 = OpIAdd  %23  %420 %422
+%424 = OpConvertUToF  %24  %423
+%425 = OpLoad  %22  %58
+%426 = OpCompositeExtract  %6  %424 0
+%427 = OpCompositeExtract  %6  %424 1
+%428 = OpCompositeExtract  %6  %424 0
+%429 = OpCompositeExtract  %6  %424 1
+%430 = OpCompositeConstruct  %22  %426 %427 %428 %429
+%431 = OpFAdd  %22  %425 %430
+%432 = OpLoad  %6  %55
+%433 = OpCompositeConstruct  %22  %432 %432 %432 %432
+%434 = OpFAdd  %22  %431 %433
+OpStore %66 %434
 OpReturn
 OpFunctionEnd

--- a/tests/out/spv/image.spvasm
+++ b/tests/out/spv/image.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 546
+; Bound: 523
 OpCapability Shader
 OpCapability Image1D
 OpCapability Sampled1D
@@ -10,19 +10,19 @@ OpCapability ImageQuery
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %82 "main" %79
-OpEntryPoint GLCompute %172 "depth_load" %170
-OpEntryPoint Vertex %194 "queries" %192
-OpEntryPoint Vertex %259 "levels_queries" %258
-OpEntryPoint Fragment %299 "texture_sample" %298
-OpEntryPoint Fragment %444 "texture_sample_comparison" %442
-OpEntryPoint Fragment %499 "gather" %498
-OpEntryPoint Fragment %534 "depth_no_comparison" %533
+OpEntryPoint GLCompute %171 "depth_load" %169
+OpEntryPoint Vertex %192 "queries" %190
+OpEntryPoint Vertex %244 "levels_queries" %243
+OpEntryPoint Fragment %276 "texture_sample" %275
+OpEntryPoint Fragment %421 "texture_sample_comparison" %419
+OpEntryPoint Fragment %476 "gather" %475
+OpEntryPoint Fragment %511 "depth_no_comparison" %510
 OpExecutionMode %82 LocalSize 16 1 1
-OpExecutionMode %172 LocalSize 16 1 1
-OpExecutionMode %299 OriginUpperLeft
-OpExecutionMode %444 OriginUpperLeft
-OpExecutionMode %499 OriginUpperLeft
-OpExecutionMode %534 OriginUpperLeft
+OpExecutionMode %171 LocalSize 16 1 1
+OpExecutionMode %276 OriginUpperLeft
+OpExecutionMode %421 OriginUpperLeft
+OpExecutionMode %476 OriginUpperLeft
+OpExecutionMode %511 OriginUpperLeft
 OpName %35 "image_mipmapped_src"
 OpName %37 "image_multisampled_src"
 OpName %39 "image_depth_multisampled_src"
@@ -47,16 +47,16 @@ OpName %74 "image_2d_array_depth"
 OpName %76 "image_cube_depth"
 OpName %79 "local_id"
 OpName %82 "main"
-OpName %170 "local_id"
-OpName %172 "depth_load"
-OpName %194 "queries"
-OpName %259 "levels_queries"
-OpName %294 "a"
-OpName %299 "texture_sample"
-OpName %438 "a"
-OpName %444 "texture_sample_comparison"
-OpName %499 "gather"
-OpName %534 "depth_no_comparison"
+OpName %169 "local_id"
+OpName %171 "depth_load"
+OpName %192 "queries"
+OpName %244 "levels_queries"
+OpName %271 "a"
+OpName %276 "texture_sample"
+OpName %415 "a"
+OpName %421 "texture_sample_comparison"
+OpName %476 "gather"
+OpName %511 "depth_no_comparison"
 OpDecorate %35 DescriptorSet 0
 OpDecorate %35 Binding 0
 OpDecorate %37 DescriptorSet 0
@@ -105,13 +105,13 @@ OpDecorate %74 Binding 3
 OpDecorate %76 DescriptorSet 1
 OpDecorate %76 Binding 4
 OpDecorate %79 BuiltIn LocalInvocationId
-OpDecorate %170 BuiltIn LocalInvocationId
-OpDecorate %192 BuiltIn Position
-OpDecorate %258 BuiltIn Position
-OpDecorate %298 Location 0
-OpDecorate %442 Location 0
-OpDecorate %498 Location 0
-OpDecorate %533 Location 0
+OpDecorate %169 BuiltIn LocalInvocationId
+OpDecorate %190 BuiltIn Position
+OpDecorate %243 BuiltIn Position
+OpDecorate %275 Location 0
+OpDecorate %419 Location 0
+OpDecorate %475 Location 0
+OpDecorate %510 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 0
 %3 = OpTypeImage %4 2D 0 0 0 1 Unknown
@@ -193,38 +193,38 @@ OpDecorate %533 Location 0
 %83 = OpTypeFunction %2
 %90 = OpConstant  %14  10
 %91 = OpConstant  %14  20
-%112 = OpTypeVector %14 3
-%170 = OpVariable  %80  Input
-%193 = OpTypePointer Output %25
-%192 = OpVariable  %193  Output
-%203 = OpConstant  %4  0
-%258 = OpVariable  %193  Output
-%295 = OpTypePointer Function %25
-%296 = OpConstantNull  %25
-%298 = OpVariable  %193  Output
-%305 = OpConstant  %7  0.5
-%306 = OpConstant  %7  2.3
-%307 = OpConstant  %7  2.0
-%308 = OpConstant  %14  0
-%313 = OpTypeSampledImage %17
-%318 = OpTypeSampledImage %18
-%339 = OpTypeSampledImage %20
-%400 = OpTypeSampledImage %22
-%439 = OpTypePointer Function %7
-%440 = OpConstantNull  %7
-%443 = OpTypePointer Output %7
-%442 = OpVariable  %443  Output
-%452 = OpTypeSampledImage %29
-%457 = OpTypeSampledImage %30
-%470 = OpTypeSampledImage %31
-%477 = OpConstant  %7  0.0
-%498 = OpVariable  %193  Output
-%510 = OpConstant  %4  1
-%513 = OpConstant  %4  3
-%518 = OpTypeSampledImage %3
-%521 = OpTypeVector %14 4
-%522 = OpTypeSampledImage %19
-%533 = OpVariable  %193  Output
+%111 = OpTypeVector %14 3
+%169 = OpVariable  %80  Input
+%191 = OpTypePointer Output %25
+%190 = OpVariable  %191  Output
+%201 = OpConstant  %4  0
+%243 = OpVariable  %191  Output
+%272 = OpTypePointer Function %25
+%273 = OpConstantNull  %25
+%275 = OpVariable  %191  Output
+%282 = OpConstant  %7  0.5
+%283 = OpConstant  %7  2.3
+%284 = OpConstant  %7  2.0
+%285 = OpConstant  %14  0
+%290 = OpTypeSampledImage %17
+%295 = OpTypeSampledImage %18
+%316 = OpTypeSampledImage %20
+%377 = OpTypeSampledImage %22
+%416 = OpTypePointer Function %7
+%417 = OpConstantNull  %7
+%420 = OpTypePointer Output %7
+%419 = OpVariable  %420  Output
+%429 = OpTypeSampledImage %29
+%434 = OpTypeSampledImage %30
+%447 = OpTypeSampledImage %31
+%454 = OpConstant  %7  0.0
+%475 = OpVariable  %191  Output
+%487 = OpConstant  %4  1
+%490 = OpConstant  %4  3
+%495 = OpTypeSampledImage %3
+%498 = OpTypeVector %14 4
+%499 = OpTypeSampledImage %19
+%510 = OpVariable  %191  Output
 %82 = OpFunction  %2  None %83
 %78 = OpLabel
 %81 = OpLoad  %12  %79
@@ -236,485 +236,462 @@ OpDecorate %533 Location 0
 %89 = OpLoad  %10  %49
 OpBranch %92
 %92 = OpLabel
-%93 = OpImageQuerySize  %13  %86
-%94 = OpBitcast  %15  %93
-%95 = OpVectorShuffle  %15  %81 %81 0 1
-%96 = OpIMul  %15  %94 %95
-%97 = OpBitcast  %13  %96
-%98 = OpCompositeConstruct  %13  %90 %91
-%99 = OpSRem  %13  %97 %98
-%100 = OpCompositeExtract  %4  %81 2
-%101 = OpBitcast  %14  %100
-%102 = OpImageFetch  %16  %84 %99 Lod %101
-%103 = OpCompositeExtract  %4  %81 2
-%104 = OpBitcast  %14  %103
-%105 = OpImageFetch  %16  %85 %99 Sample %104
-%106 = OpImageRead  %16  %86 %99
+%93 = OpImageQuerySize  %15  %86
+%94 = OpVectorShuffle  %15  %81 %81 0 1
+%95 = OpIMul  %15  %93 %94
+%96 = OpBitcast  %13  %95
+%97 = OpCompositeConstruct  %13  %90 %91
+%98 = OpSRem  %13  %96 %97
+%99 = OpCompositeExtract  %4  %81 2
+%100 = OpBitcast  %14  %99
+%101 = OpImageFetch  %16  %84 %98 Lod %100
+%102 = OpCompositeExtract  %4  %81 2
+%103 = OpBitcast  %14  %102
+%104 = OpImageFetch  %16  %85 %98 Sample %103
+%105 = OpImageRead  %16  %86 %98
+%106 = OpCompositeExtract  %4  %81 2
 %107 = OpCompositeExtract  %4  %81 2
-%108 = OpCompositeExtract  %4  %81 2
-%109 = OpBitcast  %14  %108
-%110 = OpIAdd  %14  %109 %33
-%111 = OpBitcast  %14  %107
-%113 = OpCompositeConstruct  %112  %99 %111
-%114 = OpImageFetch  %16  %87 %113 Lod %110
-%115 = OpCompositeExtract  %4  %81 2
-%116 = OpBitcast  %14  %115
-%117 = OpCompositeExtract  %4  %81 2
-%118 = OpBitcast  %14  %117
-%119 = OpIAdd  %14  %118 %33
-%120 = OpCompositeConstruct  %112  %99 %116
-%121 = OpImageFetch  %16  %87 %120 Lod %119
-%122 = OpCompositeExtract  %4  %81 0
-%123 = OpBitcast  %14  %122
-%124 = OpCompositeExtract  %4  %81 2
-%125 = OpBitcast  %14  %124
-%126 = OpImageFetch  %16  %88 %123 Lod %125
-%127 = OpBitcast  %15  %99
-%128 = OpCompositeExtract  %4  %81 2
-%129 = OpBitcast  %14  %128
-%130 = OpImageFetch  %16  %84 %127 Lod %129
-%131 = OpBitcast  %15  %99
-%132 = OpCompositeExtract  %4  %81 2
-%133 = OpBitcast  %14  %132
-%134 = OpImageFetch  %16  %85 %131 Sample %133
-%135 = OpBitcast  %15  %99
-%136 = OpImageRead  %16  %86 %135
-%137 = OpBitcast  %15  %99
+%108 = OpBitcast  %14  %107
+%109 = OpIAdd  %14  %108 %33
+%110 = OpBitcast  %14  %106
+%112 = OpCompositeConstruct  %111  %98 %110
+%113 = OpImageFetch  %16  %87 %112 Lod %109
+%114 = OpCompositeExtract  %4  %81 2
+%115 = OpBitcast  %14  %114
+%116 = OpCompositeExtract  %4  %81 2
+%117 = OpBitcast  %14  %116
+%118 = OpIAdd  %14  %117 %33
+%119 = OpCompositeConstruct  %111  %98 %115
+%120 = OpImageFetch  %16  %87 %119 Lod %118
+%121 = OpCompositeExtract  %4  %81 0
+%122 = OpBitcast  %14  %121
+%123 = OpCompositeExtract  %4  %81 2
+%124 = OpBitcast  %14  %123
+%125 = OpImageFetch  %16  %88 %122 Lod %124
+%126 = OpBitcast  %15  %98
+%127 = OpCompositeExtract  %4  %81 2
+%128 = OpBitcast  %14  %127
+%129 = OpImageFetch  %16  %84 %126 Lod %128
+%130 = OpBitcast  %15  %98
+%131 = OpCompositeExtract  %4  %81 2
+%132 = OpBitcast  %14  %131
+%133 = OpImageFetch  %16  %85 %130 Sample %132
+%134 = OpBitcast  %15  %98
+%135 = OpImageRead  %16  %86 %134
+%136 = OpBitcast  %15  %98
+%137 = OpCompositeExtract  %4  %81 2
 %138 = OpCompositeExtract  %4  %81 2
-%139 = OpCompositeExtract  %4  %81 2
-%140 = OpBitcast  %14  %139
-%141 = OpIAdd  %14  %140 %33
-%142 = OpCompositeConstruct  %12  %137 %138
-%143 = OpImageFetch  %16  %87 %142 Lod %141
-%144 = OpBitcast  %15  %99
-%145 = OpCompositeExtract  %4  %81 2
-%146 = OpBitcast  %14  %145
-%147 = OpCompositeExtract  %4  %81 2
-%148 = OpBitcast  %14  %147
-%149 = OpIAdd  %14  %148 %33
-%150 = OpBitcast  %4  %146
-%151 = OpCompositeConstruct  %12  %144 %150
-%152 = OpImageFetch  %16  %87 %151 Lod %149
-%153 = OpCompositeExtract  %4  %81 0
-%155 = OpCompositeExtract  %4  %81 2
-%156 = OpBitcast  %14  %155
-%157 = OpImageFetch  %16  %88 %153 Lod %156
-%158 = OpCompositeExtract  %14  %99 0
-%159 = OpIAdd  %16  %102 %105
-%160 = OpIAdd  %16  %159 %106
-%161 = OpIAdd  %16  %160 %114
-%162 = OpIAdd  %16  %161 %121
-OpImageWrite %89 %158 %162
-%163 = OpCompositeExtract  %14  %99 0
-%164 = OpBitcast  %4  %163
-%165 = OpIAdd  %16  %130 %134
-%166 = OpIAdd  %16  %165 %136
-%167 = OpIAdd  %16  %166 %143
-%168 = OpIAdd  %16  %167 %152
-OpImageWrite %89 %164 %168
+%139 = OpBitcast  %14  %138
+%140 = OpIAdd  %14  %139 %33
+%141 = OpCompositeConstruct  %12  %136 %137
+%142 = OpImageFetch  %16  %87 %141 Lod %140
+%143 = OpBitcast  %15  %98
+%144 = OpCompositeExtract  %4  %81 2
+%145 = OpBitcast  %14  %144
+%146 = OpCompositeExtract  %4  %81 2
+%147 = OpBitcast  %14  %146
+%148 = OpIAdd  %14  %147 %33
+%149 = OpBitcast  %4  %145
+%150 = OpCompositeConstruct  %12  %143 %149
+%151 = OpImageFetch  %16  %87 %150 Lod %148
+%152 = OpCompositeExtract  %4  %81 0
+%154 = OpCompositeExtract  %4  %81 2
+%155 = OpBitcast  %14  %154
+%156 = OpImageFetch  %16  %88 %152 Lod %155
+%157 = OpCompositeExtract  %14  %98 0
+%158 = OpIAdd  %16  %101 %104
+%159 = OpIAdd  %16  %158 %105
+%160 = OpIAdd  %16  %159 %113
+%161 = OpIAdd  %16  %160 %120
+OpImageWrite %89 %157 %161
+%162 = OpCompositeExtract  %14  %98 0
+%163 = OpBitcast  %4  %162
+%164 = OpIAdd  %16  %129 %133
+%165 = OpIAdd  %16  %164 %135
+%166 = OpIAdd  %16  %165 %142
+%167 = OpIAdd  %16  %166 %151
+OpImageWrite %89 %163 %167
 OpReturn
 OpFunctionEnd
-%172 = OpFunction  %2  None %83
-%169 = OpLabel
-%171 = OpLoad  %12  %170
-%173 = OpLoad  %6  %39
-%174 = OpLoad  %8  %41
-%175 = OpLoad  %10  %49
-OpBranch %176
-%176 = OpLabel
-%177 = OpImageQuerySize  %13  %174
-%178 = OpBitcast  %15  %177
-%179 = OpVectorShuffle  %15  %171 %171 0 1
-%180 = OpIMul  %15  %178 %179
-%181 = OpBitcast  %13  %180
-%182 = OpCompositeConstruct  %13  %90 %91
-%183 = OpSRem  %13  %181 %182
-%184 = OpCompositeExtract  %4  %171 2
-%185 = OpBitcast  %14  %184
-%186 = OpImageFetch  %25  %173 %183 Sample %185
-%187 = OpCompositeExtract  %7  %186 0
-%188 = OpCompositeExtract  %14  %183 0
-%189 = OpConvertFToU  %4  %187
-%190 = OpCompositeConstruct  %16  %189 %189 %189 %189
-OpImageWrite %175 %188 %190
+%171 = OpFunction  %2  None %83
+%168 = OpLabel
+%170 = OpLoad  %12  %169
+%172 = OpLoad  %6  %39
+%173 = OpLoad  %8  %41
+%174 = OpLoad  %10  %49
+OpBranch %175
+%175 = OpLabel
+%176 = OpImageQuerySize  %15  %173
+%177 = OpVectorShuffle  %15  %170 %170 0 1
+%178 = OpIMul  %15  %176 %177
+%179 = OpBitcast  %13  %178
+%180 = OpCompositeConstruct  %13  %90 %91
+%181 = OpSRem  %13  %179 %180
+%182 = OpCompositeExtract  %4  %170 2
+%183 = OpBitcast  %14  %182
+%184 = OpImageFetch  %25  %172 %181 Sample %183
+%185 = OpCompositeExtract  %7  %184 0
+%186 = OpCompositeExtract  %14  %181 0
+%187 = OpConvertFToU  %4  %185
+%188 = OpCompositeConstruct  %16  %187 %187 %187 %187
+OpImageWrite %174 %186 %188
 OpReturn
 OpFunctionEnd
-%194 = OpFunction  %2  None %83
-%191 = OpLabel
-%195 = OpLoad  %17  %51
-%196 = OpLoad  %18  %53
-%197 = OpLoad  %20  %58
-%198 = OpLoad  %21  %60
-%199 = OpLoad  %22  %62
-%200 = OpLoad  %23  %64
-%201 = OpLoad  %24  %66
-OpBranch %202
-%202 = OpLabel
-%204 = OpImageQuerySizeLod  %14  %195 %203
-%205 = OpBitcast  %4  %204
-%206 = OpBitcast  %14  %205
-%207 = OpImageQuerySizeLod  %14  %195 %206
-%208 = OpBitcast  %4  %207
-%209 = OpImageQuerySizeLod  %13  %196 %203
-%210 = OpBitcast  %15  %209
-%211 = OpImageQuerySizeLod  %13  %196 %33
-%212 = OpBitcast  %15  %211
-%213 = OpImageQuerySizeLod  %112  %197 %203
-%214 = OpBitcast  %12  %213
-%215 = OpVectorShuffle  %15  %214 %214 0 1
-%216 = OpImageQuerySizeLod  %112  %197 %33
-%217 = OpBitcast  %12  %216
-%218 = OpVectorShuffle  %15  %217 %217 0 1
-%219 = OpImageQuerySizeLod  %13  %198 %203
-%220 = OpBitcast  %15  %219
-%221 = OpImageQuerySizeLod  %13  %198 %33
-%222 = OpBitcast  %15  %221
-%223 = OpImageQuerySizeLod  %112  %199 %203
-%224 = OpBitcast  %12  %223
-%225 = OpVectorShuffle  %15  %224 %224 0 0
-%226 = OpImageQuerySizeLod  %112  %199 %33
-%227 = OpBitcast  %12  %226
-%228 = OpVectorShuffle  %15  %227 %227 0 0
-%229 = OpImageQuerySizeLod  %112  %200 %203
-%230 = OpBitcast  %12  %229
-%231 = OpImageQuerySizeLod  %112  %200 %33
-%232 = OpBitcast  %12  %231
-%233 = OpImageQuerySize  %13  %201
-%234 = OpBitcast  %15  %233
-%235 = OpCompositeExtract  %4  %210 1
-%236 = OpIAdd  %4  %205 %235
-%237 = OpCompositeExtract  %4  %212 1
-%238 = OpIAdd  %4  %236 %237
-%239 = OpCompositeExtract  %4  %215 1
-%240 = OpIAdd  %4  %238 %239
-%241 = OpCompositeExtract  %4  %218 1
-%242 = OpIAdd  %4  %240 %241
-%243 = OpCompositeExtract  %4  %220 1
-%244 = OpIAdd  %4  %242 %243
-%245 = OpCompositeExtract  %4  %222 1
-%246 = OpIAdd  %4  %244 %245
-%247 = OpCompositeExtract  %4  %225 1
-%248 = OpIAdd  %4  %246 %247
-%249 = OpCompositeExtract  %4  %228 1
-%250 = OpIAdd  %4  %248 %249
-%251 = OpCompositeExtract  %4  %230 2
-%252 = OpIAdd  %4  %250 %251
-%253 = OpCompositeExtract  %4  %232 2
-%254 = OpIAdd  %4  %252 %253
-%255 = OpConvertUToF  %7  %254
-%256 = OpCompositeConstruct  %25  %255 %255 %255 %255
-OpStore %192 %256
+%192 = OpFunction  %2  None %83
+%189 = OpLabel
+%193 = OpLoad  %17  %51
+%194 = OpLoad  %18  %53
+%195 = OpLoad  %20  %58
+%196 = OpLoad  %21  %60
+%197 = OpLoad  %22  %62
+%198 = OpLoad  %23  %64
+%199 = OpLoad  %24  %66
+OpBranch %200
+%200 = OpLabel
+%202 = OpImageQuerySizeLod  %4  %193 %201
+%203 = OpBitcast  %14  %202
+%204 = OpImageQuerySizeLod  %4  %193 %203
+%205 = OpImageQuerySizeLod  %15  %194 %201
+%206 = OpImageQuerySizeLod  %15  %194 %33
+%207 = OpImageQuerySizeLod  %12  %195 %201
+%208 = OpVectorShuffle  %15  %207 %207 0 1
+%209 = OpImageQuerySizeLod  %12  %195 %33
+%210 = OpVectorShuffle  %15  %209 %209 0 1
+%211 = OpImageQuerySizeLod  %15  %196 %201
+%212 = OpImageQuerySizeLod  %15  %196 %33
+%213 = OpImageQuerySizeLod  %12  %197 %201
+%214 = OpVectorShuffle  %15  %213 %213 0 0
+%215 = OpImageQuerySizeLod  %12  %197 %33
+%216 = OpVectorShuffle  %15  %215 %215 0 0
+%217 = OpImageQuerySizeLod  %12  %198 %201
+%218 = OpImageQuerySizeLod  %12  %198 %33
+%219 = OpImageQuerySize  %15  %199
+%220 = OpCompositeExtract  %4  %205 1
+%221 = OpIAdd  %4  %202 %220
+%222 = OpCompositeExtract  %4  %206 1
+%223 = OpIAdd  %4  %221 %222
+%224 = OpCompositeExtract  %4  %208 1
+%225 = OpIAdd  %4  %223 %224
+%226 = OpCompositeExtract  %4  %210 1
+%227 = OpIAdd  %4  %225 %226
+%228 = OpCompositeExtract  %4  %211 1
+%229 = OpIAdd  %4  %227 %228
+%230 = OpCompositeExtract  %4  %212 1
+%231 = OpIAdd  %4  %229 %230
+%232 = OpCompositeExtract  %4  %214 1
+%233 = OpIAdd  %4  %231 %232
+%234 = OpCompositeExtract  %4  %216 1
+%235 = OpIAdd  %4  %233 %234
+%236 = OpCompositeExtract  %4  %217 2
+%237 = OpIAdd  %4  %235 %236
+%238 = OpCompositeExtract  %4  %218 2
+%239 = OpIAdd  %4  %237 %238
+%240 = OpConvertUToF  %7  %239
+%241 = OpCompositeConstruct  %25  %240 %240 %240 %240
+OpStore %190 %241
 OpReturn
 OpFunctionEnd
-%259 = OpFunction  %2  None %83
-%257 = OpLabel
-%260 = OpLoad  %18  %53
-%261 = OpLoad  %20  %58
-%262 = OpLoad  %21  %60
-%263 = OpLoad  %22  %62
-%264 = OpLoad  %23  %64
-%265 = OpLoad  %24  %66
-OpBranch %266
-%266 = OpLabel
-%267 = OpImageQueryLevels  %14  %260
-%268 = OpBitcast  %4  %267
-%269 = OpImageQueryLevels  %14  %261
-%270 = OpBitcast  %4  %269
-%271 = OpImageQuerySizeLod  %112  %261 %203
-%272 = OpCompositeExtract  %14  %271 2
-%273 = OpBitcast  %4  %272
-%274 = OpImageQueryLevels  %14  %262
-%275 = OpBitcast  %4  %274
-%276 = OpImageQueryLevels  %14  %263
-%277 = OpBitcast  %4  %276
-%278 = OpImageQuerySizeLod  %112  %263 %203
-%279 = OpCompositeExtract  %14  %278 2
-%280 = OpBitcast  %4  %279
-%281 = OpImageQueryLevels  %14  %264
-%282 = OpBitcast  %4  %281
-%283 = OpImageQuerySamples  %14  %265
-%284 = OpBitcast  %4  %283
-%285 = OpIAdd  %4  %273 %280
-%286 = OpIAdd  %4  %285 %284
-%287 = OpIAdd  %4  %286 %268
-%288 = OpIAdd  %4  %287 %270
-%289 = OpIAdd  %4  %288 %282
-%290 = OpIAdd  %4  %289 %275
-%291 = OpIAdd  %4  %290 %277
-%292 = OpConvertUToF  %7  %291
-%293 = OpCompositeConstruct  %25  %292 %292 %292 %292
-OpStore %258 %293
+%244 = OpFunction  %2  None %83
+%242 = OpLabel
+%245 = OpLoad  %18  %53
+%246 = OpLoad  %20  %58
+%247 = OpLoad  %21  %60
+%248 = OpLoad  %22  %62
+%249 = OpLoad  %23  %64
+%250 = OpLoad  %24  %66
+OpBranch %251
+%251 = OpLabel
+%252 = OpImageQueryLevels  %4  %245
+%253 = OpImageQueryLevels  %4  %246
+%254 = OpImageQuerySizeLod  %12  %246 %201
+%255 = OpCompositeExtract  %4  %254 2
+%256 = OpImageQueryLevels  %4  %247
+%257 = OpImageQueryLevels  %4  %248
+%258 = OpImageQuerySizeLod  %12  %248 %201
+%259 = OpCompositeExtract  %4  %258 2
+%260 = OpImageQueryLevels  %4  %249
+%261 = OpImageQuerySamples  %4  %250
+%262 = OpIAdd  %4  %255 %259
+%263 = OpIAdd  %4  %262 %261
+%264 = OpIAdd  %4  %263 %252
+%265 = OpIAdd  %4  %264 %253
+%266 = OpIAdd  %4  %265 %260
+%267 = OpIAdd  %4  %266 %256
+%268 = OpIAdd  %4  %267 %257
+%269 = OpConvertUToF  %7  %268
+%270 = OpCompositeConstruct  %25  %269 %269 %269 %269
+OpStore %243 %270
 OpReturn
 OpFunctionEnd
-%299 = OpFunction  %2  None %83
-%297 = OpLabel
-%294 = OpVariable  %295  Function %296
-%300 = OpLoad  %17  %51
-%301 = OpLoad  %18  %53
-%302 = OpLoad  %20  %58
-%303 = OpLoad  %22  %62
-%304 = OpLoad  %26  %68
-OpBranch %309
-%309 = OpLabel
-%310 = OpCompositeConstruct  %27  %305 %305
-%311 = OpCompositeConstruct  %28  %305 %305 %305
-%312 = OpCompositeExtract  %7  %310 0
-%314 = OpSampledImage  %313  %300 %304
-%315 = OpImageSampleImplicitLod  %25  %314 %312
-%316 = OpLoad  %25  %294
-%317 = OpFAdd  %25  %316 %315
-OpStore %294 %317
-%319 = OpSampledImage  %318  %301 %304
-%320 = OpImageSampleImplicitLod  %25  %319 %310
-%321 = OpLoad  %25  %294
+%276 = OpFunction  %2  None %83
+%274 = OpLabel
+%271 = OpVariable  %272  Function %273
+%277 = OpLoad  %17  %51
+%278 = OpLoad  %18  %53
+%279 = OpLoad  %20  %58
+%280 = OpLoad  %22  %62
+%281 = OpLoad  %26  %68
+OpBranch %286
+%286 = OpLabel
+%287 = OpCompositeConstruct  %27  %282 %282
+%288 = OpCompositeConstruct  %28  %282 %282 %282
+%289 = OpCompositeExtract  %7  %287 0
+%291 = OpSampledImage  %290  %277 %281
+%292 = OpImageSampleImplicitLod  %25  %291 %289
+%293 = OpLoad  %25  %271
+%294 = OpFAdd  %25  %293 %292
+OpStore %271 %294
+%296 = OpSampledImage  %295  %278 %281
+%297 = OpImageSampleImplicitLod  %25  %296 %287
+%298 = OpLoad  %25  %271
+%299 = OpFAdd  %25  %298 %297
+OpStore %271 %299
+%300 = OpSampledImage  %295  %278 %281
+%301 = OpImageSampleImplicitLod  %25  %300 %287 ConstOffset %34
+%302 = OpLoad  %25  %271
+%303 = OpFAdd  %25  %302 %301
+OpStore %271 %303
+%304 = OpSampledImage  %295  %278 %281
+%305 = OpImageSampleExplicitLod  %25  %304 %287 Lod %283
+%306 = OpLoad  %25  %271
+%307 = OpFAdd  %25  %306 %305
+OpStore %271 %307
+%308 = OpSampledImage  %295  %278 %281
+%309 = OpImageSampleExplicitLod  %25  %308 %287 Lod|ConstOffset %283 %34
+%310 = OpLoad  %25  %271
+%311 = OpFAdd  %25  %310 %309
+OpStore %271 %311
+%312 = OpSampledImage  %295  %278 %281
+%313 = OpImageSampleImplicitLod  %25  %312 %287 Bias|ConstOffset %284 %34
+%314 = OpLoad  %25  %271
+%315 = OpFAdd  %25  %314 %313
+OpStore %271 %315
+%317 = OpConvertUToF  %7  %201
+%318 = OpCompositeConstruct  %28  %287 %317
+%319 = OpSampledImage  %316  %279 %281
+%320 = OpImageSampleImplicitLod  %25  %319 %318
+%321 = OpLoad  %25  %271
 %322 = OpFAdd  %25  %321 %320
-OpStore %294 %322
-%323 = OpSampledImage  %318  %301 %304
-%324 = OpImageSampleImplicitLod  %25  %323 %310 ConstOffset %34
-%325 = OpLoad  %25  %294
-%326 = OpFAdd  %25  %325 %324
-OpStore %294 %326
-%327 = OpSampledImage  %318  %301 %304
-%328 = OpImageSampleExplicitLod  %25  %327 %310 Lod %306
-%329 = OpLoad  %25  %294
-%330 = OpFAdd  %25  %329 %328
-OpStore %294 %330
-%331 = OpSampledImage  %318  %301 %304
-%332 = OpImageSampleExplicitLod  %25  %331 %310 Lod|ConstOffset %306 %34
-%333 = OpLoad  %25  %294
+OpStore %271 %322
+%323 = OpConvertUToF  %7  %201
+%324 = OpCompositeConstruct  %28  %287 %323
+%325 = OpSampledImage  %316  %279 %281
+%326 = OpImageSampleImplicitLod  %25  %325 %324 ConstOffset %34
+%327 = OpLoad  %25  %271
+%328 = OpFAdd  %25  %327 %326
+OpStore %271 %328
+%329 = OpConvertUToF  %7  %201
+%330 = OpCompositeConstruct  %28  %287 %329
+%331 = OpSampledImage  %316  %279 %281
+%332 = OpImageSampleExplicitLod  %25  %331 %330 Lod %283
+%333 = OpLoad  %25  %271
 %334 = OpFAdd  %25  %333 %332
-OpStore %294 %334
-%335 = OpSampledImage  %318  %301 %304
-%336 = OpImageSampleImplicitLod  %25  %335 %310 Bias|ConstOffset %307 %34
-%337 = OpLoad  %25  %294
-%338 = OpFAdd  %25  %337 %336
-OpStore %294 %338
-%340 = OpConvertUToF  %7  %203
-%341 = OpCompositeConstruct  %28  %310 %340
-%342 = OpSampledImage  %339  %302 %304
-%343 = OpImageSampleImplicitLod  %25  %342 %341
-%344 = OpLoad  %25  %294
-%345 = OpFAdd  %25  %344 %343
-OpStore %294 %345
-%346 = OpConvertUToF  %7  %203
-%347 = OpCompositeConstruct  %28  %310 %346
-%348 = OpSampledImage  %339  %302 %304
-%349 = OpImageSampleImplicitLod  %25  %348 %347 ConstOffset %34
-%350 = OpLoad  %25  %294
-%351 = OpFAdd  %25  %350 %349
-OpStore %294 %351
-%352 = OpConvertUToF  %7  %203
-%353 = OpCompositeConstruct  %28  %310 %352
-%354 = OpSampledImage  %339  %302 %304
-%355 = OpImageSampleExplicitLod  %25  %354 %353 Lod %306
-%356 = OpLoad  %25  %294
-%357 = OpFAdd  %25  %356 %355
-OpStore %294 %357
-%358 = OpConvertUToF  %7  %203
-%359 = OpCompositeConstruct  %28  %310 %358
-%360 = OpSampledImage  %339  %302 %304
-%361 = OpImageSampleExplicitLod  %25  %360 %359 Lod|ConstOffset %306 %34
-%362 = OpLoad  %25  %294
-%363 = OpFAdd  %25  %362 %361
-OpStore %294 %363
-%364 = OpConvertUToF  %7  %203
-%365 = OpCompositeConstruct  %28  %310 %364
-%366 = OpSampledImage  %339  %302 %304
-%367 = OpImageSampleImplicitLod  %25  %366 %365 Bias|ConstOffset %307 %34
-%368 = OpLoad  %25  %294
-%369 = OpFAdd  %25  %368 %367
-OpStore %294 %369
-%370 = OpConvertSToF  %7  %308
-%371 = OpCompositeConstruct  %28  %310 %370
-%372 = OpSampledImage  %339  %302 %304
-%373 = OpImageSampleImplicitLod  %25  %372 %371
-%374 = OpLoad  %25  %294
-%375 = OpFAdd  %25  %374 %373
-OpStore %294 %375
-%376 = OpConvertSToF  %7  %308
-%377 = OpCompositeConstruct  %28  %310 %376
-%378 = OpSampledImage  %339  %302 %304
-%379 = OpImageSampleImplicitLod  %25  %378 %377 ConstOffset %34
-%380 = OpLoad  %25  %294
-%381 = OpFAdd  %25  %380 %379
-OpStore %294 %381
-%382 = OpConvertSToF  %7  %308
-%383 = OpCompositeConstruct  %28  %310 %382
-%384 = OpSampledImage  %339  %302 %304
-%385 = OpImageSampleExplicitLod  %25  %384 %383 Lod %306
-%386 = OpLoad  %25  %294
-%387 = OpFAdd  %25  %386 %385
-OpStore %294 %387
-%388 = OpConvertSToF  %7  %308
-%389 = OpCompositeConstruct  %28  %310 %388
-%390 = OpSampledImage  %339  %302 %304
-%391 = OpImageSampleExplicitLod  %25  %390 %389 Lod|ConstOffset %306 %34
-%392 = OpLoad  %25  %294
-%393 = OpFAdd  %25  %392 %391
-OpStore %294 %393
-%394 = OpConvertSToF  %7  %308
-%395 = OpCompositeConstruct  %28  %310 %394
-%396 = OpSampledImage  %339  %302 %304
-%397 = OpImageSampleImplicitLod  %25  %396 %395 Bias|ConstOffset %307 %34
-%398 = OpLoad  %25  %294
-%399 = OpFAdd  %25  %398 %397
-OpStore %294 %399
-%401 = OpConvertUToF  %7  %203
-%402 = OpCompositeConstruct  %25  %311 %401
-%403 = OpSampledImage  %400  %303 %304
-%404 = OpImageSampleImplicitLod  %25  %403 %402
-%405 = OpLoad  %25  %294
-%406 = OpFAdd  %25  %405 %404
-OpStore %294 %406
-%407 = OpConvertUToF  %7  %203
-%408 = OpCompositeConstruct  %25  %311 %407
-%409 = OpSampledImage  %400  %303 %304
-%410 = OpImageSampleExplicitLod  %25  %409 %408 Lod %306
-%411 = OpLoad  %25  %294
-%412 = OpFAdd  %25  %411 %410
-OpStore %294 %412
-%413 = OpConvertUToF  %7  %203
-%414 = OpCompositeConstruct  %25  %311 %413
-%415 = OpSampledImage  %400  %303 %304
-%416 = OpImageSampleImplicitLod  %25  %415 %414 Bias %307
-%417 = OpLoad  %25  %294
-%418 = OpFAdd  %25  %417 %416
-OpStore %294 %418
-%419 = OpConvertSToF  %7  %308
-%420 = OpCompositeConstruct  %25  %311 %419
-%421 = OpSampledImage  %400  %303 %304
-%422 = OpImageSampleImplicitLod  %25  %421 %420
-%423 = OpLoad  %25  %294
-%424 = OpFAdd  %25  %423 %422
-OpStore %294 %424
-%425 = OpConvertSToF  %7  %308
-%426 = OpCompositeConstruct  %25  %311 %425
-%427 = OpSampledImage  %400  %303 %304
-%428 = OpImageSampleExplicitLod  %25  %427 %426 Lod %306
-%429 = OpLoad  %25  %294
-%430 = OpFAdd  %25  %429 %428
-OpStore %294 %430
-%431 = OpConvertSToF  %7  %308
-%432 = OpCompositeConstruct  %25  %311 %431
-%433 = OpSampledImage  %400  %303 %304
-%434 = OpImageSampleImplicitLod  %25  %433 %432 Bias %307
-%435 = OpLoad  %25  %294
-%436 = OpFAdd  %25  %435 %434
-OpStore %294 %436
-%437 = OpLoad  %25  %294
-OpStore %298 %437
+OpStore %271 %334
+%335 = OpConvertUToF  %7  %201
+%336 = OpCompositeConstruct  %28  %287 %335
+%337 = OpSampledImage  %316  %279 %281
+%338 = OpImageSampleExplicitLod  %25  %337 %336 Lod|ConstOffset %283 %34
+%339 = OpLoad  %25  %271
+%340 = OpFAdd  %25  %339 %338
+OpStore %271 %340
+%341 = OpConvertUToF  %7  %201
+%342 = OpCompositeConstruct  %28  %287 %341
+%343 = OpSampledImage  %316  %279 %281
+%344 = OpImageSampleImplicitLod  %25  %343 %342 Bias|ConstOffset %284 %34
+%345 = OpLoad  %25  %271
+%346 = OpFAdd  %25  %345 %344
+OpStore %271 %346
+%347 = OpConvertSToF  %7  %285
+%348 = OpCompositeConstruct  %28  %287 %347
+%349 = OpSampledImage  %316  %279 %281
+%350 = OpImageSampleImplicitLod  %25  %349 %348
+%351 = OpLoad  %25  %271
+%352 = OpFAdd  %25  %351 %350
+OpStore %271 %352
+%353 = OpConvertSToF  %7  %285
+%354 = OpCompositeConstruct  %28  %287 %353
+%355 = OpSampledImage  %316  %279 %281
+%356 = OpImageSampleImplicitLod  %25  %355 %354 ConstOffset %34
+%357 = OpLoad  %25  %271
+%358 = OpFAdd  %25  %357 %356
+OpStore %271 %358
+%359 = OpConvertSToF  %7  %285
+%360 = OpCompositeConstruct  %28  %287 %359
+%361 = OpSampledImage  %316  %279 %281
+%362 = OpImageSampleExplicitLod  %25  %361 %360 Lod %283
+%363 = OpLoad  %25  %271
+%364 = OpFAdd  %25  %363 %362
+OpStore %271 %364
+%365 = OpConvertSToF  %7  %285
+%366 = OpCompositeConstruct  %28  %287 %365
+%367 = OpSampledImage  %316  %279 %281
+%368 = OpImageSampleExplicitLod  %25  %367 %366 Lod|ConstOffset %283 %34
+%369 = OpLoad  %25  %271
+%370 = OpFAdd  %25  %369 %368
+OpStore %271 %370
+%371 = OpConvertSToF  %7  %285
+%372 = OpCompositeConstruct  %28  %287 %371
+%373 = OpSampledImage  %316  %279 %281
+%374 = OpImageSampleImplicitLod  %25  %373 %372 Bias|ConstOffset %284 %34
+%375 = OpLoad  %25  %271
+%376 = OpFAdd  %25  %375 %374
+OpStore %271 %376
+%378 = OpConvertUToF  %7  %201
+%379 = OpCompositeConstruct  %25  %288 %378
+%380 = OpSampledImage  %377  %280 %281
+%381 = OpImageSampleImplicitLod  %25  %380 %379
+%382 = OpLoad  %25  %271
+%383 = OpFAdd  %25  %382 %381
+OpStore %271 %383
+%384 = OpConvertUToF  %7  %201
+%385 = OpCompositeConstruct  %25  %288 %384
+%386 = OpSampledImage  %377  %280 %281
+%387 = OpImageSampleExplicitLod  %25  %386 %385 Lod %283
+%388 = OpLoad  %25  %271
+%389 = OpFAdd  %25  %388 %387
+OpStore %271 %389
+%390 = OpConvertUToF  %7  %201
+%391 = OpCompositeConstruct  %25  %288 %390
+%392 = OpSampledImage  %377  %280 %281
+%393 = OpImageSampleImplicitLod  %25  %392 %391 Bias %284
+%394 = OpLoad  %25  %271
+%395 = OpFAdd  %25  %394 %393
+OpStore %271 %395
+%396 = OpConvertSToF  %7  %285
+%397 = OpCompositeConstruct  %25  %288 %396
+%398 = OpSampledImage  %377  %280 %281
+%399 = OpImageSampleImplicitLod  %25  %398 %397
+%400 = OpLoad  %25  %271
+%401 = OpFAdd  %25  %400 %399
+OpStore %271 %401
+%402 = OpConvertSToF  %7  %285
+%403 = OpCompositeConstruct  %25  %288 %402
+%404 = OpSampledImage  %377  %280 %281
+%405 = OpImageSampleExplicitLod  %25  %404 %403 Lod %283
+%406 = OpLoad  %25  %271
+%407 = OpFAdd  %25  %406 %405
+OpStore %271 %407
+%408 = OpConvertSToF  %7  %285
+%409 = OpCompositeConstruct  %25  %288 %408
+%410 = OpSampledImage  %377  %280 %281
+%411 = OpImageSampleImplicitLod  %25  %410 %409 Bias %284
+%412 = OpLoad  %25  %271
+%413 = OpFAdd  %25  %412 %411
+OpStore %271 %413
+%414 = OpLoad  %25  %271
+OpStore %275 %414
 OpReturn
 OpFunctionEnd
-%444 = OpFunction  %2  None %83
-%441 = OpLabel
-%438 = OpVariable  %439  Function %440
-%445 = OpLoad  %26  %70
-%446 = OpLoad  %29  %72
-%447 = OpLoad  %30  %74
-%448 = OpLoad  %31  %76
-OpBranch %449
-%449 = OpLabel
-%450 = OpCompositeConstruct  %27  %305 %305
-%451 = OpCompositeConstruct  %28  %305 %305 %305
-%453 = OpSampledImage  %452  %446 %445
-%454 = OpImageSampleDrefImplicitLod  %7  %453 %450 %305
-%455 = OpLoad  %7  %438
-%456 = OpFAdd  %7  %455 %454
-OpStore %438 %456
-%458 = OpConvertUToF  %7  %203
-%459 = OpCompositeConstruct  %28  %450 %458
-%460 = OpSampledImage  %457  %447 %445
-%461 = OpImageSampleDrefImplicitLod  %7  %460 %459 %305
-%462 = OpLoad  %7  %438
-%463 = OpFAdd  %7  %462 %461
-OpStore %438 %463
-%464 = OpConvertSToF  %7  %308
-%465 = OpCompositeConstruct  %28  %450 %464
-%466 = OpSampledImage  %457  %447 %445
-%467 = OpImageSampleDrefImplicitLod  %7  %466 %465 %305
-%468 = OpLoad  %7  %438
-%469 = OpFAdd  %7  %468 %467
-OpStore %438 %469
-%471 = OpSampledImage  %470  %448 %445
-%472 = OpImageSampleDrefImplicitLod  %7  %471 %451 %305
-%473 = OpLoad  %7  %438
-%474 = OpFAdd  %7  %473 %472
-OpStore %438 %474
-%475 = OpSampledImage  %452  %446 %445
-%476 = OpImageSampleDrefExplicitLod  %7  %475 %450 %305 Lod %477
-%478 = OpLoad  %7  %438
-%479 = OpFAdd  %7  %478 %476
-OpStore %438 %479
-%480 = OpConvertUToF  %7  %203
-%481 = OpCompositeConstruct  %28  %450 %480
-%482 = OpSampledImage  %457  %447 %445
-%483 = OpImageSampleDrefExplicitLod  %7  %482 %481 %305 Lod %477
-%484 = OpLoad  %7  %438
-%485 = OpFAdd  %7  %484 %483
-OpStore %438 %485
-%486 = OpConvertSToF  %7  %308
-%487 = OpCompositeConstruct  %28  %450 %486
-%488 = OpSampledImage  %457  %447 %445
-%489 = OpImageSampleDrefExplicitLod  %7  %488 %487 %305 Lod %477
-%490 = OpLoad  %7  %438
-%491 = OpFAdd  %7  %490 %489
-OpStore %438 %491
-%492 = OpSampledImage  %470  %448 %445
-%493 = OpImageSampleDrefExplicitLod  %7  %492 %451 %305 Lod %477
-%494 = OpLoad  %7  %438
-%495 = OpFAdd  %7  %494 %493
-OpStore %438 %495
-%496 = OpLoad  %7  %438
-OpStore %442 %496
+%421 = OpFunction  %2  None %83
+%418 = OpLabel
+%415 = OpVariable  %416  Function %417
+%422 = OpLoad  %26  %70
+%423 = OpLoad  %29  %72
+%424 = OpLoad  %30  %74
+%425 = OpLoad  %31  %76
+OpBranch %426
+%426 = OpLabel
+%427 = OpCompositeConstruct  %27  %282 %282
+%428 = OpCompositeConstruct  %28  %282 %282 %282
+%430 = OpSampledImage  %429  %423 %422
+%431 = OpImageSampleDrefImplicitLod  %7  %430 %427 %282
+%432 = OpLoad  %7  %415
+%433 = OpFAdd  %7  %432 %431
+OpStore %415 %433
+%435 = OpConvertUToF  %7  %201
+%436 = OpCompositeConstruct  %28  %427 %435
+%437 = OpSampledImage  %434  %424 %422
+%438 = OpImageSampleDrefImplicitLod  %7  %437 %436 %282
+%439 = OpLoad  %7  %415
+%440 = OpFAdd  %7  %439 %438
+OpStore %415 %440
+%441 = OpConvertSToF  %7  %285
+%442 = OpCompositeConstruct  %28  %427 %441
+%443 = OpSampledImage  %434  %424 %422
+%444 = OpImageSampleDrefImplicitLod  %7  %443 %442 %282
+%445 = OpLoad  %7  %415
+%446 = OpFAdd  %7  %445 %444
+OpStore %415 %446
+%448 = OpSampledImage  %447  %425 %422
+%449 = OpImageSampleDrefImplicitLod  %7  %448 %428 %282
+%450 = OpLoad  %7  %415
+%451 = OpFAdd  %7  %450 %449
+OpStore %415 %451
+%452 = OpSampledImage  %429  %423 %422
+%453 = OpImageSampleDrefExplicitLod  %7  %452 %427 %282 Lod %454
+%455 = OpLoad  %7  %415
+%456 = OpFAdd  %7  %455 %453
+OpStore %415 %456
+%457 = OpConvertUToF  %7  %201
+%458 = OpCompositeConstruct  %28  %427 %457
+%459 = OpSampledImage  %434  %424 %422
+%460 = OpImageSampleDrefExplicitLod  %7  %459 %458 %282 Lod %454
+%461 = OpLoad  %7  %415
+%462 = OpFAdd  %7  %461 %460
+OpStore %415 %462
+%463 = OpConvertSToF  %7  %285
+%464 = OpCompositeConstruct  %28  %427 %463
+%465 = OpSampledImage  %434  %424 %422
+%466 = OpImageSampleDrefExplicitLod  %7  %465 %464 %282 Lod %454
+%467 = OpLoad  %7  %415
+%468 = OpFAdd  %7  %467 %466
+OpStore %415 %468
+%469 = OpSampledImage  %447  %425 %422
+%470 = OpImageSampleDrefExplicitLod  %7  %469 %428 %282 Lod %454
+%471 = OpLoad  %7  %415
+%472 = OpFAdd  %7  %471 %470
+OpStore %415 %472
+%473 = OpLoad  %7  %415
+OpStore %419 %473
 OpReturn
 OpFunctionEnd
-%499 = OpFunction  %2  None %83
-%497 = OpLabel
-%500 = OpLoad  %18  %53
-%501 = OpLoad  %3  %55
-%502 = OpLoad  %19  %56
-%503 = OpLoad  %26  %68
-%504 = OpLoad  %26  %70
-%505 = OpLoad  %29  %72
-OpBranch %506
-%506 = OpLabel
-%507 = OpCompositeConstruct  %27  %305 %305
-%508 = OpSampledImage  %318  %500 %503
-%509 = OpImageGather  %25  %508 %507 %510
-%511 = OpSampledImage  %318  %500 %503
-%512 = OpImageGather  %25  %511 %507 %513 ConstOffset %34
-%514 = OpSampledImage  %452  %505 %504
-%515 = OpImageDrefGather  %25  %514 %507 %305
-%516 = OpSampledImage  %452  %505 %504
-%517 = OpImageDrefGather  %25  %516 %507 %305 ConstOffset %34
-%519 = OpSampledImage  %518  %501 %503
-%520 = OpImageGather  %16  %519 %507 %203
-%523 = OpSampledImage  %522  %502 %503
-%524 = OpImageGather  %521  %523 %507 %203
-%525 = OpConvertUToF  %25  %520
-%526 = OpConvertSToF  %25  %524
-%527 = OpFAdd  %25  %525 %526
-%528 = OpFAdd  %25  %509 %512
-%529 = OpFAdd  %25  %528 %515
-%530 = OpFAdd  %25  %529 %517
-%531 = OpFAdd  %25  %530 %527
-OpStore %498 %531
+%476 = OpFunction  %2  None %83
+%474 = OpLabel
+%477 = OpLoad  %18  %53
+%478 = OpLoad  %3  %55
+%479 = OpLoad  %19  %56
+%480 = OpLoad  %26  %68
+%481 = OpLoad  %26  %70
+%482 = OpLoad  %29  %72
+OpBranch %483
+%483 = OpLabel
+%484 = OpCompositeConstruct  %27  %282 %282
+%485 = OpSampledImage  %295  %477 %480
+%486 = OpImageGather  %25  %485 %484 %487
+%488 = OpSampledImage  %295  %477 %480
+%489 = OpImageGather  %25  %488 %484 %490 ConstOffset %34
+%491 = OpSampledImage  %429  %482 %481
+%492 = OpImageDrefGather  %25  %491 %484 %282
+%493 = OpSampledImage  %429  %482 %481
+%494 = OpImageDrefGather  %25  %493 %484 %282 ConstOffset %34
+%496 = OpSampledImage  %495  %478 %480
+%497 = OpImageGather  %16  %496 %484 %201
+%500 = OpSampledImage  %499  %479 %480
+%501 = OpImageGather  %498  %500 %484 %201
+%502 = OpConvertUToF  %25  %497
+%503 = OpConvertSToF  %25  %501
+%504 = OpFAdd  %25  %502 %503
+%505 = OpFAdd  %25  %486 %489
+%506 = OpFAdd  %25  %505 %492
+%507 = OpFAdd  %25  %506 %494
+%508 = OpFAdd  %25  %507 %504
+OpStore %475 %508
 OpReturn
 OpFunctionEnd
-%534 = OpFunction  %2  None %83
-%532 = OpLabel
-%535 = OpLoad  %26  %68
-%536 = OpLoad  %29  %72
-OpBranch %537
-%537 = OpLabel
-%538 = OpCompositeConstruct  %27  %305 %305
-%539 = OpSampledImage  %452  %536 %535
-%540 = OpImageSampleImplicitLod  %25  %539 %538
-%541 = OpCompositeExtract  %7  %540 0
-%542 = OpSampledImage  %452  %536 %535
-%543 = OpImageGather  %25  %542 %538 %203
-%544 = OpCompositeConstruct  %25  %541 %541 %541 %541
-%545 = OpFAdd  %25  %544 %543
-OpStore %533 %545
+%511 = OpFunction  %2  None %83
+%509 = OpLabel
+%512 = OpLoad  %26  %68
+%513 = OpLoad  %29  %72
+OpBranch %514
+%514 = OpLabel
+%515 = OpCompositeConstruct  %27  %282 %282
+%516 = OpSampledImage  %429  %513 %512
+%517 = OpImageSampleImplicitLod  %25  %516 %515
+%518 = OpCompositeExtract  %7  %517 0
+%519 = OpSampledImage  %429  %513 %512
+%520 = OpImageGather  %25  %519 %515 %201
+%521 = OpCompositeConstruct  %25  %518 %518 %518 %518
+%522 = OpFAdd  %25  %521 %520
+OpStore %510 %522
 OpReturn
 OpFunctionEnd


### PR DESCRIPTION
This pull request conditionally casts Sints in OpImageQuery functions where previously it was assumed to always be Sint and simplifies the backend by removing unneeded casts.

fixes https://github.com/gfx-rs/naga/issues/2354