### PR TITLE
[wgsl-in] Miscellaneous cleanups to construction lowering

### DIFF
--- a/src/front/wgsl/lower/construction.rs
+++ b/src/front/wgsl/lower/construction.rs
@@ -489,14 +489,8 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
     /// in [`ctx.module`] a suitable Naga `Type` and return a
     /// [`ConcreteConstructorHandle::Type`] value holding its handle.
     ///
-    /// Note that constructing an [`Array`] type may require inserting
-    /// [`Constant`]s as well as `Type`s into `ctx.module`, to represent the
-    /// array's length.
-    ///
     /// [`Type`]: crate::Type
     /// [`ctx.module`]: ExpressionContext::module
-    /// [`Array`]: crate::TypeInner::Array
-    /// [`Constant`]: crate::Constant
     fn constructor<'out>(
         &mut self,
         constructor: &ast::ConstructorType<'source>,

--- a/src/front/wgsl/lower/construction.rs
+++ b/src/front/wgsl/lower/construction.rs
@@ -466,18 +466,16 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 crate::Expression::Compose { ty, components }
             }
 
-            // Array constructor
-            (components, ConcreteConstructor::Type(ty, &crate::TypeInner::Array { .. })) => {
+            // Array or Struct constructor
+            (
+                components,
+                ConcreteConstructor::Type(
+                    ty,
+                    &crate::TypeInner::Array { .. } | &crate::TypeInner::Struct { .. },
+                ),
+            ) => {
                 let components = components.into_components_vec();
                 crate::Expression::Compose { ty, components }
-            }
-
-            // Struct constructor
-            (components, ConcreteConstructor::Type(ty, &crate::TypeInner::Struct { .. })) => {
-                crate::Expression::Compose {
-                    ty,
-                    components: components.into_components_vec(),
-                }
             }
 
             // ERRORS

--- a/src/front/wgsl/lower/mod.rs
+++ b/src/front/wgsl/lower/mod.rs
@@ -32,6 +32,7 @@ macro_rules! resolve_inner {
         $ctx.typifier()[$expr].inner_with(&$ctx.module.types)
     }};
 }
+pub(super) use resolve_inner;
 
 /// Resolves the inner types of two given expressions.
 ///
@@ -64,7 +65,6 @@ macro_rules! resolve {
         &$ctx.typifier()[$expr]
     }};
 }
-pub(super) use resolve;
 
 /// State for constructing a `crate::Module`.
 pub struct GlobalContext<'source, 'temp, 'out> {


### PR DESCRIPTION
- Doc fix for `Lowerer::constructor`.

- Delete `ComponentsHandle` type.

  In `front:wgsl::lower::construct`, build `Components` values directly,
  rather than building a `ComponentsHandle` and then calling its
  `borrow` method.

- Consolidate array and struct cases in construction.
