### PR TITLE
[refactor] make use of `resolve_type` wherever possible

### DIFF
--- a/src/back/hlsl/help.rs
+++ b/src/back/hlsl/help.rs
@@ -244,7 +244,7 @@ impl<'a, W: Write> super::Writer<'a, W> {
         const MIP_LEVEL_PARAM: &str = "mip_level";
 
         // Write function return type and name
-        let ret_ty = func_ctx.info[expr_handle].ty.inner_with(&module.types);
+        let ret_ty = func_ctx.resolve_type(expr_handle, &module.types);
         self.write_value_type(module, ret_ty)?;
         write!(self.out, " ")?;
         self.write_wrapped_image_query_function_name(wiq)?;
@@ -891,7 +891,7 @@ impl<'a, W: Write> super::Writer<'a, W> {
                     }
                 }
                 crate::Expression::ImageQuery { image, query } => {
-                    let wiq = match *func_ctx.info[image].ty.inner_with(&module.types) {
+                    let wiq = match *func_ctx.resolve_type(image, &module.types) {
                         crate::TypeInner::Image {
                             dim,
                             arrayed,
@@ -912,9 +912,8 @@ impl<'a, W: Write> super::Writer<'a, W> {
                 // Write `WrappedConstructor` for structs that are loaded from `AddressSpace::Storage`
                 // since they will later be used by the fn `write_storage_load`
                 crate::Expression::Load { pointer } => {
-                    let pointer_space = func_ctx.info[pointer]
-                        .ty
-                        .inner_with(&module.types)
+                    let pointer_space = func_ctx
+                        .resolve_type(pointer, &module.types)
                         .pointer_space();
 
                     if let Some(crate::AddressSpace::Storage { .. }) = pointer_space {
@@ -1016,7 +1015,7 @@ impl<'a, W: Write> super::Writer<'a, W> {
         if extra == 0 {
             self.write_expr(module, coordinate, func_ctx)?;
         } else {
-            let num_coords = match *func_ctx.info[coordinate].ty.inner_with(&module.types) {
+            let num_coords = match *func_ctx.resolve_type(coordinate, &module.types) {
                 crate::TypeInner::Scalar { .. } => 1,
                 crate::TypeInner::Vector { size, .. } => size as usize,
                 _ => unreachable!(),

--- a/src/back/hlsl/storage.rs
+++ b/src/back/hlsl/storage.rs
@@ -466,7 +466,7 @@ impl<W: fmt::Write> super::Writer<'_, W> {
                 }
             };
 
-            let parent = match *func_ctx.info[next_expr].ty.inner_with(&module.types) {
+            let parent = match *func_ctx.resolve_type(next_expr, &module.types) {
                 crate::TypeInner::Pointer { base, .. } => match module.types[base].inner {
                     crate::TypeInner::Struct { ref members, .. } => Parent::Struct(members),
                     crate::TypeInner::Array { stride, .. } => Parent::Array { stride },

--- a/src/back/mod.rs
+++ b/src/back/mod.rs
@@ -135,7 +135,7 @@ impl FunctionCtx<'_> {
                     };
                 }
                 crate::Expression::AccessIndex { base, index } => {
-                    match *self.info[base].ty.inner_with(&module.types) {
+                    match *self.resolve_type(base, &module.types) {
                         crate::TypeInner::Struct { ref members, .. } => {
                             if let Some(crate::Binding::BuiltIn(bi)) =
                                 members[index as usize].binding

--- a/src/back/msl/writer.rs
+++ b/src/back/msl/writer.rs
@@ -2624,11 +2624,7 @@ impl<W: Write> Writer<W> {
                             )?;
                         }
 
-                        let info = &context.expression.info[handle];
-                        let ptr_class = info
-                            .ty
-                            .inner_with(&context.expression.module.types)
-                            .pointer_space();
+                        let ptr_class = context.expression.resolve_type(handle).pointer_space();
                         let expr_name = if ptr_class.is_some() {
                             None // don't bake pointer expressions (just yet)
                         } else if let Some(name) =


### PR DESCRIPTION
Makes code nicer. The SPIR-V backend is missing a `resolve_type` fn but we can add that later.