### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "naga"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Naga Developers"]
 edition = "2021"
 description = "Shader translation infrastructure"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,14 +66,14 @@ unicode-xid = { version = "0.2.3", optional = true }
 
 [dev-dependencies]
 bincode = "1"
-criterion = { version = "0.3", features = [] }
+criterion = { version = "0.5", features = [] }
 diff = "0.1"
-env_logger = "0.9"
+env_logger = "0.10"
 hlsl-snapshots = { path = "./hlsl-snapshots"}
 # Require at least version 0.7.1 of ron, this version changed how floating points are
 # serialized by forcing them to always have the decimal part, this makes it backwards
 # incompatible with our tests because we do a syntatic diff and not a semantic one.
-ron = "~0.7.1"
+ron = "0.8.0"
 rspirv = { version = "0.11", git = "https://github.com/gfx-rs/rspirv", rev = "b969f175d5663258b4891e44b76c1544da9661ab" }
 serde = { version = "1.0", features = ["derive"] }
 spirv = { version = "0.2", features = ["deserialize"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "naga-cli"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Naga Developers"]
 edition = "2021"
 description = "Shader translation command line tool"
@@ -10,7 +10,7 @@ keywords = ["shader", "SPIR-V", "GLSL", "MSL"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-naga = { version = "0.12", path = "../", features = ["validate", "span", "wgsl-in", "wgsl-out", "glsl-in", "glsl-out", "spv-in", "spv-out", "msl-out", "hlsl-out", "dot-out", "serialize", "deserialize"] }
+naga = { version = "0.13", path = "../", features = ["validate", "span", "wgsl-in", "wgsl-out", "glsl-in", "glsl-out", "spv-in", "spv-out", "msl-out", "hlsl-out", "dot-out", "serialize", "deserialize"] }
 bincode = "1"
 log = "0.4"
 codespan-reporting = "0.11"


### PR DESCRIPTION
Bumps various dependencies ahead of release.

**This also bumps MSRV from 1.63 to 1.64 after indexmap bumped their MSRV**