### PR TITLE
[ci] Specify -HV 2018 to dxc

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -255,7 +255,14 @@ fn run(args: Args) -> anyhow::Result<()> {
                                     bin,
                                     file,
                                     config_item,
-                                    &["-Wno-parentheses-equality", "-Zi", "-Qembed_debug", "-Od"],
+                                    &[
+                                        "-Wno-parentheses-equality",
+                                        "-Zi",
+                                        "-Qembed_debug",
+                                        "-Od",
+                                        "-HV",
+                                        "2018",
+                                    ],
                                 )
                             })
                         }


### PR DESCRIPTION
[DX Compiler release for August 2023 ](https://github.com/microsoft/DirectXShaderCompiler/releases/tag/v1.7.2308) was just released, and that made [HLSL 2021](https://github.com/microsoft/DirectXShaderCompiler/wiki/HLSL-2021) the default, breaking the CI build.

We currently generate hlsl that is not valid HLSL 2021, as there [binary logic operators can only be used with scalars](https://github.com/microsoft/DirectXShaderCompiler/wiki/HLSL-2021#logical-operation-short-circuiting-for-scalars), so we need to change generation:

```diff
-  doit = vec && (ShouldIDoIt(vec) || !ShouldINotDoIt(vec));
+  doit = and(vec, or(ShouldIDoIt(vec), !ShouldINotDoIt(vec)));
```

While possible (changing `countLeadingZeros()` and `select()` writing is enough to pass CI), fxc does not support HLSL 2021 (and the `and()`, `or()` and `select()` intrinsics are only available in HLSL 2021).

So this PR specifies `-HV 2018` to dxc, which was the previous default version.