### PR TITLE
clippy: Remove extra Iterator bounds.

### DIFF
--- a/src/front/wgsl/error.rs
+++ b/src/front/wgsl/error.rs
@@ -17,7 +17,7 @@ pub struct ParseError {
 }
 
 impl ParseError {
-    pub fn labels(&self) -> impl Iterator<Item = (Span, &str)> + ExactSizeIterator + '_ {
+    pub fn labels(&self) -> impl ExactSizeIterator<Item = (Span, &str)> + '_ {
         self.labels
             .iter()
             .map(|&(span, ref msg)| (span, msg.as_ref()))

--- a/src/span.rs
+++ b/src/span.rs
@@ -181,7 +181,7 @@ impl<E> WithSpan<E> {
     }
 
     /// Iterator over stored [`SpanContext`]s.
-    pub fn spans(&self) -> impl Iterator<Item = &SpanContext> + ExactSizeIterator {
+    pub fn spans(&self) -> impl ExactSizeIterator<Item = &SpanContext> {
         #[cfg(feature = "span")]
         return self.spans.iter();
         #[cfg(not(feature = "span"))]


### PR DESCRIPTION
`Iterator` is a supertrait of `ExactSizeIterator`, so specifying `ExactSizeIterator` is enough.