### PR TITLE
[glsl/spv-in] `modf` & `frexp` follow-up

### DIFF
--- a/src/front/glsl/builtins.rs
+++ b/src/front/glsl/builtins.rs
@@ -1408,62 +1408,8 @@ fn inject_common_builtin(
                 declaration.overloads.push(module.add_builtin(args, fun))
             }
         }
-        "modf" | "frexp" => {
-            // bits layout
-            // bit 0 through 1 - dims
-            for bits in 0..0b100 {
-                let size = match bits {
-                    0b00 => None,
-                    0b01 => Some(VectorSize::Bi),
-                    0b10 => Some(VectorSize::Tri),
-                    _ => Some(VectorSize::Quad),
-                };
-
-                let ty = module.types.insert(
-                    Type {
-                        name: None,
-                        inner: match size {
-                            Some(size) => TypeInner::Vector {
-                                size,
-                                kind: Sk::Float,
-                                width: float_width,
-                            },
-                            None => TypeInner::Scalar {
-                                kind: Sk::Float,
-                                width: float_width,
-                            },
-                        },
-                    },
-                    Span::default(),
-                );
-
-                let parameters = vec![ty, ty];
-
-                let fun = match name {
-                    "modf" => MacroCall::MathFunction(MathFunction::Modf),
-                    "frexp" => MacroCall::MathFunction(MathFunction::Frexp),
-                    _ => unreachable!(),
-                };
-
-                declaration.overloads.push(Overload {
-                    parameters,
-                    parameters_info: vec![
-                        ParameterInfo {
-                            qualifier: ParameterQualifier::In,
-                            depth: false,
-                        },
-                        ParameterInfo {
-                            qualifier: ParameterQualifier::Out,
-                            depth: false,
-                        },
-                    ],
-                    kind: FunctionKind::Macro(fun),
-                    defined: false,
-                    internal: true,
-                    void: false,
-                })
-            }
-        }
+        // TODO: https://github.com/gfx-rs/naga/issues/2526
+        // "modf" | "frexp" => { ... }
         "cross" => {
             let args = vec![
                 TypeInner::Vector {

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -2953,7 +2953,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                         Glo::InverseSqrt => Mf::InverseSqrt,
                         Glo::MatrixInverse => Mf::Inverse,
                         Glo::Determinant => Mf::Determinant,
-                        Glo::Modf => Mf::Modf,
+                        Glo::ModfStruct => Mf::Modf,
                         Glo::FMin | Glo::UMin | Glo::SMin | Glo::NMin => Mf::Min,
                         Glo::FMax | Glo::UMax | Glo::SMax | Glo::NMax => Mf::Max,
                         Glo::FClamp | Glo::UClamp | Glo::SClamp | Glo::NClamp => Mf::Clamp,
@@ -2961,7 +2961,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                         Glo::Step => Mf::Step,
                         Glo::SmoothStep => Mf::SmoothStep,
                         Glo::Fma => Mf::Fma,
-                        Glo::Frexp => Mf::Frexp, //TODO: FrexpStruct?
+                        Glo::FrexpStruct => Mf::Frexp,
                         Glo::Ldexp => Mf::Ldexp,
                         Glo::Length => Mf::Length,
                         Glo::Distance => Mf::Distance,
@@ -2982,7 +2982,16 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                         Glo::UnpackSnorm2x16 => Mf::Unpack2x16snorm,
                         Glo::FindILsb => Mf::FindLsb,
                         Glo::FindUMsb | Glo::FindSMsb => Mf::FindMsb,
-                        _ => return Err(Error::UnsupportedExtInst(inst_id)),
+                        // TODO: https://github.com/gfx-rs/naga/issues/2526
+                        Glo::Modf | Glo::Frexp => return Err(Error::UnsupportedExtInst(inst_id)),
+                        Glo::IMix
+                        | Glo::PackDouble2x32
+                        | Glo::UnpackDouble2x32
+                        | Glo::InterpolateAtCentroid
+                        | Glo::InterpolateAtSample
+                        | Glo::InterpolateAtOffset => {
+                            return Err(Error::UnsupportedExtInst(inst_id))
+                        }
                     };
 
                     let arg_count = fun.argument_count();


### PR DESCRIPTION
Follow-up to https://github.com/gfx-rs/naga/pull/2454.
Remaining work tracked by https://github.com/gfx-rs/wgpu/issues/4506.