### PR TITLE
[msl-out] Make varyings' struct members unique

### DIFF
--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -3713,16 +3713,14 @@ impl<W: Write> Writer<W> {
                                 member.ty,
                                 member.binding.as_ref(),
                             ));
-                            let name_key = &NameKey::StructMember(arg.ty, member_index);
-                            flattened_member_names.insert(
-                                NameKey::StructMember(arg.ty, member_index),
-                                match member.binding {
-                                    Some(crate::Binding::Location { .. }) => {
-                                        varyings_namer.call(&self.names[name_key])
-                                    }
-                                    _ => self.namer.call(&self.names[name_key]),
-                                },
-                            );
+                            let name_key = NameKey::StructMember(arg.ty, member_index);
+                            let name = match member.binding {
+                                Some(crate::Binding::Location { .. }) => {
+                                    varyings_namer.call(&self.names[&name_key])
+                                }
+                                _ => self.namer.call(&self.names[&name_key]),
+                            };
+                            flattened_member_names.insert(name_key, name);
                         }
                     }
                     _ => flattened_arguments.push((

--- a/tests/in/msl-varyings.wgsl
+++ b/tests/in/msl-varyings.wgsl
@@ -1,0 +1,22 @@
+struct Vertex {
+    @location(0) position: vec2f
+}
+
+struct NoteInstance {
+    @location(1) position: vec2f
+}
+
+struct VertexOutput {
+    @builtin(position) position: vec4f
+}
+
+@vertex
+fn vs_main(vertex: Vertex, note: NoteInstance) -> VertexOutput {
+    var out: VertexOutput;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput, note: NoteInstance) -> @location(0) vec4f {
+    return in.position;
+}

--- a/tests/in/msl-varyings.wgsl
+++ b/tests/in/msl-varyings.wgsl
@@ -18,5 +18,6 @@ fn vs_main(vertex: Vertex, note: NoteInstance) -> VertexOutput {
 
 @fragment
 fn fs_main(in: VertexOutput, note: NoteInstance) -> @location(0) vec4f {
+    let position = vec3(1f);
     return in.position;
 }

--- a/tests/out/msl/msl-varyings.msl
+++ b/tests/out/msl/msl-varyings.msl
@@ -1,0 +1,49 @@
+// language: metal2.0
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+struct Vertex {
+    metal::float2 position;
+};
+struct NoteInstance {
+    metal::float2 position;
+};
+struct VertexOutput {
+    metal::float4 position;
+};
+
+struct vs_mainInput {
+    metal::float2 position [[attribute(0)]];
+    metal::float2 position_1 [[attribute(1)]];
+};
+struct vs_mainOutput {
+    metal::float4 position [[position]];
+};
+vertex vs_mainOutput vs_main(
+  vs_mainInput varyings [[stage_in]]
+) {
+    const Vertex vertex_ = { varyings.position };
+    const NoteInstance note = { varyings.position_1 };
+    VertexOutput out = {};
+    VertexOutput _e3 = out;
+    const auto _tmp = _e3;
+    return vs_mainOutput { _tmp.position };
+}
+
+
+struct fs_mainInput {
+    metal::float2 position_3 [[user(loc1), center_perspective]];
+};
+struct fs_mainOutput {
+    metal::float4 member_1 [[color(0)]];
+};
+fragment fs_mainOutput fs_main(
+  fs_mainInput varyings_1 [[stage_in]]
+, metal::float4 position_2 [[position]]
+) {
+    const VertexOutput in = { position_2 };
+    const NoteInstance note_1 = { varyings_1.position_3 };
+    return fs_mainOutput { in.position };
+}

--- a/tests/out/msl/msl-varyings.msl
+++ b/tests/out/msl/msl-varyings.msl
@@ -34,16 +34,17 @@ vertex vs_mainOutput vs_main(
 
 
 struct fs_mainInput {
-    metal::float2 position_3 [[user(loc1), center_perspective]];
+    metal::float2 position [[user(loc1), center_perspective]];
 };
 struct fs_mainOutput {
     metal::float4 member_1 [[color(0)]];
 };
 fragment fs_mainOutput fs_main(
   fs_mainInput varyings_1 [[stage_in]]
-, metal::float4 position_2 [[position]]
+, metal::float4 position [[position]]
 ) {
-    const VertexOutput in = { position_2 };
-    const NoteInstance note_1 = { varyings_1.position_3 };
+    const VertexOutput in = { position };
+    const NoteInstance note_1 = { varyings_1.position };
+    metal::float3 position_1 = metal::float3(1.0);
     return fs_mainOutput { in.position };
 }

--- a/tests/out/msl/shadow.msl
+++ b/tests/out/msl/shadow.msl
@@ -133,8 +133,8 @@ fragment fs_mainOutput fs_main(
 
 
 struct fs_main_without_storageInput {
-    metal::float3 world_normal_1 [[user(loc0), center_perspective]];
-    metal::float4 world_position_1 [[user(loc1), center_perspective]];
+    metal::float3 world_normal [[user(loc0), center_perspective]];
+    metal::float4 world_position [[user(loc1), center_perspective]];
 };
 struct fs_main_without_storageOutput {
     metal::float4 member_2 [[color(0)]];
@@ -148,7 +148,7 @@ fragment fs_main_without_storageOutput fs_main_without_storage(
 , metal::depth2d_array<float, metal::access::sample> t_shadow [[user(fake0)]]
 , metal::sampler sampler_shadow [[user(fake0)]]
 ) {
-    const VertexOutput in_1 = { proj_position_1, varyings_2.world_normal_1, varyings_2.world_position_1 };
+    const VertexOutput in_1 = { proj_position_1, varyings_2.world_normal, varyings_2.world_position };
     metal::float3 color_1 = {};
     uint i_1 = {};
     metal::float3 normal_2 = metal::normalize(in_1.world_normal);

--- a/tests/out/msl/shadow.msl
+++ b/tests/out/msl/shadow.msl
@@ -133,8 +133,8 @@ fragment fs_mainOutput fs_main(
 
 
 struct fs_main_without_storageInput {
-    metal::float3 world_normal [[user(loc0), center_perspective]];
-    metal::float4 world_position [[user(loc1), center_perspective]];
+    metal::float3 world_normal_1 [[user(loc0), center_perspective]];
+    metal::float4 world_position_1 [[user(loc1), center_perspective]];
 };
 struct fs_main_without_storageOutput {
     metal::float4 member_2 [[color(0)]];
@@ -148,7 +148,7 @@ fragment fs_main_without_storageOutput fs_main_without_storage(
 , metal::depth2d_array<float, metal::access::sample> t_shadow [[user(fake0)]]
 , metal::sampler sampler_shadow [[user(fake0)]]
 ) {
-    const VertexOutput in_1 = { proj_position_1, varyings_2.world_normal, varyings_2.world_position };
+    const VertexOutput in_1 = { proj_position_1, varyings_2.world_normal_1, varyings_2.world_position_1 };
     metal::float3 color_1 = {};
     uint i_1 = {};
     metal::float3 normal_2 = metal::normalize(in_1.world_normal);

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -777,6 +777,7 @@ fn convert_wgsl() {
             "constructors",
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,
         ),
+        ("msl-varyings", Targets::METAL),
     ];
 
     for &(name, targets) in inputs.iter() {


### PR DESCRIPTION
Fixes #1490

Naming conflicts can occur when multiple structs get flattened into one varyings struct.
This moves the `namer.call` invocation into the flattening routine so that each member gets a unique name.