### PR TITLE
[wgsl-in] Handle modf and frexp

### DIFF
--- a/src/back/glsl/keywords.rs
+++ b/src/back/glsl/keywords.rs
@@ -477,4 +477,9 @@ pub const RESERVED_KEYWORDS: &[&str] = &[
     // entry point name (should not be shadowed)
     //
     "main",
+    // Naga utilities:
+    super::MODF_FUNCTION,
+    super::MODF_STRUCT,
+    super::FREXP_FUNCTION,
+    super::FREXP_STRUCT,
 ];

--- a/src/back/hlsl/help.rs
+++ b/src/back/hlsl/help.rs
@@ -781,6 +781,52 @@ impl<'a, W: Write> super::Writer<'a, W> {
         Ok(())
     }
 
+    pub(super) fn write_special_functions(&mut self, module: &crate::Module) -> BackendResult {
+        if module.special_types.frexp_result.is_some() {
+            let function_name = super::writer::FREXP_FUNCTION;
+            let struct_name = super::writer::FREXP_STRUCT;
+            writeln!(
+                self.out,
+                "struct {struct_name} {{
+    float fract;
+    int exp;
+}};
+
+{struct_name} {function_name}(in float arg) {{
+    float exp;
+    float fract = frexp(arg, exp);
+    {struct_name} result;
+    result.exp = exp;
+    result.fract = fract;
+    return result;
+}}"
+            )?;
+            writeln!(self.out)?;
+        }
+        if module.special_types.modf_result.is_some() {
+            let function_name = super::writer::MODF_FUNCTION;
+            let struct_name = super::writer::MODF_STRUCT;
+            writeln!(
+                self.out,
+                "struct {struct_name} {{
+    float fract;
+    float whole;
+}};
+
+{struct_name} {function_name}(in float arg) {{
+    float whole;
+    float fract = modf(arg, whole);
+    {struct_name} result;
+    result.whole = whole;
+    result.fract = fract;
+    return result;
+}}"
+            )?;
+            writeln!(self.out)?;
+        }
+        Ok(())
+    }
+
     /// Helper function that writes compose wrapped functions
     pub(super) fn write_wrapped_compose_functions(
         &mut self,

--- a/src/back/hlsl/keywords.rs
+++ b/src/back/hlsl/keywords.rs
@@ -814,6 +814,11 @@ pub const RESERVED: &[&str] = &[
     "TextureBuffer",
     "ConstantBuffer",
     "RayQuery",
+    // Naga utilities
+    super::writer::FREXP_FUNCTION,
+    super::writer::FREXP_STRUCT,
+    super::writer::MODF_FUNCTION,
+    super::writer::MODF_STRUCT,
 ];
 
 // DXC scalar types, from https://github.com/microsoft/DirectXShaderCompiler/blob/18c9e114f9c314f93e68fbc72ce207d4ed2e65ae/tools/clang/lib/AST/ASTContextHLSL.cpp#L48-L254

--- a/src/back/msl/keywords.rs
+++ b/src/back/msl/keywords.rs
@@ -214,4 +214,8 @@ pub const RESERVED: &[&str] = &[
     // Naga utilities
     "DefaultConstructible",
     "clamped_lod_e",
+    super::writer::FREXP_FUNCTION,
+    super::writer::FREXP_STRUCT,
+    super::writer::MODF_FUNCTION,
+    super::writer::MODF_STRUCT,
 ];

--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -396,6 +396,17 @@ impl<'w> BlockContext<'w> {
 
                         load_id
                     }
+                    crate::TypeInner::FrexpResult | crate::TypeInner::ModfResult => {
+                        let id = self.gen_id();
+                        let base_id = self.cached[base];
+                        block.body.push(Instruction::composite_extract(
+                            result_type_id,
+                            id,
+                            base_id,
+                            &[index],
+                        ));
+                        id
+                    }
                     ref other => {
                         log::error!("Unable to access index of {:?}", other);
                         return Err(Error::FeatureNotImplemented("access index for type"));
@@ -787,8 +798,8 @@ impl<'w> BlockContext<'w> {
                     Mf::Floor => MathOp::Ext(spirv::GLOp::Floor),
                     Mf::Fract => MathOp::Ext(spirv::GLOp::Fract),
                     Mf::Trunc => MathOp::Ext(spirv::GLOp::Trunc),
-                    Mf::Modf => MathOp::Ext(spirv::GLOp::Modf),
-                    Mf::Frexp => MathOp::Ext(spirv::GLOp::Frexp),
+                    Mf::Modf => MathOp::Ext(spirv::GLOp::ModfStruct),
+                    Mf::Frexp => MathOp::Ext(spirv::GLOp::FrexpStruct),
                     Mf::Ldexp => MathOp::Ext(spirv::GLOp::Ldexp),
                     // geometry
                     Mf::Dot => match *self.fun_info[arg].ty.inner_with(&self.ir_module.types) {

--- a/src/back/spv/mod.rs
+++ b/src/back/spv/mod.rs
@@ -403,6 +403,8 @@ fn make_local(inner: &crate::TypeInner) -> Option<LocalType> {
         crate::TypeInner::RayQuery => LocalType::RayQuery,
         crate::TypeInner::Array { .. }
         | crate::TypeInner::Struct { .. }
+        | crate::TypeInner::FrexpResult
+        | crate::TypeInner::ModfResult
         | crate::TypeInner::BindingArray { .. } => return None,
     })
 }

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -1223,6 +1223,12 @@ impl<W: Write> Writer<W> {
                             &self.names[&NameKey::StructMember(ty, index)]
                         )?
                     }
+                    TypeInner::FrexpResult => {
+                        write!(self.out, ".{}", if index == 0 { "fract" } else { "exp" })?
+                    }
+                    TypeInner::ModfResult => {
+                        write!(self.out, ".{}", if index == 0 { "fract" } else { "whole" })?
+                    }
                     ref other => return Err(Error::Custom(format!("Cannot index {other:?}"))),
                 }
             }

--- a/src/front/type_gen.rs
+++ b/src/front/type_gen.rs
@@ -311,4 +311,34 @@ impl crate::Module {
         self.special_types.ray_intersection = Some(handle);
         handle
     }
+
+    /// Populate this module's [`crate::SpecialTypes::modf_result`] type.
+    pub fn generate_modf_result(&mut self) {
+        if self.special_types.modf_result.is_some() {
+            return;
+        }
+        let handle = self.types.insert(
+            crate::Type {
+                name: Some("__naga_modf_result".to_string()),
+                inner: crate::TypeInner::ModfResult,
+            },
+            Span::UNDEFINED,
+        );
+        self.special_types.modf_result = Some(handle);
+    }
+
+    /// Populate this module's [`crate::SpecialTypes::frexp_result`] type.
+    pub fn generate_frexp_result(&mut self) {
+        if self.special_types.frexp_result.is_some() {
+            return;
+        }
+        let handle = self.types.insert(
+            crate::Type {
+                name: Some("__naga_frexp_result".to_string()),
+                inner: crate::TypeInner::FrexpResult,
+            },
+            Span::UNDEFINED,
+        );
+        self.special_types.frexp_result = Some(handle);
+    }
 }

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -185,6 +185,8 @@ impl crate::TypeInner {
             Ti::Sampler { .. } => "sampler".to_string(),
             Ti::AccelerationStructure => "acceleration_structure".to_string(),
             Ti::RayQuery => "ray_query".to_string(),
+            Ti::FrexpResult => "__frexp_result_f32".to_string(),
+            Ti::ModfResult => "__modf_result_f32".to_string(),
             Ti::BindingArray { base, size, .. } => {
                 let member_type = &gctx.types[base];
                 let base = member_type.name.as_deref().unwrap_or("unknown");

--- a/src/front/wgsl/tests.rs
+++ b/src/front/wgsl/tests.rs
@@ -438,10 +438,11 @@ fn binary_expression_mixed_scalar_and_vector_operands() {
 #[test]
 fn parse_pointers() {
     parse_str(
-        "fn foo() {
+        "fn foo(a: ptr<private, f32>) -> f32 { return *a; }
+    fn bar() {
         var x: f32 = 1.0;
         let px = &x;
-        let py = frexp(0.5, px);
+        let py = foo(px);
     }",
     )
     .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -672,7 +672,10 @@ pub struct Type {
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub enum TypeInner {
     /// Number of integral or floating-point kind.
-    Scalar { kind: ScalarKind, width: Bytes },
+    Scalar {
+        kind: ScalarKind,
+        width: Bytes,
+    },
     /// Vector of numbers.
     Vector {
         size: VectorSize,
@@ -686,7 +689,10 @@ pub enum TypeInner {
         width: Bytes,
     },
     /// Atomic scalar.
-    Atomic { kind: ScalarKind, width: Bytes },
+    Atomic {
+        kind: ScalarKind,
+        width: Bytes,
+    },
     /// Pointer to another type.
     ///
     /// Pointers to scalars and vectors should be treated as equivalent to
@@ -795,13 +801,21 @@ pub enum TypeInner {
         class: ImageClass,
     },
     /// Can be used to sample values from images.
-    Sampler { comparison: bool },
+    Sampler {
+        comparison: bool,
+    },
 
     /// Opaque object representing an acceleration structure of geometry.
     AccelerationStructure,
 
     /// Locally used handle for ray queries.
     RayQuery,
+
+    // The built-in structure returned by frexp.
+    FrexpResult,
+
+    // The built-in structure returned by modf.
+    ModfResult,
 
     /// Array of bindings.
     ///
@@ -842,7 +856,10 @@ pub enum TypeInner {
     /// [`DATA`]: crate::valid::TypeFlags::DATA
     /// [`ARGUMENT`]: crate::valid::TypeFlags::ARGUMENT
     /// [naga#1864]: https://github.com/gfx-rs/naga/issues/1864
-    BindingArray { base: Handle<Type>, size: ArraySize },
+    BindingArray {
+        base: Handle<Type>,
+        size: ArraySize,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialOrd)]
@@ -1961,6 +1978,14 @@ pub struct SpecialTypes {
     /// Call [`Module::generate_ray_intersection_type`] to populate
     /// this if needed and return the handle.
     pub ray_intersection: Option<Handle<Type>>,
+
+    // Type for `__modf_result_f32`.
+    //
+    pub modf_result: Option<Handle<Type>>,
+
+    // Type for `__frexp_result_f32 `.
+    //
+    pub frexp_result: Option<Handle<Type>>,
 }
 
 /// Shader module.

--- a/src/proc/layouter.rs
+++ b/src/proc/layouter.rs
@@ -234,6 +234,10 @@ impl Layouter {
                         alignment,
                     }
                 }
+                Ti::FrexpResult { .. } | Ti::ModfResult { .. } => TypeLayout {
+                    size: 8,
+                    alignment: Alignment::EIGHT,
+                },
                 Ti::Image { .. }
                 | Ti::Sampler { .. }
                 | Ti::AccelerationStructure

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -229,6 +229,7 @@ impl super::TypeInner {
             | Self::AccelerationStructure
             | Self::RayQuery
             | Self::BindingArray { .. } => 0,
+            Self::FrexpResult { .. } | Self::ModfResult { .. } => 8,
         }
     }
 
@@ -375,8 +376,8 @@ impl super::MathFunction {
             Self::Round => 1,
             Self::Fract => 1,
             Self::Trunc => 1,
-            Self::Modf => 2,
-            Self::Frexp => 2,
+            Self::Modf => 1,
+            Self::Frexp => 1,
             Self::Ldexp => 2,
             // exponent
             Self::Exp => 1,

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -270,6 +270,7 @@ impl super::Validator {
                             resolve_index_limit(module, top, &module.types[base].inner, false)?
                         }
                         Ti::Struct { ref members, .. } => members.len() as u32,
+                        Ti::FrexpResult | Ti::ModfResult => 2,
                         ref other => {
                             log::error!("Indexing of {:?}", other);
                             return Err(ExpressionError::InvalidBaseType(top));
@@ -1015,33 +1016,16 @@ impl super::Validator {
                         }
                     }
                     Mf::Modf | Mf::Frexp | Mf::Ldexp => {
-                        let arg1_ty = match (arg1_ty, arg2_ty, arg3_ty) {
-                            (Some(ty1), None, None) => ty1,
-                            _ => return Err(ExpressionError::WrongArgumentCount(fun)),
-                        };
-                        let (size0, width0) = match *arg_ty {
+                        if arg1_ty.is_some() | arg2_ty.is_some() | arg3_ty.is_some() {
+                            return Err(ExpressionError::WrongArgumentCount(fun));
+                        }
+                        if !matches!(
+                            *arg_ty,
                             Ti::Scalar {
                                 kind: Sk::Float,
-                                width,
-                            } => (None, width),
-                            Ti::Vector {
-                                kind: Sk::Float,
-                                size,
-                                width,
-                            } => (Some(size), width),
-                            _ => return Err(ExpressionError::InvalidArgumentType(fun, 0, arg)),
-                        };
-                        let good = match *arg1_ty {
-                            Ti::Pointer { base, space: _ } => module.types[base].inner == *arg_ty,
-                            Ti::ValuePointer {
-                                size,
-                                kind: Sk::Float,
-                                width,
-                                space: _,
-                            } => size == size0 && width == width0,
-                            _ => false,
-                        };
-                        if !good {
+                                width: 4,
+                            },
+                        ) {
                             return Err(ExpressionError::InvalidArgumentType(
                                 fun,
                                 1,

--- a/src/valid/handles.rs
+++ b/src/valid/handles.rs
@@ -54,6 +54,8 @@ impl super::Validator {
                 | crate::TypeInner::Image { .. }
                 | crate::TypeInner::Sampler { .. }
                 | crate::TypeInner::AccelerationStructure
+                | crate::TypeInner::FrexpResult
+                | crate::TypeInner::ModfResult
                 | crate::TypeInner::RayQuery => (),
                 crate::TypeInner::Pointer { base, space: _ } => {
                     this_handle.check_dep(base)?;

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -255,6 +255,8 @@ impl crate::TypeInner {
             | Self::Atomic { .. }
             | Self::Pointer { .. }
             | Self::ValuePointer { .. }
+            | Self::FrexpResult { .. }
+            | Self::ModfResult { .. }
             | Self::Struct { .. } => true,
             Self::Array { .. }
             | Self::Image { .. }

--- a/src/valid/type.rs
+++ b/src/valid/type.rs
@@ -568,6 +568,9 @@ impl super::Validator {
                 self.require_type_capability(Capabilities::RAY_QUERY)?;
                 TypeInfo::new(TypeFlags::DATA | TypeFlags::SIZED, Alignment::ONE)
             }
+            Ti::FrexpResult | Ti::ModfResult => {
+                TypeInfo::new(TypeFlags::DATA | TypeFlags::SIZED, Alignment::EIGHT)
+            }
             Ti::BindingArray { base, size } => {
                 if base >= handle {
                     return Err(TypeError::InvalidArrayBaseType(base));

--- a/tests/in/math-functions.wgsl
+++ b/tests/in/math-functions.wgsl
@@ -29,4 +29,10 @@ fn main() {
     let clz_b = countLeadingZeros(1u);
     let clz_c = countLeadingZeros(vec2(-1));
     let clz_d = countLeadingZeros(vec2(1u));
+    let modf_a = modf(1.5);
+    let modf_b = modf(1.5).fract;
+    let modf_c = modf(1.5).whole;
+    let frexp_a = frexp(1.5);
+    let frexp_b = frexp(1.5).fract;
+    let frexp_c = frexp(1.5).exp;
 }

--- a/tests/out/glsl/math-functions.main.Fragment.glsl
+++ b/tests/out/glsl/math-functions.main.Fragment.glsl
@@ -3,6 +3,26 @@
 precision highp float;
 precision highp int;
 
+struct naga_frexp_result {
+    float fract;
+    int exp;
+};
+
+naga_frexp_result naga_frexp(float arg) {
+    int exp;
+    float fract = frexp(arg, exp);
+    return naga_frexp_result(fract, exp);
+}
+struct naga_modf_result {
+    float fract;
+    float whole;
+};
+
+naga_modf_result naga_modf(float arg) {
+    float whole;
+    float fract = modf(arg, whole);
+    return naga_modf_result(fract, whole);
+}
 
 void main() {
     vec4 v = vec4(0.0);
@@ -34,5 +54,11 @@ void main() {
     ivec2 _e58 = ivec2(-1);
     ivec2 clz_c = mix(ivec2(31) - findMSB(_e58), ivec2(0), lessThan(_e58, ivec2(0)));
     uvec2 clz_d = uvec2(ivec2(31) - findMSB(uvec2(1u)));
+    naga_modf_result modf_a = naga_modf(1.5);
+    float modf_b = naga_modf(1.5).fract;
+    float modf_c = naga_modf(1.5).whole;
+    naga_frexp_result frexp_a = naga_frexp(1.5);
+    float frexp_b = naga_frexp(1.5).fract;
+    int frexp_c = naga_frexp(1.5).exp;
 }
 

--- a/tests/out/hlsl/math-functions.hlsl
+++ b/tests/out/hlsl/math-functions.hlsl
@@ -1,3 +1,31 @@
+struct naga_frexp_result {
+    float fract;
+    int exp;
+};
+
+naga_frexp_result naga_frexp(in float arg) {
+    float exp;
+    float fract = frexp(arg, exp);
+    naga_frexp_result result;
+    result.exp = exp;
+    result.fract = fract;
+    return result;
+}
+
+struct naga_modf_result {
+    float fract;
+    float whole;
+};
+
+naga_modf_result naga_modf(in float arg) {
+    float whole;
+    float fract = modf(arg, whole);
+    naga_modf_result result;
+    result.whole = whole;
+    result.fract = fract;
+    return result;
+}
+
 void main()
 {
     float4 v = (0.0).xxxx;
@@ -29,4 +57,10 @@ void main()
     int2 _expr58 = (-1).xx;
     int2 clz_c = (_expr58 < (0).xx ? (0).xx : (31).xx - asint(firstbithigh(_expr58)));
     uint2 clz_d = ((31u).xx - firstbithigh((1u).xx));
+    struct naga_modf_result modf_a = naga_modf(1.5);
+    float modf_b = naga_modf(1.5).fract;
+    float modf_c = naga_modf(1.5).whole;
+    struct naga_frexp_result frexp_a = naga_frexp(1.5);
+    float frexp_b = naga_frexp(1.5).fract;
+    int frexp_c = naga_frexp(1.5).exp;
 }

--- a/tests/out/ir/access.ron
+++ b/tests/out/ir/access.ron
@@ -334,6 +334,8 @@
     special_types: (
         ray_desc: None,
         ray_intersection: None,
+        modf_result: None,
+        frexp_result: None,
     ),
     constants: [],
     global_variables: [

--- a/tests/out/ir/collatz.ron
+++ b/tests/out/ir/collatz.ron
@@ -41,6 +41,8 @@
     special_types: (
         ray_desc: None,
         ray_intersection: None,
+        modf_result: None,
+        frexp_result: None,
     ),
     constants: [],
     global_variables: [

--- a/tests/out/ir/shadow.ron
+++ b/tests/out/ir/shadow.ron
@@ -266,6 +266,8 @@
     special_types: (
         ray_desc: None,
         ray_intersection: None,
+        modf_result: None,
+        frexp_result: None,
     ),
     constants: [
         (

--- a/tests/out/msl/math-functions.msl
+++ b/tests/out/msl/math-functions.msl
@@ -5,6 +5,28 @@
 using metal::uint;
 
 
+struct naga_frexp_result {
+    float fract;
+    int exp;
+};
+
+struct naga_frexp_result naga_frexp(float arg) {
+    int exp;
+    float fract = metal::frexp(arg, exp);
+    return naga_frexp_result{ fract, exp };
+};
+
+struct naga_modf_result {
+    float fract;
+    float whole;
+};
+
+struct naga_modf_result naga_modf(float arg) {
+    float whole;
+    float fract = metal::modf(arg, whole);
+    return naga_modf_result{ fract, whole };
+};
+
 fragment void main_(
 ) {
     metal::float4 v = metal::float4(0.0);
@@ -38,4 +60,10 @@ fragment void main_(
     uint clz_b = metal::clz(1u);
     metal::int2 clz_c = metal::clz(metal::int2(-1));
     metal::uint2 clz_d = metal::clz(metal::uint2(1u));
+    naga_modf_result modf_a = naga_modf(1.5);
+    float modf_b = naga_modf(1.5).fract;
+    float modf_c = naga_modf(1.5).whole;
+    naga_frexp_result frexp_a = naga_frexp(1.5);
+    float frexp_b = naga_frexp(1.5).fract;
+    int frexp_c = naga_frexp(1.5).exp;
 }

--- a/tests/out/spv/math-functions.spvasm
+++ b/tests/out/spv/math-functions.spvasm
@@ -1,97 +1,114 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 87
+; Bound: 100
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %8 "main"
-OpExecutionMode %8 OriginUpperLeft
+OpEntryPoint Fragment %10 "main"
+OpExecutionMode %10 OriginUpperLeft
+OpMemberDecorate %7 0 Offset 0
+OpMemberDecorate %7 1 Offset 4
+OpMemberDecorate %8 0 Offset 0
+OpMemberDecorate %8 1 Offset 4
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpTypeVector %4 4
 %6 = OpTypeInt 32 1
 %5 = OpTypeVector %6 2
-%9 = OpTypeFunction %2
-%10 = OpConstant  %4  1.0
-%11 = OpConstant  %4  0.0
-%12 = OpConstantNull  %5
-%13 = OpTypeInt 32 0
-%14 = OpConstant  %13  0
-%15 = OpConstant  %6  -1
-%16 = OpConstant  %13  1
-%17 = OpConstant  %6  0
-%18 = OpConstant  %13  4294967295
-%19 = OpConstant  %6  1
-%27 = OpConstantComposite  %3  %11 %11 %11 %11
-%28 = OpConstantComposite  %3  %10 %10 %10 %10
-%31 = OpConstantNull  %6
-%44 = OpTypeVector %13 2
-%54 = OpConstant  %13  32
-%64 = OpConstantComposite  %44  %54 %54
-%76 = OpConstant  %6  31
-%82 = OpConstantComposite  %5  %76 %76
-%8 = OpFunction  %2  None %9
-%7 = OpLabel
-OpBranch %20
-%20 = OpLabel
-%21 = OpCompositeConstruct  %3  %11 %11 %11 %11
-%22 = OpExtInst  %4  %1 Degrees %10
-%23 = OpExtInst  %4  %1 Radians %10
-%24 = OpExtInst  %3  %1 Degrees %21
-%25 = OpExtInst  %3  %1 Radians %21
-%26 = OpExtInst  %3  %1 FClamp %21 %27 %28
-%29 = OpExtInst  %3  %1 Refract %21 %21 %10
-%32 = OpCompositeExtract  %6  %12 0
-%33 = OpCompositeExtract  %6  %12 0
-%34 = OpIMul  %6  %32 %33
-%35 = OpIAdd  %6  %31 %34
-%36 = OpCompositeExtract  %6  %12 1
-%37 = OpCompositeExtract  %6  %12 1
-%38 = OpIMul  %6  %36 %37
-%30 = OpIAdd  %6  %35 %38
-%39 = OpCopyObject  %13  %14
-%40 = OpExtInst  %13  %1 FindUMsb %39
-%41 = OpExtInst  %6  %1 FindSMsb %15
-%42 = OpCompositeConstruct  %5  %15 %15
-%43 = OpExtInst  %5  %1 FindSMsb %42
-%45 = OpCompositeConstruct  %44  %16 %16
-%46 = OpExtInst  %44  %1 FindUMsb %45
-%47 = OpExtInst  %6  %1 FindILsb %15
-%48 = OpExtInst  %13  %1 FindILsb %16
-%49 = OpCompositeConstruct  %5  %15 %15
-%50 = OpExtInst  %5  %1 FindILsb %49
-%51 = OpCompositeConstruct  %44  %16 %16
-%52 = OpExtInst  %44  %1 FindILsb %51
-%55 = OpExtInst  %13  %1 FindILsb %14
-%53 = OpExtInst  %13  %1 UMin %54 %55
-%57 = OpExtInst  %6  %1 FindILsb %17
-%56 = OpExtInst  %6  %1 UMin %54 %57
-%59 = OpExtInst  %13  %1 FindILsb %18
-%58 = OpExtInst  %13  %1 UMin %54 %59
-%61 = OpExtInst  %6  %1 FindILsb %15
-%60 = OpExtInst  %6  %1 UMin %54 %61
-%62 = OpCompositeConstruct  %44  %14 %14
-%65 = OpExtInst  %44  %1 FindILsb %62
-%63 = OpExtInst  %44  %1 UMin %64 %65
-%66 = OpCompositeConstruct  %5  %17 %17
-%68 = OpExtInst  %5  %1 FindILsb %66
-%67 = OpExtInst  %5  %1 UMin %64 %68
-%69 = OpCompositeConstruct  %44  %16 %16
-%71 = OpExtInst  %44  %1 FindILsb %69
-%70 = OpExtInst  %44  %1 UMin %64 %71
-%72 = OpCompositeConstruct  %5  %19 %19
-%74 = OpExtInst  %5  %1 FindILsb %72
-%73 = OpExtInst  %5  %1 UMin %64 %74
-%77 = OpExtInst  %6  %1 FindUMsb %15
-%75 = OpISub  %6  %76 %77
-%79 = OpExtInst  %6  %1 FindUMsb %16
-%78 = OpISub  %13  %76 %79
-%80 = OpCompositeConstruct  %5  %15 %15
-%83 = OpExtInst  %5  %1 FindUMsb %80
-%81 = OpISub  %5  %82 %83
-%84 = OpCompositeConstruct  %44  %16 %16
-%86 = OpExtInst  %5  %1 FindUMsb %84
-%85 = OpISub  %44  %82 %86
+%7 = OpTypeStruct %4 %4
+%8 = OpTypeStruct %4 %6
+%11 = OpTypeFunction %2
+%12 = OpConstant  %4  1.0
+%13 = OpConstant  %4  0.0
+%14 = OpConstantNull  %5
+%15 = OpTypeInt 32 0
+%16 = OpConstant  %15  0
+%17 = OpConstant  %6  -1
+%18 = OpConstant  %15  1
+%19 = OpConstant  %6  0
+%20 = OpConstant  %15  4294967295
+%21 = OpConstant  %6  1
+%22 = OpConstant  %4  1.5
+%30 = OpConstantComposite  %3  %13 %13 %13 %13
+%31 = OpConstantComposite  %3  %12 %12 %12 %12
+%34 = OpConstantNull  %6
+%47 = OpTypeVector %15 2
+%57 = OpConstant  %15  32
+%67 = OpConstantComposite  %47  %57 %57
+%79 = OpConstant  %6  31
+%85 = OpConstantComposite  %5  %79 %79
+%10 = OpFunction  %2  None %11
+%9 = OpLabel
+OpBranch %23
+%23 = OpLabel
+%24 = OpCompositeConstruct  %3  %13 %13 %13 %13
+%25 = OpExtInst  %4  %1 Degrees %12
+%26 = OpExtInst  %4  %1 Radians %12
+%27 = OpExtInst  %3  %1 Degrees %24
+%28 = OpExtInst  %3  %1 Radians %24
+%29 = OpExtInst  %3  %1 FClamp %24 %30 %31
+%32 = OpExtInst  %3  %1 Refract %24 %24 %12
+%35 = OpCompositeExtract  %6  %14 0
+%36 = OpCompositeExtract  %6  %14 0
+%37 = OpIMul  %6  %35 %36
+%38 = OpIAdd  %6  %34 %37
+%39 = OpCompositeExtract  %6  %14 1
+%40 = OpCompositeExtract  %6  %14 1
+%41 = OpIMul  %6  %39 %40
+%33 = OpIAdd  %6  %38 %41
+%42 = OpCopyObject  %15  %16
+%43 = OpExtInst  %15  %1 FindUMsb %42
+%44 = OpExtInst  %6  %1 FindSMsb %17
+%45 = OpCompositeConstruct  %5  %17 %17
+%46 = OpExtInst  %5  %1 FindSMsb %45
+%48 = OpCompositeConstruct  %47  %18 %18
+%49 = OpExtInst  %47  %1 FindUMsb %48
+%50 = OpExtInst  %6  %1 FindILsb %17
+%51 = OpExtInst  %15  %1 FindILsb %18
+%52 = OpCompositeConstruct  %5  %17 %17
+%53 = OpExtInst  %5  %1 FindILsb %52
+%54 = OpCompositeConstruct  %47  %18 %18
+%55 = OpExtInst  %47  %1 FindILsb %54
+%58 = OpExtInst  %15  %1 FindILsb %16
+%56 = OpExtInst  %15  %1 UMin %57 %58
+%60 = OpExtInst  %6  %1 FindILsb %19
+%59 = OpExtInst  %6  %1 UMin %57 %60
+%62 = OpExtInst  %15  %1 FindILsb %20
+%61 = OpExtInst  %15  %1 UMin %57 %62
+%64 = OpExtInst  %6  %1 FindILsb %17
+%63 = OpExtInst  %6  %1 UMin %57 %64
+%65 = OpCompositeConstruct  %47  %16 %16
+%68 = OpExtInst  %47  %1 FindILsb %65
+%66 = OpExtInst  %47  %1 UMin %67 %68
+%69 = OpCompositeConstruct  %5  %19 %19
+%71 = OpExtInst  %5  %1 FindILsb %69
+%70 = OpExtInst  %5  %1 UMin %67 %71
+%72 = OpCompositeConstruct  %47  %18 %18
+%74 = OpExtInst  %47  %1 FindILsb %72
+%73 = OpExtInst  %47  %1 UMin %67 %74
+%75 = OpCompositeConstruct  %5  %21 %21
+%77 = OpExtInst  %5  %1 FindILsb %75
+%76 = OpExtInst  %5  %1 UMin %67 %77
+%80 = OpExtInst  %6  %1 FindUMsb %17
+%78 = OpISub  %6  %79 %80
+%82 = OpExtInst  %6  %1 FindUMsb %18
+%81 = OpISub  %15  %79 %82
+%83 = OpCompositeConstruct  %5  %17 %17
+%86 = OpExtInst  %5  %1 FindUMsb %83
+%84 = OpISub  %5  %85 %86
+%87 = OpCompositeConstruct  %47  %18 %18
+%89 = OpExtInst  %5  %1 FindUMsb %87
+%88 = OpISub  %47  %85 %89
+%90 = OpExtInst  %7  %1 ModfStruct %22
+%91 = OpExtInst  %7  %1 ModfStruct %22
+%92 = OpCompositeExtract  %4  %91 0
+%93 = OpExtInst  %7  %1 ModfStruct %22
+%94 = OpCompositeExtract  %4  %93 1
+%95 = OpExtInst  %8  %1 FrexpStruct %22
+%96 = OpExtInst  %8  %1 FrexpStruct %22
+%97 = OpCompositeExtract  %4  %96 0
+%98 = OpExtInst  %8  %1 FrexpStruct %22
+%99 = OpCompositeExtract  %6  %98 1
 OpReturn
 OpFunctionEnd

--- a/tests/out/wgsl/math-functions.wgsl
+++ b/tests/out/wgsl/math-functions.wgsl
@@ -28,4 +28,10 @@ fn main() {
     let clz_b = countLeadingZeros(1u);
     let clz_c = countLeadingZeros(vec2<i32>(-1));
     let clz_d = countLeadingZeros(vec2<u32>(1u));
+    let modf_a = modf(1.5);
+    let modf_b = modf(1.5).fract;
+    let modf_c = modf(1.5).whole;
+    let frexp_a = frexp(1.5);
+    let frexp_b = frexp(1.5).fract;
+    let frexp_c = frexp(1.5).exp;
 }


### PR DESCRIPTION
- Fixes #1161
- Fixes #594 (this is outdated/a duplicate, and can be closed regardless of this PR)
- Replaces #1441 

Another approach than what is done here would be to use `TypeInner::Struct` to reuse struct handling logic. There are some changes necessary there to handle naming correctly, and e.g. avoid writing out the struct in wgsl-out (which already has the struct defined).

Let med know if you want that done instead (and if so, how to proceed there - perhaps adding something like a `enum StructType { UserDefined, ModfResult, FrexpResult }` (and perhaps `AtomicCompareExchangeWeaResult`?) to `TypeInner::Struct`)!