### PR TITLE
Validate storage buffer access

### DIFF
--- a/tests/in/glsl/buffer.frag
+++ b/tests/in/glsl/buffer.frag
@@ -4,10 +4,6 @@ layout(set = 0, binding = 0) buffer testBufferBlock {
     uint[] data;
 } testBuffer;
 
-layout(set = 0, binding = 1) writeonly buffer testBufferWriteOnlyBlock {
-    uint[] data;
-} testBufferWriteOnly;
-
 layout(set = 0, binding = 2) readonly buffer testBufferReadOnlyBlock {
     uint[] data;
 } testBufferReadOnly;
@@ -15,8 +11,6 @@ layout(set = 0, binding = 2) readonly buffer testBufferReadOnlyBlock {
 void main() {
     uint a = testBuffer.data[0];
     testBuffer.data[1] = 2;
-
-    testBufferWriteOnly.data[1] = 2;
 
     uint b = testBufferReadOnly.data[0];
 }

--- a/tests/out/wgsl/buffer-frag.wgsl
+++ b/tests/out/wgsl/buffer-frag.wgsl
@@ -2,18 +2,12 @@ struct testBufferBlock {
     data: array<u32>,
 }
 
-struct testBufferWriteOnlyBlock {
-    data: array<u32>,
-}
-
 struct testBufferReadOnlyBlock {
     data: array<u32>,
 }
 
 @group(0) @binding(0) 
 var<storage, read_write> testBuffer: testBufferBlock;
-@group(0) @binding(1) 
-var<storage, read_write> testBufferWriteOnly: testBufferWriteOnlyBlock;
 @group(0) @binding(2) 
 var<storage> testBufferReadOnly: testBufferReadOnlyBlock;
 
@@ -21,12 +15,11 @@ fn main_1() {
     var a: u32;
     var b: u32;
 
-    let _e12 = testBuffer.data[0];
-    a = _e12;
+    let _e9 = testBuffer.data[0];
+    a = _e9;
     testBuffer.data[1] = u32(2);
-    testBufferWriteOnly.data[1] = u32(2);
-    let _e27 = testBufferReadOnly.data[0];
-    b = _e27;
+    let _e19 = testBufferReadOnly.data[0];
+    b = _e19;
     return;
 }
 


### PR DESCRIPTION
Storage buffers only support `read` or `read_write` access modes (not `write`).

Related: https://github.com/gfx-rs/naga/issues/2160, https://github.com/gfx-rs/wgpu/pull/3984