### PR TITLE
Subgroup Operations

### DIFF
--- a/src/back/dot/mod.rs
+++ b/src/back/dot/mod.rs
@@ -296,14 +296,14 @@ impl StatementGraph {
                     self.emits.push((id, result));
                     "SubgroupCollectiveOperation" // FIXME
                 }
-                S::SubgroupBroadcast {
+                S::SubgroupGather {
                     ref mode,
                     argument,
                     result,
                 } => {
                     self.dependencies.push((id, argument, "arg"));
                     self.emits.push((id, result));
-                    "SubgroupBroadcast" // FIXME
+                    "SubgroupGather" // FIXME
                 }
             };
             // Set the last node to the merge node

--- a/src/back/dot/mod.rs
+++ b/src/back/dot/mod.rs
@@ -283,6 +283,25 @@ impl StatementGraph {
                     self.emits.push((id, result));
                     "SubgroupBallot"
                 }
+                S::SubgroupCollectiveOperation {
+                    ref op,
+                    ref collective_op,
+                    argument,
+                    result,
+                } => {
+                    self.dependencies.push((id, argument, "arg"));
+                    self.emits.push((id, result));
+                    "SubgroupCollectiveOperation" // FIXME
+                }
+                S::SubgroupBroadcast {
+                    ref mode,
+                    argument,
+                    result,
+                } => {
+                    self.dependencies.push((id, argument, "arg"));
+                    self.emits.push((id, result));
+                    "SubgroupBroadcast" // FIXME
+                }
             };
             // Set the last node to the merge node
             last_node = merge_id;
@@ -591,6 +610,7 @@ fn write_function_expressions(
                 (format!("rayQueryGet{}Intersection", ty).into(), 4)
             }
             E::SubgroupBallotResult => ("SubgroupBallotResult".into(), 4),
+            E::SubgroupOperationResult { .. } => ("SubgroupOperationResult".into(), 4),
         };
 
         // give uniform expressions an outline

--- a/src/back/dot/mod.rs
+++ b/src/back/dot/mod.rs
@@ -287,8 +287,8 @@ impl StatementGraph {
                     "SubgroupBallot"
                 }
                 S::SubgroupCollectiveOperation {
-                    ref op,
-                    ref collective_op,
+                    op,
+                    collective_op,
                     argument,
                     result,
                 } => {
@@ -297,7 +297,7 @@ impl StatementGraph {
                     "SubgroupCollectiveOperation" // FIXME
                 }
                 S::SubgroupGather {
-                    ref mode,
+                    mode,
                     argument,
                     result,
                 } => {

--- a/src/back/dot/mod.rs
+++ b/src/back/dot/mod.rs
@@ -279,6 +279,10 @@ impl StatementGraph {
                         crate::RayQueryFunction::Terminate => "RayQueryTerminate",
                     }
                 }
+                S::SubgroupBallot { result } => {
+                    self.emits.push((id, result));
+                    "SubgroupBallot"
+                }
             };
             // Set the last node to the merge node
             last_node = merge_id;
@@ -586,6 +590,7 @@ fn write_function_expressions(
                 let ty = if committed { "Committed" } else { "Candidate" };
                 (format!("rayQueryGet{}Intersection", ty).into(), 4)
             }
+            E::SubgroupBallotResult => ("SubgroupBallotResult".into(), 4),
         };
 
         // give uniform expressions an outline

--- a/src/back/dot/mod.rs
+++ b/src/back/dot/mod.rs
@@ -279,7 +279,10 @@ impl StatementGraph {
                         crate::RayQueryFunction::Terminate => "RayQueryTerminate",
                     }
                 }
-                S::SubgroupBallot { result } => {
+                S::SubgroupBallot { result, predicate } => {
+                    if let Some(predicate) = predicate {
+                        self.dependencies.push((id, predicate, "predicate"));
+                    }
                     self.emits.push((id, result));
                     "SubgroupBallot"
                 }

--- a/src/back/glsl/features.rs
+++ b/src/back/glsl/features.rs
@@ -43,6 +43,8 @@ bitflags::bitflags! {
         const IMAGE_SIZE = 1 << 20;
         /// Dual source blending
         const DUAL_SOURCE_BLENDING = 1 << 21;
+        /// Subgroup operations
+        const SUBGROUP_OPERATIONS = 1 << 22;
     }
 }
 
@@ -106,6 +108,7 @@ impl FeaturesManager {
         check_feature!(SAMPLE_VARIABLES, 400, 300);
         check_feature!(DYNAMIC_ARRAY_SIZE, 430, 310);
         check_feature!(DUAL_SOURCE_BLENDING, 330, 300 /* with extension */);
+        check_feature!(SUBGROUP_OPERATIONS, 430, 310);
         match version {
             Version::Embedded { is_webgl: true, .. } => check_feature!(MULTI_VIEW, 140, 300),
             _ => check_feature!(MULTI_VIEW, 140, 310),
@@ -233,6 +236,22 @@ impl FeaturesManager {
         if self.0.contains(Features::DUAL_SOURCE_BLENDING) && version.is_es() {
             // https://registry.khronos.org/OpenGL/extensions/EXT/EXT_blend_func_extended.txt
             writeln!(out, "#extension GL_EXT_blend_func_extended : require")?;
+        }
+
+        if self.0.contains(Features::SUBGROUP_OPERATIONS) {
+            // https://registry.khronos.org/OpenGL/extensions/KHR/KHR_shader_subgroup.txt
+            writeln!(out, "#extension GL_KHR_shader_subgroup_basic : require")?;
+            writeln!(out, "#extension GL_KHR_shader_subgroup_vote : require")?;
+            writeln!(
+                out,
+                "#extension GL_KHR_shader_subgroup_arithmetic : require"
+            )?;
+            writeln!(out, "#extension GL_KHR_shader_subgroup_ballot : require")?;
+            writeln!(out, "#extension GL_KHR_shader_subgroup_shuffle : require")?;
+            writeln!(
+                out,
+                "#extension GL_KHR_shader_subgroup_shuffle_relative : require"
+            )?;
         }
 
         Ok(())
@@ -454,6 +473,10 @@ impl<'a, W> Writer<'a, W> {
                             features.request(Features::TEXTURE_LEVELS)
                         }
                     }
+                }
+                Expression::SubgroupBallotResult |
+                Expression::SubgroupOperationResult { .. } => {
+                    features.request(Features::SUBGROUP_OPERATIONS)
                 }
                 _ => {}
             }

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -3991,6 +3991,9 @@ impl<'a, W: Write> Writer<'a, W> {
         if flags.contains(crate::Barrier::WORK_GROUP) {
             writeln!(self.out, "{level}memoryBarrierShared();")?;
         }
+        if flags.contains(crate::Barrier::SUB_GROUP) {
+            unimplemented!() // FIXME
+        }
         writeln!(self.out, "{level}barrier();")?;
         Ok(())
     }

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -2266,15 +2266,15 @@ impl<'a, W: Write> Writer<'a, W> {
                 write!(self.out, ");")?;
             }
             Statement::SubgroupCollectiveOperation {
-                ref op,
-                ref collective_op,
+                op,
+                collective_op,
                 argument,
                 result,
             } => {
                 unimplemented!(); // FIXME:
             }
             Statement::SubgroupGather {
-                ref mode,
+                mode,
                 argument,
                 result,
             } => {

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -2273,7 +2273,7 @@ impl<'a, W: Write> Writer<'a, W> {
             } => {
                 unimplemented!(); // FIXME:
             }
-            Statement::SubgroupBroadcast {
+            Statement::SubgroupGather {
                 ref mode,
                 argument,
                 result,

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -2260,6 +2260,21 @@ impl<'a, W: Write> Writer<'a, W> {
 
                 writeln!(self.out, "subgroupBallot(true);")?;
             }
+            Statement::SubgroupCollectiveOperation {
+                ref op,
+                ref collective_op,
+                argument,
+                result,
+            } => {
+                unimplemented!(); // FIXME:
+            }
+            Statement::SubgroupBroadcast {
+                ref mode,
+                argument,
+                result,
+            } => {
+                unimplemented!(); // FIXME
+            }
         }
 
         Ok(())
@@ -3434,6 +3449,7 @@ impl<'a, W: Write> Writer<'a, W> {
             | Expression::AtomicResult { .. }
             | Expression::RayQueryProceedResult
             | Expression::WorkGroupUniformLoadResult { .. }
+            | Expression::SubgroupOperationResult { .. }
             | Expression::SubgroupBallotResult => unreachable!(),
             // `ArrayLength` is written as `expr.length()` and we convert it to a uint
             Expression::ArrayLength(expr) => {

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -2263,7 +2263,7 @@ impl<'a, W: Write> Writer<'a, W> {
                     Some(predicate) => self.write_expr(predicate, ctx)?,
                     None => write!(self.out, "true")?,
                 }
-                write!(self.out, ");")?;
+                writeln!(self.out, ");")?;
             }
             Statement::SubgroupCollectiveOperation {
                 op,
@@ -2271,14 +2271,103 @@ impl<'a, W: Write> Writer<'a, W> {
                 argument,
                 result,
             } => {
-                unimplemented!(); // FIXME:
+                write!(self.out, "{level}")?;
+                let res_name = format!("{}{}", back::BAKE_PREFIX, result.index());
+                let res_ty = ctx.info[result].ty.inner_with(&self.module.types);
+                self.write_value_type(res_ty)?;
+                write!(self.out, " {res_name} = ")?;
+                self.named_expressions.insert(result, res_name);
+
+                match (collective_op, op) {
+                    (crate::CollectiveOperation::Reduce, crate::SubgroupOperation::All) => {
+                        write!(self.out, "subgroupAll(")?
+                    }
+                    (crate::CollectiveOperation::Reduce, crate::SubgroupOperation::Any) => {
+                        write!(self.out, "subgroupAny(")?
+                    }
+                    (crate::CollectiveOperation::Reduce, crate::SubgroupOperation::Add) => {
+                        write!(self.out, "subgroupAdd(")?
+                    }
+                    (crate::CollectiveOperation::Reduce, crate::SubgroupOperation::Mul) => {
+                        write!(self.out, "subgroupMul(")?
+                    }
+                    (crate::CollectiveOperation::Reduce, crate::SubgroupOperation::Max) => {
+                        write!(self.out, "subgroupMax(")?
+                    }
+                    (crate::CollectiveOperation::Reduce, crate::SubgroupOperation::Min) => {
+                        write!(self.out, "subgroupMin(")?
+                    }
+                    (crate::CollectiveOperation::Reduce, crate::SubgroupOperation::And) => {
+                        write!(self.out, "subgroupAnd(")?
+                    }
+                    (crate::CollectiveOperation::Reduce, crate::SubgroupOperation::Or) => {
+                        write!(self.out, "subgroupOr(")?
+                    }
+                    (crate::CollectiveOperation::Reduce, crate::SubgroupOperation::Xor) => {
+                        write!(self.out, "subgroupXor(")?
+                    }
+                    (crate::CollectiveOperation::ExclusiveScan, crate::SubgroupOperation::Add) => {
+                        write!(self.out, "subgroupExclusiveAdd(")?
+                    }
+                    (crate::CollectiveOperation::ExclusiveScan, crate::SubgroupOperation::Mul) => {
+                        write!(self.out, "subgroupExclusiveMul(")?
+                    }
+                    (crate::CollectiveOperation::InclusiveScan, crate::SubgroupOperation::Add) => {
+                        write!(self.out, "subgroupInclusiveAdd(")?
+                    }
+                    (crate::CollectiveOperation::InclusiveScan, crate::SubgroupOperation::Mul) => {
+                        write!(self.out, "subgroupInclusiveMul(")?
+                    }
+                    _ => unimplemented!(),
+                }
+                self.write_expr(argument, ctx)?;
+                writeln!(self.out, ");")?;
             }
             Statement::SubgroupGather {
                 mode,
                 argument,
                 result,
             } => {
-                unimplemented!(); // FIXME
+                write!(self.out, "{level}")?;
+                let res_name = format!("{}{}", back::BAKE_PREFIX, result.index());
+                let res_ty = ctx.info[result].ty.inner_with(&self.module.types);
+                self.write_value_type(res_ty)?;
+                write!(self.out, " {res_name} = ")?;
+                self.named_expressions.insert(result, res_name);
+
+                match mode {
+                    crate::GatherMode::BroadcastFirst => {
+                        write!(self.out, "subgroupBroadcastFirst(")?;
+                    }
+                    crate::GatherMode::Broadcast(_) => {
+                        write!(self.out, "subgroupBroadcast(")?;
+                    }
+                    crate::GatherMode::Shuffle(_) => {
+                        write!(self.out, "subgroupShuffle(")?;
+                    }
+                    crate::GatherMode::ShuffleDown(_) => {
+                        write!(self.out, "subgroupShuffleDown(")?;
+                    }
+                    crate::GatherMode::ShuffleUp(_) => {
+                        write!(self.out, "subgroupShuffleUp(")?;
+                    }
+                    crate::GatherMode::ShuffleXor(_) => {
+                        write!(self.out, "subgroupShuffleXor(")?;
+                    }
+                }
+                self.write_expr(argument, ctx)?;
+                match mode {
+                    crate::GatherMode::BroadcastFirst => {}
+                    crate::GatherMode::Broadcast(index)
+                    | crate::GatherMode::Shuffle(index)
+                    | crate::GatherMode::ShuffleDown(index)
+                    | crate::GatherMode::ShuffleUp(index)
+                    | crate::GatherMode::ShuffleXor(index) => {
+                        write!(self.out, ", ")?;
+                        self.write_expr(index, ctx)?;
+                    }
+                }
+                writeln!(self.out, ");")?;
             }
         }
 
@@ -4013,7 +4102,7 @@ impl<'a, W: Write> Writer<'a, W> {
             writeln!(self.out, "{level}memoryBarrierShared();")?;
         }
         if flags.contains(crate::Barrier::SUB_GROUP) {
-            unimplemented!() // FIXME
+            writeln!(self.out, "{level}subgroupMemoryBarrier();")?;
         }
         writeln!(self.out, "{level}barrier();")?;
         Ok(())
@@ -4192,9 +4281,10 @@ const fn glsl_built_in(
         Bi::WorkGroupSize => "gl_WorkGroupSize",
         Bi::NumWorkGroups => "gl_NumWorkGroups",
         // subgroup
-        Bi::NumSubgroups | Bi::SubgroupId => todo!(),
-        Bi::SubgroupInvocationId => "gl_SubgroupInvocationID",
+        Bi::NumSubgroups => "gl_NumSubgroups",
+        Bi::SubgroupId => "gl_SubgroupID",
         Bi::SubgroupSize => "gl_SubgroupSize",
+        Bi::SubgroupInvocationId => "gl_SubgroupInvocationID",
     }
 }
 

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -4167,6 +4167,9 @@ const fn glsl_built_in(
         Bi::WorkGroupId => "gl_WorkGroupID",
         Bi::WorkGroupSize => "gl_WorkGroupSize",
         Bi::NumWorkGroups => "gl_NumWorkGroups",
+        // subgroup
+        Bi::SubgroupInvocationId => "gl_SubgroupInvocationID",
+        Bi::SubgroupSize => "gl_SubgroupSize",
     }
 }
 

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -2250,7 +2250,7 @@ impl<'a, W: Write> Writer<'a, W> {
                 writeln!(self.out, ");")?;
             }
             Statement::RayQuery { .. } => unreachable!(),
-            Statement::SubgroupBallot { result } => {
+            Statement::SubgroupBallot { result, predicate } => {
                 write!(self.out, "{level}")?;
                 let res_name = format!("{}{}", back::BAKE_PREFIX, result.index());
                 let res_ty = ctx.info[result].ty.inner_with(&self.module.types);
@@ -2258,7 +2258,12 @@ impl<'a, W: Write> Writer<'a, W> {
                 write!(self.out, " {res_name} = ")?;
                 self.named_expressions.insert(result, res_name);
 
-                writeln!(self.out, "subgroupBallot(true);")?;
+                write!(self.out, "subgroupBallot(")?;
+                match predicate {
+                    Some(predicate) => self.write_expr(predicate, ctx)?,
+                    None => write!(self.out, "true")?,
+                }
+                write!(self.out, ");")?;
             }
             Statement::SubgroupCollectiveOperation {
                 ref op,

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -2250,6 +2250,16 @@ impl<'a, W: Write> Writer<'a, W> {
                 writeln!(self.out, ");")?;
             }
             Statement::RayQuery { .. } => unreachable!(),
+            Statement::SubgroupBallot { result } => {
+                write!(self.out, "{level}")?;
+                let res_name = format!("{}{}", back::BAKE_PREFIX, result.index());
+                let res_ty = ctx.info[result].ty.inner_with(&self.module.types);
+                self.write_value_type(res_ty)?;
+                write!(self.out, " {res_name} = ")?;
+                self.named_expressions.insert(result, res_name);
+
+                writeln!(self.out, "subgroupBallot(true);")?;
+            }
         }
 
         Ok(())
@@ -3423,7 +3433,8 @@ impl<'a, W: Write> Writer<'a, W> {
             Expression::CallResult(_)
             | Expression::AtomicResult { .. }
             | Expression::RayQueryProceedResult
-            | Expression::WorkGroupUniformLoadResult { .. } => unreachable!(),
+            | Expression::WorkGroupUniformLoadResult { .. }
+            | Expression::SubgroupBallotResult => unreachable!(),
             // `ArrayLength` is written as `expr.length()` and we convert it to a uint
             Expression::ArrayLength(expr) => {
                 write!(self.out, "uint(")?;

--- a/src/back/glsl/mod.rs
+++ b/src/back/glsl/mod.rs
@@ -4192,6 +4192,7 @@ const fn glsl_built_in(
         Bi::WorkGroupSize => "gl_WorkGroupSize",
         Bi::NumWorkGroups => "gl_NumWorkGroups",
         // subgroup
+        Bi::NumSubgroups | Bi::SubgroupId => todo!(),
         Bi::SubgroupInvocationId => "gl_SubgroupInvocationID",
         Bi::SubgroupSize => "gl_SubgroupSize",
     }

--- a/src/back/hlsl/conv.rs
+++ b/src/back/hlsl/conv.rs
@@ -166,13 +166,13 @@ impl crate::BuiltIn {
             // to this field will get replaced with references to `SPECIAL_CBUF_VAR`
             // in `Writer::write_expr`.
             Self::NumWorkGroups => "SV_GroupID",
-
-            Self::NumSubgroups | Self::SubgroupId => todo!(),
-            Self::SubgroupInvocationId
-            | Self::SubgroupSize
-            | Self::BaseInstance
-            | Self::BaseVertex
-            | Self::WorkGroupSize => return Err(Error::Unimplemented(format!("builtin {self:?}"))),
+            Self::SubgroupSize
+            | Self::SubgroupInvocationId
+            | Self::NumSubgroups
+            | Self::SubgroupId => return Err(Error::Unimplemented(format!("builtin {self:?}"))),
+            Self::BaseInstance | Self::BaseVertex | Self::WorkGroupSize => {
+                return Err(Error::Unimplemented(format!("builtin {self:?}")))
+            }
             Self::PointSize | Self::ViewIndex | Self::PointCoord => {
                 return Err(Error::Custom(format!("Unsupported builtin {self:?}")))
             }

--- a/src/back/hlsl/conv.rs
+++ b/src/back/hlsl/conv.rs
@@ -166,9 +166,12 @@ impl crate::BuiltIn {
             // to this field will get replaced with references to `SPECIAL_CBUF_VAR`
             // in `Writer::write_expr`.
             Self::NumWorkGroups => "SV_GroupID",
-            Self::BaseInstance | Self::BaseVertex | Self::WorkGroupSize => {
-                return Err(Error::Unimplemented(format!("builtin {self:?}")))
-            }
+
+            Self::SubgroupInvocationId
+            | Self::SubgroupSize
+            | Self::BaseInstance
+            | Self::BaseVertex
+            | Self::WorkGroupSize => return Err(Error::Unimplemented(format!("builtin {self:?}"))),
             Self::PointSize | Self::ViewIndex | Self::PointCoord => {
                 return Err(Error::Custom(format!("Unsupported builtin {self:?}")))
             }

--- a/src/back/hlsl/conv.rs
+++ b/src/back/hlsl/conv.rs
@@ -167,6 +167,7 @@ impl crate::BuiltIn {
             // in `Writer::write_expr`.
             Self::NumWorkGroups => "SV_GroupID",
 
+            Self::NumSubgroups | Self::SubgroupId => todo!(),
             Self::SubgroupInvocationId
             | Self::SubgroupSize
             | Self::BaseInstance

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -2013,6 +2013,21 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
 
                 writeln!(self.out, "WaveActiveBallot(true);")?;
             }
+            Statement::SubgroupCollectiveOperation {
+                ref op,
+                ref collective_op,
+                argument,
+                result,
+            } => {
+                unimplemented!(); // FIXME
+            }
+            Statement::SubgroupBroadcast {
+                ref mode,
+                argument,
+                result,
+            } => {
+                unimplemented!(); // FIXME
+            }
         }
 
         Ok(())
@@ -3162,7 +3177,8 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
             | Expression::AtomicResult { .. }
             | Expression::WorkGroupUniformLoadResult { .. }
             | Expression::RayQueryProceedResult
-            | Expression::SubgroupBallotResult => {}
+            | Expression::SubgroupBallotResult
+            | Expression::SubgroupOperationResult { .. } => {}
         }
 
         if !closing_bracket.is_empty() {

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -2026,7 +2026,7 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
             } => {
                 unimplemented!(); // FIXME
             }
-            Statement::SubgroupBroadcast {
+            Statement::SubgroupGather {
                 ref mode,
                 argument,
                 result,

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -3229,6 +3229,9 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
         if barrier.contains(crate::Barrier::WORK_GROUP) {
             writeln!(self.out, "{level}GroupMemoryBarrierWithGroupSync();")?;
         }
+        if barrier.contains(crate::Barrier::SUB_GROUP) {
+            unimplemented!() // FIXME
+        }
         Ok(())
     }
 }

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -2004,6 +2004,15 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 writeln!(self.out, "{level}}}")?
             }
             Statement::RayQuery { .. } => unreachable!(),
+            Statement::SubgroupBallot { result } => {
+                write!(self.out, "{level}")?;
+
+                let name = format!("{}{}", back::BAKE_PREFIX, result.index());
+                write!(self.out, "const uint4 {name} = ")?;
+                self.named_expressions.insert(result, name);
+
+                writeln!(self.out, "WaveActiveBallot(true);")?;
+            }
         }
 
         Ok(())
@@ -3152,7 +3161,8 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
             Expression::CallResult(_)
             | Expression::AtomicResult { .. }
             | Expression::WorkGroupUniformLoadResult { .. }
-            | Expression::RayQueryProceedResult => {}
+            | Expression::RayQueryProceedResult
+            | Expression::SubgroupBallotResult => {}
         }
 
         if !closing_bracket.is_empty() {

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -2019,15 +2019,15 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 writeln!(self.out, ");")?;
             }
             Statement::SubgroupCollectiveOperation {
-                ref op,
-                ref collective_op,
+                op,
+                collective_op,
                 argument,
                 result,
             } => {
                 unimplemented!(); // FIXME
             }
             Statement::SubgroupGather {
-                ref mode,
+                mode,
                 argument,
                 result,
             } => {

--- a/src/back/hlsl/writer.rs
+++ b/src/back/hlsl/writer.rs
@@ -2004,14 +2004,19 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                 writeln!(self.out, "{level}}}")?
             }
             Statement::RayQuery { .. } => unreachable!(),
-            Statement::SubgroupBallot { result } => {
+            Statement::SubgroupBallot { result, predicate } => {
                 write!(self.out, "{level}")?;
 
                 let name = format!("{}{}", back::BAKE_PREFIX, result.index());
                 write!(self.out, "const uint4 {name} = ")?;
                 self.named_expressions.insert(result, name);
 
-                writeln!(self.out, "WaveActiveBallot(true);")?;
+                write!(self.out, "WaveActiveBallot(")?;
+                match predicate {
+                    Some(predicate) => self.write_expr(module, predicate, func_ctx)?,
+                    None => write!(self.out, "true")?,
+                }
+                writeln!(self.out, ");")?;
             }
             Statement::SubgroupCollectiveOperation {
                 ref op,

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -437,6 +437,9 @@ impl ResolvedBinding {
                     Bi::WorkGroupId => "threadgroup_position_in_grid",
                     Bi::WorkGroupSize => "dispatch_threads_per_threadgroup",
                     Bi::NumWorkGroups => "threadgroups_per_grid",
+                    // subgroup
+                    Bi::SubgroupInvocationId => "simdgroup_index_in_threadgroup",
+                    Bi::SubgroupSize => "simdgroups_per_threadgroup",
                     Bi::CullDistance | Bi::ViewIndex => {
                         return Err(Error::UnsupportedBuiltIn(built_in))
                     }

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -438,9 +438,10 @@ impl ResolvedBinding {
                     Bi::WorkGroupSize => "dispatch_threads_per_threadgroup",
                     Bi::NumWorkGroups => "threadgroups_per_grid",
                     // subgroup
-                    Bi::NumSubgroups | Bi::SubgroupId => todo!(),
-                    Bi::SubgroupInvocationId => "simdgroup_index_in_threadgroup",
-                    Bi::SubgroupSize => "simdgroups_per_threadgroup",
+                    Bi::NumSubgroups => "simdgroups_per_threadgroup",
+                    Bi::SubgroupId => "simdgroup_index_in_threadgroup",
+                    Bi::SubgroupSize => "threads_per_simdgroup",
+                    Bi::SubgroupInvocationId => "thread_index_in_simdgroup",
                     Bi::CullDistance | Bi::ViewIndex => {
                         return Err(Error::UnsupportedBuiltIn(built_in))
                     }

--- a/src/back/msl/mod.rs
+++ b/src/back/msl/mod.rs
@@ -438,6 +438,7 @@ impl ResolvedBinding {
                     Bi::WorkGroupSize => "dispatch_threads_per_threadgroup",
                     Bi::NumWorkGroups => "threadgroups_per_grid",
                     // subgroup
+                    Bi::NumSubgroups | Bi::SubgroupId => todo!(),
                     Bi::SubgroupInvocationId => "simdgroup_index_in_threadgroup",
                     Bi::SubgroupSize => "simdgroups_per_threadgroup",
                     Bi::CullDistance | Bi::ViewIndex => {

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -3027,15 +3027,15 @@ impl<W: Write> Writer<W> {
                     writeln!(self.out, ");")?;
                 }
                 crate::Statement::SubgroupCollectiveOperation {
-                    ref op,
-                    ref collective_op,
+                    op,
+                    collective_op,
                     argument,
                     result,
                 } => {
                     unimplemented!(); // FIXME
                 }
                 crate::Statement::SubgroupGather {
-                    ref mode,
+                    mode,
                     argument,
                     result,
                 } => {

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -3012,12 +3012,19 @@ impl<W: Write> Writer<W> {
                         }
                     }
                 }
-                crate::Statement::SubgroupBallot { result } => {
+                crate::Statement::SubgroupBallot { result, predicate } => {
                     write!(self.out, "{level}")?;
                     let name = self.namer.call("");
                     self.start_baking_expression(result, &context.expression, &name)?;
                     self.named_expressions.insert(result, name);
-                    write!(self.out, "{NAMESPACE}::simd_active_threads_mask();")?;
+                    write!(self.out, "{NAMESPACE}::simd_ballot(;")?;
+                    match predicate {
+                        Some(predicate) => {
+                            self.put_expression(predicate, &context.expression, true)?
+                        }
+                        None => write!(self.out, "true")?,
+                    }
+                    writeln!(self.out, ");")?;
                 }
                 crate::Statement::SubgroupCollectiveOperation {
                     ref op,

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1936,6 +1936,7 @@ impl<W: Write> Writer<W> {
             | crate::Expression::AtomicResult { .. }
             | crate::Expression::WorkGroupUniformLoadResult { .. }
             | crate::Expression::SubgroupBallotResult
+            | crate::Expression::SubgroupOperationResult { .. }
             | crate::Expression::RayQueryProceedResult => {
                 unreachable!()
             }
@@ -3017,6 +3018,21 @@ impl<W: Write> Writer<W> {
                     self.start_baking_expression(result, &context.expression, &name)?;
                     self.named_expressions.insert(result, name);
                     write!(self.out, "{NAMESPACE}::simd_active_threads_mask();")?;
+                }
+                crate::Statement::SubgroupCollectiveOperation {
+                    ref op,
+                    ref collective_op,
+                    argument,
+                    result,
+                } => {
+                    unimplemented!(); // FIXME
+                }
+                crate::Statement::SubgroupBroadcast {
+                    ref mode,
+                    argument,
+                    result,
+                } => {
+                    unimplemented!(); // FIXME
                 }
             }
         }

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1935,6 +1935,7 @@ impl<W: Write> Writer<W> {
             crate::Expression::CallResult(_)
             | crate::Expression::AtomicResult { .. }
             | crate::Expression::WorkGroupUniformLoadResult { .. }
+            | crate::Expression::SubgroupBallotResult
             | crate::Expression::RayQueryProceedResult => {
                 unreachable!()
             }
@@ -1997,7 +1998,6 @@ impl<W: Write> Writer<W> {
                 }
                 write!(self.out, "}}")?;
             }
-            crate::Expression::SubgroupBallotResult => todo!(),
         }
         Ok(())
     }
@@ -3011,7 +3011,13 @@ impl<W: Write> Writer<W> {
                         }
                     }
                 }
-                crate::Statement::SubgroupBallot { result } => todo!(),
+                crate::Statement::SubgroupBallot { result } => {
+                    write!(self.out, "{level}")?;
+                    let name = self.namer.call("");
+                    self.start_baking_expression(result, &context.expression, &name)?;
+                    self.named_expressions.insert(result, name);
+                    write!(self.out, "{NAMESPACE}::simd_active_threads_mask();")?;
+                }
             }
         }
 

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -4354,6 +4354,9 @@ impl<W: Write> Writer<W> {
                 "{level}{NAMESPACE}::threadgroup_barrier({NAMESPACE}::mem_flags::mem_threadgroup);",
             )?;
         }
+        if flags.contains(crate::Barrier::SUB_GROUP) {
+            unimplemented!(); // FIXME
+        }
         Ok(())
     }
 }

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -3034,7 +3034,7 @@ impl<W: Write> Writer<W> {
                 } => {
                     unimplemented!(); // FIXME
                 }
-                crate::Statement::SubgroupBroadcast {
+                crate::Statement::SubgroupGather {
                     ref mode,
                     argument,
                     result,

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -4739,8 +4739,8 @@ fn test_stack_size() {
         }
         let stack_size = addresses_end - addresses_start;
         // check the size (in debug only)
-        // last observed macOS value: 19152 (CI)
-        if !(9000..=20000).contains(&stack_size) {
+        // last observed macOS value: 22256 (CI)
+        if !(15000..=25000).contains(&stack_size) {
             panic!("`put_block` stack size {stack_size} has changed!");
         }
     }

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -1997,6 +1997,7 @@ impl<W: Write> Writer<W> {
                 }
                 write!(self.out, "}}")?;
             }
+            crate::Expression::SubgroupBallotResult => todo!(),
         }
         Ok(())
     }
@@ -3010,6 +3011,7 @@ impl<W: Write> Writer<W> {
                         }
                     }
                 }
+                crate::Statement::SubgroupBallot { result } => todo!(),
             }
         }
 

--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -1131,7 +1131,8 @@ impl<'w> BlockContext<'w> {
             | crate::Expression::AtomicResult { .. }
             | crate::Expression::WorkGroupUniformLoadResult { .. }
             | crate::Expression::RayQueryProceedResult
-            | crate::Expression::SubgroupBallotResult => self.cached[expr_handle],
+            | crate::Expression::SubgroupBallotResult
+            | crate::Expression::SubgroupOperationResult { .. } => self.cached[expr_handle],
             crate::Expression::As {
                 expr,
                 kind,
@@ -2360,6 +2361,21 @@ impl<'w> BlockContext<'w> {
                         predicate,
                     ));
                     self.cached[result] = id;
+                }
+                crate::Statement::SubgroupCollectiveOperation {
+                    ref op,
+                    ref collective_op,
+                    argument,
+                    result,
+                } => {
+                    self.write_subgroup_operation(op, collective_op, argument, result, &mut block);
+                }
+                crate::Statement::SubgroupBroadcast {
+                    ref mode,
+                    argument,
+                    result,
+                } => {
+                    unimplemented!() // FIXME
                 }
             }
         }

--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -2373,7 +2373,7 @@ impl<'w> BlockContext<'w> {
                 } => {
                     self.write_subgroup_operation(op, collective_op, argument, result, &mut block)?;
                 }
-                crate::Statement::SubgroupBroadcast {
+                crate::Statement::SubgroupGather {
                     ref mode,
                     argument,
                     result,

--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -2340,7 +2340,7 @@ impl<'w> BlockContext<'w> {
                 crate::Statement::RayQuery { query, ref fun } => {
                     self.write_ray_query_function(query, fun, &mut block);
                 }
-                crate::Statement::SubgroupBallot { result } => {
+                crate::Statement::SubgroupBallot { result, predicate } => {
                     self.writer.require_any(
                         "GroupNonUniformBallot",
                         &[spirv::Capability::GroupNonUniformBallot],
@@ -2352,7 +2352,10 @@ impl<'w> BlockContext<'w> {
                         pointer_space: None,
                     }));
                     let exec_scope_id = self.get_index_constant(spirv::Scope::Subgroup as u32);
-                    let predicate = self.writer.get_constant_scalar(crate::Literal::Bool(true));
+                    let predicate = match predicate {
+                        Some(predicate) => self.cached[predicate],
+                        None => self.writer.get_constant_scalar(crate::Literal::Bool(true)),
+                    };
                     let id = self.gen_id();
                     block.body.push(Instruction::group_non_uniform_ballot(
                         vec4_u32_type_id,

--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -2368,14 +2368,14 @@ impl<'w> BlockContext<'w> {
                     argument,
                     result,
                 } => {
-                    self.write_subgroup_operation(op, collective_op, argument, result, &mut block);
+                    self.write_subgroup_operation(op, collective_op, argument, result, &mut block)?;
                 }
                 crate::Statement::SubgroupBroadcast {
                     ref mode,
                     argument,
                     result,
                 } => {
-                    unimplemented!() // FIXME
+                    self.write_subgroup_broadcast(mode, argument, result, &mut block)?;
                 }
             }
         }

--- a/src/back/spv/block.rs
+++ b/src/back/spv/block.rs
@@ -2340,6 +2340,10 @@ impl<'w> BlockContext<'w> {
                     self.write_ray_query_function(query, fun, &mut block);
                 }
                 crate::Statement::SubgroupBallot { result } => {
+                    self.writer.require_any(
+                        "GroupNonUniformBallot",
+                        &[spirv::Capability::GroupNonUniformBallot],
+                    )?;
                     let vec4_u32_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
                         vector_size: Some(crate::VectorSize::Quad),
                         kind: crate::ScalarKind::Uint,

--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -1054,22 +1054,6 @@ impl super::Instruction {
 
         instruction
     }
-    pub(super) fn group_non_uniform_broadcast(
-        result_type_id: Word,
-        id: Word,
-        exec_scope_id: Word,
-        value: Word,
-        index: Word,
-    ) -> Self {
-        let mut instruction = Self::new(Op::GroupNonUniformBroadcast);
-        instruction.set_type(result_type_id);
-        instruction.set_result(id);
-        instruction.add_operand(exec_scope_id);
-        instruction.add_operand(value);
-        instruction.add_operand(index);
-
-        instruction
-    }
     pub(super) fn group_non_uniform_broadcast_first(
         result_type_id: Word,
         id: Word,
@@ -1084,6 +1068,23 @@ impl super::Instruction {
 
         instruction
     }
+    pub(super) fn group_non_uniform_gather(
+        op: Op,
+        result_type_id: Word,
+        id: Word,
+        exec_scope_id: Word,
+        value: Word,
+        index: Word,
+    ) -> Self {
+        let mut instruction = Self::new(op);
+        instruction.set_type(result_type_id);
+        instruction.set_result(id);
+        instruction.add_operand(exec_scope_id);
+        instruction.add_operand(value);
+        instruction.add_operand(index);
+
+        instruction
+    }
     pub(super) fn group_non_uniform_arithmetic(
         op: Op,
         result_type_id: Word,
@@ -1092,10 +1093,6 @@ impl super::Instruction {
         group_op: Option<spirv::GroupOperation>,
         value: Word,
     ) -> Self {
-        println!(
-            "{:?}",
-            (op, result_type_id, id, exec_scope_id, group_op, value)
-        );
         let mut instruction = Self::new(op);
         instruction.set_type(result_type_id);
         instruction.set_result(id);

--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -1037,6 +1037,23 @@ impl super::Instruction {
         instruction.add_operand(semantics_id);
         instruction
     }
+
+    // Group Instructions
+
+    pub(super) fn group_non_uniform_ballot(
+        result_type_id: Word,
+        id: Word,
+        exec_scope_id: Word,
+        predicate: Word,
+    ) -> Self {
+        let mut instruction = Self::new(Op::GroupNonUniformBallot);
+        instruction.set_type(result_type_id);
+        instruction.set_result(id);
+        instruction.add_operand(exec_scope_id);
+        instruction.add_operand(predicate);
+
+        instruction
+    }
 }
 
 impl From<crate::StorageFormat> for spirv::ImageFormat {

--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -1054,6 +1054,23 @@ impl super::Instruction {
 
         instruction
     }
+    pub(super) fn group_non_uniform_arithmetic(
+        op: Op,
+        result_type_id: Word,
+        id: Word,
+        exec_scope_id: Word,
+        group_op: spirv::GroupOperation,
+        value: Word,
+    ) -> Self {
+        let mut instruction = Self::new(op);
+        instruction.set_type(result_type_id);
+        instruction.set_result(id);
+        instruction.add_operand(exec_scope_id);
+        instruction.add_operand(group_op as u32);
+        instruction.add_operand(value);
+
+        instruction
+    }
 }
 
 impl From<crate::StorageFormat> for spirv::ImageFormat {

--- a/src/back/spv/instructions.rs
+++ b/src/back/spv/instructions.rs
@@ -1054,19 +1054,55 @@ impl super::Instruction {
 
         instruction
     }
+    pub(super) fn group_non_uniform_broadcast(
+        result_type_id: Word,
+        id: Word,
+        exec_scope_id: Word,
+        value: Word,
+        index: Word,
+    ) -> Self {
+        let mut instruction = Self::new(Op::GroupNonUniformBroadcast);
+        instruction.set_type(result_type_id);
+        instruction.set_result(id);
+        instruction.add_operand(exec_scope_id);
+        instruction.add_operand(value);
+        instruction.add_operand(index);
+
+        instruction
+    }
+    pub(super) fn group_non_uniform_broadcast_first(
+        result_type_id: Word,
+        id: Word,
+        exec_scope_id: Word,
+        value: Word,
+    ) -> Self {
+        let mut instruction = Self::new(Op::GroupNonUniformBroadcastFirst);
+        instruction.set_type(result_type_id);
+        instruction.set_result(id);
+        instruction.add_operand(exec_scope_id);
+        instruction.add_operand(value);
+
+        instruction
+    }
     pub(super) fn group_non_uniform_arithmetic(
         op: Op,
         result_type_id: Word,
         id: Word,
         exec_scope_id: Word,
-        group_op: spirv::GroupOperation,
+        group_op: Option<spirv::GroupOperation>,
         value: Word,
     ) -> Self {
+        println!(
+            "{:?}",
+            (op, result_type_id, id, exec_scope_id, group_op, value)
+        );
         let mut instruction = Self::new(op);
         instruction.set_type(result_type_id);
         instruction.set_result(id);
         instruction.add_operand(exec_scope_id);
-        instruction.add_operand(group_op as u32);
+        if let Some(group_op) = group_op {
+            instruction.add_operand(group_op as u32);
+        }
         instruction.add_operand(value);
 
         instruction

--- a/src/back/spv/mod.rs
+++ b/src/back/spv/mod.rs
@@ -13,6 +13,7 @@ mod layout;
 mod ray;
 mod recyclable;
 mod selection;
+mod subgroup;
 mod writer;
 
 pub use spirv::Capability;

--- a/src/back/spv/subgroup.rs
+++ b/src/back/spv/subgroup.rs
@@ -94,7 +94,7 @@ impl<'w> BlockContext<'w> {
     }
     pub(super) fn write_subgroup_broadcast(
         &mut self,
-        mode: &crate::BroadcastMode,
+        mode: &crate::GatherMode,
         argument: Handle<crate::Expression>,
         result: Handle<crate::Expression>,
         block: &mut Block,
@@ -112,7 +112,7 @@ impl<'w> BlockContext<'w> {
 
         let arg_id = self.cached[argument];
         match mode {
-            crate::BroadcastMode::Index(index) => {
+            crate::GatherMode::Broadcast(index) => {
                 let index_id = self.cached[*index];
                 block.body.push(Instruction::group_non_uniform_broadcast(
                     result_type_id,
@@ -122,7 +122,7 @@ impl<'w> BlockContext<'w> {
                     index_id,
                 ));
             }
-            crate::BroadcastMode::First => {
+            crate::GatherMode::BroadcastFirst => {
                 block
                     .body
                     .push(Instruction::group_non_uniform_broadcast_first(

--- a/src/back/spv/subgroup.rs
+++ b/src/back/spv/subgroup.rs
@@ -132,6 +132,10 @@ impl<'w> BlockContext<'w> {
                         arg_id,
                     ));
             }
+            crate::GatherMode::Shuffle(index)
+            | crate::GatherMode::ShuffleDown(index)
+            | crate::GatherMode::ShuffleUp(index)
+            | crate::GatherMode::ShuffleXor(index) => todo!(),
         }
         self.cached[result] = id;
         Ok(())

--- a/src/back/spv/subgroup.rs
+++ b/src/back/spv/subgroup.rs
@@ -1,7 +1,43 @@
 use super::{Block, BlockContext, Error, Instruction};
-use crate::{arena::Handle, TypeInner};
+use crate::{
+    arena::Handle,
+    back::spv::{LocalType, LookupType},
+    TypeInner,
+};
 
 impl<'w> BlockContext<'w> {
+    pub(super) fn write_subgroup_ballot(
+        &mut self,
+        predicate: &Option<Handle<crate::Expression>>,
+        result: Handle<crate::Expression>,
+        block: &mut Block,
+    ) -> Result<(), Error> {
+        self.writer.require_any(
+            "GroupNonUniformBallot",
+            &[spirv::Capability::GroupNonUniformBallot],
+        )?;
+        let vec4_u32_type_id = self.get_type_id(LookupType::Local(LocalType::Value {
+            vector_size: Some(crate::VectorSize::Quad),
+            kind: crate::ScalarKind::Uint,
+            width: 4,
+            pointer_space: None,
+        }));
+        let exec_scope_id = self.get_index_constant(spirv::Scope::Subgroup as u32);
+        let predicate = if let Some(predicate) = *predicate {
+            self.cached[predicate]
+        } else {
+            self.writer.get_constant_scalar(crate::Literal::Bool(true))
+        };
+        let id = self.gen_id();
+        block.body.push(Instruction::group_non_uniform_ballot(
+            vec4_u32_type_id,
+            id,
+            exec_scope_id,
+            predicate,
+        ));
+        self.cached[result] = id;
+        Ok(())
+    }
     pub(super) fn write_subgroup_operation(
         &mut self,
         op: &crate::SubgroupOperation,
@@ -11,7 +47,7 @@ impl<'w> BlockContext<'w> {
         block: &mut Block,
     ) -> Result<(), Error> {
         use crate::SubgroupOperation as sg;
-        match op {
+        match *op {
             sg::All | sg::Any => {
                 self.writer.require_any(
                     "GroupNonUniformVote",
@@ -21,11 +57,7 @@ impl<'w> BlockContext<'w> {
             _ => {
                 self.writer.require_any(
                     "GroupNonUniformArithmetic",
-                    &[
-                        spirv::Capability::GroupNonUniformArithmetic,
-                        spirv::Capability::GroupNonUniformClustered,
-                        spirv::Capability::GroupNonUniformPartitionedNV,
-                    ],
+                    &[spirv::Capability::GroupNonUniformArithmetic],
                 )?;
             }
         }
@@ -35,14 +67,14 @@ impl<'w> BlockContext<'w> {
         let result_type_id = self.get_expression_type_id(result_ty);
         let result_ty_inner = result_ty.inner_with(&self.ir_module.types);
 
-        let (is_scalar, kind) = match result_ty_inner {
+        let (is_scalar, kind) = match *result_ty_inner {
             TypeInner::Scalar { kind, .. } => (true, kind),
             TypeInner::Vector { kind, .. } => (false, kind),
             _ => unimplemented!(),
         };
 
         use crate::ScalarKind as sk;
-        let spirv_op = match (kind, op) {
+        let spirv_op = match (kind, *op) {
             (sk::Bool, sg::All) if is_scalar => spirv::Op::GroupNonUniformAll,
             (sk::Bool, sg::Any) if is_scalar => spirv::Op::GroupNonUniformAny,
             (_, sg::All | sg::Any) => unimplemented!(),
@@ -71,9 +103,9 @@ impl<'w> BlockContext<'w> {
         let exec_scope_id = self.get_index_constant(spirv::Scope::Subgroup as u32);
 
         use crate::CollectiveOperation as c;
-        let group_op = match op {
+        let group_op = match *op {
             sg::All | sg::Any => None,
-            _ => Some(match collective_op {
+            _ => Some(match *collective_op {
                 c::Reduce => spirv::GroupOperation::Reduce,
                 c::InclusiveScan => spirv::GroupOperation::InclusiveScan,
                 c::ExclusiveScan => spirv::GroupOperation::ExclusiveScan,
@@ -92,7 +124,7 @@ impl<'w> BlockContext<'w> {
         self.cached[result] = id;
         Ok(())
     }
-    pub(super) fn write_subgroup_broadcast(
+    pub(super) fn write_subgroup_gather(
         &mut self,
         mode: &crate::GatherMode,
         argument: Handle<crate::Expression>,
@@ -103,6 +135,26 @@ impl<'w> BlockContext<'w> {
             "GroupNonUniformBallot",
             &[spirv::Capability::GroupNonUniformBallot],
         )?;
+        match *mode {
+            crate::GatherMode::BroadcastFirst | crate::GatherMode::Broadcast(_) => {
+                self.writer.require_any(
+                    "GroupNonUniformBallot",
+                    &[spirv::Capability::GroupNonUniformBallot],
+                )?;
+            }
+            crate::GatherMode::Shuffle(_) | crate::GatherMode::ShuffleXor(_) => {
+                self.writer.require_any(
+                    "GroupNonUniformShuffle",
+                    &[spirv::Capability::GroupNonUniformShuffle],
+                )?;
+            }
+            crate::GatherMode::ShuffleDown(_) | crate::GatherMode::ShuffleUp(_) => {
+                self.writer.require_any(
+                    "GroupNonUniformShuffleRelative",
+                    &[spirv::Capability::GroupNonUniformShuffleRelative],
+                )?;
+            }
+        }
 
         let id = self.gen_id();
         let result_ty = &self.fun_info[result].ty;
@@ -111,17 +163,7 @@ impl<'w> BlockContext<'w> {
         let exec_scope_id = self.get_index_constant(spirv::Scope::Subgroup as u32);
 
         let arg_id = self.cached[argument];
-        match mode {
-            crate::GatherMode::Broadcast(index) => {
-                let index_id = self.cached[*index];
-                block.body.push(Instruction::group_non_uniform_broadcast(
-                    result_type_id,
-                    id,
-                    exec_scope_id,
-                    arg_id,
-                    index_id,
-                ));
-            }
+        match *mode {
             crate::GatherMode::BroadcastFirst => {
                 block
                     .body
@@ -132,10 +174,29 @@ impl<'w> BlockContext<'w> {
                         arg_id,
                     ));
             }
-            crate::GatherMode::Shuffle(index)
+            crate::GatherMode::Broadcast(index)
+            | crate::GatherMode::Shuffle(index)
             | crate::GatherMode::ShuffleDown(index)
             | crate::GatherMode::ShuffleUp(index)
-            | crate::GatherMode::ShuffleXor(index) => todo!(),
+            | crate::GatherMode::ShuffleXor(index) => {
+                let index_id = self.cached[index];
+                let op = match *mode {
+                    crate::GatherMode::BroadcastFirst => unreachable!(),
+                    crate::GatherMode::Broadcast(_) => spirv::Op::GroupNonUniformBroadcast,
+                    crate::GatherMode::Shuffle(_) => spirv::Op::GroupNonUniformShuffle,
+                    crate::GatherMode::ShuffleDown(_) => spirv::Op::GroupNonUniformShuffleDown,
+                    crate::GatherMode::ShuffleUp(_) => spirv::Op::GroupNonUniformShuffleUp,
+                    crate::GatherMode::ShuffleXor(_) => spirv::Op::GroupNonUniformShuffleXor,
+                };
+                block.body.push(Instruction::group_non_uniform_gather(
+                    op,
+                    result_type_id,
+                    id,
+                    exec_scope_id,
+                    arg_id,
+                    index_id,
+                ));
+            }
         }
         self.cached[result] = id;
         Ok(())

--- a/src/back/spv/subgroup.rs
+++ b/src/back/spv/subgroup.rs
@@ -1,0 +1,83 @@
+use super::{Block, BlockContext, Error, Instruction};
+use crate::{arena::Handle, TypeInner};
+
+impl<'w> BlockContext<'w> {
+    pub(super) fn write_subgroup_operation(
+        &mut self,
+        op: &crate::SubgroupOperation,
+        collective_op: &crate::CollectiveOperation,
+        argument: Handle<crate::Expression>,
+        result: Handle<crate::Expression>,
+        block: &mut Block,
+    ) -> Result<(), Error> {
+        self.writer.require_any(
+            "GroupNonUniformArithmetic",
+            &[
+                spirv::Capability::GroupNonUniformArithmetic,
+                spirv::Capability::GroupNonUniformClustered,
+                spirv::Capability::GroupNonUniformPartitionedNV,
+            ],
+        )?;
+
+        let id = self.gen_id();
+        let result_ty = &self.fun_info[result].ty;
+        let result_type_id = self.get_expression_type_id(result_ty);
+        let result_ty_inner = result_ty.inner_with(&self.ir_module.types);
+        let kind = result_ty_inner.scalar_kind().unwrap();
+
+        let (is_scalar, kind) = match result_ty_inner {
+            TypeInner::Scalar { kind, .. } => (true, kind),
+            TypeInner::Vector { kind, .. } => (false, kind),
+            _ => unimplemented!(),
+        };
+
+        use crate::ScalarKind as sk;
+        use crate::SubgroupOperation as sg;
+        let spirv_op = match (kind, op) {
+            (sk::Bool, sg::All) if is_scalar => spirv::Op::GroupNonUniformAll,
+            (sk::Bool, sg::Any) if is_scalar => spirv::Op::GroupNonUniformAny,
+            (_, sg::All | sg::Any) => unimplemented!(),
+
+            (sk::Sint | sk::Uint, sg::Add) => spirv::Op::GroupNonUniformIAdd,
+            (sk::Float, sg::Add) => spirv::Op::GroupNonUniformFAdd,
+            (sk::Sint | sk::Uint, sg::Mul) => spirv::Op::GroupNonUniformIMul,
+            (sk::Float, sg::Mul) => spirv::Op::GroupNonUniformFMul,
+            (sk::Sint, sg::Max) => spirv::Op::GroupNonUniformSMax,
+            (sk::Uint, sg::Max) => spirv::Op::GroupNonUniformUMax,
+            (sk::Float, sg::Max) => spirv::Op::GroupNonUniformFMax,
+            (sk::Sint, sg::Min) => spirv::Op::GroupNonUniformSMin,
+            (sk::Uint, sg::Min) => spirv::Op::GroupNonUniformUMin,
+            (sk::Float, sg::Min) => spirv::Op::GroupNonUniformFMin,
+            (sk::Bool, sg::Add | sg::Mul | sg::Min | sg::Max) => unimplemented!(),
+
+            (sk::Sint | sk::Uint, sg::And) => spirv::Op::GroupNonUniformBitwiseAnd,
+            (sk::Sint | sk::Uint, sg::Or) => spirv::Op::GroupNonUniformBitwiseOr,
+            (sk::Sint | sk::Uint, sg::Xor) => spirv::Op::GroupNonUniformBitwiseXor,
+            (sk::Float, sg::And | sg::Or | sg::Xor) => unimplemented!(),
+            (sk::Bool, sg::And) => spirv::Op::GroupNonUniformLogicalAnd,
+            (sk::Bool, sg::Or) => spirv::Op::GroupNonUniformLogicalOr,
+            (sk::Bool, sg::Xor) => spirv::Op::GroupNonUniformLogicalXor,
+        };
+
+        let exec_scope_id = self.get_index_constant(spirv::Scope::Subgroup as u32);
+
+        use crate::CollectiveOperation as c;
+        let group_op = match collective_op {
+            c::Reduce => spirv::GroupOperation::Reduce,
+            c::InclusiveScan => spirv::GroupOperation::InclusiveScan,
+            c::ExclusiveScan => spirv::GroupOperation::ExclusiveScan,
+        };
+
+        let arg_id = self.cached[argument];
+        block.body.push(Instruction::group_non_uniform_arithmetic(
+            spirv_op,
+            result_type_id,
+            id,
+            exec_scope_id,
+            group_op,
+            arg_id,
+        ));
+        self.cached[result] = id;
+        Ok(())
+    }
+}

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1594,6 +1594,7 @@ impl Writer {
                     Bi::WorkGroupSize => BuiltIn::WorkgroupSize,
                     Bi::NumWorkGroups => BuiltIn::NumWorkgroups,
                     // Subgroup
+                    Bi::NumSubgroups | Bi::SubgroupId => todo!(),
                     Bi::SubgroupInvocationId => {
                         self.require_any(
                             "`subgroup_invocation_id` built-in",

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1314,7 +1314,11 @@ impl Writer {
             spirv::MemorySemantics::WORKGROUP_MEMORY,
             flags.contains(crate::Barrier::WORK_GROUP),
         );
-        let exec_scope_id = self.get_index_constant(spirv::Scope::Workgroup as u32);
+        let exec_scope_id = if flags.contains(crate::Barrier::SUB_GROUP) {
+            self.get_index_constant(spirv::Scope::Subgroup as u32)
+        } else {
+            self.get_index_constant(spirv::Scope::Workgroup as u32)
+        };
         let mem_scope_id = self.get_index_constant(memory_scope as u32);
         let semantics_id = self.get_index_constant(semantics.bits());
         block.body.push(Instruction::control_barrier(

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1594,15 +1594,31 @@ impl Writer {
                     Bi::WorkGroupSize => BuiltIn::WorkgroupSize,
                     Bi::NumWorkGroups => BuiltIn::NumWorkgroups,
                     // Subgroup
-                    Bi::NumSubgroups | Bi::SubgroupId => todo!(),
-                    Bi::SubgroupInvocationId => {
+                    Bi::NumSubgroups => {
                         self.require_any(
-                            "`subgroup_invocation_id` built-in",
+                            "`num_subgroups` built-in",
                             &[spirv::Capability::GroupNonUniform],
                         )?;
-                        BuiltIn::SubgroupLocalInvocationId
+                        BuiltIn::NumSubgroups
+                    }
+                    Bi::SubgroupId => {
+                        self.require_any(
+                            "`subgroup_id` built-in",
+                            &[spirv::Capability::GroupNonUniform],
+                        )?;
+                        BuiltIn::SubgroupId
                     }
                     Bi::SubgroupSize => {
+                        self.require_any(
+                            "`subgroup_size` built-in",
+                            &[
+                                spirv::Capability::GroupNonUniform,
+                                spirv::Capability::SubgroupBallotKHR,
+                            ],
+                        )?;
+                        BuiltIn::SubgroupSize
+                    }
+                    Bi::SubgroupInvocationId => {
                         self.require_any(
                             "`subgroup_invocation_id` built-in",
                             &[
@@ -1610,7 +1626,7 @@ impl Writer {
                                 spirv::Capability::SubgroupBallotKHR,
                             ],
                         )?;
-                        BuiltIn::SubgroupSize
+                        BuiltIn::SubgroupLocalInvocationId
                     }
                 };
 

--- a/src/back/spv/writer.rs
+++ b/src/back/spv/writer.rs
@@ -1589,6 +1589,24 @@ impl Writer {
                     Bi::WorkGroupId => BuiltIn::WorkgroupId,
                     Bi::WorkGroupSize => BuiltIn::WorkgroupSize,
                     Bi::NumWorkGroups => BuiltIn::NumWorkgroups,
+                    // Subgroup
+                    Bi::SubgroupInvocationId => {
+                        self.require_any(
+                            "`subgroup_invocation_id` built-in",
+                            &[spirv::Capability::GroupNonUniform],
+                        )?;
+                        BuiltIn::SubgroupLocalInvocationId
+                    }
+                    Bi::SubgroupSize => {
+                        self.require_any(
+                            "`subgroup_invocation_id` built-in",
+                            &[
+                                spirv::Capability::GroupNonUniform,
+                                spirv::Capability::SubgroupBallotKHR,
+                            ],
+                        )?;
+                        BuiltIn::SubgroupSize
+                    }
                 };
 
                 self.decorate(id, Decoration::BuiltIn, &[built_in as u32]);

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -921,13 +921,17 @@ impl<W: Write> Writer<W> {
                 }
             }
             Statement::RayQuery { .. } => unreachable!(),
-            Statement::SubgroupBallot { result } => {
+            Statement::SubgroupBallot { result, predicate } => {
                 write!(self.out, "{level}")?;
                 let res_name = format!("{}{}", back::BAKE_PREFIX, result.index());
                 self.start_named_expr(module, result, func_ctx, &res_name)?;
                 self.named_expressions.insert(result, res_name);
 
-                writeln!(self.out, "subgroupBallot();")?;
+                writeln!(self.out, "subgroupBallot(")?;
+                if let Some(predicate) = predicate {
+                    self.write_expr(module, predicate, func_ctx)?;
+                }
+                writeln!(self.out, ");")?;
             }
             Statement::SubgroupCollectiveOperation {
                 ref op,

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -941,7 +941,7 @@ impl<W: Write> Writer<W> {
             } => {
                 unimplemented!() // FIXME
             }
-            Statement::SubgroupBroadcast {
+            Statement::SubgroupGather {
                 ref mode,
                 argument,
                 result,

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -1789,6 +1789,7 @@ fn builtin_str(built_in: crate::BuiltIn) -> Result<&'static str, Error> {
         Bi::SampleMask => "sample_mask",
         Bi::PrimitiveIndex => "primitive_index",
         Bi::ViewIndex => "view_index",
+        Bi::NumSubgroups | Bi::SubgroupId => todo!(),
         Bi::SubgroupInvocationId => "subgroup_invocation_id",
         Bi::SubgroupSize => "subgroup_size",
         Bi::BaseInstance

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -1769,6 +1769,8 @@ fn builtin_str(built_in: crate::BuiltIn) -> Result<&'static str, Error> {
         Bi::SampleMask => "sample_mask",
         Bi::PrimitiveIndex => "primitive_index",
         Bi::ViewIndex => "view_index",
+        Bi::SubgroupInvocationId => "subgroup_invocation_id",
+        Bi::SubgroupSize => "subgroup_size",
         Bi::BaseInstance
         | Bi::BaseVertex
         | Bi::ClipDistance

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -929,6 +929,21 @@ impl<W: Write> Writer<W> {
 
                 writeln!(self.out, "subgroupBallot();")?;
             }
+            Statement::SubgroupCollectiveOperation {
+                ref op,
+                ref collective_op,
+                argument,
+                result,
+            } => {
+                unimplemented!() // FIXME
+            }
+            Statement::SubgroupBroadcast {
+                ref mode,
+                argument,
+                result,
+            } => {
+                unimplemented!() // FIXME
+            }
         }
 
         Ok(())
@@ -1668,6 +1683,7 @@ impl<W: Write> Writer<W> {
             | Expression::AtomicResult { .. }
             | Expression::RayQueryProceedResult
             | Expression::SubgroupBallotResult
+            | Expression::SubgroupOperationResult { .. }
             | Expression::WorkGroupUniformLoadResult { .. } => {}
         }
 

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -934,15 +934,15 @@ impl<W: Write> Writer<W> {
                 writeln!(self.out, ");")?;
             }
             Statement::SubgroupCollectiveOperation {
-                ref op,
-                ref collective_op,
+                op,
+                collective_op,
                 argument,
                 result,
             } => {
                 unimplemented!() // FIXME
             }
             Statement::SubgroupGather {
-                ref mode,
+                mode,
                 argument,
                 result,
             } => {

--- a/src/back/wgsl/writer.rs
+++ b/src/back/wgsl/writer.rs
@@ -921,6 +921,14 @@ impl<W: Write> Writer<W> {
                 }
             }
             Statement::RayQuery { .. } => unreachable!(),
+            Statement::SubgroupBallot { result } => {
+                write!(self.out, "{level}")?;
+                let res_name = format!("{}{}", back::BAKE_PREFIX, result.index());
+                self.start_named_expr(module, result, func_ctx, &res_name)?;
+                self.named_expressions.insert(result, res_name);
+
+                writeln!(self.out, "subgroupBallot();")?;
+            }
         }
 
         Ok(())
@@ -1659,6 +1667,7 @@ impl<W: Write> Writer<W> {
             Expression::CallResult(_)
             | Expression::AtomicResult { .. }
             | Expression::RayQueryProceedResult
+            | Expression::SubgroupBallotResult
             | Expression::WorkGroupUniformLoadResult { .. } => {}
         }
 

--- a/src/compact/expressions.rs
+++ b/src/compact/expressions.rs
@@ -55,6 +55,7 @@ impl<'tracer> ExpressionTracer<'tracer> {
                 | Ex::GlobalVariable(_)
                 | Ex::LocalVariable(_)
                 | Ex::CallResult(_)
+                | Ex::SubgroupBallotResult // FIXME: ???
                 | Ex::RayQueryProceedResult => {}
 
                 Ex::Constant(handle) => {
@@ -222,6 +223,7 @@ impl ModuleMap {
             | Ex::GlobalVariable(_)
             | Ex::LocalVariable(_)
             | Ex::CallResult(_)
+            | Ex::SubgroupBallotResult // FIXME: ???
             | Ex::RayQueryProceedResult => {}
 
             // Expressions that contain handles that need to be adjusted.

--- a/src/compact/expressions.rs
+++ b/src/compact/expressions.rs
@@ -157,6 +157,7 @@ impl<'tracer> ExpressionTracer<'tracer> {
                 Ex::AtomicResult { ty, comparison: _ } => self.trace_type(ty),
                 Ex::WorkGroupUniformLoadResult { ty } => self.trace_type(ty),
                 Ex::ArrayLength(expr) => work_list.push(expr),
+                Ex::SubgroupOperationResult { ty } => self.trace_type(ty),
                 Ex::RayQueryGetIntersection {
                     query,
                     committed: _,
@@ -351,6 +352,7 @@ impl ModuleMap {
                 comparison: _,
             } => self.types.adjust(ty),
             Ex::WorkGroupUniformLoadResult { ref mut ty } => self.types.adjust(ty),
+            Ex::SubgroupOperationResult { ref mut ty } => self.types.adjust(ty),
             Ex::ArrayLength(ref mut expr) => adjust(expr),
             Ex::RayQueryGetIntersection {
                 ref mut query,

--- a/src/compact/statements.rs
+++ b/src/compact/statements.rs
@@ -95,7 +95,10 @@ impl FunctionTracer<'_> {
                         self.trace_expression(query);
                         self.trace_ray_query_function(fun);
                     }
-                    St::SubgroupBallot { result } => {
+                    St::SubgroupBallot { result, predicate } => {
+                        if let Some(predicate) = predicate {
+                            self.trace_expression(predicate);
+                        }
                         self.trace_expression(result);
                     }
                     St::SubgroupCollectiveOperation {
@@ -267,7 +270,15 @@ impl FunctionMap {
                         adjust(query);
                         self.adjust_ray_query_function(fun);
                     }
-                    St::SubgroupBallot { ref mut result } => adjust(result),
+                    St::SubgroupBallot {
+                        ref mut result,
+                        ref mut predicate,
+                    } => {
+                        if let Some(ref mut predicate) = predicate {
+                            adjust(predicate);
+                        }
+                        adjust(result);
+                    }
                     St::SubgroupCollectiveOperation {
                         ref mut op,
                         ref mut collective_op,

--- a/src/compact/statements.rs
+++ b/src/compact/statements.rs
@@ -117,7 +117,11 @@ impl FunctionTracer<'_> {
                     } => {
                         match mode {
                             crate::GatherMode::BroadcastFirst => {}
-                            crate::GatherMode::Broadcast(index) => self.trace_expression(index),
+                            crate::GatherMode::Broadcast(index)
+                            | crate::GatherMode::Shuffle(index)
+                            | crate::GatherMode::ShuffleDown(index)
+                            | crate::GatherMode::ShuffleUp(index)
+                            | crate::GatherMode::ShuffleXor(index) => self.trace_expression(index),
                         }
                         self.trace_expression(argument);
                         self.trace_expression(result);
@@ -296,7 +300,11 @@ impl FunctionMap {
                     } => {
                         match *mode {
                             crate::GatherMode::BroadcastFirst => {}
-                            crate::GatherMode::Broadcast(ref mut index) => adjust(index),
+                            crate::GatherMode::Broadcast(ref mut index)
+                            | crate::GatherMode::Shuffle(ref mut index)
+                            | crate::GatherMode::ShuffleDown(ref mut index)
+                            | crate::GatherMode::ShuffleUp(ref mut index)
+                            | crate::GatherMode::ShuffleXor(ref mut index) => adjust(index),
                         }
                         adjust(argument);
                         adjust(result);

--- a/src/compact/statements.rs
+++ b/src/compact/statements.rs
@@ -102,8 +102,8 @@ impl FunctionTracer<'_> {
                         self.trace_expression(result);
                     }
                     St::SubgroupCollectiveOperation {
-                        ref op,
-                        ref collective_op,
+                        op: _,
+                        collective_op: _,
                         argument,
                         result,
                     } => {
@@ -111,12 +111,13 @@ impl FunctionTracer<'_> {
                         self.trace_expression(result);
                     }
                     St::SubgroupGather {
-                        ref mode,
+                        mode,
                         argument,
                         result,
                     } => {
-                        if let crate::GatherMode::Broadcast(expr) = *mode {
-                            self.trace_expression(expr);
+                        match mode {
+                            crate::GatherMode::BroadcastFirst => {}
+                            crate::GatherMode::Broadcast(index) => self.trace_expression(index),
                         }
                         self.trace_expression(argument);
                         self.trace_expression(result);
@@ -274,14 +275,14 @@ impl FunctionMap {
                         ref mut result,
                         ref mut predicate,
                     } => {
-                        if let Some(ref mut predicate) = predicate {
+                        if let Some(ref mut predicate) = *predicate {
                             adjust(predicate);
                         }
                         adjust(result);
                     }
                     St::SubgroupCollectiveOperation {
-                        ref mut op,
-                        ref mut collective_op,
+                        op: _,
+                        collective_op: _,
                         ref mut argument,
                         ref mut result,
                     } => {
@@ -293,8 +294,9 @@ impl FunctionMap {
                         ref mut argument,
                         ref mut result,
                     } => {
-                        if let crate::GatherMode::Broadcast(expr) = mode {
-                            adjust(expr);
+                        match *mode {
+                            crate::GatherMode::BroadcastFirst => {}
+                            crate::GatherMode::Broadcast(ref mut index) => adjust(index),
                         }
                         adjust(argument);
                         adjust(result);

--- a/src/compact/statements.rs
+++ b/src/compact/statements.rs
@@ -95,6 +95,9 @@ impl FunctionTracer<'_> {
                         self.trace_expression(query);
                         self.trace_ray_query_function(fun);
                     }
+                    St::SubgroupBallot { result } => {
+                        self.trace_expression(result);
+                    }
 
                     // Trivial statements.
                     St::Break
@@ -244,6 +247,7 @@ impl FunctionMap {
                         adjust(query);
                         self.adjust_ray_query_function(fun);
                     }
+                    St::SubgroupBallot { ref mut result } => adjust(result),
 
                     // Trivial statements.
                     St::Break

--- a/src/compact/statements.rs
+++ b/src/compact/statements.rs
@@ -98,6 +98,26 @@ impl FunctionTracer<'_> {
                     St::SubgroupBallot { result } => {
                         self.trace_expression(result);
                     }
+                    St::SubgroupCollectiveOperation {
+                        ref op,
+                        ref collective_op,
+                        argument,
+                        result,
+                    } => {
+                        self.trace_expression(argument);
+                        self.trace_expression(result);
+                    }
+                    St::SubgroupBroadcast {
+                        ref mode,
+                        argument,
+                        result,
+                    } => {
+                        if let crate::BroadcastMode::Index(expr) = *mode {
+                            self.trace_expression(expr);
+                        }
+                        self.trace_expression(argument);
+                        self.trace_expression(result);
+                    }
 
                     // Trivial statements.
                     St::Break
@@ -248,6 +268,26 @@ impl FunctionMap {
                         self.adjust_ray_query_function(fun);
                     }
                     St::SubgroupBallot { ref mut result } => adjust(result),
+                    St::SubgroupCollectiveOperation {
+                        ref mut op,
+                        ref mut collective_op,
+                        ref mut argument,
+                        ref mut result,
+                    } => {
+                        adjust(argument);
+                        adjust(result);
+                    }
+                    St::SubgroupBroadcast {
+                        ref mut mode,
+                        ref mut argument,
+                        ref mut result,
+                    } => {
+                        if let crate::BroadcastMode::Index(expr) = mode {
+                            adjust(expr);
+                        }
+                        adjust(argument);
+                        adjust(result);
+                    }
 
                     // Trivial statements.
                     St::Break

--- a/src/compact/statements.rs
+++ b/src/compact/statements.rs
@@ -110,12 +110,12 @@ impl FunctionTracer<'_> {
                         self.trace_expression(argument);
                         self.trace_expression(result);
                     }
-                    St::SubgroupBroadcast {
+                    St::SubgroupGather {
                         ref mode,
                         argument,
                         result,
                     } => {
-                        if let crate::BroadcastMode::Index(expr) = *mode {
+                        if let crate::GatherMode::Broadcast(expr) = *mode {
                             self.trace_expression(expr);
                         }
                         self.trace_expression(argument);
@@ -288,12 +288,12 @@ impl FunctionMap {
                         adjust(argument);
                         adjust(result);
                     }
-                    St::SubgroupBroadcast {
+                    St::SubgroupGather {
                         ref mut mode,
                         ref mut argument,
                         ref mut result,
                     } => {
-                        if let crate::BroadcastMode::Index(expr) = mode {
+                        if let crate::GatherMode::Broadcast(expr) = mode {
                             adjust(expr);
                         }
                         adjust(argument);

--- a/src/front/spv/error.rs
+++ b/src/front/spv/error.rs
@@ -54,6 +54,8 @@ pub enum Error {
     UnknownBinaryOperator(spirv::Op),
     #[error("unknown relational function {0:?}")]
     UnknownRelationalFunction(spirv::Op),
+    #[error("unsupported group opeation %{0}")]
+    UnsupportedGroupOperation(spirv::Word),
     #[error("invalid parameter {0:?}")]
     InvalidParameter(spirv::Op),
     #[error("invalid operand count {1} for {0:?}")]
@@ -116,8 +118,8 @@ pub enum Error {
     FunctionCallCycle(spirv::Word),
     #[error("invalid array size {0:?}")]
     InvalidArraySize(Handle<crate::Constant>),
-    #[error("invalid barrier scope %{0}")]
-    InvalidBarrierScope(spirv::Word),
+    #[error("invalid execution scope %{0}")]
+    InvalidExecutionScope(spirv::Word),
     #[error("invalid barrier memory semantics %{0}")]
     InvalidBarrierMemorySemantics(spirv::Word),
     #[error(

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -3844,7 +3844,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                 S::WorkGroupUniformLoad { .. } => unreachable!(),
                 S::SubgroupBallot { .. } => unreachable!(), // FIXME??
                 S::SubgroupCollectiveOperation { .. } => unreachable!(),
-                S::SubgroupBroadcast { .. } => unreachable!(),
+                S::SubgroupGather { .. } => unreachable!(),
             }
             i += 1;
         }

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -3842,6 +3842,7 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                     }
                 }
                 S::WorkGroupUniformLoad { .. } => unreachable!(),
+                S::SubgroupBallot { .. } => unreachable!(),
             }
             i += 1;
         }

--- a/src/front/spv/mod.rs
+++ b/src/front/spv/mod.rs
@@ -3842,7 +3842,9 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
                     }
                 }
                 S::WorkGroupUniformLoad { .. } => unreachable!(),
-                S::SubgroupBallot { .. } => unreachable!(),
+                S::SubgroupBallot { .. } => unreachable!(), // FIXME??
+                S::SubgroupCollectiveOperation { .. } => unreachable!(),
+                S::SubgroupBroadcast { .. } => unreachable!(),
             }
             i += 1;
         }

--- a/src/front/wgsl/lower/mod.rs
+++ b/src/front/wgsl/lower/mod.rs
@@ -2290,6 +2290,16 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                             )?;
                             return Ok(Some(handle));
                         }
+                        "subgroupBallot" => {
+                            ctx.prepare_args(arguments, 0, span).finish()?;
+
+                            let result = ctx
+                                .interrupt_emitter(crate::Expression::SubgroupBallotResult, span);
+                            let rctx = ctx.runtime_expression_ctx(span)?;
+                            rctx.block
+                                .push(crate::Statement::SubgroupBallot { result }, span);
+                            return Ok(Some(result));
+                        }
                         _ => return Err(Error::UnknownIdent(function.span, function.name)),
                     }
                 };

--- a/src/front/wgsl/lower/mod.rs
+++ b/src/front/wgsl/lower/mod.rs
@@ -2301,13 +2301,19 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                             return Ok(Some(handle));
                         }
                         "subgroupBallot" => {
-                            ctx.prepare_args(arguments, 0, span).finish()?;
+                            let mut args = ctx.prepare_args(arguments, 0, span);
+                            let predicate = if arguments.len() == 1 {
+                                Some(self.expression(args.next()?, ctx.reborrow())?)
+                            } else {
+                                None
+                            };
+                            args.finish()?;
 
                             let result = ctx
                                 .interrupt_emitter(crate::Expression::SubgroupBallotResult, span);
                             let rctx = ctx.runtime_expression_ctx(span)?;
                             rctx.block
-                                .push(crate::Statement::SubgroupBallot { result }, span);
+                                .push(crate::Statement::SubgroupBallot { result, predicate }, span);
                             return Ok(Some(result));
                         }
                         "subgroupBroadcast" => {

--- a/src/front/wgsl/lower/mod.rs
+++ b/src/front/wgsl/lower/mod.rs
@@ -2331,8 +2331,8 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                             );
                             let rctx = ctx.runtime_expression_ctx(span)?;
                             rctx.block.push(
-                                crate::Statement::SubgroupBroadcast {
-                                    mode: crate::BroadcastMode::Index(index),
+                                crate::Statement::SubgroupGather {
+                                    mode: crate::GatherMode::Broadcast(index),
                                     argument,
                                     result,
                                 },
@@ -2354,8 +2354,8 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                             );
                             let rctx = ctx.runtime_expression_ctx(span)?;
                             rctx.block.push(
-                                crate::Statement::SubgroupBroadcast {
-                                    mode: crate::BroadcastMode::First,
+                                crate::Statement::SubgroupGather {
+                                    mode: crate::GatherMode::BroadcastFirst,
                                     argument,
                                     result,
                                 },

--- a/src/front/wgsl/lower/mod.rs
+++ b/src/front/wgsl/lower/mod.rs
@@ -2310,7 +2310,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                             args.finish()?;
 
                             let result = ctx
-                                .interrupt_emitter(crate::Expression::SubgroupBallotResult, span);
+                                .interrupt_emitter(crate::Expression::SubgroupBallotResult, span)?;
                             let rctx = ctx.runtime_expression_ctx(span)?;
                             rctx.block
                                 .push(crate::Statement::SubgroupBallot { result, predicate }, span);
@@ -2328,7 +2328,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                             let result = ctx.interrupt_emitter(
                                 crate::Expression::SubgroupOperationResult { ty },
                                 span,
-                            );
+                            )?;
                             let rctx = ctx.runtime_expression_ctx(span)?;
                             rctx.block.push(
                                 crate::Statement::SubgroupGather {
@@ -2351,7 +2351,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                             let result = ctx.interrupt_emitter(
                                 crate::Expression::SubgroupOperationResult { ty },
                                 span,
-                            );
+                            )?;
                             let rctx = ctx.runtime_expression_ctx(span)?;
                             rctx.block.push(
                                 crate::Statement::SubgroupGather {
@@ -2569,7 +2569,8 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
         let ty = ctx.register_type(argument)?;
 
-        let result = ctx.interrupt_emitter(crate::Expression::SubgroupOperationResult { ty }, span);
+        let result =
+            ctx.interrupt_emitter(crate::Expression::SubgroupOperationResult { ty }, span)?;
         let rctx = ctx.runtime_expression_ctx(span)?;
         rctx.block.push(
             crate::Statement::SubgroupCollectiveOperation {

--- a/src/front/wgsl/lower/mod.rs
+++ b/src/front/wgsl/lower/mod.rs
@@ -2308,6 +2308,45 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                                 .push(crate::Statement::SubgroupBallot { result }, span);
                             return Ok(Some(result));
                         }
+                        "subgroupBroadcast" => {
+                            unimplemented!(); // FIXME
+                        }
+                        "subgroupBroadcastFirst" => {
+                            unimplemented!(); // FIXME
+                        }
+                        "subgroupAll" => {
+                            unimplemented!(); // FIXME
+                        }
+                        "subgroupAny" => {
+                            unimplemented!(); // FIXME
+                        }
+                        "subgroupAdd" => {
+                            unimplemented!(); // FIXME
+                        }
+                        "subgroupMul" => {
+                            unimplemented!(); // FIXME
+                        }
+                        "subgroupMin" => {
+                            unimplemented!(); // FIXME
+                        }
+                        "subgroupMax" => {
+                            unimplemented!(); // FIXME
+                        }
+                        "subgroupAnd" => {
+                            unimplemented!(); // FIXME
+                        }
+                        "subgroupOr" => {
+                            unimplemented!(); // FIXME
+                        }
+                        "subgroupXor" => {
+                            unimplemented!(); // FIXME
+                        }
+                        "subgroupPrefixAdd" => {
+                            unimplemented!(); // FIXME
+                        }
+                        "subgroupPrefixMul" => {
+                            unimplemented!(); // FIXME
+                        }
                         _ => return Err(Error::UnknownIdent(function.span, function.name)),
                     }
                 };

--- a/src/front/wgsl/lower/mod.rs
+++ b/src/front/wgsl/lower/mod.rs
@@ -1917,6 +1917,8 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     }
                 } else if let Some(fun) = Texture::map(function.name) {
                     self.texture_sample_helper(fun, arguments, span, ctx.reborrow())?
+                } else if let Some((op, cop)) = conv::map_subgroup_operation(function.name) {
+                    return Ok(Some(self.subgroup_helper(span, op, cop, arguments, ctx)?));
                 } else {
                     match function.name {
                         "select" => {
@@ -2309,43 +2311,51 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                             return Ok(Some(result));
                         }
                         "subgroupBroadcast" => {
-                            unimplemented!(); // FIXME
+                            let mut args = ctx.prepare_args(arguments, 2, span);
+
+                            let index = self.expression(args.next()?, ctx.reborrow())?;
+                            let argument = self.expression(args.next()?, ctx.reborrow())?;
+                            args.finish()?;
+
+                            let ty = ctx.register_type(argument)?;
+
+                            let result = ctx.interrupt_emitter(
+                                crate::Expression::SubgroupOperationResult { ty },
+                                span,
+                            );
+                            let rctx = ctx.runtime_expression_ctx(span)?;
+                            rctx.block.push(
+                                crate::Statement::SubgroupBroadcast {
+                                    mode: crate::BroadcastMode::Index(index),
+                                    argument,
+                                    result,
+                                },
+                                span,
+                            );
+                            return Ok(Some(result));
                         }
                         "subgroupBroadcastFirst" => {
-                            unimplemented!(); // FIXME
-                        }
-                        "subgroupAll" => {
-                            unimplemented!(); // FIXME
-                        }
-                        "subgroupAny" => {
-                            unimplemented!(); // FIXME
-                        }
-                        "subgroupAdd" => {
-                            unimplemented!(); // FIXME
-                        }
-                        "subgroupMul" => {
-                            unimplemented!(); // FIXME
-                        }
-                        "subgroupMin" => {
-                            unimplemented!(); // FIXME
-                        }
-                        "subgroupMax" => {
-                            unimplemented!(); // FIXME
-                        }
-                        "subgroupAnd" => {
-                            unimplemented!(); // FIXME
-                        }
-                        "subgroupOr" => {
-                            unimplemented!(); // FIXME
-                        }
-                        "subgroupXor" => {
-                            unimplemented!(); // FIXME
-                        }
-                        "subgroupPrefixAdd" => {
-                            unimplemented!(); // FIXME
-                        }
-                        "subgroupPrefixMul" => {
-                            unimplemented!(); // FIXME
+                            let mut args = ctx.prepare_args(arguments, 1, span);
+
+                            let argument = self.expression(args.next()?, ctx.reborrow())?;
+                            args.finish()?;
+
+                            let ty = ctx.register_type(argument)?;
+
+                            let result = ctx.interrupt_emitter(
+                                crate::Expression::SubgroupOperationResult { ty },
+                                span,
+                            );
+                            let rctx = ctx.runtime_expression_ctx(span)?;
+                            rctx.block.push(
+                                crate::Statement::SubgroupBroadcast {
+                                    mode: crate::BroadcastMode::First,
+                                    argument,
+                                    result,
+                                },
+                                span,
+                            );
+                            return Ok(Some(result));
                         }
                         _ => return Err(Error::UnknownIdent(function.span, function.name)),
                     }
@@ -2537,6 +2547,34 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             level,
             depth_ref,
         })
+    }
+    fn subgroup_helper(
+        &mut self,
+        span: Span,
+        op: crate::SubgroupOperation,
+        collective_op: crate::CollectiveOperation,
+        arguments: &[Handle<ast::Expression<'source>>],
+        mut ctx: ExpressionContext<'source, '_, '_>,
+    ) -> Result<Handle<crate::Expression>, Error<'source>> {
+        let mut args = ctx.prepare_args(arguments, 1, span);
+
+        let argument = self.expression(args.next()?, ctx.reborrow())?;
+        args.finish()?;
+
+        let ty = ctx.register_type(argument)?;
+
+        let result = ctx.interrupt_emitter(crate::Expression::SubgroupOperationResult { ty }, span);
+        let rctx = ctx.runtime_expression_ctx(span)?;
+        rctx.block.push(
+            crate::Statement::SubgroupCollectiveOperation {
+                op,
+                collective_op,
+                argument,
+                result,
+            },
+            span,
+        );
+        Ok(result)
     }
 
     fn r#struct(

--- a/src/front/wgsl/lower/mod.rs
+++ b/src/front/wgsl/lower/mod.rs
@@ -2085,6 +2085,14 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                                 .push(crate::Statement::Barrier(crate::Barrier::WORK_GROUP), span);
                             return Ok(None);
                         }
+                        "subgroupBarrier" => {
+                            ctx.prepare_args(arguments, 0, span).finish()?;
+
+                            let rctx = ctx.runtime_expression_ctx(span)?;
+                            rctx.block
+                                .push(crate::Statement::Barrier(crate::Barrier::SUB_GROUP), span);
+                            return Ok(None);
+                        }
                         "workgroupUniformLoad" => {
                             let mut args = ctx.prepare_args(arguments, 1, span);
                             let expr = args.next()?;

--- a/src/front/wgsl/lower/mod.rs
+++ b/src/front/wgsl/lower/mod.rs
@@ -1918,7 +1918,13 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 } else if let Some(fun) = Texture::map(function.name) {
                     self.texture_sample_helper(fun, arguments, span, ctx.reborrow())?
                 } else if let Some((op, cop)) = conv::map_subgroup_operation(function.name) {
-                    return Ok(Some(self.subgroup_helper(span, op, cop, arguments, ctx)?));
+                    return Ok(Some(
+                        self.subgroup_operation_helper(span, op, cop, arguments, ctx)?,
+                    ));
+                } else if let Some(mode) = conv::map_subgroup_gather(function.name) {
+                    return Ok(Some(
+                        self.subgroup_gather_helper(span, mode, arguments, ctx)?,
+                    ));
                 } else {
                     match function.name {
                         "select" => {
@@ -2316,53 +2322,6 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                                 .push(crate::Statement::SubgroupBallot { result, predicate }, span);
                             return Ok(Some(result));
                         }
-                        "subgroupBroadcast" => {
-                            let mut args = ctx.prepare_args(arguments, 2, span);
-
-                            let index = self.expression(args.next()?, ctx.reborrow())?;
-                            let argument = self.expression(args.next()?, ctx.reborrow())?;
-                            args.finish()?;
-
-                            let ty = ctx.register_type(argument)?;
-
-                            let result = ctx.interrupt_emitter(
-                                crate::Expression::SubgroupOperationResult { ty },
-                                span,
-                            )?;
-                            let rctx = ctx.runtime_expression_ctx(span)?;
-                            rctx.block.push(
-                                crate::Statement::SubgroupGather {
-                                    mode: crate::GatherMode::Broadcast(index),
-                                    argument,
-                                    result,
-                                },
-                                span,
-                            );
-                            return Ok(Some(result));
-                        }
-                        "subgroupBroadcastFirst" => {
-                            let mut args = ctx.prepare_args(arguments, 1, span);
-
-                            let argument = self.expression(args.next()?, ctx.reborrow())?;
-                            args.finish()?;
-
-                            let ty = ctx.register_type(argument)?;
-
-                            let result = ctx.interrupt_emitter(
-                                crate::Expression::SubgroupOperationResult { ty },
-                                span,
-                            )?;
-                            let rctx = ctx.runtime_expression_ctx(span)?;
-                            rctx.block.push(
-                                crate::Statement::SubgroupGather {
-                                    mode: crate::GatherMode::BroadcastFirst,
-                                    argument,
-                                    result,
-                                },
-                                span,
-                            );
-                            return Ok(Some(result));
-                        }
                         _ => return Err(Error::UnknownIdent(function.span, function.name)),
                     }
                 };
@@ -2554,7 +2513,8 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             depth_ref,
         })
     }
-    fn subgroup_helper(
+
+    fn subgroup_operation_helper(
         &mut self,
         span: Span,
         op: crate::SubgroupOperation,
@@ -2576,6 +2536,46 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             crate::Statement::SubgroupCollectiveOperation {
                 op,
                 collective_op,
+                argument,
+                result,
+            },
+            span,
+        );
+        Ok(result)
+    }
+
+    fn subgroup_gather_helper(
+        &mut self,
+        span: Span,
+        mode: crate::GatherMode,
+        arguments: &[Handle<ast::Expression<'source>>],
+        mut ctx: ExpressionContext<'source, '_, '_>,
+    ) -> Result<Handle<crate::Expression>, Error<'source>> {
+        let mut args = ctx.prepare_args(arguments, 2, span);
+
+        let argument = self.expression(args.next()?, ctx.reborrow())?;
+        let index = if let crate::GatherMode::BroadcastFirst = mode {
+            Handle::new(NonZeroU32::new(u32::MAX).unwrap())
+        } else {
+            self.expression(args.next()?, ctx.reborrow())?
+        };
+        args.finish()?;
+
+        let ty = ctx.register_type(argument)?;
+
+        let result =
+            ctx.interrupt_emitter(crate::Expression::SubgroupOperationResult { ty }, span)?;
+        let rctx = ctx.runtime_expression_ctx(span)?;
+        rctx.block.push(
+            crate::Statement::SubgroupGather {
+                mode: match mode {
+                    crate::GatherMode::BroadcastFirst => crate::GatherMode::BroadcastFirst,
+                    crate::GatherMode::Broadcast(_) => crate::GatherMode::Broadcast(index),
+                    crate::GatherMode::Shuffle(_) => crate::GatherMode::Shuffle(index),
+                    crate::GatherMode::ShuffleDown(_) => crate::GatherMode::ShuffleDown(index),
+                    crate::GatherMode::ShuffleUp(_) => crate::GatherMode::ShuffleUp(index),
+                    crate::GatherMode::ShuffleXor(_) => crate::GatherMode::ShuffleXor(index),
+                },
                 argument,
                 result,
             },

--- a/src/front/wgsl/parse/conv.rs
+++ b/src/front/wgsl/parse/conv.rs
@@ -35,8 +35,10 @@ pub fn map_built_in(word: &str, span: Span) -> Result<crate::BuiltIn, Error<'_>>
         "workgroup_id" => crate::BuiltIn::WorkGroupId,
         "num_workgroups" => crate::BuiltIn::NumWorkGroups,
         // subgroup
-        "subgroup_invocation_id" => crate::BuiltIn::SubgroupInvocationId,
+        "num_subgroups" => crate::BuiltIn::NumSubgroups,
+        "subgroup_id" => crate::BuiltIn::SubgroupId,
         "subgroup_size" => crate::BuiltIn::SubgroupSize,
+        "subgroup_invocation_id" => crate::BuiltIn::SubgroupInvocationId,
         _ => return Err(Error::UnknownBuiltin(span)),
     })
 }
@@ -254,8 +256,25 @@ pub fn map_subgroup_operation(
         "subgroupAnd" => (sg::And, co::Reduce),
         "subgroupOr" => (sg::Or, co::Reduce),
         "subgroupXor" => (sg::Xor, co::Reduce),
-        "subgroupPrefixAdd" => (sg::Add, co::InclusiveScan),
-        "subgroupPrefixMul" => (sg::Mul, co::InclusiveScan),
+        "subgroupPrefixExclusiveAdd" => (sg::Add, co::ExclusiveScan),
+        "subgroupPrefixExclusiveMul" => (sg::Mul, co::ExclusiveScan),
+        "subgroupPrefixInclusiveAdd" => (sg::Add, co::InclusiveScan),
+        "subgroupPrefixInclusiveMul" => (sg::Mul, co::InclusiveScan),
+        _ => return None,
+    })
+}
+
+pub fn map_subgroup_gather(word: &str) -> Option<crate::GatherMode> {
+    use crate::GatherMode as gm;
+    use crate::Handle;
+    use std::num::NonZeroU32;
+    Some(match word {
+        "subgroupBroadcastFirst" => gm::BroadcastFirst,
+        "subgroupBroadcast" => gm::Broadcast(Handle::new(NonZeroU32::new(u32::MAX).unwrap())),
+        "subgroupShuffle" => gm::Shuffle(Handle::new(NonZeroU32::new(u32::MAX).unwrap())),
+        "subgroupShuffleDown" => gm::ShuffleDown(Handle::new(NonZeroU32::new(u32::MAX).unwrap())),
+        "subgroupShuffleUp" => gm::ShuffleUp(Handle::new(NonZeroU32::new(u32::MAX).unwrap())),
+        "subgroupShuffleXor" => gm::ShuffleXor(Handle::new(NonZeroU32::new(u32::MAX).unwrap())),
         _ => return None,
     })
 }

--- a/src/front/wgsl/parse/conv.rs
+++ b/src/front/wgsl/parse/conv.rs
@@ -238,3 +238,24 @@ pub fn map_conservative_depth(
         _ => Err(Error::UnknownConservativeDepth(span)),
     }
 }
+
+pub fn map_subgroup_operation(
+    word: &str,
+) -> Option<(crate::SubgroupOperation, crate::CollectiveOperation)> {
+    use crate::CollectiveOperation as co;
+    use crate::SubgroupOperation as sg;
+    Some(match word {
+        "subgroupAll" => (sg::All, co::Reduce),
+        "subgroupAny" => (sg::Any, co::Reduce),
+        "subgroupAdd" => (sg::Add, co::Reduce),
+        "subgroupMul" => (sg::Mul, co::Reduce),
+        "subgroupMin" => (sg::Min, co::Reduce),
+        "subgroupMax" => (sg::Max, co::Reduce),
+        "subgroupAnd" => (sg::And, co::Reduce),
+        "subgroupOr" => (sg::Or, co::Reduce),
+        "subgroupXor" => (sg::Xor, co::Reduce),
+        "subgroupPrefixAdd" => (sg::Add, co::InclusiveScan),
+        "subgroupPrefixMul" => (sg::Mul, co::InclusiveScan),
+        _ => return None,
+    })
+}

--- a/src/front/wgsl/parse/conv.rs
+++ b/src/front/wgsl/parse/conv.rs
@@ -34,6 +34,9 @@ pub fn map_built_in(word: &str, span: Span) -> Result<crate::BuiltIn, Error<'_>>
         "local_invocation_index" => crate::BuiltIn::LocalInvocationIndex,
         "workgroup_id" => crate::BuiltIn::WorkGroupId,
         "num_workgroups" => crate::BuiltIn::NumWorkGroups,
+        // subgroup
+        "subgroup_invocation_id" => crate::BuiltIn::SubgroupInvocationId,
+        "subgroup_size" => crate::BuiltIn::SubgroupSize,
         _ => return Err(Error::UnknownBuiltin(span)),
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1269,9 +1269,11 @@ bitflags::bitflags! {
     #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
     pub struct Barrier: u32 {
         /// Barrier affects all `AddressSpace::Storage` accesses.
-        const STORAGE = 0x1;
+        const STORAGE = 1 << 0;
         /// Barrier affects all `AddressSpace::WorkGroup` accesses.
-        const WORK_GROUP = 0x2;
+        const WORK_GROUP = 1 << 1;
+        /// Barrier synchronizes execution across all invocations within a subgroup that exectue this instruction.
+        const SUB_GROUP = 1 << 2;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1270,6 +1270,10 @@ pub enum SwizzleComponent {
 pub enum GatherMode {
     BroadcastFirst,
     Broadcast(Handle<Expression>),
+    Shuffle(Handle<Expression>),
+    ShuffleDown(Handle<Expression>),
+    ShuffleUp(Handle<Expression>),
+    ShuffleXor(Handle<Expression>),
 }
 
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1897,34 +1897,17 @@ pub enum Statement {
         result: Handle<Expression>,
     },
 
-    // subgroupBroadcast(value, lane) -> value
-    // subgroupBroadcastFirst(value) -> value
     SubgroupBroadcast {
         /// Specifies which thread to broadcast from
         mode: BroadcastMode,
         /// The value to broadcast over
         argument: Handle<Expression>,
-        /// The [`SubgroupBroadcastResult`] expression representing this load's result.
+        /// The [`SubgroupOperationResult`] expression representing this load's result.
         ///
-        /// [`SubgroupBroadcastResult`]: Expression::SubgroupBroadcastResult
+        /// [`SubgroupOperationResult`]: Expression::SubgroupOperationResult
         result: Handle<Expression>,
     },
 
-    // Reduction on bool
-    // subgroupAll(bool) -> bool
-    // subgroupAny(bool) -> bool
-    // Reduction on float, int
-    // subgroupMin(value) -> value
-    // subgroupMax(value) -> value
-    // subgroupAdd(value) -> value
-    // subgroupMul(value) -> value
-    // Reduction on int
-    // subgroupAnd(value) -> value
-    // subgroupOr(value) -> value
-    // subgroupXor(value) -> value
-    // Scan on float, int
-    // subgroupPrefixAdd(value) -> value
-    // subgroupPrefixMul(value) -> value
     /// Compute a collective operation across all active threads in th subgroup
     SubgroupCollectiveOperation {
         /// What operation to compute

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1261,6 +1261,42 @@ pub enum SwizzleComponent {
     W = 3,
 }
 
+#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub enum BroadcastMode {
+    First,
+    Index(Handle<Expression>),
+}
+
+#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub enum SubgroupOperation {
+    All,
+    Any,
+    Add,
+    Mul,
+    Min,
+    Max,
+    And,
+    Or,
+    Xor,
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(Serialize))]
+#[cfg_attr(feature = "deserialize", derive(Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub enum CollectiveOperation {
+    Reduce = 0,
+    InclusiveScan = 1,
+    ExclusiveScan = 2,
+}
+
 bitflags::bitflags! {
     /// Memory barrier flags.
     #[cfg_attr(feature = "serialize", derive(Serialize))]
@@ -1578,6 +1614,9 @@ pub enum Expression {
         committed: bool,
     },
     SubgroupBallotResult,
+    SubgroupOperationResult {
+        ty: Handle<Type>,
+    },
 }
 
 pub use block::Block;
@@ -1850,10 +1889,53 @@ pub enum Statement {
         /// The specific operation we're performing on `query`.
         fun: RayQueryFunction,
     },
+    // subgroupBallot(bool) -> vec4<u32>
     SubgroupBallot {
         /// The [`SubgroupBallotResult`] expression representing this load's result.
         ///
         /// [`SubgroupBallotResult`]: Expression::SubgroupBallotResult
+        result: Handle<Expression>,
+    },
+
+    // subgroupBroadcast(value, lane) -> value
+    // subgroupBroadcastFirst(value) -> value
+    SubgroupBroadcast {
+        /// Specifies which thread to broadcast from
+        mode: BroadcastMode,
+        /// The value to broadcast over
+        argument: Handle<Expression>,
+        /// The [`SubgroupBroadcastResult`] expression representing this load's result.
+        ///
+        /// [`SubgroupBroadcastResult`]: Expression::SubgroupBroadcastResult
+        result: Handle<Expression>,
+    },
+
+    // Reduction on bool
+    // subgroupAll(bool) -> bool
+    // subgroupAny(bool) -> bool
+    // Reduction on float, int
+    // subgroupMin(value) -> value
+    // subgroupMax(value) -> value
+    // subgroupAdd(value) -> value
+    // subgroupMul(value) -> value
+    // Reduction on int
+    // subgroupAnd(value) -> value
+    // subgroupOr(value) -> value
+    // subgroupXor(value) -> value
+    // Scan on float, int
+    // subgroupPrefixAdd(value) -> value
+    // subgroupPrefixMul(value) -> value
+    /// Compute a collective operation across all active threads in th subgroup
+    SubgroupCollectiveOperation {
+        /// What operation to compute
+        op: SubgroupOperation,
+        /// How to combine the results
+        collective_op: CollectiveOperation,
+        /// The value to compute over
+        argument: Handle<Expression>,
+        /// The [`SubgroupOperationResult`] expression representing this load's result.
+        ///
+        /// [`SubgroupOperationResult`]: Expression::SubgroupOperationResult
         result: Handle<Expression>,
     },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,8 +436,8 @@ pub enum BuiltIn {
     WorkGroupSize,
     NumWorkGroups,
     // subgroup
-    SubgroupInvocationId,
     SubgroupSize,
+    SubgroupInvocationId,
 }
 
 /// Number of bytes per scalar.
@@ -1265,9 +1265,9 @@ pub enum SwizzleComponent {
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-pub enum BroadcastMode {
-    First,
-    Index(Handle<Expression>),
+pub enum GatherMode {
+    BroadcastFirst,
+    Broadcast(Handle<Expression>),
 }
 
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
@@ -1899,9 +1899,9 @@ pub enum Statement {
         predicate: Option<Handle<Expression>>,
     },
 
-    SubgroupBroadcast {
-        /// Specifies which thread to broadcast from
-        mode: BroadcastMode,
+    SubgroupGather {
+        /// Specifies which thread to gather from
+        mode: GatherMode,
         /// The value to broadcast over
         argument: Handle<Expression>,
         /// The [`SubgroupOperationResult`] expression representing this load's result.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,6 +435,9 @@ pub enum BuiltIn {
     WorkGroupId,
     WorkGroupSize,
     NumWorkGroups,
+    // subgroup
+    SubgroupInvocationId,
+    SubgroupSize,
 }
 
 /// Number of bytes per scalar.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,6 +436,8 @@ pub enum BuiltIn {
     WorkGroupSize,
     NumWorkGroups,
     // subgroup
+    NumSubgroups,
+    SubgroupId,
     SubgroupSize,
     SubgroupInvocationId,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1399,7 +1399,9 @@ pub enum Expression {
     ///
     /// For [`TypeInner::Atomic`] the result is a corresponding scalar.
     /// For other types behind the `pointer<T>`, the result is `T`.
-    Load { pointer: Handle<Expression> },
+    Load {
+        pointer: Handle<Expression>,
+    },
     /// Sample a point from a sampled or a depth image.
     ImageSample {
         image: Handle<Expression>,
@@ -1539,7 +1541,10 @@ pub enum Expression {
     /// Result of calling another function.
     CallResult(Handle<Function>),
     /// Result of an atomic operation.
-    AtomicResult { ty: Handle<Type>, comparison: bool },
+    AtomicResult {
+        ty: Handle<Type>,
+        comparison: bool,
+    },
     /// Result of a [`WorkGroupUniformLoad`] statement.
     ///
     /// [`WorkGroupUniformLoad`]: Statement::WorkGroupUniformLoad
@@ -1567,6 +1572,7 @@ pub enum Expression {
         query: Handle<Expression>,
         committed: bool,
     },
+    SubgroupBallotResult,
 }
 
 pub use block::Block;
@@ -1838,6 +1844,12 @@ pub enum Statement {
 
         /// The specific operation we're performing on `query`.
         fun: RayQueryFunction,
+    },
+    SubgroupBallot {
+        /// The [`SubgroupBallotResult`] expression representing this load's result.
+        ///
+        /// [`SubgroupBallotResult`]: Expression::SubgroupBallotResult
+        result: Handle<Expression>,
     },
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1895,6 +1895,8 @@ pub enum Statement {
         ///
         /// [`SubgroupBallotResult`]: Expression::SubgroupBallotResult
         result: Handle<Expression>,
+        /// The value from this thread to store in the ballot
+        predicate: Option<Handle<Expression>>,
     },
 
     SubgroupBroadcast {

--- a/src/proc/constant_evaluator.rs
+++ b/src/proc/constant_evaluator.rs
@@ -133,6 +133,8 @@ pub enum ConstantEvaluatorError {
     ImageExpression,
     #[error("Constants don't support ray query expressions")]
     RayQueryExpression,
+    #[error("Constants don't support subgroup expressions")]
+    SubgroupExpression,
     #[error("Cannot access the type")]
     InvalidAccessBase,
     #[error("Cannot access at the index")]
@@ -438,6 +440,12 @@ impl<'a> ConstantEvaluator<'a> {
             | Expression::ImageQuery { .. } => Err(ConstantEvaluatorError::ImageExpression),
             Expression::RayQueryProceedResult | Expression::RayQueryGetIntersection { .. } => {
                 Err(ConstantEvaluatorError::RayQueryExpression)
+            }
+            Expression::SubgroupBallotResult { .. } => {
+                Err(ConstantEvaluatorError::SubgroupExpression)
+            }
+            Expression::SubgroupOperationResult { .. } => {
+                Err(ConstantEvaluatorError::SubgroupExpression)
             }
         }
     }

--- a/src/proc/terminator.rs
+++ b/src/proc/terminator.rs
@@ -39,7 +39,7 @@ pub fn ensure_block_returns(block: &mut crate::Block) {
             | S::WorkGroupUniformLoad { .. }
             | S::SubgroupBallot { .. }
             | S::SubgroupCollectiveOperation { .. }
-            | S::SubgroupBroadcast { .. }
+            | S::SubgroupGather { .. }
             | S::Barrier(_)),
         )
         | None => block.push(S::Return { value: None }, Default::default()),

--- a/src/proc/terminator.rs
+++ b/src/proc/terminator.rs
@@ -37,6 +37,7 @@ pub fn ensure_block_returns(block: &mut crate::Block) {
             | S::RayQuery { .. }
             | S::Atomic { .. }
             | S::WorkGroupUniformLoad { .. }
+            | S::SubgroupBallot { .. }
             | S::Barrier(_)),
         )
         | None => block.push(S::Return { value: None }, Default::default()),

--- a/src/proc/terminator.rs
+++ b/src/proc/terminator.rs
@@ -38,6 +38,8 @@ pub fn ensure_block_returns(block: &mut crate::Block) {
             | S::Atomic { .. }
             | S::WorkGroupUniformLoad { .. }
             | S::SubgroupBallot { .. }
+            | S::SubgroupCollectiveOperation { .. }
+            | S::SubgroupBroadcast { .. }
             | S::Barrier(_)),
         )
         | None => block.push(S::Return { value: None }, Default::default()),

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -905,6 +905,11 @@ impl<'a> ResolveContext<'a> {
                     .ok_or(ResolveError::MissingSpecialType)?;
                 TypeResolution::Handle(result)
             }
+            crate::Expression::SubgroupBallotResult => TypeResolution::Value(Ti::Vector {
+                kind: crate::ScalarKind::Uint,
+                size: crate::VectorSize::Quad,
+                width: 4,
+            }),
         })
     }
 }

--- a/src/proc/typifier.rs
+++ b/src/proc/typifier.rs
@@ -638,6 +638,7 @@ impl<'a> ResolveContext<'a> {
                 | crate::BinaryOperator::ShiftRight => past(left)?.clone(),
             },
             crate::Expression::AtomicResult { ty, .. } => TypeResolution::Handle(ty),
+            crate::Expression::SubgroupOperationResult { ty } => TypeResolution::Handle(ty),
             crate::Expression::WorkGroupUniformLoadResult { ty } => TypeResolution::Handle(ty),
             crate::Expression::Select { accept, .. } => past(accept)?.clone(),
             crate::Expression::Derivative { expr, .. } => past(expr)?.clone(),

--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -1009,13 +1009,13 @@ impl FunctionInfo {
                     let _ = self.add_ref(argument); // FIXME
                     FunctionUniformity::new()
                 }
-                S::SubgroupBroadcast {
+                S::SubgroupGather {
                     ref mode,
                     argument,
                     result,
                 } => {
                     let _ = self.add_ref(argument);
-                    if let crate::BroadcastMode::Index(expr) = *mode {
+                    if let crate::GatherMode::Broadcast(expr) = *mode {
                         let _ = self.add_ref(expr);
                     }
                     FunctionUniformity::new()

--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -1015,8 +1015,15 @@ impl FunctionInfo {
                     result: _,
                 } => {
                     let _ = self.add_ref(argument);
-                    if let crate::GatherMode::Broadcast(expr) = mode {
-                        let _ = self.add_ref(expr);
+                    match mode {
+                        crate::GatherMode::BroadcastFirst => {}
+                        crate::GatherMode::Broadcast(index)
+                        | crate::GatherMode::Shuffle(index)
+                        | crate::GatherMode::ShuffleDown(index)
+                        | crate::GatherMode::ShuffleUp(index)
+                        | crate::GatherMode::ShuffleXor(index) => {
+                            let _ = self.add_ref(index);
+                        }
                     }
                     FunctionUniformity::new()
                 }

--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -744,7 +744,7 @@ impl FunctionInfo {
                 non_uniform_result: None, // FIXME
                 requirements: UniformityRequirements::empty(),
             },
-            E::SubgroupOperationResult { ty } => Uniformity {
+            E::SubgroupOperationResult { .. } => Uniformity {
                 non_uniform_result: None, // FIXME
                 requirements: UniformityRequirements::empty(),
             },
@@ -1001,21 +1001,21 @@ impl FunctionInfo {
                     FunctionUniformity::new()
                 }
                 S::SubgroupCollectiveOperation {
-                    ref op,
-                    ref collective_op,
+                    op: _,
+                    collective_op: _,
                     argument,
                     result: _,
                 } => {
-                    let _ = self.add_ref(argument); // FIXME
+                    let _ = self.add_ref(argument);
                     FunctionUniformity::new()
                 }
                 S::SubgroupGather {
-                    ref mode,
+                    mode,
                     argument,
-                    result,
+                    result: _,
                 } => {
                     let _ = self.add_ref(argument);
-                    if let crate::GatherMode::Broadcast(expr) = *mode {
+                    if let crate::GatherMode::Broadcast(expr) = mode {
                         let _ = self.add_ref(expr);
                     }
                     FunctionUniformity::new()

--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -991,14 +991,22 @@ impl FunctionInfo {
                     }
                     FunctionUniformity::new()
                 }
-                S::SubgroupBallot { result: _ } => FunctionUniformity::new(),
+                S::SubgroupBallot {
+                    result: _,
+                    predicate,
+                } => {
+                    if let Some(predicate) = predicate {
+                        let _ = self.add_ref(predicate);
+                    }
+                    FunctionUniformity::new()
+                }
                 S::SubgroupCollectiveOperation {
                     ref op,
                     ref collective_op,
                     argument,
                     result: _,
                 } => {
-                    let _ = self.add_ref(argument);
+                    let _ = self.add_ref(argument); // FIXME
                     FunctionUniformity::new()
                 }
                 S::SubgroupBroadcast {

--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -741,7 +741,11 @@ impl FunctionInfo {
                 requirements: UniformityRequirements::empty(),
             },
             E::SubgroupBallotResult => Uniformity {
-                non_uniform_result: None,
+                non_uniform_result: None, // FIXME
+                requirements: UniformityRequirements::empty(),
+            },
+            E::SubgroupOperationResult { ty } => Uniformity {
+                non_uniform_result: None, // FIXME
                 requirements: UniformityRequirements::empty(),
             },
         };
@@ -988,6 +992,26 @@ impl FunctionInfo {
                     FunctionUniformity::new()
                 }
                 S::SubgroupBallot { result: _ } => FunctionUniformity::new(),
+                S::SubgroupCollectiveOperation {
+                    ref op,
+                    ref collective_op,
+                    argument,
+                    result: _,
+                } => {
+                    let _ = self.add_ref(argument);
+                    FunctionUniformity::new()
+                }
+                S::SubgroupBroadcast {
+                    ref mode,
+                    argument,
+                    result,
+                } => {
+                    let _ = self.add_ref(argument);
+                    if let crate::BroadcastMode::Index(expr) = *mode {
+                        let _ = self.add_ref(expr);
+                    }
+                    FunctionUniformity::new()
+                }
             };
 
             disruptor = disruptor.or(uniformity.exit_disruptor());

--- a/src/valid/analyzer.rs
+++ b/src/valid/analyzer.rs
@@ -740,6 +740,10 @@ impl FunctionInfo {
                 non_uniform_result: self.add_ref(query),
                 requirements: UniformityRequirements::empty(),
             },
+            E::SubgroupBallotResult => Uniformity {
+                non_uniform_result: None,
+                requirements: UniformityRequirements::empty(),
+            },
         };
 
         let ty = resolve_context.resolve(expression, |h| Ok(&self[h].ty))?;
@@ -983,6 +987,7 @@ impl FunctionInfo {
                     }
                     FunctionUniformity::new()
                 }
+                S::SubgroupBallot { result: _ } => FunctionUniformity::new(),
             };
 
             disruptor = disruptor.or(uniformity.exit_disruptor());

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -1538,6 +1538,7 @@ impl super::Validator {
                 }
             },
             E::SubgroupBallotResult => ShaderStages::COMPUTE | ShaderStages::FRAGMENT,
+            E::SubgroupOperationResult { ty } => ShaderStages::COMPUTE, // FIXME
         };
         Ok(stages)
     }

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -1537,6 +1537,7 @@ impl super::Validator {
                     return Err(ExpressionError::InvalidRayQueryType(query));
                 }
             },
+            E::SubgroupBallotResult => ShaderStages::COMPUTE | ShaderStages::FRAGMENT,
         };
         Ok(stages)
     }

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -1538,7 +1538,7 @@ impl super::Validator {
                 }
             },
             E::SubgroupBallotResult => ShaderStages::COMPUTE | ShaderStages::FRAGMENT,
-            E::SubgroupOperationResult { ty } => ShaderStages::COMPUTE, // FIXME
+            E::SubgroupOperationResult { .. } => ShaderStages::COMPUTE, // FIXME
         };
         Ok(stages)
     }

--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -919,6 +919,9 @@ impl super::Validator {
                         crate::RayQueryFunction::Terminate => {}
                     }
                 }
+                S::SubgroupBallot { result } => {
+                    self.emit_expression(result, context)?;
+                }
             }
         }
         Ok(BlockInfo { stages, finished })

--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -473,12 +473,12 @@ impl super::Validator {
     #[cfg(feature = "validate")]
     fn validate_subgroup_broadcast(
         &mut self,
-        mode: &crate::BroadcastMode,
+        mode: &crate::GatherMode,
         argument: Handle<crate::Expression>,
         result: Handle<crate::Expression>,
         context: &BlockContext,
     ) -> Result<(), WithSpan<FunctionError>> {
-        if let crate::BroadcastMode::Index(expr) = *mode {
+        if let crate::GatherMode::Broadcast(expr) = *mode {
             let index_ty = context.resolve_type(expr, &self.valid_expression_set)?;
             match index_ty {
                 crate::TypeInner::Scalar {
@@ -1056,7 +1056,7 @@ impl super::Validator {
                 } => {
                     self.validate_subgroup_operation(op, collective_op, argument, result, context)?;
                 }
-                S::SubgroupBroadcast {
+                S::SubgroupGather {
                     ref mode,
                     argument,
                     result,

--- a/src/valid/function.rs
+++ b/src/valid/function.rs
@@ -485,7 +485,11 @@ impl super::Validator {
     ) -> Result<(), WithSpan<FunctionError>> {
         match *mode {
             crate::GatherMode::BroadcastFirst => {}
-            crate::GatherMode::Broadcast(index) => {
+            crate::GatherMode::Broadcast(index)
+            | crate::GatherMode::Shuffle(index)
+            | crate::GatherMode::ShuffleDown(index)
+            | crate::GatherMode::ShuffleUp(index)
+            | crate::GatherMode::ShuffleXor(index) => {
                 let index_ty = context.resolve_type(index, &self.valid_expression_set)?;
                 match *index_ty {
                     crate::TypeInner::Scalar {

--- a/src/valid/handles.rs
+++ b/src/valid/handles.rs
@@ -394,6 +394,7 @@ impl super::Validator {
             }
             crate::Expression::AtomicResult { .. }
             | crate::Expression::RayQueryProceedResult
+            | crate::Expression::SubgroupBallotResult
             | crate::Expression::WorkGroupUniformLoadResult { .. } => (),
             crate::Expression::ArrayLength(array) => {
                 handle.check_dep(array)?;
@@ -537,6 +538,10 @@ impl super::Validator {
                     }
                     crate::RayQueryFunction::Terminate => {}
                 }
+                Ok(())
+            }
+            crate::Statement::SubgroupBallot { result } => {
+                validate_expr(result)?;
                 Ok(())
             }
             crate::Statement::Break

--- a/src/valid/handles.rs
+++ b/src/valid/handles.rs
@@ -547,8 +547,8 @@ impl super::Validator {
                 Ok(())
             }
             crate::Statement::SubgroupCollectiveOperation {
-                op,
-                collective_op,
+                op: _,
+                collective_op: _,
                 argument,
                 result,
             } => {
@@ -556,13 +556,15 @@ impl super::Validator {
                 validate_expr(result)?;
                 Ok(())
             }
-            crate::Statement::SubgroupBroadcast {
+            crate::Statement::SubgroupGather {
                 mode,
                 argument,
                 result,
             } => {
-                if let crate::BroadcastMode::Index(expr) = mode {
-                    validate_expr(expr)?;
+                validate_expr(argument)?;
+                match mode {
+                    crate::GatherMode::BroadcastFirst => {}
+                    crate::GatherMode::Broadcast(index) => validate_expr(index)?,
                 }
                 validate_expr(result)?;
                 Ok(())

--- a/src/valid/handles.rs
+++ b/src/valid/handles.rs
@@ -395,6 +395,7 @@ impl super::Validator {
             crate::Expression::AtomicResult { .. }
             | crate::Expression::RayQueryProceedResult
             | crate::Expression::SubgroupBallotResult
+            | crate::Expression::SubgroupOperationResult { .. }
             | crate::Expression::WorkGroupUniformLoadResult { .. } => (),
             crate::Expression::ArrayLength(array) => {
                 handle.check_dep(array)?;
@@ -541,6 +542,27 @@ impl super::Validator {
                 Ok(())
             }
             crate::Statement::SubgroupBallot { result } => {
+                validate_expr(result)?;
+                Ok(())
+            }
+            crate::Statement::SubgroupCollectiveOperation {
+                op,
+                collective_op,
+                argument,
+                result,
+            } => {
+                validate_expr(argument)?;
+                validate_expr(result)?;
+                Ok(())
+            }
+            crate::Statement::SubgroupBroadcast {
+                mode,
+                argument,
+                result,
+            } => {
+                if let crate::BroadcastMode::Index(expr) = mode {
+                    validate_expr(expr)?;
+                }
                 validate_expr(result)?;
                 Ok(())
             }

--- a/src/valid/handles.rs
+++ b/src/valid/handles.rs
@@ -564,7 +564,11 @@ impl super::Validator {
                 validate_expr(argument)?;
                 match mode {
                     crate::GatherMode::BroadcastFirst => {}
-                    crate::GatherMode::Broadcast(index) => validate_expr(index)?,
+                    crate::GatherMode::Broadcast(index)
+                    | crate::GatherMode::Shuffle(index)
+                    | crate::GatherMode::ShuffleDown(index)
+                    | crate::GatherMode::ShuffleUp(index)
+                    | crate::GatherMode::ShuffleXor(index) => validate_expr(index)?,
                 }
                 validate_expr(result)?;
                 Ok(())

--- a/src/valid/handles.rs
+++ b/src/valid/handles.rs
@@ -541,7 +541,8 @@ impl super::Validator {
                 }
                 Ok(())
             }
-            crate::Statement::SubgroupBallot { result } => {
+            crate::Statement::SubgroupBallot { result, predicate } => {
+                validate_expr_opt(predicate)?;
                 validate_expr(result)?;
                 Ok(())
             }

--- a/src/valid/interface.rs
+++ b/src/valid/interface.rs
@@ -299,7 +299,15 @@ impl VaryingContext<'_> {
                                 width,
                             },
                     ),
-                    Bi::SubgroupInvocationId | Bi::SubgroupSize => (
+                    Bi::SubgroupInvocationId => (
+                        self.stage == St::Compute && !self.output,
+                        *ty_inner
+                            == Ti::Scalar {
+                                kind: Sk::Uint,
+                                width,
+                            },
+                    ),
+                    Bi::SubgroupSize => (
                         match self.stage {
                             St::Compute | St::Fragment => !self.output,
                             St::Vertex => false,

--- a/src/valid/interface.rs
+++ b/src/valid/interface.rs
@@ -299,6 +299,17 @@ impl VaryingContext<'_> {
                                 width,
                             },
                     ),
+                    Bi::SubgroupInvocationId | Bi::SubgroupSize => (
+                        match self.stage {
+                            St::Compute | St::Fragment => !self.output,
+                            St::Vertex => false,
+                        },
+                        *ty_inner
+                            == Ti::Scalar {
+                                kind: Sk::Uint,
+                                width,
+                            },
+                    ),
                 };
 
                 if !visible {

--- a/src/valid/interface.rs
+++ b/src/valid/interface.rs
@@ -299,7 +299,7 @@ impl VaryingContext<'_> {
                                 width,
                             },
                     ),
-                    Bi::SubgroupInvocationId => (
+                    Bi::NumSubgroups | Bi::SubgroupId => (
                         self.stage == St::Compute && !self.output,
                         *ty_inner
                             == Ti::Scalar {
@@ -307,7 +307,7 @@ impl VaryingContext<'_> {
                                 width,
                             },
                     ),
-                    Bi::SubgroupSize => (
+                    Bi::SubgroupSize | Bi::SubgroupInvocationId => (
                         match self.stage {
                             St::Compute | St::Fragment => !self.output,
                             St::Vertex => false,

--- a/tests/in/subgroup-operations.param.ron
+++ b/tests/in/subgroup-operations.param.ron
@@ -1,0 +1,26 @@
+(
+	spv: (
+		version: (1, 3),
+	),
+	msl: (
+	    lang_version: (2, 4),
+		per_entry_point_map: {},
+		inline_samplers: [],
+		spirv_cross_compatibility: false,
+		fake_missing_bindings: false,
+		zero_initialize_workgroup_memory: true,
+	),
+	glsl: (
+		version: Desktop(430),
+		writer_flags: (""),
+		binding_map: { },
+		zero_initialize_workgroup_memory: true,
+	),
+	hlsl: (
+		shader_model: V6_0,
+		binding_map: {},
+		fake_missing_bindings: true,
+		special_constants_binding: None,
+		zero_initialize_workgroup_memory: true,
+	),
+)

--- a/tests/in/subgroup-operations.wgsl
+++ b/tests/in/subgroup-operations.wgsl
@@ -1,0 +1,32 @@
+@compute @workgroup_size(1)
+fn main(
+    @builtin(num_subgroups) num_subgroups: u32,
+    @builtin(subgroup_id) subgroup_id: u32,
+    @builtin(subgroup_size) subgroup_size: u32,
+    @builtin(subgroup_invocation_id) subgroup_invocation_id: u32,
+) {
+    subgroupBarrier();
+
+    subgroupBallot((subgroup_invocation_id & 1u) == 1u);
+
+    subgroupAll(subgroup_invocation_id != 0u);
+    subgroupAny(subgroup_invocation_id == 0u);
+    subgroupAdd(subgroup_invocation_id);
+    subgroupMul(subgroup_invocation_id);
+    subgroupMin(subgroup_invocation_id);
+    subgroupMax(subgroup_invocation_id);
+    subgroupAnd(subgroup_invocation_id);
+    subgroupOr(subgroup_invocation_id);
+    subgroupXor(subgroup_invocation_id);
+    subgroupPrefixExclusiveAdd(subgroup_invocation_id);
+    subgroupPrefixExclusiveMul(subgroup_invocation_id);
+    subgroupPrefixInclusiveAdd(subgroup_invocation_id);
+    subgroupPrefixInclusiveMul(subgroup_invocation_id);
+
+    subgroupBroadcastFirst(subgroup_invocation_id);
+    subgroupBroadcast(subgroup_invocation_id, 4u);
+    subgroupShuffle(subgroup_invocation_id, subgroup_size - 1u - subgroup_invocation_id);
+    subgroupShuffleDown(subgroup_invocation_id, 1u);
+    subgroupShuffleUp(subgroup_invocation_id, 1u);
+    subgroupShuffleXor(subgroup_invocation_id, subgroup_size - 1u);
+}

--- a/tests/out/glsl/subgroup-operations.main.Compute.glsl
+++ b/tests/out/glsl/subgroup-operations.main.Compute.glsl
@@ -1,0 +1,41 @@
+#version 430 core
+#extension GL_ARB_compute_shader : require
+#extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_vote : require
+#extension GL_KHR_shader_subgroup_arithmetic : require
+#extension GL_KHR_shader_subgroup_ballot : require
+#extension GL_KHR_shader_subgroup_shuffle : require
+#extension GL_KHR_shader_subgroup_shuffle_relative : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+
+void main() {
+    uint num_subgroups = gl_NumSubgroups;
+    uint subgroup_id = gl_SubgroupID;
+    uint subgroup_size = gl_SubgroupSize;
+    uint subgroup_invocation_id = gl_SubgroupInvocationID;
+    subgroupMemoryBarrier();
+    barrier();
+    uvec4 _e8 = subgroupBallot(((subgroup_invocation_id & 1u) == 1u));
+    bool _e11 = subgroupAll((subgroup_invocation_id != 0u));
+    bool _e14 = subgroupAny((subgroup_invocation_id == 0u));
+    uint _e15 = subgroupAdd(subgroup_invocation_id);
+    uint _e16 = subgroupMul(subgroup_invocation_id);
+    uint _e17 = subgroupMin(subgroup_invocation_id);
+    uint _e18 = subgroupMax(subgroup_invocation_id);
+    uint _e19 = subgroupAnd(subgroup_invocation_id);
+    uint _e20 = subgroupOr(subgroup_invocation_id);
+    uint _e21 = subgroupXor(subgroup_invocation_id);
+    uint _e22 = subgroupExclusiveAdd(subgroup_invocation_id);
+    uint _e23 = subgroupExclusiveMul(subgroup_invocation_id);
+    uint _e24 = subgroupInclusiveAdd(subgroup_invocation_id);
+    uint _e25 = subgroupInclusiveMul(subgroup_invocation_id);
+    uint _e26 = subgroupBroadcastFirst(subgroup_invocation_id);
+    uint _e28 = subgroupBroadcast(subgroup_invocation_id, 4u);
+    uint _e32 = subgroupShuffle(subgroup_invocation_id, ((subgroup_size - 1u) - subgroup_invocation_id));
+    uint _e34 = subgroupShuffleDown(subgroup_invocation_id, 1u);
+    uint _e36 = subgroupShuffleUp(subgroup_invocation_id, 1u);
+    uint _e39 = subgroupShuffleXor(subgroup_invocation_id, (subgroup_size - 1u));
+    return;
+}
+

--- a/tests/out/hlsl/subgroup-operations.hlsl
+++ b/tests/out/hlsl/subgroup-operations.hlsl
@@ -1,0 +1,32 @@
+[numthreads(1, 1, 1)]
+void main(uint3 __local_invocation_id : SV_GroupThreadID)
+{
+    if (all(__local_invocation_id == uint3(0u, 0u, 0u))) {
+    }
+    GroupMemoryBarrierWithGroupSync();
+    const uint num_subgroups = (1u + WaveGetLaneCount() - 1u) / WaveGetLaneCount();
+    const uint subgroup_id = (__local_invocation_id.x * 1u + __local_invocation_id.y * 1u + __local_invocation_id.z) / WaveGetLaneCount();
+    const uint subgroup_size = WaveGetLaneCount();
+    const uint subgroup_invocation_id = WaveGetLaneIndex();
+    const uint4 _e8 = WaveActiveBallot(((subgroup_invocation_id & 1u) == 1u));
+    const bool _e11 = WaveActiveAllTrue((subgroup_invocation_id != 0u));
+    const bool _e14 = WaveActiveAnyTrue((subgroup_invocation_id == 0u));
+    const uint _e15 = WaveActiveSum(subgroup_invocation_id);
+    const uint _e16 = WaveActiveProduct(subgroup_invocation_id);
+    const uint _e17 = WaveActiveMin(subgroup_invocation_id);
+    const uint _e18 = WaveActiveMax(subgroup_invocation_id);
+    const uint _e19 = WaveActiveBitAnd(subgroup_invocation_id);
+    const uint _e20 = WaveActiveBitOr(subgroup_invocation_id);
+    const uint _e21 = WaveActiveBitXor(subgroup_invocation_id);
+    const uint _e22 = WavePrefixSum(subgroup_invocation_id);
+    const uint _e23 = WavePrefixProduct(subgroup_invocation_id);
+    const uint _e24 = subgroup_invocation_id + WavePrefixSum(subgroup_invocation_id);
+    const uint _e25 = subgroup_invocation_id * WavePrefixProduct(subgroup_invocation_id);
+    const uint _e26 = WaveReadLaneFirst(subgroup_invocation_id);
+    const uint _e28 = WaveReadLaneAt(subgroup_invocation_id, 4u);
+    const uint _e32 = WaveReadLaneAt(subgroup_invocation_id, ((subgroup_size - 1u) - subgroup_invocation_id));
+    const uint _e34 = WaveReadLaneAt(subgroup_invocation_id, WaveGetLaneIndex() + 1u);
+    const uint _e36 = WaveReadLaneAt(subgroup_invocation_id, WaveGetLaneIndex() - 1u);
+    const uint _e39 = WaveReadLaneAt(subgroup_invocation_id, WaveGetLaneIndex() ^ (subgroup_size - 1u));
+    return;
+}

--- a/tests/out/hlsl/subgroup-operations.ron
+++ b/tests/out/hlsl/subgroup-operations.ron
@@ -1,0 +1,12 @@
+(
+    vertex:[
+    ],
+    fragment:[
+    ],
+    compute:[
+        (
+            entry_point:"main",
+            target_profile:"cs_6_0",
+        ),
+    ],
+)

--- a/tests/out/msl/subgroup-operations.msl
+++ b/tests/out/msl/subgroup-operations.msl
@@ -1,0 +1,38 @@
+// language: metal2.4
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+
+struct main_Input {
+};
+kernel void main_(
+  uint num_subgroups [[simdgroups_per_threadgroup]]
+, uint subgroup_id [[simdgroup_index_in_threadgroup]]
+, uint subgroup_size [[threads_per_simdgroup]]
+, uint subgroup_invocation_id [[thread_index_in_simdgroup]]
+) {
+    metal::simdgroup_barrier(metal::mem_flags::mem_threadgroup);
+    metal::uint4 unnamed = uint4((uint64_t)metal::simd_ballot((subgroup_invocation_id & 1u) == 1u), 0, 0, 0);
+    bool unnamed_1 = metal::simd_all(subgroup_invocation_id != 0u);
+    bool unnamed_2 = metal::simd_any(subgroup_invocation_id == 0u);
+    uint unnamed_3 = metal::simd_sum(subgroup_invocation_id);
+    uint unnamed_4 = metal::simd_product(subgroup_invocation_id);
+    uint unnamed_5 = metal::simd_min(subgroup_invocation_id);
+    uint unnamed_6 = metal::simd_max(subgroup_invocation_id);
+    uint unnamed_7 = metal::simd_and(subgroup_invocation_id);
+    uint unnamed_8 = metal::simd_or(subgroup_invocation_id);
+    uint unnamed_9 = metal::simd_xor(subgroup_invocation_id);
+    uint unnamed_10 = metal::simd_prefix_exclusive_sum(subgroup_invocation_id);
+    uint unnamed_11 = metal::simd_prefix_exclusive_product(subgroup_invocation_id);
+    uint unnamed_12 = metal::simd_prefix_inclusive_sum(subgroup_invocation_id);
+    uint unnamed_13 = metal::simd_prefix_inclusive_product(subgroup_invocation_id);
+    uint unnamed_14 = metal::simd_broadcast_first(subgroup_invocation_id);
+    uint unnamed_15 = metal::simd_broadcast(subgroup_invocation_id, 4u);
+    uint unnamed_16 = metal::simd_shuffle(subgroup_invocation_id, (subgroup_size - 1u) - subgroup_invocation_id);
+    uint unnamed_17 = metal::simd_shuffle_down(subgroup_invocation_id, 1u);
+    uint unnamed_18 = metal::simd_shuffle_up(subgroup_invocation_id, 1u);
+    uint unnamed_19 = metal::simd_shuffle_xor(subgroup_invocation_id, subgroup_size - 1u);
+    return;
+}

--- a/tests/out/spv/subgroup-operations.spvasm
+++ b/tests/out/spv/subgroup-operations.spvasm
@@ -1,0 +1,73 @@
+; SPIR-V
+; Version: 1.3
+; Generator: rspirv
+; Bound: 52
+OpCapability Shader
+OpCapability GroupNonUniform
+OpCapability GroupNonUniformBallot
+OpCapability GroupNonUniformVote
+OpCapability GroupNonUniformArithmetic
+OpCapability GroupNonUniformShuffle
+OpCapability GroupNonUniformShuffleRelative
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %15 "main" %6 %9 %11 %13
+OpExecutionMode %15 LocalSize 1 1 1
+OpDecorate %6 BuiltIn NumSubgroups
+OpDecorate %9 BuiltIn SubgroupId
+OpDecorate %11 BuiltIn SubgroupSize
+OpDecorate %13 BuiltIn SubgroupLocalInvocationId
+%2 = OpTypeVoid
+%3 = OpTypeInt 32 0
+%4 = OpTypeBool
+%7 = OpTypePointer Input %3
+%6 = OpVariable  %7  Input
+%9 = OpVariable  %7  Input
+%11 = OpVariable  %7  Input
+%13 = OpVariable  %7  Input
+%16 = OpTypeFunction %2
+%17 = OpConstant  %3  1
+%18 = OpConstant  %3  0
+%19 = OpConstant  %3  4
+%21 = OpConstant  %3  3
+%22 = OpConstant  %3  2
+%23 = OpConstant  %3  8
+%26 = OpTypeVector %3 4
+%15 = OpFunction  %2  None %16
+%5 = OpLabel
+%8 = OpLoad  %3  %6
+%10 = OpLoad  %3  %9
+%12 = OpLoad  %3  %11
+%14 = OpLoad  %3  %13
+OpBranch %20
+%20 = OpLabel
+OpControlBarrier %21 %22 %23
+%24 = OpBitwiseAnd  %3  %14 %17
+%25 = OpIEqual  %4  %24 %17
+%27 = OpGroupNonUniformBallot  %26  %21 %25
+%28 = OpINotEqual  %4  %14 %18
+%29 = OpGroupNonUniformAll  %4  %21 %28
+%30 = OpIEqual  %4  %14 %18
+%31 = OpGroupNonUniformAny  %4  %21 %30
+%32 = OpGroupNonUniformIAdd  %3  %21 Reduce %14
+%33 = OpGroupNonUniformIMul  %3  %21 Reduce %14
+%34 = OpGroupNonUniformUMin  %3  %21 Reduce %14
+%35 = OpGroupNonUniformUMax  %3  %21 Reduce %14
+%36 = OpGroupNonUniformBitwiseAnd  %3  %21 Reduce %14
+%37 = OpGroupNonUniformBitwiseOr  %3  %21 Reduce %14
+%38 = OpGroupNonUniformBitwiseXor  %3  %21 Reduce %14
+%39 = OpGroupNonUniformIAdd  %3  %21 ExclusiveScan %14
+%40 = OpGroupNonUniformIMul  %3  %21 ExclusiveScan %14
+%41 = OpGroupNonUniformIAdd  %3  %21 InclusiveScan %14
+%42 = OpGroupNonUniformIMul  %3  %21 InclusiveScan %14
+%43 = OpGroupNonUniformBroadcastFirst  %3  %21 %14
+%44 = OpGroupNonUniformBroadcast  %3  %21 %14 %19
+%45 = OpISub  %3  %12 %17
+%46 = OpISub  %3  %45 %14
+%47 = OpGroupNonUniformShuffle  %3  %21 %14 %46
+%48 = OpGroupNonUniformShuffleDown  %3  %21 %14 %17
+%49 = OpGroupNonUniformShuffleUp  %3  %21 %14 %17
+%50 = OpISub  %3  %12 %17
+%51 = OpGroupNonUniformShuffleXor  %3  %21 %14 %50
+OpReturn
+OpFunctionEnd

--- a/tests/out/wgsl/subgroup-operations.wgsl
+++ b/tests/out/wgsl/subgroup-operations.wgsl
@@ -1,0 +1,26 @@
+@compute @workgroup_size(1, 1, 1) 
+fn main(@builtin(num_subgroups) num_subgroups: u32, @builtin(subgroup_id) subgroup_id: u32, @builtin(subgroup_size) subgroup_size: u32, @builtin(subgroup_invocation_id) subgroup_invocation_id: u32) {
+    subgroupBarrier();
+    let _e8 = subgroupBallot(
+((subgroup_invocation_id & 1u) == 1u));
+    let _e11 = subgroupAll((subgroup_invocation_id != 0u));
+    let _e14 = subgroupAny((subgroup_invocation_id == 0u));
+    let _e15 = subgroupAdd(subgroup_invocation_id);
+    let _e16 = subgroupMul(subgroup_invocation_id);
+    let _e17 = subgroupMin(subgroup_invocation_id);
+    let _e18 = subgroupMax(subgroup_invocation_id);
+    let _e19 = subgroupAnd(subgroup_invocation_id);
+    let _e20 = subgroupOr(subgroup_invocation_id);
+    let _e21 = subgroupXor(subgroup_invocation_id);
+    let _e22 = subgroupPrefixExclusiveAdd(subgroup_invocation_id);
+    let _e23 = subgroupPrefixExclusiveMul(subgroup_invocation_id);
+    let _e24 = subgroupPrefixInclusiveAdd(subgroup_invocation_id);
+    let _e25 = subgroupPrefixInclusiveMul(subgroup_invocation_id);
+    let _e26 = subgroupBroadcastFirst(subgroup_invocation_id);
+    let _e28 = subgroupBroadcast(subgroup_invocation_id, 4u);
+    let _e32 = subgroupShuffle(subgroup_invocation_id, ((subgroup_size - 1u) - subgroup_invocation_id));
+    let _e34 = subgroupShuffleDown(subgroup_invocation_id, 1u);
+    let _e36 = subgroupShuffleUp(subgroup_invocation_id, 1u);
+    let _e39 = subgroupShuffleXor(subgroup_invocation_id, (subgroup_size - 1u));
+    return;
+}

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -782,6 +782,10 @@ fn convert_wgsl() {
             Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,
         ),
         ("separate-entry-points", Targets::SPIRV | Targets::GLSL),
+        (
+            "subgroup-operations",
+            Targets::SPIRV | Targets::METAL | Targets::GLSL | Targets::HLSL | Targets::WGSL,
+        ),
     ];
 
     for &(name, targets) in inputs.iter() {


### PR DESCRIPTION
This continues the work of #2523, which looks like it was abandoned.

Voter operations (booleans):
- `subgroupBallot() -> vec4<u32>`
- `subgroupBallot(vote: bool) -> vec4<u32>`
- `subgroupAll(vote: bool) -> bool`
- `subgroupAny(vote: bool) -> bool`

Gather operations (scalars and vectors of f32, i32, u32):
- `subgroupBroadcastFirst(value) -> value`
- `subgroupBroadcast(value, index) -> value`
- `subgroupShuffle(value, index) -> value`
- `subgroupShuffleDown(value, index_offset) -> value`
- `subgroupShuffleUp(value, index_offset) -> value`
- `subgroupShuffleXor(value, index_mask) -> value`

Reduce operations (scalars and vectors of i32, u32):
- `subgroupAnd(value) -> value`
- `subgroupOr(value) -> value`
- `subgroupXor(value) -> value`

Reduce operations (scalars and vectors of f32, i32, u32):
- `subgroupAdd(value) -> value`
- `subgroupMul(value) -> value`
- `subgroupMin(value) -> value`
- `subgroupMax(value) -> value`

Scan operations (scalars and vectors of f32, i32, u32):
- `subgroupPrefixExclusiveAdd(value) -> value`
- `subgroupPrefixExclusiveMul(value) -> value`
- `subgroupPrefixInclusiveAdd(value) -> value`
- `subgroupPrefixInclusiveMul(value) -> value`

Built-ins values added to the compute stage only:
- `num_subgroups: u32`
- `subgroup_id: u32`

Built-ins values added to the compute stage and fragment stage:
- `subgroup_size: u32`
- `subgroup_invocation_id: u32`

---

- [x] Implement wgsl-in
- [x] Implement wgsl-out
- [x] Implement spv-in
- [x] Implement spv-out
- [x] Implement glsl-out
- [x] Implement hlsl-out
- [x] Implement msl-out
- [x] Implement dot-out
- [x] Snapshots / tests
- [ ] FRAGMENT quad group operations
- [ ] Decide what kinds of `subgroupBarrier()` make sense
- [ ] Compaction
- [ ] Analyzer
- [ ] Validation