### PR TITLE
Remove useless calls to `into_iter()`.

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -75,9 +75,8 @@ impl Block {
 
     pub fn splice<R: RangeBounds<usize> + Clone>(&mut self, range: R, other: Self) {
         #[cfg(feature = "span")]
-        self.span_info
-            .splice(range.clone(), other.span_info.into_iter());
-        self.body.splice(range, other.body.into_iter());
+        self.span_info.splice(range.clone(), other.span_info);
+        self.body.splice(range, other.body);
     }
     pub fn span_iter(&self) -> impl Iterator<Item = (&Statement, &Span)> {
         #[cfg(feature = "span")]


### PR DESCRIPTION
The `splice()` call takes `IntoIterator`, so calling `into_iter()` is not needed.