### PR TITLE
Require new `Capabilities::BINDING_ARRAY` for `binding_array` type.

### DIFF
--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -114,6 +114,8 @@ bitflags::bitflags! {
         const RAY_QUERY = 0x1000;
         /// Support for generating two sources for blending from fragement shaders
         const DUAL_SOURCE_BLENDING = 0x2000;
+        /// Support for binding arrays.
+        const BINDING_ARRAY = 0x4000;
     }
 }
 

--- a/src/valid/type.rs
+++ b/src/valid/type.rs
@@ -569,6 +569,7 @@ impl super::Validator {
                 TypeInfo::new(TypeFlags::DATA | TypeFlags::SIZED, Alignment::ONE)
             }
             Ti::BindingArray { base, size } => {
+                self.require_type_capability(Capabilities::BINDING_ARRAY)?;
                 if base >= handle {
                     return Err(TypeError::InvalidArrayBaseType(base));
                 }

--- a/tests/in/binding-buffer-arrays.param.ron
+++ b/tests/in/binding-buffer-arrays.param.ron
@@ -1,5 +1,5 @@
 (
-	god_mode: false,
+	god_mode: true,
 	spv: (
 		version: (1, 1),
 		binding_map: {

--- a/tests/in/spv/binding-arrays.dynamic.param.ron
+++ b/tests/in/spv/binding-arrays.dynamic.param.ron
@@ -1,0 +1,3 @@
+(
+	god_mode: true,
+)

--- a/tests/in/spv/binding-arrays.static.param.ron
+++ b/tests/in/spv/binding-arrays.static.param.ron
@@ -1,0 +1,3 @@
+(
+	god_mode: true,
+)


### PR DESCRIPTION
Introduce a new `Capabilities::BINDING_ARRAY` flag, which enables use of the Naga `TypeInner::BindingArray` type.

Adjust tests that exercise binding arrays to pass this flag.