### PR TITLE
Rename some ConstantEvaluator-associated types and values.

### DIFF
--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -245,7 +245,7 @@ impl<'w> BlockContext<'w> {
             crate::Expression::ZeroValue(_) => self.writer.get_constant_null(result_type_id),
             crate::Expression::Compose { ty, ref components } => {
                 self.temp_list.clear();
-                if self.expression_constness.contains(expr_handle) {
+                if self.expression_constness.is_const(expr_handle) {
                     self.temp_list.extend(
                         crate::proc::flatten_compose(
                             ty,
@@ -274,7 +274,7 @@ impl<'w> BlockContext<'w> {
                 let value_id = self.cached[value];
                 let components = &[value_id; 4][..size as usize];
 
-                if self.expression_constness.contains(expr_handle) {
+                if self.expression_constness.is_const(expr_handle) {
                     let ty = self
                         .writer
                         .get_expression_lookup_type(&self.fun_info[expr_handle].ty);
@@ -1777,7 +1777,7 @@ impl<'w> BlockContext<'w> {
                 crate::Statement::Emit(ref range) => {
                     for handle in range.clone() {
                         // omit const expressions as we've already cached those
-                        if !self.expression_constness.contains(handle) {
+                        if !self.expression_constness.is_const(handle) {
                             self.cache_expression_value(handle, &mut block)?;
                         }
                     }

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -629,7 +629,7 @@ impl Writer {
         context.cached.reset(ir_function.expressions.len());
         for (handle, expr) in ir_function.expressions.iter() {
             if (expr.needs_pre_emit() && !matches!(*expr, crate::Expression::LocalVariable(_)))
-                || context.expression_constness.contains(handle)
+                || context.expression_constness.is_const(handle)
             {
                 context.cache_expression_value(handle, &mut prelude)?;
             }

--- a/src/front/glsl/context.rs
+++ b/src/front/glsl/context.rs
@@ -248,12 +248,12 @@ impl<'a> Context<'a> {
     }
 
     pub fn add_expression(&mut self, expr: Expression, meta: Span) -> Result<Handle<Expression>> {
-        let (expressions, extra_data) = if self.is_const {
+        let (expressions, function_info) = if self.is_const {
             (&mut self.module.const_expressions, None)
         } else {
             (
                 &mut self.expressions,
-                Some(crate::proc::ConstantEvaluatorExtraData {
+                Some(crate::proc::FunctionLocalData {
                     const_expressions: &self.module.const_expressions,
                     expression_constness: &mut self.expression_constness,
                     emitter: &mut self.emitter,
@@ -266,7 +266,7 @@ impl<'a> Context<'a> {
             types: &mut self.module.types,
             constants: &self.module.constants,
             expressions,
-            extra_data,
+            function_local_data: function_info,
         };
 
         let res = eval.try_eval_and_append(&expr, meta).map_err(|e| Error {

--- a/src/front/glsl/parser/declarations.rs
+++ b/src/front/glsl/parser/declarations.rs
@@ -251,7 +251,7 @@ impl<'source> ParsingContext<'source> {
             } else if ctx.external {
                 init.and_then(|expr| ctx.ctx.lift_up_const_expression(expr).ok())
             } else {
-                init.filter(|expr| ctx.ctx.expression_constness.contains(*expr))
+                init.filter(|expr| ctx.ctx.expression_constness.is_const(*expr))
             };
 
             let pointer = ctx.add_var(frontend, ty, name, maybe_const_expr, meta)?;

--- a/src/front/wgsl/lower/mod.rs
+++ b/src/front/wgsl/lower/mod.rs
@@ -6,8 +6,8 @@ use crate::front::wgsl::parse::number::Number;
 use crate::front::wgsl::parse::{ast, conv};
 use crate::front::Typifier;
 use crate::proc::{
-    ensure_block_returns, Alignment, ConstantEvaluator, ConstantEvaluatorExtraData, Emitter,
-    Layouter, ResolveContext, TypeResolution,
+    ensure_block_returns, Alignment, ConstantEvaluator, Emitter, FunctionLocalData, Layouter,
+    ResolveContext, TypeResolution,
 };
 use crate::{Arena, FastHashMap, FastIndexMap, Handle, Span};
 
@@ -344,7 +344,7 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
                     types: &mut self.module.types,
                     constants: &self.module.constants,
                     expressions: rctx.naga_expressions,
-                    extra_data: Some(ConstantEvaluatorExtraData {
+                    function_local_data: Some(FunctionLocalData {
                         const_expressions: &self.module.const_expressions,
                         expression_constness: rctx.expression_constness,
                         emitter: rctx.emitter,
@@ -362,7 +362,7 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
                     types: &mut self.module.types,
                     constants: &self.module.constants,
                     expressions: &mut self.module.const_expressions,
-                    extra_data: None,
+                    function_local_data: None,
                 };
 
                 eval.try_eval_and_append(&expr, span)
@@ -1184,7 +1184,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
                     let (const_initializer, initializer) = {
                         match initializer {
-                            Some(init) if ctx.expression_constness.contains(init) => {
+                            Some(init) if ctx.expression_constness.is_const(init) => {
                                 (Some(init), None)
                             }
                             Some(init) => (None, Some(init)),

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -11,8 +11,7 @@ mod terminator;
 mod typifier;
 
 pub use constant_evaluator::{
-    ConstantEvaluator, ConstantEvaluatorError, ConstantEvaluatorExtraData,
-    ExpressionConstnessTracker,
+    ConstantEvaluator, ConstantEvaluatorError, ExpressionConstnessTracker, FunctionLocalData,
 };
 pub use emitter::Emitter;
 pub use index::{BoundsCheckPolicies, BoundsCheckPolicy, IndexableLength, IndexableLengthError};


### PR DESCRIPTION
These names seem more informative. "Extra Data" is pretty noisy. "Info" is at least what Naga already uses for "Data collected about this other thing" (ModuleInfo, FunctionInfo, etc.).

- `ExpressionConstnessTracker::contains` -> `is_const`
- `ConstantEvaluatorExtraData` -> `FunctionConstantInfo` 
- `ConstantEvaluator::extra_data` -> `function_info`
