### PR TITLE
[msl-out] Add and fix min version checks

### DIFF
--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -127,8 +127,6 @@ pub enum Error {
     UnsupportedBuiltIn(crate::BuiltIn),
     #[error("capability {0:?} is not supported")]
     CapabilityNotSupported(crate::valid::Capabilities),
-    #[error("address space {0:?} is not supported for target MSL version")]
-    UnsupportedAddressSpace(crate::AddressSpace),
     #[error("attribute '{0}' is not supported for target MSL version")]
     UnsupportedAttribute(String),
 }
@@ -197,7 +195,7 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Self {
         Options {
-            lang_version: (2, 0),
+            lang_version: (1, 0),
             per_entry_point_map: EntryPointResourceMap::default(),
             inline_samplers: Vec::new(),
             spirv_cross_compatibility: false,

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -135,6 +135,8 @@ pub enum Error {
     UnsupportedWriteableStorageBuffer,
     #[error("can not use writeable storage textures in {0:?} stage prior to MSL 1.2")]
     UnsupportedWriteableStorageTexture(crate::ShaderStage),
+    #[error("can not use read-write storage textures prior to MSL 1.2")]
+    UnsupportedRWStorageTexture,
 }
 
 #[derive(Clone, Debug, PartialEq, thiserror::Error)]

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -129,6 +129,8 @@ pub enum Error {
     CapabilityNotSupported(crate::valid::Capabilities),
     #[error("attribute '{0}' is not supported for target MSL version")]
     UnsupportedAttribute(String),
+    #[error("function '{0}' is not supported for target MSL version")]
+    UnsupportedFunction(String),
     #[error("can not use writeable storage buffers in fragment stage prior to MSL 1.2")]
     UnsupportedWriteableStorageBuffer,
     #[error("can not use writeable storage textures in {0:?} stage prior to MSL 1.2")]

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -129,6 +129,10 @@ pub enum Error {
     CapabilityNotSupported(crate::valid::Capabilities),
     #[error("attribute '{0}' is not supported for target MSL version")]
     UnsupportedAttribute(String),
+    #[error("can not use writeable storage buffers in fragment stage prior to MSL 1.2")]
+    UnsupportedWriteableStorageBuffer,
+    #[error("can not use writeable storage textures in {0:?} stage prior to MSL 1.2")]
+    UnsupportedWriteableStorageTexture(crate::ShaderStage),
 }
 
 #[derive(Clone, Debug, PartialEq, thiserror::Error)]

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -141,6 +141,8 @@ pub enum Error {
     UnsupportedArrayOf(String),
     #[error("array of type '{0:?}' is not supported")]
     UnsupportedArrayOfType(Handle<crate::Type>),
+    #[error("ray tracing is not supported prior to MSL 2.3")]
+    UnsupportedRayTracing,
 }
 
 #[derive(Clone, Debug, PartialEq, thiserror::Error)]

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -258,6 +258,11 @@ impl Options {
                     crate::BuiltIn::InstanceIndex if self.lang_version < (1, 2) => {
                         return Err(Error::UnsupportedAttribute("instance_id".to_string()));
                     }
+                    // macOS: Since Metal 2.2
+                    // iOS: Since Metal 2.3 (check depends on https://github.com/gfx-rs/naga/issues/2164)
+                    crate::BuiltIn::PrimitiveIndex if self.lang_version < (2, 2) => {
+                        return Err(Error::UnsupportedAttribute("primitive_id".to_string()));
+                    }
                     _ => {}
                 }
 

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -232,16 +232,25 @@ impl Options {
     ) -> Result<ResolvedBinding, Error> {
         match *binding {
             crate::Binding::BuiltIn(mut built_in) => {
-                if let crate::BuiltIn::Position { ref mut invariant } = built_in {
-                    if *invariant && self.lang_version < (2, 1) {
-                        return Err(Error::UnsupportedAttribute("invariant".to_string()));
-                    }
+                match built_in {
+                    crate::BuiltIn::Position { ref mut invariant } => {
+                        if *invariant && self.lang_version < (2, 1) {
+                            return Err(Error::UnsupportedAttribute("invariant".to_string()));
+                        }
 
-                    // The 'invariant' attribute may only appear on vertex
-                    // shader outputs, not fragment shader inputs.
-                    if !matches!(mode, LocationMode::VertexOutput) {
-                        *invariant = false;
+                        // The 'invariant' attribute may only appear on vertex
+                        // shader outputs, not fragment shader inputs.
+                        if !matches!(mode, LocationMode::VertexOutput) {
+                            *invariant = false;
+                        }
                     }
+                    crate::BuiltIn::BaseInstance if self.lang_version < (1, 2) => {
+                        return Err(Error::UnsupportedAttribute("base_instance".to_string()));
+                    }
+                    crate::BuiltIn::InstanceIndex if self.lang_version < (1, 2) => {
+                        return Err(Error::UnsupportedAttribute("instance_id".to_string()));
+                    }
+                    _ => {}
                 }
 
                 Ok(ResolvedBinding::BuiltIn(built_in))

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -137,6 +137,10 @@ pub enum Error {
     UnsupportedWriteableStorageTexture(crate::ShaderStage),
     #[error("can not use read-write storage textures prior to MSL 1.2")]
     UnsupportedRWStorageTexture,
+    #[error("array of '{0}' is not supported for target MSL version")]
+    UnsupportedArrayOf(String),
+    #[error("array of type '{0:?}' is not supported")]
+    UnsupportedArrayOfType(Handle<crate::Type>),
 }
 
 #[derive(Clone, Debug, PartialEq, thiserror::Error)]

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -3940,9 +3940,6 @@ impl<W: Write> Writer<W> {
                 let resolved = match var.space {
                     crate::AddressSpace::PushConstant => options.resolve_push_constants(ep).ok(),
                     crate::AddressSpace::WorkGroup => None,
-                    crate::AddressSpace::Storage { .. } if options.lang_version < (2, 0) => {
-                        return Err(Error::UnsupportedAddressSpace(var.space))
-                    }
                     _ => options
                         .resolve_resource_binding(ep, var.binding.as_ref().unwrap())
                         .ok(),

--- a/tests/in/access.param.ron
+++ b/tests/in/access.param.ron
@@ -5,7 +5,7 @@
 		adjust_coordinate_space: false,
 	),
 	msl: (
-		lang_version: (2, 0),
+		lang_version: (1, 2),
 		per_entry_point_map: {
 			"foo_vert": (
 				resources: {

--- a/tests/in/bitcast.params.ron
+++ b/tests/in/bitcast.params.ron
@@ -1,6 +1,6 @@
 (
 	msl: (
-		lang_version: (1, 2),
+		lang_version: (1, 0),
 		per_entry_point_map: {
 			"main": (
 				resources: {

--- a/tests/in/boids.param.ron
+++ b/tests/in/boids.param.ron
@@ -5,7 +5,7 @@
 		adjust_coordinate_space: false,
 	),
 	msl: (
-		lang_version: (2, 0),
+		lang_version: (1, 0),
 		per_entry_point_map: {
 			"main": (
 				resources: {

--- a/tests/in/bounds-check-image-restrict.param.ron
+++ b/tests/in/bounds-check-image-restrict.param.ron
@@ -13,4 +13,12 @@
 		binding_map: { },
 		zero_initialize_workgroup_memory: true,
 	),
+	msl: (
+		lang_version: (1, 2),
+		per_entry_point_map: {},
+		inline_samplers: [],
+		spirv_cross_compatibility: false,
+		fake_missing_bindings: true,
+		zero_initialize_workgroup_memory: true,
+	),
 )

--- a/tests/in/bounds-check-image-rzsw.param.ron
+++ b/tests/in/bounds-check-image-rzsw.param.ron
@@ -13,4 +13,12 @@
 		binding_map: { },
 		zero_initialize_workgroup_memory: true,
 	),
+	msl: (
+		lang_version: (1, 2),
+		per_entry_point_map: {},
+		inline_samplers: [],
+		spirv_cross_compatibility: false,
+		fake_missing_bindings: true,
+		zero_initialize_workgroup_memory: true,
+	),
 )

--- a/tests/in/dualsource.param.ron
+++ b/tests/in/dualsource.param.ron
@@ -1,13 +1,11 @@
 (
     god_mode: true,
-    vertex:[
-    ],
-    fragment:[
-        (
-            entry_point:"main",
-            target_profile:"ps_5_1",
-        ),
-    ],
-    compute:[
-    ],
+    msl: (
+		lang_version: (1, 2),
+		per_entry_point_map: {},
+		inline_samplers: [],
+		spirv_cross_compatibility: false,
+		fake_missing_bindings: false,
+		zero_initialize_workgroup_memory: true,
+	),
 )

--- a/tests/in/padding.param.ron
+++ b/tests/in/padding.param.ron
@@ -5,7 +5,7 @@
 		adjust_coordinate_space: false,
 	),
 	msl: (
-		lang_version: (2, 0),
+		lang_version: (1, 0),
 		per_entry_point_map: {
 			"vertex": (
 				resources: {

--- a/tests/in/resource-binding-map.param.ron
+++ b/tests/in/resource-binding-map.param.ron
@@ -1,7 +1,7 @@
 (
 	god_mode: true,
 	msl: (
-		lang_version: (2, 0),
+		lang_version: (1, 0),
 		per_entry_point_map: {
 			"entry_point_one": (
 				resources: {

--- a/tests/in/workgroup-var-init.param.ron
+++ b/tests/in/workgroup-var-init.param.ron
@@ -5,7 +5,7 @@
 		adjust_coordinate_space: false,
 	),
 	msl: (
-		lang_version: (2, 0),
+		lang_version: (1, 0),
 		per_entry_point_map: {
 			"main": (
 				resources: {

--- a/tests/out/msl/access.msl
+++ b/tests/out/msl/access.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.2
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/array-in-ctor.msl
+++ b/tests/out/msl/array-in-ctor.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/array-in-function-return-type.msl
+++ b/tests/out/msl/array-in-function-return-type.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/atomicOps.msl
+++ b/tests/out/msl/atomicOps.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/bitcast.msl
+++ b/tests/out/msl/bitcast.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/boids.msl
+++ b/tests/out/msl/boids.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/bounds-check-image-restrict.msl
+++ b/tests/out/msl/bounds-check-image-restrict.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.2
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/bounds-check-image-rzsw.msl
+++ b/tests/out/msl/bounds-check-image-rzsw.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.2
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/bounds-check-restrict.msl
+++ b/tests/out/msl/bounds-check-restrict.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/bounds-check-zero-atomic.msl
+++ b/tests/out/msl/bounds-check-zero-atomic.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/bounds-check-zero.msl
+++ b/tests/out/msl/bounds-check-zero.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/break-if.msl
+++ b/tests/out/msl/break-if.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/collatz.msl
+++ b/tests/out/msl/collatz.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/const-exprs.msl
+++ b/tests/out/msl/const-exprs.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/constructors.msl
+++ b/tests/out/msl/constructors.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/control-flow.msl
+++ b/tests/out/msl/control-flow.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/do-while.msl
+++ b/tests/out/msl/do-while.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/dualsource.msl
+++ b/tests/out/msl/dualsource.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.2
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/empty-global-name.msl
+++ b/tests/out/msl/empty-global-name.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/empty.msl
+++ b/tests/out/msl/empty.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/fragment-output.msl
+++ b/tests/out/msl/fragment-output.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/functions.msl
+++ b/tests/out/msl/functions.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/globals.msl
+++ b/tests/out/msl/globals.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/image.msl
+++ b/tests/out/msl/image.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/interpolate.msl
+++ b/tests/out/msl/interpolate.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/math-functions.msl
+++ b/tests/out/msl/math-functions.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/msl-varyings.msl
+++ b/tests/out/msl/msl-varyings.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/operators.msl
+++ b/tests/out/msl/operators.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/padding.msl
+++ b/tests/out/msl/padding.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/policy-mix.msl
+++ b/tests/out/msl/policy-mix.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/quad-vert.msl
+++ b/tests/out/msl/quad-vert.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/quad.msl
+++ b/tests/out/msl/quad.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/resource-binding-map.msl
+++ b/tests/out/msl/resource-binding-map.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/shadow.msl
+++ b/tests/out/msl/shadow.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/standard.msl
+++ b/tests/out/msl/standard.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/texture-arg.msl
+++ b/tests/out/msl/texture-arg.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/workgroup-uniform-load.msl
+++ b/tests/out/msl/workgroup-uniform-load.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 

--- a/tests/out/msl/workgroup-var-init.msl
+++ b/tests/out/msl/workgroup-var-init.msl
@@ -1,4 +1,4 @@
-// language: metal2.0
+// language: metal1.0
 #include <metal_stdlib>
 #include <simd/simd.h>
 


### PR DESCRIPTION
Seems to have been added in https://github.com/gfx-rs/naga/pull/1711 but there is no mention of this requirement in the [MSL spec](https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf). I also checked previous versions on the wayback machine.