### PR TITLE
[glsl/spv-out] Cull functions that should not be available for a given stage

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -827,6 +827,11 @@ impl<'a, W: Write> Writer<'a, W> {
 
             let fun_info = &self.info[handle];
 
+            // Skip functions that that are not compatible with this entry point's stage
+            if !fun_info.available_stages.contains(ep_info.available_stages) {
+                continue;
+            }
+
             // Write the function
             self.write_function(back::FunctionType::Function(handle), function, fun_info)?;
 

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -827,7 +827,15 @@ impl<'a, W: Write> Writer<'a, W> {
 
             let fun_info = &self.info[handle];
 
-            // Skip functions that that are not compatible with this entry point's stage
+            // Skip functions that that are not compatible with this entry point's stage.
+            //
+            // When validation is enabled, it rejects modules whose entry points try to call
+            // incompatible functions, so if we got this far, then any functions incompatible
+            // with our selected entry point must not be used.
+            //
+            // When validation is disabled, `fun_info.available_stages` is always just
+            // `ShaderStages::all()`, so this will write all functions in the module, and
+            // the downstream GLSL compiler will catch any problems.
             if !fun_info.available_stages.contains(ep_info.available_stages) {
                 continue;
             }

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1952,6 +1952,11 @@ impl Writer {
                     log::info!("Skip function {:?}", ir_function.name);
                     continue;
                 }
+
+                // Skip functions that that are not compatible with this entry point's stage
+                if !info.available_stages.contains(ep_info.available_stages) {
+                    continue;
+                }
             }
             let id = self.write_function(ir_function, info, ir_module, None, &debug_info_inner)?;
             self.lookup_function.insert(handle, id);

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1953,7 +1953,15 @@ impl Writer {
                     continue;
                 }
 
-                // Skip functions that that are not compatible with this entry point's stage
+                // Skip functions that that are not compatible with this entry point's stage.
+                //
+                // When validation is enabled, it rejects modules whose entry points try to call
+                // incompatible functions, so if we got this far, then any functions incompatible
+                // with our selected entry point must not be used.
+                //
+                // When validation is disabled, `fun_info.available_stages` is always just
+                // `ShaderStages::all()`, so this will write all functions in the module, and
+                // the downstream GLSL compiler will catch any problems.
                 if !info.available_stages.contains(ep_info.available_stages) {
                     continue;
                 }

--- a/tests/in/separate-entry-points.param.ron
+++ b/tests/in/separate-entry-points.param.ron
@@ -1,0 +1,6 @@
+(
+	spv: (
+        version: (1, 0),
+		separate_entry_points: true,
+	),
+)

--- a/tests/in/separate-entry-points.wgsl
+++ b/tests/in/separate-entry-points.wgsl
@@ -1,0 +1,23 @@
+// only available in the fragment stage
+fn derivatives() {
+    let x = dpdx(0.0);
+    let y = dpdy(0.0);
+    let width = fwidth(0.0);
+}
+
+// only available in the compute stage
+fn barriers() {
+    storageBarrier();
+    workgroupBarrier();
+}
+
+@fragment
+fn fragment() -> @location(0) vec4<f32> {
+    derivatives();
+    return vec4<f32>();
+}
+
+@compute @workgroup_size(1)
+fn compute() {
+    barriers();
+}

--- a/tests/out/glsl/separate-entry-points.compute.Compute.glsl
+++ b/tests/out/glsl/separate-entry-points.compute.Compute.glsl
@@ -1,0 +1,27 @@
+#version 310 es
+
+precision highp float;
+precision highp int;
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+
+void derivatives() {
+    float x = dFdx(0.0);
+    float y = dFdy(0.0);
+    float width = fwidth(0.0);
+}
+
+void barriers() {
+    memoryBarrierBuffer();
+    barrier();
+    memoryBarrierShared();
+    barrier();
+    return;
+}
+
+void main() {
+    barriers();
+    return;
+}
+

--- a/tests/out/glsl/separate-entry-points.compute.Compute.glsl
+++ b/tests/out/glsl/separate-entry-points.compute.Compute.glsl
@@ -6,12 +6,6 @@ precision highp int;
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
 
-void derivatives() {
-    float x = dFdx(0.0);
-    float y = dFdy(0.0);
-    float width = fwidth(0.0);
-}
-
 void barriers() {
     memoryBarrierBuffer();
     barrier();

--- a/tests/out/glsl/separate-entry-points.fragment.Fragment.glsl
+++ b/tests/out/glsl/separate-entry-points.fragment.Fragment.glsl
@@ -1,0 +1,27 @@
+#version 310 es
+
+precision highp float;
+precision highp int;
+
+layout(location = 0) out vec4 _fs2p_location0;
+
+void derivatives() {
+    float x = dFdx(0.0);
+    float y = dFdy(0.0);
+    float width = fwidth(0.0);
+}
+
+void barriers() {
+    memoryBarrierBuffer();
+    barrier();
+    memoryBarrierShared();
+    barrier();
+    return;
+}
+
+void main() {
+    derivatives();
+    _fs2p_location0 = vec4(0.0);
+    return;
+}
+

--- a/tests/out/glsl/separate-entry-points.fragment.Fragment.glsl
+++ b/tests/out/glsl/separate-entry-points.fragment.Fragment.glsl
@@ -11,14 +11,6 @@ void derivatives() {
     float width = fwidth(0.0);
 }
 
-void barriers() {
-    memoryBarrierBuffer();
-    barrier();
-    memoryBarrierShared();
-    barrier();
-    return;
-}
-
 void main() {
     derivatives();
     _fs2p_location0 = vec4(0.0);

--- a/tests/out/spv/separate-entry-points.compute.spvasm
+++ b/tests/out/spv/separate-entry-points.compute.spvasm
@@ -1,43 +1,33 @@
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 25
+; Bound: 18
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %22 "compute"
-OpExecutionMode %22 LocalSize 1 1 1
+OpEntryPoint GLCompute %15 "compute"
+OpExecutionMode %15 LocalSize 1 1 1
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpTypeVector %4 4
 %7 = OpTypeFunction %2
-%8 = OpConstant  %4  0.0
-%17 = OpTypeInt 32 0
-%16 = OpConstant  %17  2
-%18 = OpConstant  %17  1
-%19 = OpConstant  %17  72
-%20 = OpConstant  %17  264
+%10 = OpTypeInt 32 0
+%9 = OpConstant  %10  2
+%11 = OpConstant  %10  1
+%12 = OpConstant  %10  72
+%13 = OpConstant  %10  264
 %6 = OpFunction  %2  None %7
 %5 = OpLabel
-OpBranch %9
-%9 = OpLabel
-%10 = OpDPdx  %4  %8
-%11 = OpDPdy  %4  %8
-%12 = OpFwidth  %4  %8
+OpBranch %8
+%8 = OpLabel
+OpControlBarrier %9 %11 %12
+OpControlBarrier %9 %9 %13
 OpReturn
 OpFunctionEnd
-%14 = OpFunction  %2  None %7
-%13 = OpLabel
-OpBranch %15
-%15 = OpLabel
-OpControlBarrier %16 %18 %19
-OpControlBarrier %16 %16 %20
-OpReturn
-OpFunctionEnd
-%22 = OpFunction  %2  None %7
-%21 = OpLabel
-OpBranch %23
-%23 = OpLabel
-%24 = OpFunctionCall  %2  %14
+%15 = OpFunction  %2  None %7
+%14 = OpLabel
+OpBranch %16
+%16 = OpLabel
+%17 = OpFunctionCall  %2  %6
 OpReturn
 OpFunctionEnd

--- a/tests/out/spv/separate-entry-points.compute.spvasm
+++ b/tests/out/spv/separate-entry-points.compute.spvasm
@@ -1,0 +1,43 @@
+; SPIR-V
+; Version: 1.0
+; Generator: rspirv
+; Bound: 25
+OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %22 "compute"
+OpExecutionMode %22 LocalSize 1 1 1
+%2 = OpTypeVoid
+%4 = OpTypeFloat 32
+%3 = OpTypeVector %4 4
+%7 = OpTypeFunction %2
+%8 = OpConstant  %4  0.0
+%17 = OpTypeInt 32 0
+%16 = OpConstant  %17  2
+%18 = OpConstant  %17  1
+%19 = OpConstant  %17  72
+%20 = OpConstant  %17  264
+%6 = OpFunction  %2  None %7
+%5 = OpLabel
+OpBranch %9
+%9 = OpLabel
+%10 = OpDPdx  %4  %8
+%11 = OpDPdy  %4  %8
+%12 = OpFwidth  %4  %8
+OpReturn
+OpFunctionEnd
+%14 = OpFunction  %2  None %7
+%13 = OpLabel
+OpBranch %15
+%15 = OpLabel
+OpControlBarrier %16 %18 %19
+OpControlBarrier %16 %16 %20
+OpReturn
+OpFunctionEnd
+%22 = OpFunction  %2  None %7
+%21 = OpLabel
+OpBranch %23
+%23 = OpLabel
+%24 = OpFunctionCall  %2  %14
+OpReturn
+OpFunctionEnd

--- a/tests/out/spv/separate-entry-points.fragment.spvasm
+++ b/tests/out/spv/separate-entry-points.fragment.spvasm
@@ -1,26 +1,21 @@
 ; SPIR-V
 ; Version: 1.0
 ; Generator: rspirv
-; Bound: 28
+; Bound: 20
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
-OpEntryPoint Fragment %24 "fragment" %22
-OpExecutionMode %24 OriginUpperLeft
-OpDecorate %22 Location 0
+OpEntryPoint Fragment %16 "fragment" %14
+OpExecutionMode %16 OriginUpperLeft
+OpDecorate %14 Location 0
 %2 = OpTypeVoid
 %4 = OpTypeFloat 32
 %3 = OpTypeVector %4 4
 %7 = OpTypeFunction %2
 %8 = OpConstant  %4  0.0
-%17 = OpTypeInt 32 0
-%16 = OpConstant  %17  2
-%18 = OpConstant  %17  1
-%19 = OpConstant  %17  72
-%20 = OpConstant  %17  264
-%23 = OpTypePointer Output %3
-%22 = OpVariable  %23  Output
-%25 = OpConstantNull  %3
+%15 = OpTypePointer Output %3
+%14 = OpVariable  %15  Output
+%17 = OpConstantNull  %3
 %6 = OpFunction  %2  None %7
 %5 = OpLabel
 OpBranch %9
@@ -30,19 +25,11 @@ OpBranch %9
 %12 = OpFwidth  %4  %8
 OpReturn
 OpFunctionEnd
-%14 = OpFunction  %2  None %7
+%16 = OpFunction  %2  None %7
 %13 = OpLabel
-OpBranch %15
-%15 = OpLabel
-OpControlBarrier %16 %18 %19
-OpControlBarrier %16 %16 %20
-OpReturn
-OpFunctionEnd
-%24 = OpFunction  %2  None %7
-%21 = OpLabel
-OpBranch %26
-%26 = OpLabel
-%27 = OpFunctionCall  %2  %6
-OpStore %22 %25
+OpBranch %18
+%18 = OpLabel
+%19 = OpFunctionCall  %2  %6
+OpStore %14 %17
 OpReturn
 OpFunctionEnd

--- a/tests/out/spv/separate-entry-points.fragment.spvasm
+++ b/tests/out/spv/separate-entry-points.fragment.spvasm
@@ -1,0 +1,48 @@
+; SPIR-V
+; Version: 1.0
+; Generator: rspirv
+; Bound: 28
+OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %24 "fragment" %22
+OpExecutionMode %24 OriginUpperLeft
+OpDecorate %22 Location 0
+%2 = OpTypeVoid
+%4 = OpTypeFloat 32
+%3 = OpTypeVector %4 4
+%7 = OpTypeFunction %2
+%8 = OpConstant  %4  0.0
+%17 = OpTypeInt 32 0
+%16 = OpConstant  %17  2
+%18 = OpConstant  %17  1
+%19 = OpConstant  %17  72
+%20 = OpConstant  %17  264
+%23 = OpTypePointer Output %3
+%22 = OpVariable  %23  Output
+%25 = OpConstantNull  %3
+%6 = OpFunction  %2  None %7
+%5 = OpLabel
+OpBranch %9
+%9 = OpLabel
+%10 = OpDPdx  %4  %8
+%11 = OpDPdy  %4  %8
+%12 = OpFwidth  %4  %8
+OpReturn
+OpFunctionEnd
+%14 = OpFunction  %2  None %7
+%13 = OpLabel
+OpBranch %15
+%15 = OpLabel
+OpControlBarrier %16 %18 %19
+OpControlBarrier %16 %16 %20
+OpReturn
+OpFunctionEnd
+%24 = OpFunction  %2  None %7
+%21 = OpLabel
+OpBranch %26
+%26 = OpLabel
+%27 = OpFunctionCall  %2  %6
+OpStore %22 %25
+OpReturn
+OpFunctionEnd

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -781,6 +781,7 @@ fn convert_wgsl() {
             "const-exprs",
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,
         ),
+        ("separate-entry-points", Targets::SPIRV | Targets::GLSL),
     ];
 
     for &(name, targets) in inputs.iter() {


### PR DESCRIPTION
fixes https://github.com/gfx-rs/naga/issues/2524

Done it for SPIR-V as well since the ability to separate entry points (https://github.com/gfx-rs/naga/pull/1329) was added to work around driver bugs and I can imagine them misbehaving in this case as well.