### PR TITLE
[wgsl-in] Fix expected min arg count of `textureLoad`

### DIFF
--- a/src/front/wgsl/lower/mod.rs
+++ b/src/front/wgsl/lower/mod.rs
@@ -2099,7 +2099,7 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                             return Ok(None);
                         }
                         "textureLoad" => {
-                            let mut args = ctx.prepare_args(arguments, 3, span);
+                            let mut args = ctx.prepare_args(arguments, 2, span);
 
                             let image = args.next()?;
                             let image_span = ctx.ast_expressions.get_span(image);
@@ -2117,7 +2117,10 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
 
                             let level = class
                                 .is_mipmapped()
-                                .then(|| self.expression(args.next()?, ctx))
+                                .then(|| {
+                                    args.min_args += 1;
+                                    self.expression(args.next()?, ctx)
+                                })
                                 .transpose()?;
 
                             let sample = class


### PR DESCRIPTION
fixes https://github.com/gfx-rs/naga/issues/2583

Also double-checked the min arg count of the other functions.

It was most likely incorrect due to the spec previously only having overloads with min 3 args but with https://github.com/gpuweb/gpuweb/pull/4326 (which we have parts of implemented already) new overloads with min 2 args have been added.