### PR TITLE
Make validation reject 64-bit floating-point literals.

### DIFF
--- a/src/proc/constant_evaluator.rs
+++ b/src/proc/constant_evaluator.rs
@@ -1231,7 +1231,7 @@ impl<'a> ConstantEvaluator<'a> {
         // expression at a time, `Compose` expressions can only refer to other
         // expressions, and `ZeroValue` expressions are always okay.
         if let Expression::Literal(literal) = expr {
-            crate::valid::validate_literal(literal)?;
+            crate::valid::check_literal_value(literal)?;
         }
 
         if let Some(FunctionLocalData {

--- a/src/valid/expression.rs
+++ b/src/valid/expression.rs
@@ -188,7 +188,7 @@ impl super::Validator {
 
         match gctx.const_expressions[handle] {
             E::Literal(literal) => {
-                validate_literal(literal)?;
+                check_literal_value(literal)?;
             }
             E::Constant(_) | E::ZeroValue(_) => {}
             E::Compose { ref components, ty } => {
@@ -343,7 +343,7 @@ impl super::Validator {
                 ShaderStages::all()
             }
             E::Literal(literal) => {
-                validate_literal(literal)?;
+                check_literal_value(literal)?;
                 ShaderStages::all()
             }
             E::Constant(_) | E::ZeroValue(_) => ShaderStages::all(),
@@ -1565,7 +1565,7 @@ impl super::Validator {
     }
 }
 
-pub fn validate_literal(literal: crate::Literal) -> Result<(), LiteralError> {
+pub fn check_literal_value(literal: crate::Literal) -> Result<(), LiteralError> {
     let is_nan = match literal {
         crate::Literal::F64(v) => v.is_nan(),
         crate::Literal::F32(v) => v.is_nan(),

--- a/src/valid/mod.rs
+++ b/src/valid/mod.rs
@@ -24,7 +24,7 @@ use std::ops;
 use crate::span::{AddSpan as _, WithSpan};
 pub use analyzer::{ExpressionInfo, FunctionInfo, GlobalUse, Uniformity, UniformityRequirements};
 pub use compose::ComposeError;
-pub use expression::{validate_literal, LiteralError};
+pub use expression::{check_literal_value, LiteralError};
 pub use expression::{ConstExpressionError, ExpressionError};
 pub use function::{CallError, FunctionError, LocalVariableError};
 pub use interface::{EntryPointError, GlobalVariableError, VaryingError};

--- a/src/valid/type.rs
+++ b/src/valid/type.rs
@@ -129,6 +129,7 @@ pub enum TypeError {
 }
 
 #[derive(Clone, Debug, thiserror::Error)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum WidthError {
     #[error("The {0:?} scalar width {1} is not supported")]
     Invalid(crate::ScalarKind, crate::Bytes),


### PR DESCRIPTION
Make expression validation and constant expression validation reject `Literal` expressions containing `F64` literals unless the `FLOAT64` capability is enabled.
