### PR TITLE
derive PartialEq on Expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ wgsl-out = []
 hlsl-out = []
 span = ["codespan-reporting", "termcolor"]
 validate = []
-expression-eq = []
 
 [[bench]]
 name = "criterion"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ wgsl-out = []
 hlsl-out = []
 span = ["codespan-reporting", "termcolor"]
 validate = []
+expression-eq = []
 
 [[bench]]
 name = "criterion"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1263,8 +1263,7 @@ bitflags::bitflags! {
 /// An expression that can be evaluated to obtain a value.
 ///
 /// This is a Single Static Assignment (SSA) scheme similar to SPIR-V.
-#[derive(Clone, Debug)]
-#[cfg_attr(any(feature = "expression-eq", test), derive(PartialEq))]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1264,7 +1264,7 @@ bitflags::bitflags! {
 ///
 /// This is a Single Static Assignment (SSA) scheme similar to SPIR-V.
 #[derive(Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(feature = "expression-eq", test), derive(PartialEq))]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]


### PR DESCRIPTION
in updating `naga_oil` i found i needed to have the `const_expressions` arena contain only unique expressions. this is needed because the equality test for `Const`s and `GlobalVariable`s does not inspect the `init` field, it just compares handles, so otherwise equal items with equivalent inits that are distinct handles do not test as equal. I rely on the `Arena::fetch_or_append` to deduplicate consts and globals which uses the derived equality.

adds the `expression-eq` feature to enable derive of `PartialEq` for `Expression`.

i note there are quite a lot of other `PartialEq` impls that are `cfg(test)`. I don't need any of them but perhaps the feature sohuld be more general and include them as well:
```rust
front::glsl::error::ErrorKind
front::glsl::error::Error

front::glsl::lex::LexerResultKind
front::glsl::lex::LexerResult

front::glsl::token::DirectiveKind
front::glsl::token::Directive
front::glsl::token::Token

valid::UniformityDisruptor
valid::compose::ComposeError
valid::expression::ExpressionError

valid::function::CallError
valid::function::AtomicError
valid::function::LocalVariableError
valid::function::FunctionError
```