### PR TITLE
snapshots: convert_wgsl: Remove redundant cubeArrayShadow entry.

### DIFF
--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -740,7 +740,6 @@ fn convert_wgsl() {
             "math-functions",
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,
         ),
-        ("cubeArrayShadow", Targets::GLSL),
         (
             "binding-arrays",
             Targets::WGSL | Targets::HLSL | Targets::METAL | Targets::SPIRV,


### PR DESCRIPTION
The duplicate entry was introduced accidentally in #1845.