### PR TITLE
[glsl-out] Use 'as f64' when writing out f32 literals

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -2215,7 +2215,9 @@ impl<'a, W: Write> Writer<'a, W> {
                     // Floats are written using `Debug` instead of `Display` because it always appends the
                     // decimal part even it's zero which is needed for a valid glsl float constant
                     crate::Literal::F64(value) => write!(self.out, "{:?}LF", value)?,
-                    crate::Literal::F32(value) => write!(self.out, "{:?}", value)?,
+                    // Use 'as f64' to work around precision issues in glsl shaders - see
+                    // https://github.com/gfx-rs/naga/issues/2436
+                    crate::Literal::F32(value) => write!(self.out, "{:?}", value as f64)?,
                     // Unsigned integers need a `u` at the end
                     //
                     // While `core` doesn't necessarily need it, it's allowed and since `es` needs it we

--- a/tests/out/glsl/boids.main.Compute.glsl
+++ b/tests/out/glsl/boids.main.Compute.glsl
@@ -131,7 +131,7 @@ void main() {
     vVel = (((_e112 + (_e113 * _e116)) + (_e119 * _e122)) + (_e125 * _e128));
     vec2 _e131 = vVel;
     vec2 _e133 = vVel;
-    vVel = (normalize(_e131) * clamp(length(_e133), 0.0, 0.1));
+    vVel = (normalize(_e131) * clamp(length(_e133), 0.0, 0.10000000149011612));
     vec2 _e139 = vPos;
     vec2 _e140 = vVel;
     float _e143 = _group_0_binding_0_cs.deltaT;

--- a/tests/out/glsl/image.texture_sample.Fragment.glsl
+++ b/tests/out/glsl/image.texture_sample.Fragment.glsl
@@ -27,10 +27,10 @@ void main() {
     vec4 _e19 = textureOffset(_group_0_binding_1_fs, vec2(tc), ivec2(3, 1));
     vec4 _e20 = a;
     a = (_e20 + _e19);
-    vec4 _e24 = textureLod(_group_0_binding_1_fs, vec2(tc), 2.3);
+    vec4 _e24 = textureLod(_group_0_binding_1_fs, vec2(tc), 2.299999952316284);
     vec4 _e25 = a;
     a = (_e25 + _e24);
-    vec4 _e29 = textureLodOffset(_group_0_binding_1_fs, vec2(tc), 2.3, ivec2(3, 1));
+    vec4 _e29 = textureLodOffset(_group_0_binding_1_fs, vec2(tc), 2.299999952316284, ivec2(3, 1));
     vec4 _e30 = a;
     a = (_e30 + _e29);
     vec4 _e35 = textureOffset(_group_0_binding_1_fs, vec2(tc), ivec2(3, 1), 2.0);
@@ -42,10 +42,10 @@ void main() {
     vec4 _e47 = textureOffset(_group_0_binding_4_fs, vec3(tc, 0u), ivec2(3, 1));
     vec4 _e48 = a;
     a = (_e48 + _e47);
-    vec4 _e53 = textureLod(_group_0_binding_4_fs, vec3(tc, 0u), 2.3);
+    vec4 _e53 = textureLod(_group_0_binding_4_fs, vec3(tc, 0u), 2.299999952316284);
     vec4 _e54 = a;
     a = (_e54 + _e53);
-    vec4 _e59 = textureLodOffset(_group_0_binding_4_fs, vec3(tc, 0u), 2.3, ivec2(3, 1));
+    vec4 _e59 = textureLodOffset(_group_0_binding_4_fs, vec3(tc, 0u), 2.299999952316284, ivec2(3, 1));
     vec4 _e60 = a;
     a = (_e60 + _e59);
     vec4 _e66 = textureOffset(_group_0_binding_4_fs, vec3(tc, 0u), ivec2(3, 1), 2.0);
@@ -57,10 +57,10 @@ void main() {
     vec4 _e78 = textureOffset(_group_0_binding_4_fs, vec3(tc, 0), ivec2(3, 1));
     vec4 _e79 = a;
     a = (_e79 + _e78);
-    vec4 _e84 = textureLod(_group_0_binding_4_fs, vec3(tc, 0), 2.3);
+    vec4 _e84 = textureLod(_group_0_binding_4_fs, vec3(tc, 0), 2.299999952316284);
     vec4 _e85 = a;
     a = (_e85 + _e84);
-    vec4 _e90 = textureLodOffset(_group_0_binding_4_fs, vec3(tc, 0), 2.3, ivec2(3, 1));
+    vec4 _e90 = textureLodOffset(_group_0_binding_4_fs, vec3(tc, 0), 2.299999952316284, ivec2(3, 1));
     vec4 _e91 = a;
     a = (_e91 + _e90);
     vec4 _e97 = textureOffset(_group_0_binding_4_fs, vec3(tc, 0), ivec2(3, 1), 2.0);
@@ -69,7 +69,7 @@ void main() {
     vec4 _e103 = texture(_group_0_binding_6_fs, vec4(tc3_, 0u));
     vec4 _e104 = a;
     a = (_e104 + _e103);
-    vec4 _e109 = textureLod(_group_0_binding_6_fs, vec4(tc3_, 0u), 2.3);
+    vec4 _e109 = textureLod(_group_0_binding_6_fs, vec4(tc3_, 0u), 2.299999952316284);
     vec4 _e110 = a;
     a = (_e110 + _e109);
     vec4 _e116 = texture(_group_0_binding_6_fs, vec4(tc3_, 0u), 2.0);
@@ -78,7 +78,7 @@ void main() {
     vec4 _e122 = texture(_group_0_binding_6_fs, vec4(tc3_, 0));
     vec4 _e123 = a;
     a = (_e123 + _e122);
-    vec4 _e128 = textureLod(_group_0_binding_6_fs, vec4(tc3_, 0), 2.3);
+    vec4 _e128 = textureLod(_group_0_binding_6_fs, vec4(tc3_, 0), 2.299999952316284);
     vec4 _e129 = a;
     a = (_e129 + _e128);
     vec4 _e135 = texture(_group_0_binding_6_fs, vec4(tc3_, 0), 2.0);

--- a/tests/out/glsl/operators.main.Compute.glsl
+++ b/tests/out/glsl/operators.main.Compute.glsl
@@ -16,7 +16,7 @@ vec4 builtins() {
     vec4 s2_ = (true ? v_f32_one : v_f32_zero);
     vec4 s3_ = mix(v_f32_one, v_f32_zero, bvec4(false, false, false, false));
     vec4 m1_ = mix(v_f32_zero, v_f32_one, v_f32_half);
-    vec4 m2_ = mix(v_f32_zero, v_f32_one, 0.1);
+    vec4 m2_ = mix(v_f32_zero, v_f32_one, 0.10000000149011612);
     float b1_ = intBitsToFloat(v_i32_one.x);
     vec4 b2_ = intBitsToFloat(v_i32_one);
     ivec4 v_i32_zero = ivec4(v_f32_zero);

--- a/tests/out/glsl/quad.frag_main.Fragment.glsl
+++ b/tests/out/glsl/quad.frag_main.Fragment.glsl
@@ -7,7 +7,7 @@ struct VertexOutput {
     vec2 uv;
     vec4 position;
 };
-const float c_scale = 1.2;
+const float c_scale = 1.2000000476837158;
 
 uniform highp sampler2D _group_0_binding_0_fs;
 

--- a/tests/out/glsl/quad.fs_extra.Fragment.glsl
+++ b/tests/out/glsl/quad.fs_extra.Fragment.glsl
@@ -7,7 +7,7 @@ struct VertexOutput {
     vec2 uv;
     vec4 position;
 };
-const float c_scale = 1.2;
+const float c_scale = 1.2000000476837158;
 
 layout(location = 0) out vec4 _fs2p_location0;
 

--- a/tests/out/glsl/quad.vert_main.Vertex.glsl
+++ b/tests/out/glsl/quad.vert_main.Vertex.glsl
@@ -7,7 +7,7 @@ struct VertexOutput {
     vec2 uv;
     vec4 position;
 };
-const float c_scale = 1.2;
+const float c_scale = 1.2000000476837158;
 
 layout(location = 0) in vec2 _p2vs_location0;
 layout(location = 1) in vec2 _p2vs_location1;

--- a/tests/out/glsl/shadow.fs_main.Fragment.glsl
+++ b/tests/out/glsl/shadow.fs_main.Fragment.glsl
@@ -21,7 +21,7 @@ struct Light {
     vec4 pos;
     vec4 color;
 };
-const vec3 c_ambient = vec3(0.05, 0.05, 0.05);
+const vec3 c_ambient = vec3(0.05000000074505806, 0.05000000074505806, 0.05000000074505806);
 const uint c_max_lights = 10u;
 
 uniform Globals_block_0Fragment { Globals _group_0_binding_0_fs; };

--- a/tests/out/glsl/shadow.fs_main_without_storage.Fragment.glsl
+++ b/tests/out/glsl/shadow.fs_main_without_storage.Fragment.glsl
@@ -21,7 +21,7 @@ struct Light {
     vec4 pos;
     vec4 color;
 };
-const vec3 c_ambient = vec3(0.05, 0.05, 0.05);
+const vec3 c_ambient = vec3(0.05000000074505806, 0.05000000074505806, 0.05000000074505806);
 const uint c_max_lights = 10u;
 
 uniform Globals_block_0Fragment { Globals _group_0_binding_0_fs; };

--- a/tests/out/glsl/shadow.vs_main.Vertex.glsl
+++ b/tests/out/glsl/shadow.vs_main.Vertex.glsl
@@ -21,7 +21,7 @@ struct Light {
     vec4 pos;
     vec4 color;
 };
-const vec3 c_ambient = vec3(0.05, 0.05, 0.05);
+const vec3 c_ambient = vec3(0.05000000074505806, 0.05000000074505806, 0.05000000074505806);
 const uint c_max_lights = 10u;
 
 uniform Globals_block_0Vertex { Globals _group_0_binding_0_vs; };


### PR DESCRIPTION
Fixes gfx-rs/wgpu#4568.

See the linked issue for more information and discussion. While this restores to pre-#2266 behaviour, we're not sure that this is the best way forward.