### PR TITLE
Properly test `-Zminimal-versions`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           tool: cargo-hack
 
       # -Z avoid-dev-deps doesn't work
-      - run: cargo +nightly hack generate-lockfile --remove-dev-deps -Z minimal-versions --offline
+      - run: cargo +nightly hack generate-lockfile --remove-dev-deps -Z minimal-versions
 
       - name: Test all features
         run: cargo +$MSRV clippy --all-features --workspace -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ name = "criterion"
 harness = false
 
 [dependencies]
-arbitrary = { version = "1.0.2", features = ["derive"], optional = true }
-bitflags = "2"
+arbitrary = { version = "1.3", features = ["derive"], optional = true }
+bitflags = "2.2"
 bit-set = "0.5"
 termcolor = { version = "1.0.4", optional = true }
 # remove termcolor dep when updating to the next version of codespan-reporting


### PR DESCRIPTION
I noticed that using `--offline` here doesn't properly go all the way down to the actual minimal version of each dependency. Bit too lazy to dig into why exactly, and I'm not sure why `--offline` was used in the first place, but we should see CI fail in a moment.