### PR TITLE
fix clippy lints introduced in 1.72 and 1.73

### DIFF
--- a/src/arena.rs
+++ b/src/arena.rs
@@ -41,10 +41,7 @@ pub struct Handle<T> {
 
 impl<T> Clone for Handle<T> {
     fn clone(&self) -> Self {
-        Handle {
-            index: self.index,
-            marker: self.marker,
-        }
+        *self
     }
 }
 
@@ -60,7 +57,7 @@ impl<T> Eq for Handle<T> {}
 
 impl<T> PartialOrd for Handle<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.index.partial_cmp(&other.index)
+        Some(self.cmp(other))
     }
 }
 

--- a/src/front/wgsl/parse/lexer.rs
+++ b/src/front/wgsl/parse/lexer.rs
@@ -350,9 +350,7 @@ impl<'a> Lexer<'a> {
         &mut self,
     ) -> Result<(&'a str, Span), Error<'a>> {
         match self.next() {
-            (Token::Word(word), span) if word == "_" => {
-                Err(Error::InvalidIdentifierUnderscore(span))
-            }
+            (Token::Word("_"), span) => Err(Error::InvalidIdentifierUnderscore(span)),
             (Token::Word(word), span) if word.starts_with("__") => {
                 Err(Error::ReservedIdentifierPrefix(span))
             }


### PR DESCRIPTION
fixes:
- [non_canonical_clone_impl](https://rust-lang.github.io/rust-clippy/master/index.html#non_canonical_clone_impl)
- [non_canonical_partial_ord_impl](https://rust-lang.github.io/rust-clippy/master/index.html#non_canonical_partial_ord_impl)
- [redundant_guards](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_guards)