### PR TITLE
wgsl-errors: Reverse "old" and "new" sides of diff output.

### DIFF
--- a/tests/wgsl-errors.rs
+++ b/tests/wgsl-errors.rs
@@ -8,7 +8,7 @@ fn check(input: &str, snapshot: &str) {
         .expect_err("expected parser error")
         .emit_to_string(input);
     if output != snapshot {
-        for diff in diff::lines(&output, snapshot) {
+        for diff in diff::lines(snapshot, &output) {
             match diff {
                 diff::Result::Left(l) => println!("-{l}"),
                 diff::Result::Both(l, _) => println!(" {l}"),


### PR DESCRIPTION
When an error snapshot test fails and we generate a diff comparing the expected output with the actual output, treat the expected output as the diff "from", and the actual output as the diff "to" - not the reverse.