### PR TITLE
Tighten up `ConstantEvaluator`'s public API.

### DIFF
--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -11,7 +11,7 @@ mod terminator;
 mod typifier;
 
 pub use constant_evaluator::{
-    ConstantEvaluator, ConstantEvaluatorError, ExpressionConstnessTracker, FunctionLocalData,
+    ConstantEvaluator, ConstantEvaluatorError, ExpressionConstnessTracker,
 };
 pub use emitter::Emitter;
 pub use index::{BoundsCheckPolicies, BoundsCheckPolicy, IndexableLength, IndexableLengthError};


### PR DESCRIPTION
- Make the fields of `ConstantEvaluator` private to the module.
- Add constructor functions `for_module` and `for_function`.
- Make `FunctionConstantInfo` private.