### PR TITLE
Properly recognize `Literal` expressions as non-dynamic indices.

### DIFF
--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -465,11 +465,13 @@ impl crate::Expression {
     /// [`Access`]: crate::Expression::Access
     /// [`ResolveContext`]: crate::proc::ResolveContext
     pub fn is_dynamic_index(&self, module: &crate::Module) -> bool {
-        if let Self::Constant(handle) = *self {
-            let constant = &module.constants[handle];
-            !matches!(constant.r#override, crate::Override::None)
-        } else {
-            true
+        match *self {
+            Self::Literal(_) | Self::ZeroValue(_) => false,
+            Self::Constant(handle) => {
+                let constant = &module.constants[handle];
+                !matches!(constant.r#override, crate::Override::None)
+            }
+            _ => true,
         }
     }
 }

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -107,25 +107,6 @@ fn unknown_identifier() {
     );
 }
 
-// #[test]
-// fn negative_index() {
-//     check(
-//         r#"
-//             fn main() -> f32 {
-//                 let a = array<f32, 3>(0., 1., 2.);
-//                 return a[-1];
-//             }
-//         "#,
-//         r#"error: expected unsigned integer constant expression, found `-1`
-//   ┌─ wgsl:4:26
-//   │
-// 4 │                 return a[-1];
-//   │                          ^^ expected unsigned integer
-
-// "#,
-//     );
-// }
-
 #[test]
 fn bad_texture() {
     check(
@@ -919,6 +900,26 @@ fn invalid_arrays() {
             source: naga::valid::TypeError::InvalidArrayBaseType(_),
             ..
         })
+    }
+
+    check_validation! {
+        r#"
+            fn main() -> f32 {
+                let a = array<f32, 3>(0., 1., 2.);
+                return a[-1];
+            }
+        "#:
+        Err(
+            naga::valid::ValidationError::Function {
+                name,
+                source: naga::valid::FunctionError::Expression {
+                    source: naga::valid::ExpressionError::NegativeIndex(_),
+                    ..
+                },
+                ..
+            }
+        )
+            if name == "main"
     }
 
     check(


### PR DESCRIPTION
Restore `negative_index` test in `tests/wgsl-errors.rs`, as part of the `invalid_arrays` test function.