### PR TITLE
snapshots: convert_spv: Don't validate the module twice.

### DIFF
--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -691,12 +691,6 @@ fn convert_spv(name: &str, adjust_coordinate_space: bool, targets: Targets) {
     )
     .unwrap();
     check_targets(&mut module, name, targets, None);
-    naga::valid::Validator::new(
-        naga::valid::ValidationFlags::all(),
-        naga::valid::Capabilities::default(),
-    )
-    .validate(&module)
-    .unwrap();
 }
 
 #[cfg(feature = "spv-in")]


### PR DESCRIPTION
Remove the call to `Validator::validate` in `convert_spv`, since it directly follows the call to `check_targets`, which also called `Validator::validate`.

The only difference between the two is whether `Parameters::god_mode` is respected, but this difference doesn't seem to have been deliberate: at the time the call to `check_targets` was added to `convert_spv` (5f21cf360, 2021-02-17), the two calls were exactly the same.