### PR TITLE
[wgsl-in] Generate no code for trivial vector/matrix construction.

### DIFF
--- a/src/front/wgsl/lower/construction.rs
+++ b/src/front/wgsl/lower/construction.rs
@@ -239,20 +239,16 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
             (
                 Components::One {
                     component,
-                    ty_inner:
-                        &crate::TypeInner::Vector {
-                            size: src_size,
-                            kind: src_kind,
-                            ..
-                        },
+                    ty_inner: &crate::TypeInner::Vector { size: src_size, .. },
                     ..
                 },
                 ConcreteConstructor::PartialVector { size: dst_size },
-            ) if dst_size == src_size => crate::Expression::As {
-                expr: component,
-                kind: src_kind,
-                convert: None,
-            },
+            ) if dst_size == src_size => {
+                // This is a trivial conversion: the sizes match, and a Partial
+                // constructor doesn't specify a scalar type, so nothing can
+                // possibly happen.
+                return Ok(component);
+            }
 
             // Matrix conversion (matrix -> matrix)
             (
@@ -296,11 +292,12 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                     columns: dst_columns,
                     rows: dst_rows,
                 },
-            ) if dst_columns == src_columns && dst_rows == src_rows => crate::Expression::As {
-                expr: component,
-                kind: crate::ScalarKind::Float,
-                convert: None,
-            },
+            ) if dst_columns == src_columns && dst_rows == src_rows => {
+                // This is a trivial conversion: the sizes match, and a Partial
+                // constructor doesn't specify a scalar type, so nothing can
+                // possibly happen.
+                return Ok(component);
+            }
 
             // Vector constructor (splat) - infer type
             (

--- a/tests/out/glsl/constructors.main.Compute.glsl
+++ b/tests/out/glsl/constructors.main.Compute.glsl
@@ -34,7 +34,5 @@ void main() {
     bool ic0_ = bool(false);
     uvec2 ic4_ = uvec2(0u, 0u);
     mat2x3 ic5_ = mat2x3(vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0));
-    uvec2 ic6_ = uvec2(0u);
-    mat2x3 ic7_ = mat2x3(0.0);
 }
 

--- a/tests/out/hlsl/constructors.hlsl
+++ b/tests/out/hlsl/constructors.hlsl
@@ -52,6 +52,4 @@ void main()
     bool ic0_ = bool((bool)0);
     uint2 ic4_ = uint2(0u, 0u);
     float2x3 ic5_ = float2x3(float3(0.0, 0.0, 0.0), float3(0.0, 0.0, 0.0));
-    uint2 ic6_ = asuint((uint2)0);
-    float2x3 ic7_ = asfloat((float2x3)0);
 }

--- a/tests/out/msl/constructors.msl
+++ b/tests/out/msl/constructors.msl
@@ -42,6 +42,4 @@ kernel void main_(
     bool ic0_ = static_cast<bool>(bool {});
     metal::uint2 ic4_ = metal::uint2(0u, 0u);
     metal::float2x3 ic5_ = metal::float2x3(metal::float3(0.0, 0.0, 0.0), metal::float3(0.0, 0.0, 0.0));
-    metal::uint2 ic6_ = as_type<metal::uint2>(metal::uint2 {});
-    metal::float2x3 ic7_ = metal::float2x3(metal::float2x3 {});
 }

--- a/tests/out/spv/constructors.spvasm
+++ b/tests/out/spv/constructors.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.1
 ; Generator: rspirv
-; Bound: 70
+; Bound: 68
 OpCapability Shader
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
@@ -79,6 +79,5 @@ OpDecorate %17 ArrayStride 4
 OpBranch %66
 %66 = OpLabel
 OpStore %63 %47
-%69 = OpCopyObject  %20  %62
 OpReturn
 OpFunctionEnd

--- a/tests/out/wgsl/constructors.wgsl
+++ b/tests/out/wgsl/constructors.wgsl
@@ -29,6 +29,4 @@ fn main() {
     let ic0_ = bool(bool());
     let ic4_ = vec2<u32>(0u, 0u);
     let ic5_ = mat2x3<f32>(vec3<f32>(0.0, 0.0, 0.0), vec3<f32>(0.0, 0.0, 0.0));
-    let ic6_ = bitcast<vec2<u32>>(vec2<u32>());
-    let ic7_ = mat2x3<f32>(mat2x3<f32>());
 }


### PR DESCRIPTION
Do not emit an `Expression::As` conversion for WGSL like `vec3(v)` where `v` is already a `vec3`. This doesn't fix any bugs, but it makes it clearer to the reader of `Lowerer::construct` that no conversion can actually take place in this case.