### PR TITLE
Disable uniformity analysis for the fragment stage

### DIFF
--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -492,7 +492,7 @@ impl super::Validator {
                             } => {}
                             _ => return Err(ExpressionError::InvalidSampleLevelBiasType(expr)),
                         }
-                        ShaderStages::all()
+                        ShaderStages::FRAGMENT
                     }
                     crate::SampleLevel::Gradient { x, y } => {
                         match resolver[x] {


### PR DESCRIPTION
Disables uniformity requirements for the following:
- derivative builtin functions
- `textureSample`
- `textureSampleBias`
- `textureSampleCompare`

These are the same builtins `derivative_uniformity` diagnostic targets.