### PR TITLE
Remove `IsFinite` & `IsNormal` completely

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -2992,12 +2992,8 @@ impl<'a, W: Write> Writer<'a, W> {
                 use crate::RelationalFunction as Rf;
 
                 let fun_name = match fun {
-                    // There's no specific function for this but we can invert the result of `isinf`
-                    Rf::IsFinite => "!isinf",
                     Rf::IsInf => "isinf",
                     Rf::IsNan => "isnan",
-                    // There's also no function for this but we can invert `isnan`
-                    Rf::IsNormal => "!isnan",
                     Rf::All => "all",
                     Rf::Any => "any",
                 };

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -3147,8 +3147,6 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                     Rf::Any => "any",
                     Rf::IsNan => "isnan",
                     Rf::IsInf => "isinf",
-                    Rf::IsFinite => "isfinite",
-                    Rf::IsNormal => "isnormal",
                 };
                 write!(self.out, "{fun_str}(")?;
                 self.write_expr(module, argument, func_ctx)?;

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1657,8 +1657,6 @@ impl<W: Write> Writer<W> {
                     crate::RelationalFunction::All => "all",
                     crate::RelationalFunction::IsNan => "isnan",
                     crate::RelationalFunction::IsInf => "isinf",
-                    crate::RelationalFunction::IsFinite => "isfinite",
-                    crate::RelationalFunction::IsNormal => "isnormal",
                 };
                 write!(self.out, "{NAMESPACE}::{op}")?;
                 self.put_call_parameters(iter::once(argument), context)?;

--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -1394,10 +1394,6 @@ impl<'w> BlockContext<'w> {
                     Rf::Any => spirv::Op::Any,
                     Rf::IsNan => spirv::Op::IsNan,
                     Rf::IsInf => spirv::Op::IsInf,
-                    //TODO: these require Kernel capability
-                    Rf::IsFinite | Rf::IsNormal => {
-                        return Err(Error::FeatureNotImplemented("is finite/normal"))
-                    }
                 };
                 let id = self.gen_id();
                 block

--- a/src/front/spv/convert.rs
+++ b/src/front/spv/convert.rs
@@ -52,8 +52,6 @@ pub(super) const fn map_relational_fun(
         Op::Any => Ok(Rf::Any),
         Op::IsNan => Ok(Rf::IsNan),
         Op::IsInf => Ok(Rf::IsInf),
-        Op::IsFinite => Ok(Rf::IsFinite),
-        Op::IsNormal => Ok(Rf::IsNormal),
         _ => Err(Error::UnknownRelationalFunction(word)),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1109,8 +1109,6 @@ pub enum RelationalFunction {
     Any,
     IsNan,
     IsInf,
-    IsFinite,
-    IsNormal,
 }
 
 /// Built-in shader function for math.

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -648,25 +648,24 @@ impl<'a> ResolveContext<'a> {
                         width: crate::BOOL_WIDTH,
                     })
                 }
-                crate::RelationalFunction::IsNan
-                | crate::RelationalFunction::IsInf
-                | crate::RelationalFunction::IsFinite
-                | crate::RelationalFunction::IsNormal => match *past(argument)?.inner_with(types) {
-                    Ti::Scalar { .. } => TypeResolution::Value(Ti::Scalar {
-                        kind: crate::ScalarKind::Bool,
-                        width: crate::BOOL_WIDTH,
-                    }),
-                    Ti::Vector { size, .. } => TypeResolution::Value(Ti::Vector {
-                        kind: crate::ScalarKind::Bool,
-                        width: crate::BOOL_WIDTH,
-                        size,
-                    }),
-                    ref other => {
-                        return Err(ResolveError::IncompatibleOperands(format!(
-                            "{fun:?}({other:?})"
-                        )))
+                crate::RelationalFunction::IsNan | crate::RelationalFunction::IsInf => {
+                    match *past(argument)?.inner_with(types) {
+                        Ti::Scalar { .. } => TypeResolution::Value(Ti::Scalar {
+                            kind: crate::ScalarKind::Bool,
+                            width: crate::BOOL_WIDTH,
+                        }),
+                        Ti::Vector { size, .. } => TypeResolution::Value(Ti::Vector {
+                            kind: crate::ScalarKind::Bool,
+                            width: crate::BOOL_WIDTH,
+                            size,
+                        }),
+                        ref other => {
+                            return Err(ResolveError::IncompatibleOperands(format!(
+                                "{fun:?}({other:?})"
+                            )))
+                        }
                     }
-                },
+                }
             },
             crate::Expression::Math {
                 fun,

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -862,7 +862,7 @@ impl super::Validator {
                             return Err(ExpressionError::InvalidBooleanVector(argument));
                         }
                     },
-                    Rf::IsNan | Rf::IsInf | Rf::IsFinite | Rf::IsNormal => match *argument_inner {
+                    Rf::IsNan | Rf::IsInf => match *argument_inner {
                         Ti::Scalar {
                             kind: Sk::Float, ..
                         }


### PR DESCRIPTION
None of the frontends support those.
SPIR-V's `OpIsFinite` & `OpIsNormal` require the `Kernel` capability which is only available in OpenCL.

References
[The OpenCL™ SPIR-V Environment Specification](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_Env.html#required-capabilities-1.0)
[Appendix A: Vulkan Environment for SPIR-V](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/chap52.html#spirvenv-capabilities)

Backends also have very limited support, only MSL supports both, HLSL supports `IsFinite`, the others don't support any.