### PR TITLE
[valid] Add `Capabilities::CUBE_ARRAY_TEXTURES`

### DIFF
--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -112,14 +112,16 @@ bitflags::bitflags! {
         const MULTISAMPLED_SHADING = 0x800;
         /// Support for ray queries and acceleration structures.
         const RAY_QUERY = 0x1000;
-        /// Support for generating two sources for blending from fragement shaders
+        /// Support for generating two sources for blending from fragement shaders.
         const DUAL_SOURCE_BLENDING = 0x2000;
+        /// Support for arrayed cube textures.
+        const CUBE_ARRAY_TEXTURES = 0x4000;
     }
 }
 
 impl Default for Capabilities {
     fn default() -> Self {
-        Self::MULTISAMPLED_SHADING
+        Self::MULTISAMPLED_SHADING | Self::CUBE_ARRAY_TEXTURES
     }
 }
 

--- a/src/valid/type.rs
+++ b/src/valid/type.rs
@@ -557,9 +557,17 @@ impl super::Validator {
 
                 ti
             }
-            Ti::Image { .. } | Ti::Sampler { .. } => {
+            Ti::Image {
+                dim,
+                arrayed,
+                class: _,
+            } => {
+                if arrayed && matches!(dim, crate::ImageDimension::Cube) {
+                    self.require_type_capability(Capabilities::CUBE_ARRAY_TEXTURES)?;
+                }
                 TypeInfo::new(TypeFlags::ARGUMENT, Alignment::ONE)
             }
+            Ti::Sampler { .. } => TypeInfo::new(TypeFlags::ARGUMENT, Alignment::ONE),
             Ti::AccelerationStructure => {
                 self.require_type_capability(Capabilities::RAY_QUERY)?;
                 TypeInfo::new(TypeFlags::ARGUMENT, Alignment::ONE)


### PR DESCRIPTION
This maps to wgpu's `wgt::DownlevelFlags::CUBE_ARRAY_TEXTURES`.