### PR TITLE
Let `ConstantEvaluator` see through `Constant` exprs in `Splat` and `Compose` exprs.

### DIFF
--- a/src/proc/constant_evaluator.rs
+++ b/src/proc/constant_evaluator.rs
@@ -217,9 +217,9 @@ impl<'a> ConstantEvaluator<'a> {
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(self.register_evaluated_expr(Expression::Compose { ty, components }, span))
             }
-            Expression::Splat { value, .. } => {
-                self.check(value)?;
-                Ok(self.register_evaluated_expr(expr.clone(), span))
+            Expression::Splat { size, value } => {
+                let value = self.check_and_get(value)?;
+                Ok(self.register_evaluated_expr(Expression::Splat { size, value }, span))
             }
             Expression::AccessIndex { base, index } => {
                 let base = self.check_and_get(base)?;
@@ -1396,6 +1396,89 @@ mod tests {
                 &Expression::Compose {
                     ty: vec2_i32_ty,
                     components: vec![h_expr, h_expr],
+                },
+                Default::default(),
+            )
+            .unwrap();
+        let solved_negate = solver
+            .try_eval_and_append(
+                &Expression::Unary {
+                    op: UnaryOperator::Negate,
+                    expr: solved_compose,
+                },
+                Default::default(),
+            )
+            .unwrap();
+
+        let pass = match const_expressions[solved_negate] {
+            Expression::Compose { ty, ref components } => {
+                ty == vec2_i32_ty
+                    && components.iter().all(|&component| {
+                        let component = &const_expressions[component];
+                        matches!(*component, Expression::Literal(Literal::I32(-4)))
+                    })
+            }
+            _ => false,
+        };
+        if !pass {
+            panic!("unexpected evaluation result")
+        }
+    }
+
+    #[test]
+    fn splat_of_constant() {
+        let mut types = UniqueArena::new();
+        let mut constants = Arena::new();
+        let mut const_expressions = Arena::new();
+
+        let i32_ty = types.insert(
+            Type {
+                name: None,
+                inner: TypeInner::Scalar {
+                    kind: ScalarKind::Sint,
+                    width: 4,
+                },
+            },
+            Default::default(),
+        );
+
+        let vec2_i32_ty = types.insert(
+            Type {
+                name: None,
+                inner: TypeInner::Vector {
+                    size: VectorSize::Bi,
+                    kind: ScalarKind::Sint,
+                    width: 4,
+                },
+            },
+            Default::default(),
+        );
+
+        let h = constants.append(
+            Constant {
+                name: None,
+                r#override: crate::Override::None,
+                ty: i32_ty,
+                init: const_expressions
+                    .append(Expression::Literal(Literal::I32(4)), Default::default()),
+            },
+            Default::default(),
+        );
+
+        let h_expr = const_expressions.append(Expression::Constant(h), Default::default());
+
+        let mut solver = ConstantEvaluator {
+            types: &mut types,
+            constants: &constants,
+            expressions: &mut const_expressions,
+            function_local_data: None,
+        };
+
+        let solved_compose = solver
+            .try_eval_and_append(
+                &Expression::Splat {
+                    size: VectorSize::Bi,
+                    value: h_expr,
                 },
                 Default::default(),
             )

--- a/src/proc/constant_evaluator.rs
+++ b/src/proc/constant_evaluator.rs
@@ -210,11 +210,12 @@ impl<'a> ConstantEvaluator<'a> {
             Expression::Literal(_) | Expression::ZeroValue(_) | Expression::Constant(_) => {
                 Ok(self.register_evaluated_expr(expr.clone(), span))
             }
-            Expression::Compose { ref components, .. } => {
-                for component in components {
-                    self.check(*component)?;
-                }
-                Ok(self.register_evaluated_expr(expr.clone(), span))
+            Expression::Compose { ty, ref components } => {
+                let components = components
+                    .iter()
+                    .map(|component| self.check_and_get(*component))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(self.register_evaluated_expr(Expression::Compose { ty, components }, span))
             }
             Expression::Splat { value, .. } => {
                 self.check(value)?;
@@ -1339,5 +1340,88 @@ mod tests {
             const_expressions[res2],
             Expression::Literal(Literal::F32(5.))
         );
+    }
+
+    #[test]
+    fn compose_of_constants() {
+        let mut types = UniqueArena::new();
+        let mut constants = Arena::new();
+        let mut const_expressions = Arena::new();
+
+        let i32_ty = types.insert(
+            Type {
+                name: None,
+                inner: TypeInner::Scalar {
+                    kind: ScalarKind::Sint,
+                    width: 4,
+                },
+            },
+            Default::default(),
+        );
+
+        let vec2_i32_ty = types.insert(
+            Type {
+                name: None,
+                inner: TypeInner::Vector {
+                    size: VectorSize::Bi,
+                    kind: ScalarKind::Sint,
+                    width: 4,
+                },
+            },
+            Default::default(),
+        );
+
+        let h = constants.append(
+            Constant {
+                name: None,
+                r#override: crate::Override::None,
+                ty: i32_ty,
+                init: const_expressions
+                    .append(Expression::Literal(Literal::I32(4)), Default::default()),
+            },
+            Default::default(),
+        );
+
+        let h_expr = const_expressions.append(Expression::Constant(h), Default::default());
+
+        let mut solver = ConstantEvaluator {
+            types: &mut types,
+            constants: &constants,
+            expressions: &mut const_expressions,
+            function_local_data: None,
+        };
+
+        let solved_compose = solver
+            .try_eval_and_append(
+                &Expression::Compose {
+                    ty: vec2_i32_ty,
+                    components: vec![h_expr, h_expr],
+                },
+                Default::default(),
+            )
+            .unwrap();
+        let solved_negate = solver
+            .try_eval_and_append(
+                &Expression::Unary {
+                    op: UnaryOperator::Negate,
+                    expr: solved_compose,
+                },
+                Default::default(),
+            )
+            .unwrap();
+
+        let pass = match const_expressions[solved_negate] {
+            Expression::Compose { ty, ref components } => {
+                ty == vec2_i32_ty
+                    && components.iter().all(|&component| {
+                        let component = &const_expressions[component];
+                        matches!(*component, Expression::Literal(Literal::I32(-4)))
+                    })
+            }
+            _ => false,
+        };
+        if !pass {
+            panic!("unexpected evaluation result")
+        }
     }
 }

--- a/tests/in/const-exprs.wgsl
+++ b/tests/in/const-exprs.wgsl
@@ -7,6 +7,8 @@ fn main() {
    index_of_compose();
    compose_three_deep();
    non_constant_initializers();
+   splat_of_constant();
+   compose_of_constant();
 }
 
 // Swizzle the value of nested Compose expressions.
@@ -45,4 +47,16 @@ fn non_constant_initializers() {
    var z = 30 + 40;
 
    out += vec4(w, x, y, z);
+}
+
+// Constant evaluation should be able to see through constants to
+// their values.
+const FOUR: i32 = 4;
+
+fn splat_of_constant() {
+    out = -vec4(FOUR);
+}
+
+fn compose_of_constant() {
+    out = -vec4(FOUR, FOUR, FOUR, FOUR);
 }

--- a/tests/out/glsl/const-exprs.main.Compute.glsl
+++ b/tests/out/glsl/const-exprs.main.Compute.glsl
@@ -52,7 +52,7 @@ void non_constant_initializers() {
 }
 
 void splat_of_constant() {
-    _group_0_binding_0_cs = -(ivec4(FOUR));
+    _group_0_binding_0_cs = ivec4(-4, -4, -4, -4);
     return;
 }
 

--- a/tests/out/glsl/const-exprs.main.Compute.glsl
+++ b/tests/out/glsl/const-exprs.main.Compute.glsl
@@ -5,6 +5,8 @@ precision highp int;
 
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
+const int FOUR = 4;
+
 layout(std430) buffer type_block_0Compute { ivec4 _group_0_binding_0_cs; };
 
 layout(std430) buffer type_1_block_1Compute { int _group_0_binding_1_cs; };
@@ -49,11 +51,23 @@ void non_constant_initializers() {
     return;
 }
 
+void splat_of_constant() {
+    _group_0_binding_0_cs = -(ivec4(FOUR));
+    return;
+}
+
+void compose_of_constant() {
+    _group_0_binding_0_cs = -(ivec4(FOUR, FOUR, FOUR, FOUR));
+    return;
+}
+
 void main() {
     swizzle_of_compose();
     index_of_compose();
     compose_three_deep();
     non_constant_initializers();
+    splat_of_constant();
+    compose_of_constant();
     return;
 }
 

--- a/tests/out/glsl/const-exprs.main.Compute.glsl
+++ b/tests/out/glsl/const-exprs.main.Compute.glsl
@@ -57,7 +57,7 @@ void splat_of_constant() {
 }
 
 void compose_of_constant() {
-    _group_0_binding_0_cs = -(ivec4(FOUR, FOUR, FOUR, FOUR));
+    _group_0_binding_0_cs = ivec4(-4, -4, -4, -4);
     return;
 }
 

--- a/tests/out/hlsl/const-exprs.hlsl
+++ b/tests/out/hlsl/const-exprs.hlsl
@@ -49,7 +49,7 @@ void non_constant_initializers()
 
 void splat_of_constant()
 {
-    out_.Store4(0, asuint(-((FOUR).xxxx)));
+    out_.Store4(0, asuint(int4(-4, -4, -4, -4)));
     return;
 }
 

--- a/tests/out/hlsl/const-exprs.hlsl
+++ b/tests/out/hlsl/const-exprs.hlsl
@@ -55,7 +55,7 @@ void splat_of_constant()
 
 void compose_of_constant()
 {
-    out_.Store4(0, asuint(-(int4(FOUR, FOUR, FOUR, FOUR))));
+    out_.Store4(0, asuint(int4(-4, -4, -4, -4)));
     return;
 }
 

--- a/tests/out/hlsl/const-exprs.hlsl
+++ b/tests/out/hlsl/const-exprs.hlsl
@@ -1,3 +1,5 @@
+static const int FOUR = 4;
+
 RWByteAddressBuffer out_ : register(u0);
 RWByteAddressBuffer out2_ : register(u1);
 
@@ -45,6 +47,18 @@ void non_constant_initializers()
     return;
 }
 
+void splat_of_constant()
+{
+    out_.Store4(0, asuint(-((FOUR).xxxx)));
+    return;
+}
+
+void compose_of_constant()
+{
+    out_.Store4(0, asuint(-(int4(FOUR, FOUR, FOUR, FOUR))));
+    return;
+}
+
 [numthreads(1, 1, 1)]
 void main()
 {
@@ -52,5 +66,7 @@ void main()
     index_of_compose();
     compose_three_deep();
     non_constant_initializers();
+    splat_of_constant();
+    compose_of_constant();
     return;
 }

--- a/tests/out/msl/const-exprs.msl
+++ b/tests/out/msl/const-exprs.msl
@@ -4,6 +4,7 @@
 
 using metal::uint;
 
+constant int FOUR = 4;
 
 void swizzle_of_compose(
     device metal::int4& out
@@ -52,6 +53,20 @@ void non_constant_initializers(
     return;
 }
 
+void splat_of_constant(
+    device metal::int4& out
+) {
+    out = -(metal::int4(FOUR));
+    return;
+}
+
+void compose_of_constant(
+    device metal::int4& out
+) {
+    out = -(metal::int4(FOUR, FOUR, FOUR, FOUR));
+    return;
+}
+
 kernel void main_(
   device metal::int4& out [[user(fake0)]]
 , device int& out2_ [[user(fake0)]]
@@ -60,5 +75,7 @@ kernel void main_(
     index_of_compose(out2_);
     compose_three_deep(out2_);
     non_constant_initializers(out);
+    splat_of_constant(out);
+    compose_of_constant(out);
     return;
 }

--- a/tests/out/msl/const-exprs.msl
+++ b/tests/out/msl/const-exprs.msl
@@ -63,7 +63,7 @@ void splat_of_constant(
 void compose_of_constant(
     device metal::int4& out
 ) {
-    out = -(metal::int4(FOUR, FOUR, FOUR, FOUR));
+    out = metal::int4(-4, -4, -4, -4);
     return;
 }
 

--- a/tests/out/msl/const-exprs.msl
+++ b/tests/out/msl/const-exprs.msl
@@ -56,7 +56,7 @@ void non_constant_initializers(
 void splat_of_constant(
     device metal::int4& out
 ) {
-    out = -(metal::int4(FOUR));
+    out = metal::int4(-4, -4, -4, -4);
     return;
 }
 

--- a/tests/out/spv/const-exprs.spvasm
+++ b/tests/out/spv/const-exprs.spvasm
@@ -1,13 +1,13 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 92
+; Bound: 90
 OpCapability Shader
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %82 "main"
-OpExecutionMode %82 LocalSize 1 1 1
+OpEntryPoint GLCompute %80 "main"
+OpExecutionMode %80 LocalSize 1 1 1
 OpDecorate %8 DescriptorSet 0
 OpDecorate %8 Binding 0
 OpDecorate %9 Block
@@ -50,9 +50,8 @@ OpMemberDecorate %12 0 Offset 0
 %53 = OpTypePointer Function %4
 %55 = OpConstantNull  %4
 %57 = OpConstantNull  %4
-%72 = OpConstantComposite  %3  %7 %7 %7 %7
-%78 = OpConstant  %4  -4
-%79 = OpConstantComposite  %3  %78 %78 %78 %78
+%72 = OpConstant  %4  -4
+%73 = OpConstantComposite  %3  %72 %72 %72 %72
 %15 = OpFunction  %2  None %16
 %14 = OpLabel
 %20 = OpAccessChain  %17  %8 %18
@@ -107,31 +106,30 @@ OpFunctionEnd
 %70 = OpFunction  %2  None %16
 %69 = OpLabel
 %71 = OpAccessChain  %17  %8 %18
-OpBranch %73
-%73 = OpLabel
-%74 = OpSNegate  %3  %72
-OpStore %71 %74
+OpBranch %74
+%74 = OpLabel
+OpStore %71 %73
 OpReturn
 OpFunctionEnd
 %76 = OpFunction  %2  None %16
 %75 = OpLabel
 %77 = OpAccessChain  %17  %8 %18
-OpBranch %80
-%80 = OpLabel
-OpStore %77 %79
+OpBranch %78
+%78 = OpLabel
+OpStore %77 %73
 OpReturn
 OpFunctionEnd
-%82 = OpFunction  %2  None %16
-%81 = OpLabel
-%83 = OpAccessChain  %17  %8 %18
-%84 = OpAccessChain  %30  %11 %18
-OpBranch %85
-%85 = OpLabel
-%86 = OpFunctionCall  %2  %15
-%87 = OpFunctionCall  %2  %29
-%88 = OpFunctionCall  %2  %36
-%89 = OpFunctionCall  %2  %48
-%90 = OpFunctionCall  %2  %70
-%91 = OpFunctionCall  %2  %76
+%80 = OpFunction  %2  None %16
+%79 = OpLabel
+%81 = OpAccessChain  %17  %8 %18
+%82 = OpAccessChain  %30  %11 %18
+OpBranch %83
+%83 = OpLabel
+%84 = OpFunctionCall  %2  %15
+%85 = OpFunctionCall  %2  %29
+%86 = OpFunctionCall  %2  %36
+%87 = OpFunctionCall  %2  %48
+%88 = OpFunctionCall  %2  %70
+%89 = OpFunctionCall  %2  %76
 OpReturn
 OpFunctionEnd

--- a/tests/out/spv/const-exprs.spvasm
+++ b/tests/out/spv/const-exprs.spvasm
@@ -1,43 +1,43 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 78
+; Bound: 92
 OpCapability Shader
 OpExtension "SPV_KHR_storage_buffer_storage_class"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %70 "main"
-OpExecutionMode %70 LocalSize 1 1 1
-OpDecorate %7 DescriptorSet 0
-OpDecorate %7 Binding 0
-OpDecorate %8 Block
-OpMemberDecorate %8 0 Offset 0
-OpDecorate %10 DescriptorSet 0
-OpDecorate %10 Binding 1
-OpDecorate %11 Block
-OpMemberDecorate %11 0 Offset 0
+OpEntryPoint GLCompute %82 "main"
+OpExecutionMode %82 LocalSize 1 1 1
+OpDecorate %8 DescriptorSet 0
+OpDecorate %8 Binding 0
+OpDecorate %9 Block
+OpMemberDecorate %9 0 Offset 0
+OpDecorate %11 DescriptorSet 0
+OpDecorate %11 Binding 1
+OpDecorate %12 Block
+OpMemberDecorate %12 0 Offset 0
 %2 = OpTypeVoid
 %4 = OpTypeInt 32 1
 %3 = OpTypeVector %4 4
 %5 = OpTypeVector %4 2
 %6 = OpTypeVector %4 3
-%8 = OpTypeStruct %3
-%9 = OpTypePointer StorageBuffer %8
-%7 = OpVariable  %9  StorageBuffer
-%11 = OpTypeStruct %4
-%12 = OpTypePointer StorageBuffer %11
-%10 = OpVariable  %12  StorageBuffer
-%15 = OpTypeFunction %2
-%16 = OpTypePointer StorageBuffer %3
-%18 = OpTypeInt 32 0
-%17 = OpConstant  %18  0
-%20 = OpConstant  %4  1
-%21 = OpConstant  %4  2
-%22 = OpConstantComposite  %5  %20 %21
-%23 = OpConstant  %4  3
-%24 = OpConstant  %4  4
-%25 = OpConstantComposite  %5  %23 %24
-%26 = OpConstantComposite  %3  %24 %23 %21 %20
+%7 = OpConstant  %4  4
+%9 = OpTypeStruct %3
+%10 = OpTypePointer StorageBuffer %9
+%8 = OpVariable  %10  StorageBuffer
+%12 = OpTypeStruct %4
+%13 = OpTypePointer StorageBuffer %12
+%11 = OpVariable  %13  StorageBuffer
+%16 = OpTypeFunction %2
+%17 = OpTypePointer StorageBuffer %3
+%19 = OpTypeInt 32 0
+%18 = OpConstant  %19  0
+%21 = OpConstant  %4  1
+%22 = OpConstant  %4  2
+%23 = OpConstantComposite  %5  %21 %22
+%24 = OpConstant  %4  3
+%25 = OpConstantComposite  %5  %24 %7
+%26 = OpConstantComposite  %3  %7 %24 %22 %21
 %30 = OpTypePointer StorageBuffer %4
 %38 = OpConstant  %4  6
 %39 = OpConstant  %4  7
@@ -50,27 +50,29 @@ OpMemberDecorate %11 0 Offset 0
 %53 = OpTypePointer Function %4
 %55 = OpConstantNull  %4
 %57 = OpConstantNull  %4
-%14 = OpFunction  %2  None %15
-%13 = OpLabel
-%19 = OpAccessChain  %16  %7 %17
+%72 = OpConstantComposite  %3  %7 %7 %7 %7
+%78 = OpConstantComposite  %3  %7 %7 %7 %7
+%15 = OpFunction  %2  None %16
+%14 = OpLabel
+%20 = OpAccessChain  %17  %8 %18
 OpBranch %27
 %27 = OpLabel
-OpStore %19 %26
+OpStore %20 %26
 OpReturn
 OpFunctionEnd
-%29 = OpFunction  %2  None %15
+%29 = OpFunction  %2  None %16
 %28 = OpLabel
-%31 = OpAccessChain  %30  %10 %17
+%31 = OpAccessChain  %30  %11 %18
 OpBranch %32
 %32 = OpLabel
 %33 = OpLoad  %4  %31
-%34 = OpIAdd  %4  %33 %21
+%34 = OpIAdd  %4  %33 %22
 OpStore %31 %34
 OpReturn
 OpFunctionEnd
-%36 = OpFunction  %2  None %15
+%36 = OpFunction  %2  None %16
 %35 = OpLabel
-%37 = OpAccessChain  %30  %10 %17
+%37 = OpAccessChain  %30  %11 %18
 OpBranch %44
 %44 = OpLabel
 %45 = OpLoad  %4  %37
@@ -78,13 +80,13 @@ OpBranch %44
 OpStore %37 %46
 OpReturn
 OpFunctionEnd
-%48 = OpFunction  %2  None %15
+%48 = OpFunction  %2  None %16
 %47 = OpLabel
 %54 = OpVariable  %53  Function %55
 %58 = OpVariable  %53  Function %51
 %52 = OpVariable  %53  Function %50
 %56 = OpVariable  %53  Function %57
-%49 = OpAccessChain  %16  %7 %17
+%49 = OpAccessChain  %17  %8 %18
 OpBranch %59
 %59 = OpLabel
 %60 = OpLoad  %4  %52
@@ -101,15 +103,35 @@ OpStore %56 %61
 OpStore %49 %68
 OpReturn
 OpFunctionEnd
-%70 = OpFunction  %2  None %15
+%70 = OpFunction  %2  None %16
 %69 = OpLabel
-%71 = OpAccessChain  %16  %7 %17
-%72 = OpAccessChain  %30  %10 %17
+%71 = OpAccessChain  %17  %8 %18
 OpBranch %73
 %73 = OpLabel
-%74 = OpFunctionCall  %2  %14
-%75 = OpFunctionCall  %2  %29
-%76 = OpFunctionCall  %2  %36
-%77 = OpFunctionCall  %2  %48
+%74 = OpSNegate  %3  %72
+OpStore %71 %74
+OpReturn
+OpFunctionEnd
+%76 = OpFunction  %2  None %16
+%75 = OpLabel
+%77 = OpAccessChain  %17  %8 %18
+OpBranch %79
+%79 = OpLabel
+%80 = OpSNegate  %3  %78
+OpStore %77 %80
+OpReturn
+OpFunctionEnd
+%82 = OpFunction  %2  None %16
+%81 = OpLabel
+%83 = OpAccessChain  %17  %8 %18
+%84 = OpAccessChain  %30  %11 %18
+OpBranch %85
+%85 = OpLabel
+%86 = OpFunctionCall  %2  %15
+%87 = OpFunctionCall  %2  %29
+%88 = OpFunctionCall  %2  %36
+%89 = OpFunctionCall  %2  %48
+%90 = OpFunctionCall  %2  %70
+%91 = OpFunctionCall  %2  %76
 OpReturn
 OpFunctionEnd

--- a/tests/out/spv/const-exprs.spvasm
+++ b/tests/out/spv/const-exprs.spvasm
@@ -51,7 +51,8 @@ OpMemberDecorate %12 0 Offset 0
 %55 = OpConstantNull  %4
 %57 = OpConstantNull  %4
 %72 = OpConstantComposite  %3  %7 %7 %7 %7
-%78 = OpConstantComposite  %3  %7 %7 %7 %7
+%78 = OpConstant  %4  -4
+%79 = OpConstantComposite  %3  %78 %78 %78 %78
 %15 = OpFunction  %2  None %16
 %14 = OpLabel
 %20 = OpAccessChain  %17  %8 %18
@@ -115,10 +116,9 @@ OpFunctionEnd
 %76 = OpFunction  %2  None %16
 %75 = OpLabel
 %77 = OpAccessChain  %17  %8 %18
-OpBranch %79
-%79 = OpLabel
-%80 = OpSNegate  %3  %78
-OpStore %77 %80
+OpBranch %80
+%80 = OpLabel
+OpStore %77 %79
 OpReturn
 OpFunctionEnd
 %82 = OpFunction  %2  None %16

--- a/tests/out/wgsl/const-exprs.wgsl
+++ b/tests/out/wgsl/const-exprs.wgsl
@@ -51,7 +51,7 @@ fn splat_of_constant() {
 }
 
 fn compose_of_constant() {
-    out = -(vec4<i32>(FOUR, FOUR, FOUR, FOUR));
+    out = vec4<i32>(-4, -4, -4, -4);
     return;
 }
 

--- a/tests/out/wgsl/const-exprs.wgsl
+++ b/tests/out/wgsl/const-exprs.wgsl
@@ -1,3 +1,5 @@
+const FOUR: i32 = 4;
+
 @group(0) @binding(0) 
 var<storage, read_write> out: vec4<i32>;
 @group(0) @binding(1) 
@@ -43,11 +45,23 @@ fn non_constant_initializers() {
     return;
 }
 
+fn splat_of_constant() {
+    out = -(vec4(FOUR));
+    return;
+}
+
+fn compose_of_constant() {
+    out = -(vec4<i32>(FOUR, FOUR, FOUR, FOUR));
+    return;
+}
+
 @compute @workgroup_size(1, 1, 1) 
 fn main() {
     swizzle_of_compose();
     index_of_compose();
     compose_three_deep();
     non_constant_initializers();
+    splat_of_constant();
+    compose_of_constant();
     return;
 }

--- a/tests/out/wgsl/const-exprs.wgsl
+++ b/tests/out/wgsl/const-exprs.wgsl
@@ -46,7 +46,7 @@ fn non_constant_initializers() {
 }
 
 fn splat_of_constant() {
-    out = -(vec4(FOUR));
+    out = vec4<i32>(-4, -4, -4, -4);
     return;
 }
 

--- a/tests/out/wgsl/module-scope.wgsl
+++ b/tests/out/wgsl/module-scope.wgsl
@@ -14,7 +14,7 @@ fn statement() {
 }
 
 fn returns() -> S {
-    return S(Value);
+    return S(1);
 }
 
 fn call() {


### PR DESCRIPTION
The `#[test]` tests may be redundant. Let me know what you think.