### PR TITLE
[glsl-out] Polyfill frexp

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -189,6 +189,10 @@ impl Version {
         *self >= Version::Desktop(400) || *self >= Version::new_gles(310)
     }
 
+    fn supports_frexp_function(&self) -> bool {
+        *self >= Version::Desktop(400) || *self >= Version::new_gles(310)
+    }
+
     fn supports_derivative_control(&self) -> bool {
         *self >= Version::Desktop(450)
     }
@@ -667,15 +671,27 @@ impl<'a, W: Write> Writer<'a, W> {
                     let struct_name = &self.names[&NameKey::Type(*struct_ty)];
 
                     writeln!(self.out)?;
-                    writeln!(
-                        self.out,
-                        "{} {defined_func_name}({arg_type_name} arg) {{
+                    if !self.options.version.supports_frexp_function()
+                        && matches!(type_key, &crate::PredeclaredType::FrexpResult { .. })
+                    {
+                        writeln!(
+                            self.out,
+                            "{struct_name} {defined_func_name}({arg_type_name} arg) {{
+    {other_type_name} other = arg == {arg_type_name}(0) ? {other_type_name}(0) : {other_type_name}({arg_type_name}(1) + log2(arg));
+    {arg_type_name} fract = arg * exp2({arg_type_name}(-other));
+    return {struct_name}(fract, other);
+}}",
+                        )?;
+                    } else {
+                        writeln!(
+                            self.out,
+                            "{struct_name} {defined_func_name}({arg_type_name} arg) {{
     {other_type_name} other;
     {arg_type_name} fract = {called_func_name}(arg, other);
-    return {}(fract, other);
+    return {struct_name}(fract, other);
 }}",
-                        struct_name, struct_name
-                    )?;
+                        )?;
+                    }
                 }
                 &crate::PredeclaredType::AtomicCompareExchangeWeakResult { .. } => {}
             }


### PR DESCRIPTION
Implementation derived from https://en.cppreference.com/w/cpp/numeric/math/frexp#Notes. 

Produces the following in `tests/out/glsl/math-functions.main.Fragment.glsl` when targeting `< 400 & 310 es`.
``` glsl
45   │ __frexp_result_f32_ naga_frexp(float arg) {
46   │     int other = arg == float(0) ? int(0) : int(float(1) + log2(arg));
47   │     float fract = arg * exp2(float(-other));
48   │     return __frexp_result_f32_(fract, other);
49   │ }
50   │
51   │ __frexp_result_vec4_f32_ naga_frexp(vec4 arg) {
52   │     ivec4 other = arg == vec4(0) ? ivec4(0) : ivec4(vec4(1) + log2(arg));
53   │     vec4 fract = arg * exp2(vec4(-other));
54   │     return __frexp_result_vec4_f32_(fract, other);
55   │ }
```