### PR TITLE
[wgsl-in] Turn `Error::Other` into `Error::Internal`, to help devs.

### DIFF
--- a/src/front/wgsl/error.rs
+++ b/src/front/wgsl/error.rs
@@ -233,7 +233,7 @@ pub enum Error<'a> {
     },
     FunctionReturnsVoid(Span),
     InvalidWorkGroupUniformLoad(Span),
-    Other,
+    Internal(&'static str),
     ExpectedConstExprConcreteIntegerScalar(Span),
     ExpectedNonNegative(Span),
     ExpectedPositiveArrayLength(Span),
@@ -667,10 +667,10 @@ impl<'a> Error<'a> {
                 labels: vec![(span, "".into())],
                 notes: vec!["passed type must be a workgroup pointer".into()],
             },
-            Error::Other => ParseError {
-                message: "other error".to_string(),
+            Error::Internal(message) => ParseError {
+                message: "internal WGSL front end error".to_string(),
                 labels: vec![],
-                notes: vec![],
+                notes: vec![message.into()],
             },
             Error::ExpectedConstExprConcreteIntegerScalar(span) => ParseError {
                 message: "must be a const-expression that resolves to a concrete integer scalar (u32 or i32)".to_string(),

--- a/src/front/wgsl/parse/mod.rs
+++ b/src/front/wgsl/parse/mod.rs
@@ -2305,13 +2305,12 @@ impl Parser {
         if !self.rules.is_empty() {
             log::error!("Reached the end of global decl, but rule stack is not empty");
             log::error!("Rules: {:?}", self.rules);
-            return Err(Error::Other);
+            return Err(Error::Internal("rule stack is not empty"));
         };
 
         match binding {
             None => Ok(()),
-            // we had the attribute but no var?
-            Some(_) => Err(Error::Other),
+            Some(_) => Err(Error::Internal("we had the attribute but no var?")),
         }
     }
 


### PR DESCRIPTION
Provide a textual message with `front::wgsl::Error::Internal`, so that a developer who sees one of these errors can at least search the source tree to find out where it came from.