### PR TITLE
Add vim .swp files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Cargo.lock
 .fuse_hidden*
 .idea
 .vscode
+*.swp
 /*.dot
 /*.metal
 /*.metallib


### PR DESCRIPTION
Gets rid of a small annoyance for vim users.