### PR TITLE
Don't warn about unused mut in tests when "validate" feature is off.

### DIFF
--- a/src/valid/interface.rs
+++ b/src/valid/interface.rs
@@ -614,6 +614,7 @@ impl super::Validator {
             return Err(EntryPointError::UnexpectedWorkgroupSize.with_span());
         }
 
+        #[cfg_attr(not(feature = "validate"), allow(unused_mut))]
         let mut info = self
             .validate_function(&ep.function, module, mod_info, true)
             .map_err(WithSpan::into_other)?;


### PR DESCRIPTION
This silences a warning that shows up when we run `cargo nextest run -p naga`:

```
warning: variable does not need to be mutable
   --> src/valid/interface.rs:618:13
    |
618 |         let mut info = self
    |             ----^^^^
    |             |
    |             help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default
```

The only assignment to `info` appears in a `"validate"`-only block.