### PR TITLE
Require that `Function` and `Private` variables be `CONSTRUCTIBLE`.

### DIFF
--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -948,10 +948,7 @@ impl super::Validator {
             .types
             .get(var.ty.index())
             .ok_or(LocalVariableError::InvalidType(var.ty))?;
-        if !type_info
-            .flags
-            .contains(super::TypeFlags::DATA | super::TypeFlags::SIZED)
-        {
+        if !type_info.flags.contains(super::TypeFlags::CONSTRUCTIBLE) {
             return Err(LocalVariableError::InvalidType(var.ty));
         }
 

--- a/src/valid/interface.rs
+++ b/src/valid/interface.rs
@@ -541,9 +541,8 @@ impl super::Validator {
 
                 (TypeFlags::empty(), true)
             }
-            crate::AddressSpace::Private | crate::AddressSpace::WorkGroup => {
-                (TypeFlags::DATA | TypeFlags::SIZED, false)
-            }
+            crate::AddressSpace::Private => (TypeFlags::CONSTRUCTIBLE, false),
+            crate::AddressSpace::WorkGroup => (TypeFlags::DATA | TypeFlags::SIZED, false),
             crate::AddressSpace::PushConstant => {
                 if !self.capabilities.contains(Capabilities::PUSH_CONSTANT) {
                     return Err(GlobalVariableError::UnsupportedCapability(

--- a/src/valid/type.rs
+++ b/src/valid/type.rs
@@ -566,7 +566,10 @@ impl super::Validator {
             }
             Ti::RayQuery => {
                 self.require_type_capability(Capabilities::RAY_QUERY)?;
-                TypeInfo::new(TypeFlags::DATA | TypeFlags::SIZED, Alignment::ONE)
+                TypeInfo::new(
+                    TypeFlags::DATA | TypeFlags::CONSTRUCTIBLE | TypeFlags::SIZED,
+                    Alignment::ONE,
+                )
             }
             Ti::BindingArray { base, size } => {
                 if base >= handle {

--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -1342,6 +1342,23 @@ fn invalid_local_vars() {
         })
         if local_var_name == "not_okay"
     }
+
+    check_validation! {
+        "
+        fn f() {
+            var x: atomic<u32>;
+        }
+        ":
+        Err(naga::valid::ValidationError::Function {
+            source: naga::valid::FunctionError::LocalVariable {
+                name: local_var_name,
+                source: naga::valid::LocalVariableError::InvalidType(_),
+                ..
+            },
+            ..
+        })
+        if local_var_name == "x"
+    }
 }
 
 #[test]


### PR DESCRIPTION
Change the validator to enforce WGSL's requirement that all variables
in the `function` and `private` address spaces must have constructible
types.

Mark the `RayQuery` type as `CONSTRUCTIBLE`, since it is intended to
be used for local variables.

Add a regression test.
