### PR TITLE
Add buffer pointer support for WGSL (SPV_EXT_physical_storage_buffer)

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -108,6 +108,7 @@ impl crate::AddressSpace {
             crate::AddressSpace::WorkGroup
             | crate::AddressSpace::Uniform
             | crate::AddressSpace::Storage { .. }
+            | crate::AddressSpace::PhysicalStorage { .. }
             | crate::AddressSpace::Handle
             | crate::AddressSpace::PushConstant => false,
         }
@@ -1072,6 +1073,8 @@ impl<'a, W: Write> Writer<'a, W> {
             crate::AddressSpace::Storage { .. } => {
                 self.write_interface_block(handle, global)?;
             }
+            // The PhysicalStorage address space is only for pointers.
+            crate::AddressSpace::PhysicalStorage { .. } => unreachable!(),
             // A global variable in the `Function` address space is a
             // contradiction in terms.
             crate::AddressSpace::Function => unreachable!(),
@@ -4180,6 +4183,7 @@ const fn glsl_storage_qualifier(space: crate::AddressSpace) -> Option<&'static s
         As::Function => None,
         As::Private => None,
         As::Storage { .. } => Some("buffer"),
+        As::PhysicalStorage { .. } => Some("buffer_reference"),
         As::Uniform => Some("uniform"),
         As::Handle => Some("uniform"),
         As::WorkGroup => Some("shared"),

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -688,6 +688,11 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 write!(self.out, "{prefix}ByteAddressBuffer")?;
                 register
             }
+            crate::AddressSpace::PhysicalStorage { .. } => {
+                return Err(Error::Unimplemented(
+                    "physical storage address space is not implemented for HLSL".to_string(),
+                ));
+            }
             crate::AddressSpace::Handle => {
                 let handle_ty = match *inner {
                     TypeInner::BindingArray { ref base, .. } => &module.types[*base].inner,

--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -1082,15 +1082,22 @@ impl<'w> BlockContext<'w> {
                 match self.write_expression_pointer(pointer, block, None)? {
                     ExpressionPointer::Ready { pointer_id } => {
                         let id = self.gen_id();
-                        let atomic_space =
+                        let (atomic_space, physical_alignment) =
                             match *self.fun_info[pointer].ty.inner_with(&self.ir_module.types) {
                                 crate::TypeInner::Pointer { base, space } => {
-                                    match self.ir_module.types[base].inner {
+                                    let physical_alignment = match space {
+                                        crate::AddressSpace::PhysicalStorage { alignment } => {
+                                            Some(alignment)
+                                        }
+                                        _ => None,
+                                    };
+                                    let atomic_space = match self.ir_module.types[base].inner {
                                         crate::TypeInner::Atomic { .. } => Some(space),
                                         _ => None,
-                                    }
+                                    };
+                                    (atomic_space, physical_alignment)
                                 }
-                                _ => None,
+                                _ => (None, None),
                             };
                         let instruction = if let Some(space) = atomic_space {
                             let (semantics, scope) = space.to_spirv_semantics_and_scope();
@@ -1102,6 +1109,14 @@ impl<'w> BlockContext<'w> {
                                 pointer_id,
                                 scope_constant_id,
                                 semantics_id,
+                            )
+                        } else if let Some(alignment) = physical_alignment {
+                            Instruction::load_aligned(
+                                result_type_id,
+                                id,
+                                pointer_id,
+                                alignment,
+                                None,
                             )
                         } else {
                             Instruction::load(result_type_id, id, pointer_id, None)
@@ -1548,6 +1563,9 @@ impl<'w> BlockContext<'w> {
                 }
                 crate::Expression::FunctionArgument(index) => {
                     break self.function.parameter_id(index);
+                }
+                crate::Expression::Load { .. } => {
+                    break self.cached[expr_handle];
                 }
                 ref other => unimplemented!("Unexpected pointer expression {:?}", other),
             }

--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -213,6 +213,22 @@ impl<'w> BlockContext<'w> {
                 let arg = &self.ir_function.arguments[index as usize];
                 self.ir_module.types[arg.ty].inner.pointer_space().is_some()
             }
+            crate::Expression::Load { pointer } => {
+                match *self.fun_info[pointer].ty.inner_with(&self.ir_module.types) {
+                    crate::TypeInner::Pointer { base, .. } => {
+                        if let crate::TypeInner::Pointer {
+                            space: crate::AddressSpace::PhysicalStorage { .. },
+                            ..
+                        } = self.ir_module.types[base].inner
+                        {
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                    _ => false,
+                }
+            }
 
             // The chain rule: if this `Access...`'s `base` operand was
             // previously omitted, then omit this one, too.

--- a/src/back/spv/helpers.rs
+++ b/src/back/spv/helpers.rs
@@ -26,6 +26,7 @@ pub(super) const fn map_storage_class(space: crate::AddressSpace) -> spirv::Stor
         crate::AddressSpace::Function => spirv::StorageClass::Function,
         crate::AddressSpace::Private => spirv::StorageClass::Private,
         crate::AddressSpace::Storage { .. } => spirv::StorageClass::StorageBuffer,
+        crate::AddressSpace::PhysicalStorage { .. } => spirv::StorageClass::PhysicalStorageBuffer,
         crate::AddressSpace::Uniform => spirv::StorageClass::Uniform,
         crate::AddressSpace::WorkGroup => spirv::StorageClass::Workgroup,
         crate::AddressSpace::PushConstant => spirv::StorageClass::PushConstant,

--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -446,6 +446,25 @@ impl super::Instruction {
         instruction
     }
 
+    pub(super) fn load_aligned(
+        result_type_id: Word,
+        id: Word,
+        pointer_id: Word,
+        alignment: u32,
+        memory_access: Option<spirv::MemoryAccess>,
+    ) -> Self {
+        let mut instruction = Self::new(Op::Load);
+        instruction.set_type(result_type_id);
+        instruction.set_result(id);
+        instruction.add_operand(pointer_id);
+
+        let memory_access = memory_access.unwrap_or(spirv::MemoryAccess::ALIGNED);
+        instruction.add_operand(memory_access.bits());
+        instruction.add_operand(alignment);
+
+        instruction
+    }
+
     pub(super) fn atomic_load(
         result_type_id: Word,
         id: Word,

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -1870,9 +1870,7 @@ const fn sampling_str(sampling: crate::Sampling) -> &'static str {
     }
 }
 
-const fn address_space_str(
-    space: crate::AddressSpace,
-) -> (Option<&'static str>, Option<&'static str>) {
+fn address_space_str(space: crate::AddressSpace) -> (Option<&'static str>, Option<String>) {
     use crate::AddressSpace as As;
 
     (
@@ -1881,10 +1879,13 @@ const fn address_space_str(
             As::Uniform => "uniform",
             As::Storage { access } => {
                 if access.contains(crate::StorageAccess::STORE) {
-                    return (Some("storage"), Some("read_write"));
+                    return (Some("storage"), Some("read_write".to_string()));
                 } else {
                     "storage"
                 }
+            }
+            As::PhysicalStorage { alignment } => {
+                return (Some("buffer"), Some(alignment.to_string()))
             }
             As::PushConstant => "push_constant",
             As::WorkGroup => "workgroup",

--- a/src/front/wgsl/parse/conv.rs
+++ b/src/front/wgsl/parse/conv.rs
@@ -9,6 +9,11 @@ pub fn map_address_space(word: &str, span: Span) -> Result<crate::AddressSpace, 
         "storage" => Ok(crate::AddressSpace::Storage {
             access: crate::StorageAccess::default(),
         }),
+        "buffer" => Ok(crate::AddressSpace::PhysicalStorage {
+            // Follow the GLSL spec and use 16 byte alignment as the default
+            // https://github.com/KhronosGroup/GLSL/blob/ad383324612d8493c78d52d0c903969fe1dddd0a/extensions/ext/GLSL_EXT_buffer_reference.txt#L139
+            alignment: 16,
+        }),
         "push_constant" => Ok(crate::AddressSpace::PushConstant),
         "function" => Ok(crate::AddressSpace::Function),
         _ => Err(Error::UnknownAddressSpace(span)),

--- a/src/front/wgsl/parse/mod.rs
+++ b/src/front/wgsl/parse/mod.rs
@@ -1220,12 +1220,32 @@ impl Parser {
                 let mut space = conv::map_address_space(ident, span)?;
                 lexer.expect(Token::Separator(','))?;
                 let base = self.type_decl(lexer, ctx)?;
-                if let crate::AddressSpace::Storage { ref mut access } = space {
-                    *access = if lexer.skip(Token::Separator(',')) {
-                        lexer.next_storage_access()?
-                    } else {
-                        crate::StorageAccess::LOAD
-                    };
+                match space {
+                    crate::AddressSpace::Storage { ref mut access } => {
+                        *access = if lexer.skip(Token::Separator(',')) {
+                            lexer.next_storage_access()?
+                        } else {
+                            crate::StorageAccess::LOAD
+                        };
+                    }
+                    crate::AddressSpace::PhysicalStorage { ref mut alignment } => {
+                        *alignment = if lexer.skip(Token::Separator(',')) {
+                            // TODO: we should probably use the constant expression evaluator here
+                            (match lexer.next() {
+                                (Token::Number(Ok(Number::I32(num))), _span) => {
+                                    u32::try_from(num).map_err(|_| Error::ExpectedNonNegative(span))
+                                }
+                                (Token::Number(Err(e)), span) => Err(Error::BadNumber(span, e)),
+                                other => Err(Error::Unexpected(
+                                    other.1,
+                                    ExpectedToken::PrimaryExpression,
+                                )),
+                            })?
+                        } else {
+                            *alignment
+                        };
+                    }
+                    _ => {}
                 }
                 lexer.expect_generic_paren('>')?;
                 ast::Type::Pointer { base, space }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,6 +403,12 @@ pub enum AddressSpace {
     Handle,
     /// Push constants.
     PushConstant,
+    /// Buffer device pointers, mutable. Only used for pointers, not allowed on GlobalVariables.
+    /// Pointers in this address space reference buffer memory directly.
+    /// Requires capability [`crate::valid::Capabilities::PHYSICAL_STORAGE_BUFFER_ADDRESSES`].
+    /// Required for Vulkan extension `VK_KHR_buffer_device_address`:
+    /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_buffer_device_address.html>
+    PhysicalStorage { alignment: u32 },
 }
 
 /// Built-in inputs and outputs.

--- a/src/proc/layouter.rs
+++ b/src/proc/layouter.rs
@@ -14,6 +14,7 @@ impl Alignment {
     pub const EIGHT: Self = Self(unsafe { NonZeroU32::new_unchecked(8) });
     pub const SIXTEEN: Self = Self(unsafe { NonZeroU32::new_unchecked(16) });
 
+    pub const BUFFER_POINTER: Self = Self::EIGHT;
     pub const MIN_UNIFORM: Self = Self::SIXTEEN;
 
     pub const fn new(n: u32) -> Option<Self> {
@@ -200,6 +201,17 @@ impl Layouter {
                         alignment: Alignment::from(rows) * alignment,
                     }
                 }
+                Ti::Pointer {
+                    space: crate::AddressSpace::PhysicalStorage { .. },
+                    ..
+                }
+                | Ti::ValuePointer {
+                    space: crate::AddressSpace::PhysicalStorage { .. },
+                    ..
+                } => TypeLayout {
+                    size,
+                    alignment: Alignment::BUFFER_POINTER,
+                },
                 Ti::Pointer { .. } | Ti::ValuePointer { .. } => TypeLayout {
                     size,
                     alignment: Alignment::ONE,

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -162,6 +162,7 @@ impl crate::Literal {
 }
 
 pub const POINTER_SPAN: u32 = 4;
+pub const BUFFER_POINTER_SPAN: u32 = 8;
 
 impl super::TypeInner {
     pub const fn scalar_kind(&self) -> Option<super::ScalarKind> {
@@ -218,6 +219,14 @@ impl super::TypeInner {
                 rows,
                 width,
             } => Alignment::from(rows) * width as u32 * columns as u32,
+            Self::Pointer {
+                space: crate::AddressSpace::PhysicalStorage { .. },
+                ..
+            }
+            | Self::ValuePointer {
+                space: crate::AddressSpace::PhysicalStorage { .. },
+                ..
+            } => BUFFER_POINTER_SPAN,
             Self::Pointer { .. } | Self::ValuePointer { .. } => POINTER_SPAN,
             Self::Array {
                 base: _,
@@ -346,6 +355,7 @@ impl super::AddressSpace {
             | crate::AddressSpace::WorkGroup => Sa::LOAD | Sa::STORE,
             crate::AddressSpace::Uniform => Sa::LOAD,
             crate::AddressSpace::Storage { access } => access,
+            crate::AddressSpace::PhysicalStorage { .. } => Sa::LOAD,
             crate::AddressSpace::Handle => Sa::LOAD,
             crate::AddressSpace::PushConstant => Sa::LOAD,
         }

--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -576,6 +576,7 @@ impl FunctionInfo {
                     As::Uniform | As::PushConstant => true,
                     // storage data is only uniform when read-only
                     As::Storage { access } => !access.contains(crate::StorageAccess::STORE),
+                    As::PhysicalStorage { .. } => false,
                     As::Handle => false,
                 };
                 Uniformity {

--- a/src/valid/interface.rs
+++ b/src/valid/interface.rs
@@ -489,6 +489,9 @@ impl super::Validator {
                 }
                 (TypeFlags::DATA | TypeFlags::HOST_SHAREABLE, true)
             }
+            crate::AddressSpace::PhysicalStorage { .. } => {
+                return Err(GlobalVariableError::InvalidUsage(var.space))
+            }
             crate::AddressSpace::Uniform => {
                 if let Err((ty_handle, disalignment)) = type_info.uniform_layout {
                     if self.flags.contains(super::ValidationFlags::STRUCT_LAYOUTS) {
@@ -739,6 +742,7 @@ impl super::Validator {
                 crate::AddressSpace::Function => unreachable!(),
                 crate::AddressSpace::Uniform => GlobalUse::READ | GlobalUse::QUERY,
                 crate::AddressSpace::Storage { access } => storage_usage(access),
+                crate::AddressSpace::PhysicalStorage { .. } => unreachable!(),
                 crate::AddressSpace::Handle => match module.types[var.ty].inner {
                     crate::TypeInner::BindingArray { base, .. } => match module.types[base].inner {
                         crate::TypeInner::Image {

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -115,6 +115,11 @@ bitflags::bitflags! {
         const RAY_QUERY = 0x1000;
         /// Support for generating two sources for blending from fragement shaders
         const DUAL_SOURCE_BLENDING = 0x2000;
+        /// Support for pointers to device buffers.
+        /// Required for using the [`crate::AddressSpace::PhysicalStorage`] pointer address space.
+        /// Required by Vulkan extension `VK_KHR_buffer_device_address`:
+        /// <https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_buffer_device_address.html>
+        const PHYSICAL_STORAGE_BUFFER_ADDRESSES = 0x2000;
     }
 }
 

--- a/tests/in/buffer-pointer.param.ron
+++ b/tests/in/buffer-pointer.param.ron
@@ -1,0 +1,6 @@
+(
+	god_mode: true,
+	spv: (
+		version: (1, 5),
+	),
+)

--- a/tests/in/buffer-pointer.wgsl
+++ b/tests/in/buffer-pointer.wgsl
@@ -1,0 +1,28 @@
+struct OtherStruct {
+    data: vec2<f32>,
+}
+
+struct MyBuffer {
+    data: vec4<f32>,
+    sub_buffer: ptr<buffer, OtherStruct, 8>, // Custom alignment = 8
+}
+
+// TODO: recursive references
+// struct MyBuffer2 {
+//     data: f32,
+//     next: ptr<buffer, MyBuffer2>,
+// }
+
+struct PushConstants {
+    buf1: ptr<buffer, MyBuffer>,    // Default alignment = 16
+    four_bytes: u32,                // Test struct member offset
+    buf2: ptr<buffer, MyBuffer, 4>, // Custom alignment = 4
+}
+var<push_constant> pc: PushConstants;
+
+@fragment
+fn main() -> @location(0) vec4<f32> {
+    var d1 = (*pc.buf1).data;
+    var d2 = (*(*pc.buf2).sub_buffer).data;
+    return d1 + vec4<f32>(d2, 0.0, 0.0);
+}

--- a/tests/out/spv/buffer-pointer.spvasm
+++ b/tests/out/spv/buffer-pointer.spvasm
@@ -1,0 +1,75 @@
+; SPIR-V
+; Version: 1.5
+; Generator: rspirv
+; Bound: 52
+OpCapability Shader
+OpCapability PhysicalStorageBufferAddresses
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
+OpEntryPoint Fragment %18 "main" %16 %12
+OpExecutionMode %18 OriginUpperLeft
+OpMemberDecorate %5 0 Offset 0
+OpMemberDecorate %8 0 Offset 0
+OpMemberDecorate %8 1 Offset 16
+OpMemberDecorate %11 0 Offset 0
+OpMemberDecorate %11 1 Offset 8
+OpMemberDecorate %11 2 Offset 16
+OpDecorate %13 Block
+OpMemberDecorate %13 0 Offset 0
+OpDecorate %16 Location 0
+%2 = OpTypeVoid
+%4 = OpTypeFloat 32
+%3 = OpTypeVector %4 2
+%5 = OpTypeStruct %3
+%6 = OpTypeVector %4 4
+%7 = OpTypePointer PhysicalStorageBuffer %5
+%8 = OpTypeStruct %6 %7
+%9 = OpTypePointer PhysicalStorageBuffer %8
+%10 = OpTypeInt 32 0
+%11 = OpTypeStruct %9 %10 %9
+%13 = OpTypeStruct %11
+%14 = OpTypePointer PushConstant %13
+%12 = OpVariable  %14  PushConstant
+%17 = OpTypePointer Output %6
+%16 = OpVariable  %17  Output
+%19 = OpTypeFunction %2
+%20 = OpTypePointer PushConstant %11
+%21 = OpConstant  %10  0
+%23 = OpConstant  %4  0.0
+%25 = OpTypePointer Function %6
+%26 = OpConstantNull  %6
+%28 = OpTypePointer Function %3
+%29 = OpConstantNull  %3
+%31 = OpTypePointer PushConstant %9
+%34 = OpTypePointer PhysicalStorageBuffer %6
+%37 = OpTypePointer PushConstant %9
+%38 = OpConstant  %10  2
+%41 = OpTypePointer PhysicalStorageBuffer %7
+%42 = OpConstant  %10  1
+%45 = OpTypePointer PhysicalStorageBuffer %3
+%18 = OpFunction  %2  None %19
+%15 = OpLabel
+%24 = OpVariable  %25  Function %26
+%27 = OpVariable  %28  Function %29
+%22 = OpAccessChain  %20  %12 %21
+OpBranch %30
+%30 = OpLabel
+%32 = OpAccessChain  %31  %22 %21
+%33 = OpLoad  %9  %32
+%35 = OpAccessChain  %34  %33 %21
+%36 = OpLoad  %6  %35 Aligned 16
+OpStore %24 %36
+%39 = OpAccessChain  %37  %22 %38
+%40 = OpLoad  %9  %39
+%43 = OpAccessChain  %41  %40 %42
+%44 = OpLoad  %7  %43 Aligned 4
+%46 = OpAccessChain  %45  %44 %21
+%47 = OpLoad  %3  %46 Aligned 8
+OpStore %27 %47
+%48 = OpLoad  %6  %24
+%49 = OpLoad  %3  %27
+%50 = OpCompositeConstruct  %6  %49 %23 %23
+%51 = OpFAdd  %6  %48 %50
+OpStore %16 %51
+OpReturn
+OpFunctionEnd

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -781,6 +781,7 @@ fn convert_wgsl() {
             "const-exprs",
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,
         ),
+        ("buffer-pointer", Targets::SPIRV),
     ];
 
     for &(name, targets) in inputs.iter() {


### PR DESCRIPTION
This will add support for the `PhysicalStorage` SPIR-V storage class, which will enable use of the [VK_KHR_buffer_device_address](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_buffer_device_address.html) Vulkan extension.

Here's some example WGSL code for what this looks like:
```wgsl
struct Buffer {
    data: vec4<f32>,
}
struct PushConstants {
    buf: ptr<buffer, Buffer, 16>, // Pointed-to type must have 16-byte alignment
}
var<push_constant> pc: PushConstants;

// Accessing the buffer
var data = (*pc.buf).data;
```

The name of the WGSL address space is `buffer` and the third parameter for the pointer is the alignment of the pointed-to Buffer, which affects load operations on the buffer. It is optional and defaults to 16, as per the [GLSL spec](https://github.com/KhronosGroup/GLSL/blob/ad383324612d8493c78d52d0c903969fe1dddd0a/extensions/ext/GLSL_EXT_buffer_reference.txt#L139).

The size and alignment of pointers in this storage class is 8 bytes, so I also had to change that.

One thing this would allow for and that I did not implement is recursive pointers:
```wgsl
struct Buffer {
    data: f32,
    next: ptr<buffer, Buffer>,
}
```