### PR TITLE
clippy: Fix unnecessary_mut_passed warning.

### DIFF
--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -157,7 +157,7 @@ impl super::Validator {
         &self,
         handle: Handle<crate::Expression>,
         gctx: crate::proc::GlobalCtx,
-        mod_info: &mut ModuleInfo,
+        mod_info: &ModuleInfo,
     ) -> Result<(), super::ConstExpressionError> {
         use crate::Expression as E;
 

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -400,7 +400,7 @@ impl Validator {
         #[cfg(feature = "validate")]
         if self.flags.contains(ValidationFlags::CONSTANTS) {
             for (handle, _) in module.const_expressions.iter() {
-                self.validate_const_expression(handle, module.to_ctx(), &mut mod_info)
+                self.validate_const_expression(handle, module.to_ctx(), &mod_info)
                     .map_err(|source| {
                         ValidationError::ConstExpression { handle, source }
                             .with_span_handle(handle, &module.const_expressions)


### PR DESCRIPTION
The `ModuleInfo` was not used mutably.