### PR TITLE
Add StorageFormat::Bgra8Unorm

### DIFF
--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -766,7 +766,7 @@ impl<'a, W: Write> Writer<'a, W> {
                             write!(self.out, "binding = {binding}")?;
                         }
                         if let Some((format, _)) = storage_format_access {
-                            let format_str = glsl_storage_format(format);
+                            let format_str = glsl_storage_format(format)?;
                             let separator = match layout_binding {
                                 Some(_) => ",",
                                 None => "",
@@ -1491,7 +1491,7 @@ impl<'a, W: Write> Writer<'a, W> {
                         ..
                     } = this.module.types[arg.ty].inner
                     {
-                        write!(this.out, "layout({}) ", glsl_storage_format(format))?;
+                        write!(this.out, "layout({}) ", glsl_storage_format(format)?)?;
                     }
 
                     // write the type
@@ -4213,10 +4213,10 @@ const fn glsl_dimension(dim: crate::ImageDimension) -> &'static str {
 }
 
 /// Helper function that returns the glsl storage format string of [`StorageFormat`](crate::StorageFormat)
-const fn glsl_storage_format(format: crate::StorageFormat) -> &'static str {
+fn glsl_storage_format(format: crate::StorageFormat) -> Result<&'static str, Error> {
     use crate::StorageFormat as Sf;
 
-    match format {
+    Ok(match format {
         Sf::R8Unorm => "r8",
         Sf::R8Snorm => "r8_snorm",
         Sf::R8Uint => "r8ui",
@@ -4256,7 +4256,13 @@ const fn glsl_storage_format(format: crate::StorageFormat) -> &'static str {
         Sf::Rg16Snorm => "rg16_snorm",
         Sf::Rgba16Unorm => "rgba16",
         Sf::Rgba16Snorm => "rgba16_snorm",
-    }
+
+        Sf::Bgra8Unorm => {
+            return Err(Error::Custom(
+                "Support format BGRA8 is not implemented".into(),
+            ))
+        }
+    })
 }
 
 fn is_value_init_supported(module: &crate::Module, ty: Handle<crate::Type>) -> bool {

--- a/src/back/hlsl/conv.rs
+++ b/src/back/hlsl/conv.rs
@@ -122,7 +122,9 @@ impl crate::StorageFormat {
             Self::Rg11b10Float => "float3",
 
             Self::Rgba16Float | Self::R32Float | Self::Rg32Float | Self::Rgba32Float => "float4",
-            Self::Rgba8Unorm | Self::Rgba16Unorm | Self::Rgb10a2Unorm => "unorm float4",
+            Self::Rgba8Unorm | Self::Bgra8Unorm | Self::Rgba16Unorm | Self::Rgb10a2Unorm => {
+                "unorm float4"
+            }
             Self::Rgba8Snorm | Self::Rgba16Snorm => "snorm float4",
 
             Self::Rgba8Uint

--- a/src/back/spv/image.rs
+++ b/src/back/spv/image.rs
@@ -1170,6 +1170,21 @@ impl<'w> BlockContext<'w> {
 
         let write = Store { image_id, value_id };
 
+        match *self.fun_info[image].ty.inner_with(&self.ir_module.types) {
+            crate::TypeInner::Image {
+                class:
+                    crate::ImageClass::Storage {
+                        format: crate::StorageFormat::Bgra8Unorm,
+                        ..
+                    },
+                ..
+            } => self.writer.require_any(
+                "Bgra8Unorm storage write",
+                &[spirv::Capability::StorageImageWriteWithoutFormat],
+            )?,
+            _ => {}
+        }
+
         match self.writer.bounds_check_policies.image_store {
             crate::proc::BoundsCheckPolicy::Restrict => {
                 let (coords, _, _) =

--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -1064,6 +1064,7 @@ impl From<crate::StorageFormat> for spirv::ImageFormat {
             Sf::Rgba8Snorm => Self::Rgba8Snorm,
             Sf::Rgba8Uint => Self::Rgba8ui,
             Sf::Rgba8Sint => Self::Rgba8i,
+            Sf::Bgra8Unorm => Self::Unknown,
             Sf::Rgb10a2Uint => Self::Rgb10a2ui,
             Sf::Rgb10a2Unorm => Self::Rgb10A2,
             Sf::Rg11b10Float => Self::R11fG11fB10f,

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -1829,6 +1829,7 @@ const fn storage_format_str(format: crate::StorageFormat) -> &'static str {
         Sf::Rgba8Snorm => "rgba8snorm",
         Sf::Rgba8Uint => "rgba8uint",
         Sf::Rgba8Sint => "rgba8sint",
+        Sf::Bgra8Unorm => "bgra8unorm",
         Sf::Rgb10a2Uint => "rgb10a2uint",
         Sf::Rgb10a2Unorm => "rgb10a2unorm",
         Sf::Rg11b10Float => "rg11b10float",

--- a/src/front/wgsl/mod.rs
+++ b/src/front/wgsl/mod.rs
@@ -71,6 +71,7 @@ impl crate::StorageFormat {
             Sf::Rgba8Snorm => "rgba8snorm",
             Sf::Rgba8Uint => "rgba8uint",
             Sf::Rgba8Sint => "rgba8sint",
+            Sf::Bgra8Unorm => "bgra8unorm",
             Sf::Rgb10a2Uint => "rgb10a2uint",
             Sf::Rgb10a2Unorm => "rgb10a2unorm",
             Sf::Rg11b10Float => "rg11b10float",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -599,6 +599,7 @@ pub enum StorageFormat {
     Rgba8Snorm,
     Rgba8Uint,
     Rgba8Sint,
+    Bgra8Unorm,
 
     // Packed 32-bit formats
     Rgb10a2Uint,

--- a/src/proc/mod.rs
+++ b/src/proc/mod.rs
@@ -39,6 +39,7 @@ impl From<super::StorageFormat> for super::ScalarKind {
             Sf::Rgba8Snorm => Sk::Float,
             Sf::Rgba8Uint => Sk::Uint,
             Sf::Rgba8Sint => Sk::Sint,
+            Sf::Bgra8Unorm => Sk::Float,
             Sf::Rgb10a2Uint => Sk::Uint,
             Sf::Rgb10a2Unorm => Sk::Float,
             Sf::Rg11b10Float => Sk::Float,


### PR DESCRIPTION
Fixes #2195 
Blocks: https://github.com/gfx-rs/wgpu/pull/3634

I'm not sure what the best course is for the wgsl backend, so I defaulted to putting the "rgba8" swizzle which is the closest available format. I suppose that the backend would have to insert some extra code to convert when interacting with the storage texture (probably that's already done in other places?).