### PR TITLE
[wgsl-out] Generate correct code for bit complement on integers.

### DIFF
--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -1600,13 +1600,10 @@ impl<W: Write> Writer<W> {
                 let unary = match op {
                     crate::UnaryOperator::Negate => "-",
                     crate::UnaryOperator::Not => {
-                        match *func_ctx.resolve_type(expr, &module.types) {
-                            TypeInner::Scalar {
-                                kind: crate::ScalarKind::Bool,
-                                ..
-                            }
-                            | TypeInner::Vector { .. } => "!",
-                            _ => "~",
+                        match func_ctx.resolve_type(expr, &module.types).scalar_kind() {
+                            Some(crate::ScalarKind::Sint) | Some(crate::ScalarKind::Uint) => "~",
+                            Some(crate::ScalarKind::Bool) => "!",
+                            _ => return Err(Error::Custom("validation failure".to_string())),
                         }
                     }
                 };

--- a/tests/out/wgsl/operators.wgsl
+++ b/tests/out/wgsl/operators.wgsl
@@ -128,8 +128,8 @@ fn arithmetic() {
 fn bit() {
     let flip0_ = ~(1);
     let flip1_ = ~(1u);
-    let flip2_ = !(vec2(1));
-    let flip3_ = !(vec3(1u));
+    let flip2_ = ~(vec2(1));
+    let flip3_ = ~(vec3(1u));
     let or0_ = (2 | 1);
     let or1_ = (2u | 1u);
     let or2_ = (vec2(2) | vec2(1));


### PR DESCRIPTION
Remove incorrect special case for `UnaryOperator::Not` on vectors.