### PR TITLE
Add `Capabilities::ATOMIC_COMPARE_EXCHANGE_WEAK`.

### DIFF
--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -373,6 +373,19 @@ impl super::Validator {
         }
 
         if let crate::AtomicFunction::Exchange { compare: Some(cmp) } = *fun {
+            if !self
+                .capabilities
+                .contains(super::Capabilities::ATOMIC_COMPARE_EXCHANGE_WEAK)
+            {
+                return Err(FunctionError::Expression {
+                    handle: result,
+                    source: ExpressionError::MissingCapabilities(
+                        super::Capabilities::ATOMIC_COMPARE_EXCHANGE_WEAK,
+                    ),
+                }
+                .with_span_handle(result, context.expressions));
+            }
+
             if context.resolve_type(cmp, &self.valid_expression_set)? != value_inner {
                 log::error!("Atomic exchange comparison has a different type from the value");
                 return Err(AtomicError::InvalidOperand(cmp)

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -114,12 +114,18 @@ bitflags::bitflags! {
         const RAY_QUERY = 0x1000;
         /// Support for generating two sources for blending from fragement shaders
         const DUAL_SOURCE_BLENDING = 0x2000;
+        /// Support for WGSL atomicCompareExchangeWeak
+        ///
+        /// This is part of the WGSL standard, but it's not implemented yet for
+        /// some backends (#1413). Our benchmark harness would like to be able
+        /// to filter out modules we can't process successfully.
+        const ATOMIC_COMPARE_EXCHANGE_WEAK = 0x4000;
     }
 }
 
 impl Default for Capabilities {
     fn default() -> Self {
-        Self::MULTISAMPLED_SHADING
+        Self::MULTISAMPLED_SHADING | Self::ATOMIC_COMPARE_EXCHANGE_WEAK
     }
 }
 


### PR DESCRIPTION
We haven't finished implementing WGSL's `atomicCompareExchangeWeak` on all platforms: wgpu#4364. It's valuable to have some configuration of validation that guarantees backends will succeed, and adding a `Capabilities` bit that is included by default but can be turned off accomplishes that.